### PR TITLE
Add Runtime.runUntilComplete() convenience method

### DIFF
--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -16,8 +16,5 @@ pub fn main() !void {
     var runtime = try zio.Runtime.init(allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(sleepTask, .{&runtime}, .{});
-    defer handle.deinit();
-
-    try runtime.run();
+    try runtime.runUntilComplete(sleepTask, .{&runtime}, .{});
 }

--- a/src/file.zig
+++ b/src/file.zig
@@ -441,13 +441,7 @@ test "File: basic read and write" {
         }
     };
 
-    var task = try runtime.spawn(TestTask.run, .{&runtime}, .{});
-    defer task.deinit();
-
-    try runtime.run();
-
-    // Clean API to check task result
-    try task.result();
+    try runtime.runUntilComplete(TestTask.run, .{&runtime}, .{});
 }
 
 test "File: positional read and write" {
@@ -486,12 +480,7 @@ test "File: positional read and write" {
         }
     };
 
-    var task = try runtime.spawn(TestTask.run, .{&runtime}, .{});
-    defer task.deinit();
-
-    try runtime.run();
-
-    try task.result();
+    try runtime.runUntilComplete(TestTask.run, .{&runtime}, .{});
 }
 
 test "File: close operation" {
@@ -520,12 +509,7 @@ test "File: close operation" {
         }
     };
 
-    var task = try runtime.spawn(TestTask.run, .{&runtime}, .{});
-    defer task.deinit();
-
-    try runtime.run();
-
-    try task.result();
+    try runtime.runUntilComplete(TestTask.run, .{&runtime}, .{});
 }
 
 test "File: reader and writer interface" {
@@ -576,10 +560,5 @@ test "File: reader and writer interface" {
         }
     };
 
-    var task = try runtime.spawn(TestTask.run, .{&runtime}, .{});
-    defer task.deinit();
-
-    try runtime.run();
-
-    try task.result();
+    try runtime.runUntilComplete(TestTask.run, .{&runtime}, .{});
 }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -208,9 +208,5 @@ test "fs: openFile and createFile with different modes" {
         }
     };
 
-    var task = try runtime.spawn(TestTask.run, .{&runtime}, .{});
-    defer task.deinit();
-
-    try runtime.run();
-    try task.result();
+    try runtime.runUntilComplete(TestTask.run, .{&runtime}, .{});
 }

--- a/src/net.zig
+++ b/src/net.zig
@@ -71,11 +71,7 @@ test "getAddressList: localhost" {
         }
     };
 
-    var task = try runtime.spawn(GetAddressListTask.run, .{ &runtime, allocator }, .{});
-    defer task.deinit();
-
-    try runtime.run();
-    try task.result();
+    try runtime.runUntilComplete(GetAddressListTask.run, .{ &runtime, allocator }, .{});
 }
 
 test "getAddressList: numeric IP" {
@@ -95,11 +91,7 @@ test "getAddressList: numeric IP" {
         }
     };
 
-    var task = try runtime.spawn(GetAddressListTask.run, .{ &runtime, allocator }, .{});
-    defer task.deinit();
-
-    try runtime.run();
-    try task.result();
+    try runtime.runUntilComplete(GetAddressListTask.run, .{ &runtime, allocator }, .{});
 }
 
 test "tcpConnectToAddress: basic connection" {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -372,10 +372,7 @@ test "Mutex tryLock" {
     };
 
     var results: [3]bool = undefined;
-    var task = try runtime.spawn(TestFn.testTryLock, .{ &runtime, &mutex, &results }, .{});
-    defer task.deinit();
-
-    try runtime.run();
+    try runtime.runUntilComplete(TestFn.testTryLock, .{ &runtime, &mutex, &results }, .{});
 
     try testing.expect(results[0]); // First tryLock should succeed
     try testing.expect(!results[1]); // Second tryLock should fail
@@ -449,10 +446,7 @@ test "Condition timedWait timeout" {
         }
     };
 
-    var task = try runtime.spawn(TestFn.waiter, .{ &runtime, &mutex, &condition, &timed_out }, .{});
-    defer task.deinit();
-
-    try runtime.run();
+    try runtime.runUntilComplete(TestFn.waiter, .{ &runtime, &mutex, &condition, &timed_out }, .{});
 
     try testing.expect(timed_out);
 }
@@ -587,10 +581,7 @@ test "ResetEvent timedWait timeout" {
         }
     };
 
-    var task = try runtime.spawn(TestFn.waiter, .{ &runtime, &reset_event, &timed_out }, .{});
-    defer task.deinit();
-
-    try runtime.run();
+    try runtime.runUntilComplete(TestFn.waiter, .{ &runtime, &reset_event, &timed_out }, .{});
 
     try testing.expect(timed_out);
     try testing.expect(!reset_event.isSet());
@@ -656,10 +647,7 @@ test "ResetEvent wait on already set event" {
         }
     };
 
-    var task = try runtime.spawn(TestFn.waiter, .{ &runtime, &reset_event, &wait_completed }, .{});
-    defer task.deinit();
-
-    try runtime.run();
+    try runtime.runUntilComplete(TestFn.waiter, .{ &runtime, &reset_event, &wait_completed }, .{});
 
     try testing.expect(wait_completed);
     try testing.expect(reset_event.isSet());


### PR DESCRIPTION
## Summary

Implements a convenience method that combines `spawn() + run() + result()` into a single call, similar to Python's `asyncio.run()` and Rust's `tokio::block_on()`.

This simplifies the common pattern of spawning a single main task and running the event loop until completion.

## Changes

- Add `runUntilComplete()` method to Runtime (src/runtime.zig)
- Add `ReturnPayload()` helper to extract payload type from error unions
- Update 9 single-task tests to use the simpler API
- Update examples/sleep.zig to demonstrate the simplified usage

## API Design

**Before:**
```zig
var handle = try runtime.spawn(myTask, .{&runtime}, .{});
defer handle.deinit();
try runtime.run();
try handle.result();
```

**After:**
```zig
try runtime.runUntilComplete(myTask, .{&runtime}, .{});
```

## Error Handling

The method returns `!ReturnPayload(func)` which properly merges:
- Errors from `spawn()` (allocation, etc.)
- Errors from `run()` (event loop errors)
- Errors from the task itself

Multi-task tests (server/client patterns) continue to use the existing `spawn() + run()` pattern as they require concurrent task execution.

## Testing

All 41 tests pass ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a convenience API to run tasks to completion in a single call, simplifying usage and error handling.
- Refactor
  - Streamlined task orchestration across examples and internal code by replacing manual task management with the new one-call flow.
- Tests
  - Updated tests to use the new API, reducing boilerplate and improving readability with no behavioral changes to test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->