### PR TITLE
Add ResetEvent synchronization primitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.claude
+/.zig-cache
+/zig-out

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -25,8 +25,10 @@ pub const Address = @import("address.zig").Address;
 // Re-export synchronization functionality
 pub const Mutex = @import("sync.zig").Mutex;
 pub const Condition = @import("sync.zig").Condition;
+pub const ResetEvent = @import("sync.zig").ResetEvent;
 
 test {
     _ = Mutex;
     _ = Condition;
+    _ = ResetEvent;
 }


### PR DESCRIPTION
## Summary
- Implements zio.ResetEvent similar to std.Thread.ResetEvent but adapted for coroutine-based runtime
- Adds atomic state management with CAS-based set() operation for thread safety
- Implements wait queue for blocked coroutines and timeout support via xev.Timer

## Features
- **Atomic state management**: Uses enum-based states (unset/is_set) with u8 storage
- **Thread-safe operations**: CAS in set() ensures only one winner wakes waiters
- **Coroutine integration**: Proper integration with runtime's markReady/waitForReady
- **Timeout support**: timedWait() method with nanosecond precision
- **Broadcast semantics**: set() wakes all waiting coroutines

## API
- `init(runtime)` - Initialize with runtime reference
- `isSet()` - Check if event is set (atomic load with acquire ordering)
- `set()` - Mark event as set using CAS, wake all waiters
- `reset()` - Clear the set state
- `wait()` - Block until event is set
- `timedWait(timeout_ns)` - Block with timeout

## Test plan
- [x] Basic set/reset/isSet operations
- [x] wait() blocking and signaling between coroutines
- [x] timedWait() timeout scenarios
- [x] Multiple waiters with broadcast wake semantics
- [x] Edge case of waiting on already-set event
- [x] All tests pass with `zig build test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a resettable event synchronization primitive for coordinating concurrent tasks. Supports set, reset, wait, and optional timeouts to avoid indefinite blocking; available via the public API for use in asynchronous workflows.

- Chores
  - Updated project ignore rules to exclude local build and cache artifacts, reducing VCS noise and preventing accidental commits of generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->