### PR TITLE
Add SimpleWaitQueue for mutex-protected use cases

### DIFF
--- a/src/utils/wait_queue.zig
+++ b/src/utils/wait_queue.zig
@@ -105,6 +105,16 @@ pub fn SimpleWaitQueue(comptime T: type) type {
             return head;
         }
 
+        /// Remove and return all items from the queue.
+        /// Must be called with external synchronization.
+        /// Returns a new queue containing all items; the original queue becomes empty.
+        /// This is useful for processing all items without repeated locking.
+        pub fn popAll(self: *Self) Self {
+            const result = self.*;
+            self.* = .empty;
+            return result;
+        }
+
         /// Remove a specific item from the queue.
         /// Must be called with external synchronization.
         /// Returns true if the item was found and removed, false otherwise.


### PR DESCRIPTION
## Summary

Introduces `SimpleWaitQueue`, a non-atomic wait queue designed for use under external synchronization (e.g., mutex). This provides better performance and simpler code compared to `WaitQueue` when atomics and mutation spinlocks are unnecessary.

Updates `Channel` to use `SimpleWaitQueue` instead of `WaitQueue`, since all queue access is already protected by the channel's mutex.

## Changes

- Add `SimpleWaitQueue` implementation to `wait_queue.zig`
- Add comprehensive tests for `SimpleWaitQueue` (4 tests)
- Update `Channel` to use `SimpleWaitQueue` for receiver/sender queues
- All existing tests pass without modification (141 tests)

## Benefits

- **Simpler code**: No complex atomic memory ordering required
- **Better performance**: Eliminates atomic operations and spinloops when accessing wait queues under mutex protection
- **Clearer design**: The mutex provides all synchronization, making the synchronization model explicit and easier to understand

## Implementation

`SimpleWaitQueue` is a straightforward doubly-linked list with:
- No atomic operations
- No mutation spinlock
- No sentinel states
- O(1) push, pop, and remove operations

Perfect for use cases like `Channel` where a mutex already protects all queue operations.