### PR TITLE
Add waiting_io and waiting_sync states to differentiate wait types

### DIFF
--- a/src/coroutines.zig
+++ b/src/coroutines.zig
@@ -11,8 +11,9 @@ pub const DEFAULT_STACK_SIZE = if (builtin.os.tag == .windows) 2 * 1024 * 1024 e
 pub const CoroutineState = enum(u8) {
     ready = 0,
     preparing_to_wait = 1,
-    waiting = 2,
-    dead = 3,
+    waiting_io = 2,
+    waiting_sync = 3,
+    dead = 4,
 };
 
 pub const stack_alignment = 16;

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -96,9 +96,9 @@ pub fn wait(self: *Condition, runtime: *Runtime, mutex: *Mutex) Cancelable!void 
     // Atomically release mutex
     mutex.unlock(runtime);
 
-    // Yield with atomic state transition (.preparing_to_wait -> .waiting)
+    // Yield with atomic state transition (.preparing_to_wait -> .waiting_sync)
     // If someone wakes us before the yield, the CAS inside yield() will fail and we won't suspend
-    executor.yield(.preparing_to_wait, .waiting, .allow_cancel) catch |err| {
+    executor.yield(.preparing_to_wait, .waiting_sync, .allow_cancel) catch |err| {
         // On cancellation, remove from queue and reacquire mutex
         _ = self.wait_queue.remove(&task.awaitable.wait_node);
         // Must reacquire mutex before returning
@@ -145,10 +145,11 @@ pub fn timedWait(self: *Condition, runtime: *Runtime, mutex: *Mutex, timeout_ns:
     // Atomically release mutex
     mutex.unlock(runtime);
 
-    // Yield with atomic state transition (.preparing_to_wait -> .waiting)
+    // Yield with atomic state transition (.preparing_to_wait -> .waiting_sync)
     // If someone wakes us before the yield, the CAS inside yield() will fail and we won't suspend
     executor.timedWaitForReadyWithCallback(
         .preparing_to_wait,
+        .waiting_sync,
         timeout_ns,
         TimeoutContext,
         &timeout_ctx,

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -86,9 +86,9 @@ pub fn lock(self: *Mutex, runtime: *Runtime) Cancelable!void {
         return;
     }
 
-    // Yield with atomic state transition (.preparing_to_wait -> .waiting)
+    // Yield with atomic state transition (.preparing_to_wait -> .waiting_sync)
     // If someone wakes us before the yield, the CAS inside yield() will fail and we won't suspend
-    executor.yield(.preparing_to_wait, .waiting, .allow_cancel) catch |err| {
+    executor.yield(.preparing_to_wait, .waiting_sync, .allow_cancel) catch |err| {
         // Cancellation - try to remove ourselves from queue
         if (!self.queue.remove(&task.awaitable.wait_node)) {
             // Already inherited the lock

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -132,9 +132,9 @@ pub fn wait(self: *ResetEvent, runtime: *Runtime) Cancelable!void {
         return;
     }
 
-    // Yield with atomic state transition (.preparing_to_wait -> .waiting)
+    // Yield with atomic state transition (.preparing_to_wait -> .waiting_sync)
     // If someone wakes us before the yield, the CAS inside yield() will fail and we won't suspend
-    executor.yield(.preparing_to_wait, .waiting, .allow_cancel) catch |err| {
+    executor.yield(.preparing_to_wait, .waiting_sync, .allow_cancel) catch |err| {
         // On cancellation, remove from queue
         _ = self.wait_queue.remove(&task.awaitable.wait_node);
         return err;
@@ -192,10 +192,11 @@ pub fn timedWait(self: *ResetEvent, runtime: *Runtime, timeout_ns: u64) error{ T
         .wait_node = &task.awaitable.wait_node,
     };
 
-    // Yield with atomic state transition (.preparing_to_wait -> .waiting)
+    // Yield with atomic state transition (.preparing_to_wait -> .waiting_sync)
     // If someone wakes us before the yield, the CAS inside yield() will fail and we won't suspend
     executor.timedWaitForReadyWithCallback(
         .preparing_to_wait,
+        .waiting_sync,
         timeout_ns,
         TimeoutContext,
         &timeout_ctx,


### PR DESCRIPTION
Split the generic .waiting state into two distinct states:
- .waiting_io: for I/O operations (xev completions, timers)
- .waiting_sync: for synchronization primitives (mutexes, conditions, channels)

This distinction enables future work stealing for tasks blocked on synchronization while keeping I/O-bound tasks pinned to their executor. It also makes the code more explicit about what type of waiting is happening.

Updated timedWaitForReady to accept desired_state parameter for flexibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced coroutine state machine to distinguish between I/O waits and synchronization waits for more precise scheduling control
  * Updated timed wait APIs with a new required parameter specifying the desired wait state
  * Modified synchronization primitives to use refined wait state transitions for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->