### PR TITLE
Refactor coroutine result handling with FutureResult

### DIFF
--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -33,9 +33,9 @@ pub fn main() !void {
     };
 
     // Spawn multiple tasks that increment shared counter
-    var tasks: [4]*zio.Task(void) = undefined;
+    var tasks: [4]zio.JoinHandle(void) = undefined;
     var task_count: usize = 0;
-    defer for (tasks[0..task_count]) |task| task.deinit();
+    defer for (tasks[0..task_count]) |*task| task.deinit();
     for (0..4) |i| {
         tasks[i] = try runtime.spawn(incrementTask, .{ &runtime, &shared_data, @as(u32, @intCast(i)) }, .{});
         task_count += 1;

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -33,11 +33,11 @@ pub fn main() !void {
     };
 
     // Spawn multiple tasks that increment shared counter
-    var tasks: [4]zio.Task(void) = undefined;
+    var tasks: [4]*zio.Task(void) = undefined;
     for (0..4) |i| {
         tasks[i] = try runtime.spawn(incrementTask, .{ &runtime, &shared_data, @as(u32, @intCast(i)) }, .{});
     }
-    defer for (&tasks) |*task| task.deinit();
+    defer for (tasks) |task| task.deinit();
 
     try runtime.run();
 

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -34,10 +34,12 @@ pub fn main() !void {
 
     // Spawn multiple tasks that increment shared counter
     var tasks: [4]*zio.Task(void) = undefined;
+    var task_count: usize = 0;
+    defer for (tasks[0..task_count]) |task| task.deinit();
     for (0..4) |i| {
         tasks[i] = try runtime.spawn(incrementTask, .{ &runtime, &shared_data, @as(u32, @intCast(i)) }, .{});
+        task_count += 1;
     }
-    defer for (tasks) |task| task.deinit();
 
     try runtime.run();
 

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -90,8 +90,8 @@ pub fn main() !void {
     var buffer = BoundedBuffer.init(&runtime);
 
     // Start 2 producers and 2 consumers
-    var producers: [2]zio.Task(void) = undefined;
-    var consumers: [2]zio.Task(void) = undefined;
+    var producers: [2]*zio.Task(void) = undefined;
+    var consumers: [2]*zio.Task(void) = undefined;
 
     for (0..2) |i| {
         producers[i] = try runtime.spawn(producer, .{ &runtime, &buffer, @as(u32, @intCast(i)) }, .{});
@@ -99,8 +99,8 @@ pub fn main() !void {
     }
 
     defer {
-        for (&producers) |*task| task.deinit();
-        for (&consumers) |*task| task.deinit();
+        for (producers) |task| task.deinit();
+        for (consumers) |task| task.deinit();
     }
 
     try runtime.run();

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -92,15 +92,19 @@ pub fn main() !void {
     // Start 2 producers and 2 consumers
     var producers: [2]*zio.Task(void) = undefined;
     var consumers: [2]*zio.Task(void) = undefined;
+    var producer_count: usize = 0;
+    var consumer_count: usize = 0;
+
+    defer {
+        for (producers[0..producer_count]) |task| task.deinit();
+        for (consumers[0..consumer_count]) |task| task.deinit();
+    }
 
     for (0..2) |i| {
         producers[i] = try runtime.spawn(producer, .{ &runtime, &buffer, @as(u32, @intCast(i)) }, .{});
+        producer_count += 1;
         consumers[i] = try runtime.spawn(consumer, .{ &runtime, &buffer, @as(u32, @intCast(i)) }, .{});
-    }
-
-    defer {
-        for (producers) |task| task.deinit();
-        for (consumers) |task| task.deinit();
+        consumer_count += 1;
     }
 
     try runtime.run();

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -90,14 +90,14 @@ pub fn main() !void {
     var buffer = BoundedBuffer.init(&runtime);
 
     // Start 2 producers and 2 consumers
-    var producers: [2]*zio.Task(void) = undefined;
-    var consumers: [2]*zio.Task(void) = undefined;
+    var producers: [2]zio.JoinHandle(void) = undefined;
+    var consumers: [2]zio.JoinHandle(void) = undefined;
     var producer_count: usize = 0;
     var consumer_count: usize = 0;
 
     defer {
-        for (producers[0..producer_count]) |task| task.deinit();
-        for (consumers[0..consumer_count]) |task| task.deinit();
+        for (producers[0..producer_count]) |*task| task.deinit();
+        for (consumers[0..consumer_count]) |*task| task.deinit();
     }
 
     for (0..2) |i| {

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -16,8 +16,8 @@ pub fn main() !void {
     var runtime = try zio.Runtime.init(allocator, .{});
     defer runtime.deinit();
 
-    var task = try runtime.spawn(sleepTask, .{&runtime}, .{});
-    defer task.deinit();
+    var handle = try runtime.spawn(sleepTask, .{&runtime}, .{});
+    defer handle.deinit();
 
     try runtime.run();
 }

--- a/examples/udp_echo.zig
+++ b/examples/udp_echo.zig
@@ -108,7 +108,7 @@ pub fn main() !void {
     for (client_messages, 0..) |message, i| {
         client_tasks[i] = try runtime.spawn(udpClient, .{ &runtime, server_port, @as(u32, @intCast(i + 1)), message }, .{});
     }
-    defer for (client_tasks) |task| task.deinit();
+    defer for (client_tasks) |*task| task.deinit();
 
     // Run the event loop
     try runtime.run();

--- a/src/future_result.zig
+++ b/src/future_result.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn FutureResult(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        const State = enum(u8) { not_set, set };
+
+        state: std.atomic.Value(State) = std.atomic.Value(State).init(.not_set),
+        result: T = undefined,
+
+        pub fn set(self: *Self, value: T) void {
+            const prev = self.state.cmpxchgStrong(.not_set, .set, .acq_rel, .monotonic);
+            if (prev == null) {
+                self.result = value;
+            }
+        }
+
+        pub fn get(self: *const Self) ?T {
+            if (self.state.load(.acquire) == .set) {
+                return self.result;
+            }
+            return null;
+        }
+    };
+}

--- a/src/future_result.zig
+++ b/src/future_result.zig
@@ -3,15 +3,16 @@ const std = @import("std");
 pub fn FutureResult(comptime T: type) type {
     return struct {
         const Self = @This();
-        const State = enum(u8) { not_set, set };
+        const State = enum(u8) { not_set, setting, set };
 
         state: std.atomic.Value(State) = std.atomic.Value(State).init(.not_set),
         result: T = undefined,
 
         pub fn set(self: *Self, value: T) void {
-            const prev = self.state.cmpxchgStrong(.not_set, .set, .acq_rel, .monotonic);
+            const prev = self.state.cmpxchgStrong(.not_set, .setting, .release, .monotonic);
             if (prev == null) {
                 self.result = value;
+                self.state.store(.set, .release);
             }
         }
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -409,11 +409,6 @@ pub const Runtime = struct {
         }
     }
 
-    pub fn getResult(self: *Runtime, comptime T: type, id: u64) ?coroutines.CoroutineResult(T) {
-        const task = self.tasks.get(id) orelse return null;
-        return task.coro.getResult(T);
-    }
-
     pub inline fn taskPtrFromCoroPtr(coro: *Coroutine) *AnyTask {
         const task: *AnyTask = @fieldParentPtr("coro", coro);
         return task;

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -10,7 +10,7 @@ pub const CoroutineOptions = coroutines.CoroutineOptions;
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
 pub const ZioError = runtime.ZioError;
-pub const Task = runtime.Task;
+pub const JoinHandle = runtime.JoinHandle;
 
 // Re-export I/O functionality
 pub const File = @import("file.zig").File;


### PR DESCRIPTION
Changes:
- Add FutureResult(T): thread-safe result container with atomic state
  - Uses CAS to ensure results are set exactly once
  - get() returns ?T based on atomic state check

- Update Coroutine:
  - Store result_ptr: ?*anyopaque instead of AnyCoroutineResult
  - init() now takes comptime Result: type and *FutureResult(Result)
  - Wrapper calls FutureResult.set() with function result
  - Remove CoroutineData.result field

- Refactor Task(T):
  - Now contains any_task, future_result, and runtime pointer
  - Simplified API: join() waits and returns result
  - deinit() uses runtime.releaseTask() with ref counting

- Update AnyTask:
  - Add destroy_fn pointer for type-erased destruction
  - Runtime uses @fieldParentPtr to get typed Task from AnyTask

- Runtime.spawn() now returns *Task(T) directly

All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Async results now use a dedicated FutureResult with single-writer semantics and non-blocking retrieval.

- Refactor
  - Task/coroutine lifecycle and join/result paths simplified to use FutureResult; spawn now returns heap-backed task handles with improved destroy/release flow and safer ownership.

- Chores
  - Examples updated to use pointer-based task handles and adjusted teardown for spawned tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->