### PR TITLE
Add task-less future object

### DIFF
--- a/src/coroutines.zig
+++ b/src/coroutines.zig
@@ -429,7 +429,7 @@ pub const Coroutine = struct {
                 coro.state = .running;
 
                 const result = @call(.always_inline, func, coro_data.args);
-                coro_data.result_ptr.set(result);
+                _ = coro_data.result_ptr.set(result);
 
                 coro.state = .dead;
                 switchContext(&coro.context, coro.parent_context_ptr);

--- a/src/future_result.zig
+++ b/src/future_result.zig
@@ -8,12 +8,14 @@ pub fn FutureResult(comptime T: type) type {
         state: std.atomic.Value(State) = std.atomic.Value(State).init(.not_set),
         result: T = undefined,
 
-        pub fn set(self: *Self, value: T) void {
+        pub fn set(self: *Self, value: T) bool {
             const prev = self.state.cmpxchgStrong(.not_set, .setting, .release, .monotonic);
             if (prev == null) {
                 self.result = value;
                 self.state.store(.set, .release);
+                return true;
             }
+            return false;
         }
 
         pub fn get(self: *const Self) ?T {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced futures support, allowing values to be awaited like coroutines and blocking tasks.
  - Added new Future types and integrated them into the awaitable system.
  - Join handles now support futures alongside existing variants.

- Refactor
  - Updated a result-setting method to return a boolean success indicator.
  - Adjusted internal usage to ignore the return value where not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->