### PR TITLE
Add spawnBlocking API for thread pool execution

### DIFF
--- a/vendor/libxev/src/main.zig
+++ b/vendor/libxev/src/main.zig
@@ -38,6 +38,7 @@ pub const Stream = stream.GenericStream;
 pub const Timer = xev.Timer;
 pub const TCP = xev.TCP;
 pub const UDP = xev.UDP;
+pub const queue_mpsc = @import("queue_mpsc.zig");
 
 comptime {
     // This ensures that all the public decls from the API are forwarded


### PR DESCRIPTION
## Summary

Implements `spawnBlocking()` to run blocking operations on a thread pool without blocking the async runtime.

## Implementation Details

- **New types**: `AnyBlockingTask`, `BlockingTask(T)` for thread pool tasks
- **Thread pool integration**: Uses `xev.ThreadPool` with async completion notifications via `xev.Async`
- **Thread-safe completion**: MPSC queue for handling completions from worker threads
- **Event loop optimization**: Uses `.no_wait` mode when work is pending to avoid unnecessary blocking
- **Memory management**: Proper ref counting (1 ref for JoinHandle, 1 ref for runtime) with automatic cleanup
- **Test coverage**: Includes smoke test for basic functionality

## Example Usage

```zig
var handle = try runtime.spawnBlocking(blockingWork, .{arg});
defer handle.deinit();
const result = handle.join();
```

## Testing

All tests pass, including the new `spawnBlocking` smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for running blocking tasks on a thread pool, with handles to await/join results like async tasks.
- Performance
  - Improved runtime responsiveness by optimizing the event loop when blocking work is pending.
- Tests
  - Added a smoke test verifying end-to-end execution and result retrieval for blocking tasks.
- Chores
  - Updated dependency to expose an internal queue utility publicly.
  - Refined initialization and teardown to account for new blocking task components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->