### PR TITLE
Rename *NoCancel to *Uncancelable to match std.io naming

### DIFF
--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -113,7 +113,7 @@ pub fn lock(self: *Mutex, runtime: *Runtime) Cancelable!void {
 ///
 /// If you need to propagate cancellation after acquiring the lock, call
 /// `runtime.checkCanceled()` after this function returns.
-pub fn lockNoCancel(self: *Mutex, runtime: *Runtime) void {
+pub fn lockUncancelable(self: *Mutex, runtime: *Runtime) void {
     runtime.beginShield();
     defer runtime.endShield();
     self.lock(runtime) catch unreachable;

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -130,7 +130,7 @@ pub fn BroadcastChannel(comptime T: type) type {
         ///
         /// This operation is shielded from cancellation to ensure cleanup completes.
         pub fn unsubscribe(self: *Self, runtime: *Runtime, consumer: *Consumer) void {
-            self.mutex.lockNoCancel(runtime);
+            self.mutex.lockUncancelable(runtime);
             defer self.mutex.unlock(runtime);
 
             self.consumers.remove(consumer);

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -207,7 +207,7 @@ pub fn Channel(comptime T: type) type {
         ///
         /// This operation is shielded from cancellation to ensure the close completes.
         pub fn close(self: *Self, rt: *Runtime, immediate: bool) void {
-            self.mutex.lockNoCancel(rt);
+            self.mutex.lockUncancelable(rt);
             defer self.mutex.unlock(rt);
 
             self.closed = true;


### PR DESCRIPTION
- Rename Mutex.lockNoCancel to lockUncancelable
- Add Condition.waitUncancelable
- Add Semaphore.waitUncancelable
- Update all usage sites to use new naming

This aligns with Zig standard library naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed a synchronization primitive method to clarify its cancellation-shielding semantics.

* **New Features**
  * Added uncancelable wait variants to condition variables and semaphores that shield critical synchronization operations from cancellation interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->