### PR TITLE
Fix macOS build: use std.c.recvmsg for kqueue backend

### DIFF
--- a/src/tcp.zig
+++ b/src/tcp.zig
@@ -786,7 +786,10 @@ test "TCP: readBuf with different ReadBuffer variants" {
                 var unused_buffer: [1]u8 = undefined;
                 var read_buf: xev.ReadBuffer = .{
                     .vectors = .{
-                        .data = .{
+                        .data = if (builtin.os.tag == .windows) .{
+                            .{ .buf = &buffer, .len = buffer.len },
+                            .{ .buf = &unused_buffer, .len = 0 }, // Second vector unused but must be valid
+                        } else .{
                             .{ .base = &buffer, .len = buffer.len },
                             .{ .base = &unused_buffer, .len = 0 }, // Second vector unused but must be valid
                         },
@@ -802,7 +805,10 @@ test "TCP: readBuf with different ReadBuffer variants" {
             {
                 var buffer1: [2]u8 = undefined;
                 var buffer2: [2]u8 = undefined;
-                var read_buf: xev.ReadBuffer = .{ .vectors = .{ .data = .{
+                var read_buf: xev.ReadBuffer = .{ .vectors = .{ .data = if (builtin.os.tag == .windows) .{
+                    .{ .buf = &buffer1, .len = buffer1.len },
+                    .{ .buf = &buffer2, .len = buffer2.len },
+                } else .{
                     .{ .base = &buffer1, .len = buffer1.len },
                     .{ .base = &buffer2, .len = buffer2.len },
                 }, .len = 2 } };

--- a/vendor/libxev/src/backend/epoll.zig
+++ b/vendor/libxev/src/backend/epoll.zig
@@ -1077,10 +1077,8 @@ pub const Completion = struct {
                             .flags = 0,
                         };
                         const result = std.os.linux.recvmsg(op.fd, &msg, 0);
-                        break :blk if (result > 0)
+                        break :blk if (result >= 0)
                             result
-                        else if (result == 0)
-                            error.EOF
                         else switch (posix.errno(result)) {
                             else => |err| posix.unexpectedErrno(err),
                         };

--- a/vendor/libxev/src/backend/kqueue.zig
+++ b/vendor/libxev/src/backend/kqueue.zig
@@ -1265,7 +1265,14 @@ pub const Completion = struct {
                             .controllen = 0,
                             .flags = 0,
                         };
-                        break :blk posix.recvmsg(op.fd, &msg, 0);
+                        const result = std.c.recvmsg(op.fd, &msg, 0);
+                        break :blk if (result > 0)
+                            @intCast(result)
+                        else if (result == 0)
+                            error.EOF
+                        else switch (posix.errno(result)) {
+                            else => |err| posix.unexpectedErrno(err),
+                        };
                     },
                 };
 
@@ -1296,9 +1303,15 @@ pub const Completion = struct {
                             .controllen = 0,
                             .flags = 0,
                         };
-                        const result = posix.recvmsg(op.fd, &msg, 0);
+                        const result = std.c.recvmsg(op.fd, &msg, 0);
                         op.addr_size = msg.namelen;
-                        break :blk result;
+                        break :blk if (result > 0)
+                            @intCast(result)
+                        else if (result == 0)
+                            error.EOF
+                        else switch (posix.errno(result)) {
+                            else => |err| posix.unexpectedErrno(err),
+                        };
                     },
                 };
 

--- a/vendor/libxev/src/backend/kqueue.zig
+++ b/vendor/libxev/src/backend/kqueue.zig
@@ -1266,10 +1266,8 @@ pub const Completion = struct {
                             .flags = 0,
                         };
                         const result = std.c.recvmsg(op.fd, &msg, 0);
-                        break :blk if (result > 0)
+                        break :blk if (result >= 0)
                             @intCast(result)
-                        else if (result == 0)
-                            error.EOF
                         else switch (posix.errno(result)) {
                             else => |err| posix.unexpectedErrno(err),
                         };
@@ -1305,10 +1303,8 @@ pub const Completion = struct {
                         };
                         const result = std.c.recvmsg(op.fd, &msg, 0);
                         op.addr_size = msg.namelen;
-                        break :blk if (result > 0)
+                        break :blk if (result >= 0)
                             @intCast(result)
-                        else if (result == 0)
-                            error.EOF
                         else switch (posix.errno(result)) {
                             else => |err| posix.unexpectedErrno(err),
                         };


### PR DESCRIPTION
The kqueue backend was calling `posix.recvmsg()` which doesn't exist in Zig 0.15.1. Only `posix.sendmsg()` exists, but there is no corresponding `recvmsg()` wrapper in `std.posix`.

This fix uses `std.c.recvmsg()` directly for macOS/BSD platforms (similar to how the epoll backend uses `std.os.linux.recvmsg()`), with manual error handling for the raw C return value.

Fixes #25

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected EOF and error translation for vectored network reads (recv/recvfrom), aligning with standard read paths to avoid spurious errors on close or no-data conditions.
  * Adjusted vectored recv control flow so zero-length reads are treated as valid results, improving robustness across backends.

* **Tests**
  * Updated TCP tests on Windows to use the platform-appropriate iovec layout, preserving cross-platform expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->