### PR TITLE
Add BindOptions with reuse_address support for UDP sockets

### DIFF
--- a/src/net/test.zig
+++ b/src/net/test.zig
@@ -163,7 +163,7 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
 pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
     const Test = struct {
         pub fn mainFn(rt: *Runtime, server_addr_inner: @TypeOf(server_addr), client_addr_inner: @TypeOf(client_addr)) !void {
-            const socket = try server_addr_inner.bind(rt);
+            const socket = try server_addr_inner.bind(rt, .{});
             defer socket.close(rt);
 
             var server_task = try rt.spawn(serverFn, .{ rt, socket }, .{});
@@ -187,7 +187,7 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
         }
 
         pub fn clientFn(rt: *Runtime, server_socket: Socket, client_addr_inner: @TypeOf(client_addr)) !void {
-            const client_socket = try client_addr_inner.bind(rt);
+            const client_socket = try client_addr_inner.bind(rt, .{});
             defer client_socket.close(rt);
 
             const test_data = "hello";

--- a/src/stdio.zig
+++ b/src/stdio.zig
@@ -585,10 +585,10 @@ fn netAcceptImpl(userdata: ?*anyopaque, server: std.Io.net.Socket.Handle) std.Io
 }
 
 fn netBindIpImpl(userdata: ?*anyopaque, address: *const std.Io.net.IpAddress, options: std.Io.net.IpAddress.BindOptions) std.Io.net.IpAddress.BindError!std.Io.net.Socket {
-    _ = options; // No options used in zio yet
+    _ = options; // std.Io BindOptions don't include reuse_address, use zio API directly for that
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
     const zio_addr = stdIoIpToZio(address.*);
-    const socket = zio_net.netBindIp(rt, zio_addr) catch |err| switch (err) {
+    const socket = zio_net.netBindIp(rt, zio_addr, .{}) catch |err| switch (err) {
         error.Canceled => return error.Canceled,
         else => return error.Unexpected,
     };


### PR DESCRIPTION
## Summary

Adds `BindOptions` to UDP socket bind operations with support for `SO_REUSEADDR`. This allows multiple processes to bind to the same address, which is essential for use cases like mDNS.

## Changes

- Add `IpAddress.BindOptions` and `UnixAddress.BindOptions` structs with `reuse_address` field
- Update `bind()` methods to accept options parameter (defaults to `reuse_address: false`)
- Apply `SO_REUSEADDR` socket option **before** binding when `reuse_address` is true
- Update `netBindIp()` and `netBindUnix()` to handle options
- Update tests to use new signature with default options `bind(rt, .{})`

## Usage

```zig
// Bind with SO_REUSEADDR (for mDNS, etc.)
const addr = try IpAddress.parseIp4("224.0.0.251", 5353);
const socket = try addr.bind(rt, .{ .reuse_address = true });

// Default behavior (no reuse)
const socket = try addr.bind(rt, .{});
```

## Implementation Details

The implementation follows the existing pattern used by TCP's `ListenOptions`. The critical fix is that socket options are applied **after socket creation but before the bind() call**, which is the correct timing for `SO_REUSEADDR` to work.

Fixes #149