### PR TITLE
Refactor timedWait to use callback-based timeout handling

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -765,6 +765,11 @@ pub const Runtime = struct {
             return error.Timeout;
         }
 
+        // Timer already completed, no need to cancel
+        if (task.timer_c.flags.state == .dead) {
+            return;
+        }
+
         // Was awakened by external markReady → cancel timer async, no wait needed
         self.loop.cancel(
             &task.timer_c,


### PR DESCRIPTION
## Summary

This PR refactors timer management in synchronization primitives to use a centralized callback-based approach, eliminating code duplication and preventing race conditions.

## Changes

- **Add `Runtime.timedWaitForReadyWithCallback()`**: New generic function that accepts a custom timeout handler callback
- **Refactor `Runtime.timedWaitForReady()`**: Now uses the callback version internally
- **Simplify `Condition.timedWait()`**: 107 lines → 33 lines (~70% reduction)
- **Simplify `ResetEvent.timedWait()`**: 114 lines → 42 lines (~63% reduction)  
- **Simplify `Runtime.sleep()`**: 19 lines → 4 lines (~80% reduction)
- **Total code reduction**: ~200 lines removed

## Key Improvements

### Callback-based timeout discrimination
The new approach uses a callback pattern where the timeout handler decides whether to wake the coroutine:
- Returns `true` if successfully removed from wait queue → real timeout, wake with `error.Timeout`
- Returns `false` if already removed by signal → ignore timeout, don't wake

This prevents race conditions where both `signal()` and the timer could call `markReady()` on the same coroutine.

### Smart timer cancellation
Checks `completion.flags.state == .dead` to avoid canceling already-completed timers, preventing unnecessary timer cancel operations and additional waitForReady cycles.

## Testing

All 54 tests pass including:
- `Condition timedWait timeout` 
- `Semaphore: timedWait timeout/success`
- `ResetEvent timedWait timeout`
- Full test suite via `./check.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible timed-wait API that accepts a user callback for timeout decisions, plus a simpler wrapper for standard timed waits.
  * Exposes per-task timer state to support the new API.

* **Refactor**
  * Unified timeout handling across mutex/condition/reset-event waits with a callback-based flow.
  * Simplified sleep and waiting logic to delegate to the new timed-wait mechanism.

* **Bug Fixes**
  * Generation-based invalidation to prevent late timer wakeups.
  * Reduces unnecessary timer cancellation; ensures atomic release/reacquire around waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->