### PR TITLE
Extract Windows TIB handling to support ARM64

### DIFF
--- a/src/coroutines.zig
+++ b/src/coroutines.zig
@@ -32,8 +32,8 @@ pub const StackPtr = [*]align(stack_alignment) u8;
 const WindowsTIB = extern struct {
     fiber_data: u64, // TEB offset 0x20
     deallocation_stack: u64, // TEB offset 0x1478
-    stack_limit: u64, // TEB offset 0x10
     stack_base: u64, // TEB offset 0x08
+    stack_limit: u64, // TEB offset 0x10
 };
 
 const ExtraContext = if (builtin.os.tag == .windows) WindowsTIB else void;
@@ -94,9 +94,9 @@ pub fn switchContext(
                 \\ movq %%r11, 24(%%rax)
                 \\ movq 0x1478(%%r10), %%r11
                 \\ movq %%r11, 32(%%rax)
-                \\ movq 0x10(%%r10), %%r11
-                \\ movq %%r11, 40(%%rax)
                 \\ movq 0x08(%%r10), %%r11
+                \\ movq %%r11, 40(%%rax)
+                \\ movq 0x10(%%r10), %%r11
                 \\ movq %%r11, 48(%%rax)
                 \\
             else
@@ -114,9 +114,9 @@ pub fn switchContext(
                 \\ movq 32(%%rcx), %%r11
                 \\ movq %%r11, 0x1478(%%r10)
                 \\ movq 40(%%rcx), %%r11
-                \\ movq %%r11, 0x10(%%r10)
-                \\ movq 48(%%rcx), %%r11
                 \\ movq %%r11, 0x08(%%r10)
+                \\ movq 48(%%rcx), %%r11
+                \\ movq %%r11, 0x10(%%r10)
                 \\
             else
                 "")
@@ -200,7 +200,7 @@ pub fn switchContext(
                 \\ ldr x10, [x18, #0x20]
                 \\ ldr x11, [x18, #0x1478]
                 \\ stp x10, x11, [x0, #24]
-                \\ ldp x11, x10, [x18, #0x08]
+                \\ ldp x10, x11, [x18, #0x08]
                 \\ stp x10, x11, [x0, #40]
                 \\
             else
@@ -216,7 +216,7 @@ pub fn switchContext(
                 \\ str x10, [x18, #0x20]
                 \\ str x11, [x18, #0x1478]
                 \\ ldp x10, x11, [x1, #40]
-                \\ stp x11, x10, [x18, #0x08]
+                \\ stp x10, x11, [x18, #0x08]
                 \\
             else
                 "")


### PR DESCRIPTION
## Summary

Refactor Windows Thread Information Block (TIB) handling in coroutines to support both x86_64 and ARM64 Windows platforms.

## Changes

- **Add `WindowsTIB` struct** to encapsulate TIB fields (`fiber_data`, `deallocation_stack`, `stack_limit`, `stack_base`)
- **Use comptime type selection** for `ExtraContext` (`WindowsTIB` on Windows, `void` elsewhere)
- **Add `extra` field** to `Context` struct for both x86_64 and aarch64 architectures
- **Optimize x86_64 TIB save/restore** to load TEB pointer once via `gs:0x30` (following boost.context pattern)
- **Add ARM64 Windows TIB handling** using x18 register (which directly contains the TEB pointer)
- **Use comptime string concatenation** to conditionally include Windows-specific assembly code
- **Update `Coroutine.setup()`** to initialize TIB for both architectures

## Technical Details

### TIB Offsets

TIB offsets are shared between x86_64 and ARM64 as they reference the same TEB structure layout:
- `fiber_data`: 0x20
- `deallocation_stack`: 0x1478
- `stack_limit`: 0x10
- `stack_base`: 0x08

### TEB Access Methods

- **x86_64**: Load TEB pointer via `gs:0x30`, then access TIB fields as offsets from that pointer
- **ARM64**: x18 register directly contains the TEB pointer, access TIB fields as offsets from x18

## Testing

All 152 tests pass on Linux x86_64.