### PR TITLE
Upgrade to Zig 0.15.2

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.1
+          version: 0.15.2
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.1
+          version: 0.15.2
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: 0.15.1
+        version: 0.15.2
 
     - name: Build
       run: zig build

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = .zio,
     .version = "0.4.0",
+    .minimum_zig_version = "0.15.2",
     .fingerprint = 0xcf1598b354d576c4,
     .paths = .{
         "build.zig",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated to Zig 0.15.2 (minimum required version)
 - `select()` and `wait()` now require futures to be passed as pointers (use `&future` instead of `future`)
 - Channel methods `isEmpty()`, `isFull()`, `tryReceive()`, `trySend()`, and `close()` no longer require a `*Runtime` parameter
 - `JoinHandle.deinit()` is now `JoinHandle.detach()`

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -503,7 +503,8 @@ test "StreamReader: takeByte reads first byte correctly" {
     // Read rest of first line
     const line1 = try reader.interface.takeDelimiterExclusive('\r');
     try testing.expectEqualStrings("1", line1);
-    _ = try reader.interface.takeDelimiterExclusive('\n');
+    _ = try reader.interface.takeByte(); // consume '\r'
+    _ = try reader.interface.takeByte(); // consume '\n'
 
     // Read second line
     const line2 = try reader.interface.takeDelimiterExclusive('\r');


### PR DESCRIPTION
## Summary

This PR upgrades the project to Zig 0.15.2, addressing a breaking behavior change in the standard library's `std.Io.Reader.takeDelimiterExclusive()` function.

## Changes

- Updated all GitHub workflow files (test.yml, docs.yml, claude.yml) to use Zig 0.15.2
- Set `minimum_zig_version = "0.15.2"` in build.zig.zon
- Fixed stream test to handle the new `takeDelimiterExclusive()` behavior
- Updated changelog

## Breaking Change in Zig 0.15.2

The `std.Io.Reader.takeDelimiterExclusive()` function behavior changed between Zig 0.15.1 and 0.15.2:

- **0.15.1**: Advanced the seek position **past** the delimiter
- **0.15.2**: Only advances the seek position **up to** (but not past) the delimiter

This means after calling `takeDelimiterExclusive()`, the delimiter must now be explicitly consumed with `takeByte()` or similar.

## Testing

All 153 tests pass successfully with Zig 0.15.2.