### PR TITLE
Use std.time.Timer in benchmarks instead of nanoTimestamp

### DIFF
--- a/benchmarks/echo_server.zig
+++ b/benchmarks/echo_server.zig
@@ -66,7 +66,7 @@ fn clientTask(
     var i: usize = 0;
     const start_idx = client_id * MESSAGES_PER_CLIENT;
     while (i < MESSAGES_PER_CLIENT) : (i += 1) {
-        const msg_start = std.time.nanoTimestamp();
+        var timer = try std.time.Timer.start();
 
         try stream.writeAll(rt, &send_buffer);
 
@@ -77,8 +77,7 @@ fn clientTask(
             bytes_received += n;
         }
 
-        const msg_end = std.time.nanoTimestamp();
-        latencies[start_idx + i] = @intCast(msg_end - msg_start);
+        latencies[start_idx + i] = timer.read();
     }
 }
 
@@ -106,7 +105,7 @@ fn benchmarkTask(
     // Wait for server to be ready
     try server_ready.wait(rt);
 
-    const start = std.time.nanoTimestamp();
+    var timer = try std.time.Timer.start();
 
     // Spawn all clients
     const client_tasks = try allocator.alloc(zio.JoinHandle(anyerror!void), NUM_CLIENTS);
@@ -123,14 +122,13 @@ fn benchmarkTask(
         try task.join(rt);
     }
 
-    const end = std.time.nanoTimestamp();
+    const elapsed_ns = timer.read();
 
     // Signal server to shut down
     server_done.set();
     try server.join(rt);
 
     // Calculate statistics
-    const elapsed_ns = @as(u64, @intCast(end - start));
     const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
     const elapsed_s = elapsed_ms / 1000.0;
 

--- a/benchmarks/ping_pong.zig
+++ b/benchmarks/ping_pong.zig
@@ -38,7 +38,7 @@ pub fn main() !void {
 
     std.debug.print("Running ping-pong benchmark with {} rounds...\n", .{NUM_ROUNDS});
 
-    const start = std.time.nanoTimestamp();
+    var timer = try std.time.Timer.start();
 
     // Spawn pinger and ponger tasks
     var pinger_task = try runtime.spawn(pinger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS }, .{});
@@ -50,8 +50,7 @@ pub fn main() !void {
     // Run until both tasks complete
     try runtime.run();
 
-    const end = std.time.nanoTimestamp();
-    const elapsed_ns = @as(u64, @intCast(end - start));
+    const elapsed_ns = timer.read();
     const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
     const elapsed_s = elapsed_ms / 1000.0;
 


### PR DESCRIPTION
## Summary
- Updated `echo_server.zig` and `ping_pong.zig` to use `std.time.Timer` instead of `std.time.nanoTimestamp()`
- `concurrent_queue_bench.zig` was already using the Timer API
- This provides more accurate and portable timing measurements

## Changes
- Replaced manual timestamp calculations with `Timer.start()` and `timer.read()`
- Simplified code by removing intermediate timestamp variables and calculations