### PR TITLE
Make sleep() propagate error.Canceled

### DIFF
--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 const zio = @import("zio");
 
-fn sleepTask(rt: *zio.Runtime) void {
+fn sleepTask(rt: *zio.Runtime) !void {
     for (0..10) |_| {
         std.log.info("Sleeping...", .{});
-        rt.sleep(1000);
+        try rt.sleep(1000);
     }
 }
 

--- a/examples/udp_echo.zig
+++ b/examples/udp_echo.zig
@@ -40,7 +40,7 @@ fn udpEchoServer(rt: *zio.Runtime, port: u16) !void {
 
 fn udpClient(rt: *zio.Runtime, server_port: u16, client_id: u32, message: []const u8) !void {
     // Give server time to start
-    rt.sleep(50 * client_id);
+    try rt.sleep(50 * client_id);
 
     const elapsed_start = getTimestamp() - start_time;
     print("[{}ms] [Client-{}] Starting\n", .{ elapsed_start, client_id });

--- a/src/udp.zig
+++ b/src/udp.zig
@@ -219,7 +219,7 @@ test "UDP: basic send and receive" {
 
     const ClientTask = struct {
         fn run(rt: *Runtime, server_port: *u16) !void {
-            rt.sleep(10); // Give server time to bind
+            try rt.sleep(10); // Give server time to bind
 
             const client_addr = try std.net.Address.parseIp4("127.0.0.1", 0);
             var socket = try UdpSocket.init(rt, client_addr);

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -11,6 +11,7 @@ pub const Runtime = runtime.Runtime;
 pub const SpawnOptions = runtime.SpawnOptions;
 pub const JoinHandle = runtime.JoinHandle;
 pub const SelectUnion = runtime.SelectUnion;
+pub const Cancelable = runtime.Cancelable;
 
 // Re-export I/O functionality
 pub const File = @import("file.zig").File;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sleep operations are now cancelable, providing greater control over task lifecycle and enabling interruption of long-running operations within concurrent contexts.

* **Improvements**
  * Enhanced error propagation in sleep operations throughout async execution paths, ensuring consistent and predictable error handling behavior in runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->