### PR TITLE
Wait for the timer to be canceled

### DIFF
--- a/src/core/timeout.zig
+++ b/src/core/timeout.zig
@@ -25,6 +25,12 @@ pub const Timeout = struct {
         task.timeouts.remove(self);
         task.maybeUpdateTimer();
         self.task = null;
+
+        // TODO: HUGE HACK: this needs proper waiting
+        // If we are the active timeout, we need to wait until it's cleared!!!
+        while (task.timer_cancel_c.state() != .dead) {
+            executor.yield(.ready, .ready, .no_cancel);
+        }
     }
 
     pub fn set(self: *Timeout, rt: *Runtime, timeout_ns: u64) void {


### PR DESCRIPTION
If we are calling `timeout.clear()`, we need to wait until the backing timer is canceled. It's because if we exit sooner, the task might actually exit, and cause memory corruption.

This is a WIP hack, needs proper waiting.