### PR TITLE
Fix flaky tcpConnectToHost test on macOS

### DIFF
--- a/src/net.zig
+++ b/src/net.zig
@@ -53,14 +53,14 @@ pub fn tcpConnectToHost(
 
     if (list.addrs.len == 0) return error.UnknownHostName;
 
+    var last_err: ?anyerror = null;
     for (list.addrs) |addr| {
-        return IpAddress.fromStd(addr).connect(rt) catch |err| switch (err) {
-            error.ConnectionRefused => {
-                continue;
-            },
-            else => return err,
+        return IpAddress.fromStd(addr).connect(rt) catch |err| {
+            last_err = err;
+            continue;
         };
     }
+    if (last_err) |err| return err;
     return error.ConnectionRefused;
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent test failures of `tcpConnectToHost: basic` on macOS due to DNS resolution race conditions.

## Problem

The test was failing on macOS with "Unexpected" errors because:

1. The server binds to `127.0.0.1` (IPv4 only)
2. The client connects to `"localhost"` 
3. On macOS, `"localhost"` resolves to both `::1` (IPv6) and `127.0.0.1` (IPv4)
4. The order of addresses varies between test runs

When the client tried IPv6 first but the server was IPv4-only, macOS would return errors like:
- `error.NetworkUnreachable`
- `error.HostUnreachable`
- `error.AddressFamilyNotSupported`

The old retry logic only caught `error.ConnectionRefused`, causing immediate failure without trying the remaining IPv4 address.

## Solution

Changed `tcpConnectToHost` to catch **all** connection errors and continue trying remaining addresses. Now only returns the last error if all addresses fail.

This matches the behavior of other networking libraries and ensures robust connection handling when DNS returns multiple address families.

## Testing

- All 18 networking tests pass on Linux
- The fix should resolve the flaky behavior on macOS by ensuring all resolved addresses are tried

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for network connection failures by capturing the final error encountered during connection attempts instead of stopping at the first non-refused error, providing more accurate diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->