### PR TITLE
Fix ref count race in spawn() and spawnBlocking()

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -467,14 +467,16 @@ pub const Executor = struct {
         try self.runtime.tasks.add(&task.impl.base.awaitable);
         errdefer _ = self.runtime.tasks.remove(&task.impl.base.awaitable);
 
+        // Increment ref count for JoinHandle BEFORE scheduling
+        // This prevents race where task completes before we create the handle
+        task.impl.base.awaitable.ref_count.incr();
+        errdefer _ = task.impl.base.awaitable.ref_count.decr();
+
         // Schedule the task to run (handles cross-thread notification)
         self.scheduleTask(&task.impl.base, .maybe_remote);
 
         // Track task spawn
         self.metrics.tasks_spawned += 1;
-
-        // Increment ref count for JoinHandle
-        task.impl.base.awaitable.ref_count.incr();
 
         return JoinHandle(Result){ .awaitable = &task.impl.base.awaitable };
     }
@@ -1222,13 +1224,15 @@ pub const Runtime = struct {
         try self.tasks.add(&task.impl.base.awaitable);
         errdefer _ = self.tasks.remove(&task.impl.base.awaitable);
 
+        // Increment ref count for JoinHandle BEFORE scheduling
+        // This prevents race where task completes before we create the handle
+        task.impl.base.awaitable.ref_count.incr();
+        errdefer _ = task.impl.base.awaitable.ref_count.decr();
+
         // Schedule the task to run on the thread pool
         thread_pool.schedule(
             xev.ThreadPool.Batch.from(&task.impl.base.thread_pool_task),
         );
-
-        // Increment ref count for JoinHandle
-        task.impl.base.awaitable.ref_count.incr();
 
         return JoinHandle(Result){ .awaitable = &task.impl.base.awaitable };
     }


### PR DESCRIPTION
## Summary

Fixes a use-after-free race condition in `spawn()` and `spawnBlocking()` where the ref count for the JoinHandle was incremented after scheduling the task.

## The Problem

When spawning tasks to different executors (or thread pool), the following race could occur:

1. `spawn()` schedules task to remote executor/thread pool
2. Task starts and completes immediately on another parallel thread
3. Task's ref count drops from 1→0 and gets destroyed
4. `spawn()` tries to increment the freed ref count → **assertion failure in `RefCounter.incr()`**

```
Thread A (spawning):              Thread B (executor):
--------------------              -------------------
create task (ref=1)
add to registry
scheduleTask() →                  → picks up task
                                  → runs task  
                                  → completes
                                  → ref_count.decr() (1→0)
                                  → task destroyed
incr() on freed memory 💥
```

This was most visible in multi-executor tests where trivial tasks could complete extremely quickly on parallel threads.

## The Fix

Both `Executor.spawn()` and `Runtime.spawnBlocking()` now:
- Increment the ref count **BEFORE** scheduling/submitting the task
- This ensures ref count goes 1→2 before the task becomes visible to other threads  
- Added proper `errdefer` cleanup in case scheduling fails

## Test Plan

- [x] All existing tests pass
- [x] The macOS CI crash that triggered this investigation should now be fixed