### PR TITLE
Add FreeBSD VM testing and expand QEMU test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,28 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-linux
+            run: native
           - os: ubuntu-latest
             target: aarch64-linux
+            run: qemu
             qemu_binary: qemu-aarch64-static
             xev_backend: epoll
           - os: ubuntu-latest
             target: riscv64-linux
+            run: qemu
             qemu_binary: qemu-riscv64-static
             xev_backend: epoll
+          - os: ubuntu-latest
+            target: x86_64-freebsd
+            run: vm
+            vm_type: freebsd
+            xev_backend: kqueue
           - os: macos-latest
             target: native
+            run: native
           - os: windows-latest
             target: native
+            run: native
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -54,24 +64,32 @@ jobs:
       timeout-minutes: 5
 
     - name: Run tests (native)
-      if: ${{ !matrix.qemu_binary }}
+      if: matrix.run == 'native'
       run: ./zig-out/bin/test
       timeout-minutes: 5
 
     - name: Run xev tests (native only)
-      if: ${{ !matrix.qemu_binary }}
+      if: matrix.run == 'native'
       run: cd vendor/libxev && zig build test
       timeout-minutes: 5
 
     - name: Install QEMU
-      if: matrix.qemu_binary
+      if: matrix.run == 'qemu'
       run: |
         sudo apt-get update -q -y
         sudo apt-get install -q -y qemu-user-static
 
     - name: Run tests (QEMU)
-      if: matrix.qemu_binary
+      if: matrix.run == 'qemu'
       run: ${{ matrix.qemu_binary }} ./zig-out/bin/test
       timeout-minutes: 10
       env:
         TEST_FILTER: event.tests.test|coroutines.test
+
+    - name: Test in FreeBSD VM
+      if: matrix.run == 'vm' && matrix.vm_type == 'freebsd'
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        run: |
+          env TEST_FILTER="event.tests.test|coroutines.test" ./zig-out/bin/test


### PR DESCRIPTION
## Summary

This PR expands CI test coverage for the event loop implementation:

- Updated QEMU runners to test both event loop and coroutine tests using the new multiple filter support
- Added FreeBSD x86_64 VM testing to validate event loop on BSD systems
- Refactored CI matrix to use explicit `run` field for better clarity

## Changes

### Test Filter Updates
- QEMU runners (aarch64, riscv64) now run: `event.tests.test|coroutines.test`
- FreeBSD VM now runs: `event.tests.test|coroutines.test`
- Uses the new multiple filter syntax from #129

### CI Matrix Updates
- Added `run` field to distinguish between `native`, `qemu`, and `vm` test execution
- Added FreeBSD x86_64 target with kqueue backend
- Updated all conditional checks to use `matrix.run` for better readability

### FreeBSD VM Testing
- Uses `vmactions/freebsd-vm@v1` to run tests in a FreeBSD VM
- Validates kqueue-based event loop implementation
- Runs same filtered tests as QEMU for consistency

## Test plan

- [x] FreeBSD VM matrix entry added with correct configuration
- [x] Test filter updated for QEMU runners
- [x] Test filter added for FreeBSD VM
- [x] Conditional checks updated to use `matrix.run` field

## Dependencies

Depends on #129 (multiple filter support) being merged to main first.