### PR TITLE
Remove executor pinning feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
 fn serverTask(rt: *zio.Runtime) !void {
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
 
-    const server = try addr.listen(rt, .{});
+    const server = try addr.listen(rt);
     defer server.close(rt);
 
-    std.log.info("Listening on 127.0.0.1:8080", .{});
+    std.log.info("Listening on 127.0.0.1:8080");
 
     while (true) {
         const stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.detach(rt);
     }
 }
@@ -97,10 +97,10 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    const rt = try zio.Runtime.init(gpa.allocator(), .{});
+    const rt = try zio.Runtime.init(gpa.allocator());
     defer rt.deinit();
 
-    var handle = try rt.spawn(serverTask, .{rt}, .{});
+    var handle = try rt.spawn(serverTask, .{rt});
     try handle.join(rt);
 }
 ```

--- a/benchmarks/concurrent_queue_bench.zig
+++ b/benchmarks/concurrent_queue_bench.zig
@@ -123,15 +123,15 @@ fn runBenchmark(comptime name: []const u8, allocator: std.mem.Allocator, comptim
     const ops_per_sec = @as(f64, @floatFromInt(num_operations)) / (@as(f64, @floatFromInt(avg)) / 1_000_000_000.0);
 
     std.debug.print("{s}:\n", .{name});
-    std.debug.print("  Avg: ", .{});
+    std.debug.print("  Avg: ");
     formatNs(avg);
     std.debug.print(" ({d:.0} ops/sec)\n", .{ops_per_sec});
-    std.debug.print("  Min: ", .{});
+    std.debug.print("  Min: ");
     formatNs(min);
-    std.debug.print("\n", .{});
-    std.debug.print("  Max: ", .{});
+    std.debug.print("\n");
+    std.debug.print("  Max: ");
     formatNs(max);
-    std.debug.print("\n\n", .{});
+    std.debug.print("\n\n");
 }
 
 fn runConcurrentBenchmark(comptime name: []const u8, allocator: std.mem.Allocator, comptime bench_fn: fn (std.mem.Allocator, usize, usize) anyerror!u64, num_threads: usize, ops_per_thread: usize, iterations: usize) !void {
@@ -151,15 +151,15 @@ fn runConcurrentBenchmark(comptime name: []const u8, allocator: std.mem.Allocato
     const ops_per_sec = @as(f64, @floatFromInt(total_ops)) / (@as(f64, @floatFromInt(avg)) / 1_000_000_000.0);
 
     std.debug.print("{s}:\n", .{name});
-    std.debug.print("  Avg: ", .{});
+    std.debug.print("  Avg: ");
     formatNs(avg);
     std.debug.print(" ({d:.0} ops/sec)\n", .{ops_per_sec});
-    std.debug.print("  Min: ", .{});
+    std.debug.print("  Min: ");
     formatNs(min);
-    std.debug.print("\n", .{});
-    std.debug.print("  Max: ", .{});
+    std.debug.print("\n");
+    std.debug.print("  Max: ");
     formatNs(max);
-    std.debug.print("\n\n", .{});
+    std.debug.print("\n\n");
 }
 
 pub fn main() !void {
@@ -167,13 +167,13 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const runtime = try Runtime.init(allocator, .{});
+    const runtime = try Runtime.init(allocator);
     defer runtime.deinit();
 
     const num_operations = 10_000;
     const iterations = 100;
 
-    std.debug.print("=== WaitQueue Benchmark ===\n\n", .{});
+    std.debug.print("=== WaitQueue Benchmark ===\n\n");
     std.debug.print("Queue size: {d} bytes\n", .{@sizeOf(WaitQueue(StandardNode))});
     std.debug.print("Node size:  {d} bytes\n\n", .{@sizeOf(StandardNode)});
 

--- a/benchmarks/ping_pong.zig
+++ b/benchmarks/ping_pong.zig
@@ -41,10 +41,10 @@ pub fn main() !void {
     var timer = try std.time.Timer.start();
 
     // Spawn pinger and ponger tasks
-    var pinger_task = try runtime.spawn(pinger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS }, .{});
+    var pinger_task = try runtime.spawn(pinger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS });
     defer pinger_task.cancel(runtime);
 
-    var ponger_task = try runtime.spawn(ponger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS }, .{});
+    var ponger_task = try runtime.spawn(ponger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS });
     defer ponger_task.cancel(runtime);
 
     // Run until both tasks complete
@@ -58,7 +58,7 @@ pub fn main() !void {
     const messages_per_sec = @as(f64, @floatFromInt(total_messages)) / elapsed_s;
     const ns_per_round = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(NUM_ROUNDS));
 
-    std.debug.print("\nResults:\n", .{});
+    std.debug.print("\nResults:\n");
     std.debug.print("  Total rounds: {}\n", .{NUM_ROUNDS});
     std.debug.print("  Total time: {d:.2} ms ({d:.3} s)\n", .{ elapsed_ms, elapsed_s });
     std.debug.print("  Time per round: {d:.0} ns\n", .{ns_per_round});

--- a/build.zig
+++ b/build.zig
@@ -89,7 +89,7 @@ pub fn build(b: *std.Build) void {
             exe.linkLibC();
         }
 
-        const install_exe = b.addInstallArtifact(exe, .{});
+        const install_exe = b.addInstallArtifact(exe);
         examples_step.dependOn(&install_exe.step);
     }
 
@@ -108,7 +108,7 @@ pub fn build(b: *std.Build) void {
         });
         exe.root_module.addImport("zio", zio);
 
-        const install_exe = b.addInstallArtifact(exe, .{});
+        const install_exe = b.addInstallArtifact(exe);
         benchmarks_step.dependOn(&install_exe.step);
     }
 
@@ -124,5 +124,5 @@ pub fn build(b: *std.Build) void {
 
     // Build tests without running them (useful for cross-compilation)
     const build_tests_step = b.step("build-tests", "Build unit tests without running");
-    build_tests_step.dependOn(&b.addInstallArtifact(lib_unit_tests, .{}).step);
+    build_tests_step.dependOn(&b.addInstallArtifact(lib_unit_tests).step);
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,16 +74,16 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
 fn serverTask(rt: *zio.Runtime) !void {
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
 
-    const server = try addr.listen(rt, .{});
+    const server = try addr.listen(rt);
     defer server.close(rt);
 
-    std.log.info("Listening on 127.0.0.1:8080", .{});
+    std.log.info("Listening on 127.0.0.1:8080");
 
     while (true) {
         const stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.deinit();
     }
 }
@@ -92,10 +92,10 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    const rt = try zio.Runtime.init(gpa.allocator(), .{});
+    const rt = try zio.Runtime.init(gpa.allocator());
     defer rt.deinit();
 
-    var handle = try rt.spawn(serverTask, .{rt}, .{});
+    var handle = try rt.spawn(serverTask, .{rt});
     try handle.join(rt);
 }
 ```

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -14,7 +14,7 @@ var sigint = try zio.Signal.init(.interrupt);
 defer sigint.deinit();
 
 try sigint.wait(rt);
-std.log.info("Received SIGINT, initiating shutdown...", .{});
+std.log.info("Received SIGINT, initiating shutdown...");
 
 server.shutdown();
 ```
@@ -35,11 +35,11 @@ const result = try zio.select(rt, .{
 });
 switch (result) {
     .sigint => {
-        std.log.info("Received SIGINT, initiating graceful shutdown...", .{});
+        std.log.info("Received SIGINT, initiating graceful shutdown...");
         server.shutdown(.{ .graceful = true });
     },
     .sigterm => {
-        std.log.info("Received SIGTERM, initiating shutdown...", .{});
+        std.log.info("Received SIGTERM, initiating shutdown...");
         server.shutdown(.{ .graceful = false });
     },
 }
@@ -61,7 +61,7 @@ while (true) {
         return err;
     };
 
-    std.log.info("Received SIGINT, initiating shutdown...", .{});
+    std.log.info("Received SIGINT, initiating shutdown...");
     server.shutdown(.{ .graceful = true });
     break;
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,7 +17,7 @@ If you configure the runtime, you can also run tasks on multiple CPU threads, al
 Tasks are created using the [`spawn()`](/zio/apidocs/#zio.runtime.Runtime.spawn) method on the runtime. The basic syntax is:
 
 ```zig
-var task = try rt.spawn(taskFunction, .{ arg1, arg2 }, .{});
+var task = try rt.spawn(taskFunction, .{ arg1, arg2 });
 ```
 
 The `spawn()` method takes three parameters:
@@ -39,7 +39,7 @@ You should use [`join()`](/zio/apidocs/#zio.runtime.JoinHandle.join) to wait on 
 In the simplest case, you would do something like this:
 
 ```zig
-var task = try rt.spawn(myTask, .{}, .{});
+var task = try rt.spawn(myTask);
 task.join();
 ```
 
@@ -50,7 +50,7 @@ fn sum(a: i32, b: i32) i32 {
     return a + b;
 }
 
-const task = try rt.spawn(sum, .{ 1, 2 }, .{});
+const task = try rt.spawn(sum, .{ 1, 2 });
 const result = rt.join(rt);
 
 std.debug.assert(result == 3);
@@ -64,7 +64,7 @@ fn divide(a: i32, b: i32) !i32 {
     return a / b;
 }
 
-const task = try rt.spawn(divide, .{ 4, 2 }, .{});
+const task = try rt.spawn(divide, .{ 4, 2 });
 const result = try rt.join(rt); // using `try` here to catch the error
 
 std.debug.assert(result == 2);
@@ -99,7 +99,7 @@ fn myTask(rt: *zio.Runtime, stream: zio.net.Stream) !void {
     }
 }
 
-var task = try rt.spawn(myTask, .{ rt, stream }, .{});
+var task = try rt.spawn(myTask, .{ rt, stream });
 
 // Later, cancel the task
 task.cancel(rt);
@@ -108,7 +108,7 @@ task.cancel(rt);
 You can safely call `cancel()` after successful `join()`, so this pattern becomes very common to clean up task resources:
 
 ```zig
-var task = try rt.spawn(myTask, .{ rt, stream }, .{});
+var task = try rt.spawn(myTask, .{ rt, stream });
 defer task.cancel(rt);
 
 // Do some other work that can fail
@@ -122,7 +122,7 @@ You can also start a task and let it run in the background. This is useful, for 
 to handle each connection in a separate task. You can do this using the [`detach()`](/zio/apidocs/#zio.runtime.JoinHandle.detach) method:
 
 ```zig
-var task = try rt.spawn(connectionHandler, .{ rt, stream }, .{});
+var task = try rt.spawn(connectionHandler, .{ rt, stream });
 task.detach(rt);
 ```
 

--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -58,24 +58,24 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
         if (!request.head.keep_alive) break;
     }
 
-    std.log.info("HTTP client disconnected", .{});
+    std.log.info("HTTP client disconnected");
 }
 
 fn serverTask(rt: *zio.Runtime) !void {
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
 
-    const server = try addr.listen(rt, .{});
+    const server = try addr.listen(rt);
     defer server.close(rt);
 
     std.log.info("HTTP server listening on {f}", .{server.socket.address});
     std.log.info("Visit http://{f} in your browser", .{server.socket.address});
-    std.log.info("Press Ctrl+C to stop the server", .{});
+    std.log.info("Press Ctrl+C to stop the server");
 
     while (true) {
         const stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.detach(rt);
     }
 }
@@ -85,9 +85,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
+    var runtime = try zio.Runtime.init(allocator);
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(serverTask, .{runtime}, .{});
+    var handle = try runtime.spawn(serverTask, .{runtime});
     try handle.join(runtime);
 }

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var runtime = try zio.Runtime.init(gpa.allocator(), .{});
+    var runtime = try zio.Runtime.init(gpa.allocator());
     defer runtime.deinit();
 
     var shared_data = SharedData{
@@ -36,13 +36,13 @@ pub fn main() !void {
     };
 
     // Spawn multiple tasks that increment shared counter
-    var task0 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 0 }, .{});
+    var task0 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 0 });
     defer task0.cancel(runtime);
-    var task1 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 1 }, .{});
+    var task1 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 1 });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 2 }, .{});
+    var task2 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 2 });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 3 }, .{});
+    var task3 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 3 });
     defer task3.cancel(runtime);
 
     try runtime.run();

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -45,7 +45,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var runtime = try zio.Runtime.init(gpa.allocator(), .{});
+    var runtime = try zio.Runtime.init(gpa.allocator());
     defer runtime.deinit();
 
     var buffer: [8]i32 = undefined;
@@ -63,13 +63,13 @@ pub fn main() !void {
     }
 
     for (0..2) |i| {
-        producers[i] = try runtime.spawn(producer, .{ runtime, &channel, @as(u32, @intCast(i)) }, .{});
+        producers[i] = try runtime.spawn(producer, .{ runtime, &channel, @as(u32, @intCast(i)) });
         producer_count += 1;
-        consumers[i] = try runtime.spawn(consumer, .{ runtime, &channel, @as(u32, @intCast(i)) }, .{});
+        consumers[i] = try runtime.spawn(consumer, .{ runtime, &channel, @as(u32, @intCast(i)) });
         consumer_count += 1;
     }
 
     try runtime.run();
 
-    std.log.info("All tasks completed.", .{});
+    std.log.info("All tasks completed.");
 }

--- a/examples/signal_demo.zig
+++ b/examples/signal_demo.zig
@@ -7,13 +7,13 @@ const zio = @import("zio");
 /// Demonstration of graceful shutdown using signal handling.
 /// Press Ctrl+C to trigger a graceful shutdown.
 fn serverTask(rt: *zio.Runtime, shutdown: *std.atomic.Value(bool)) !void {
-    std.log.info("Server started. Press Ctrl+C to stop.", .{});
+    std.log.info("Server started. Press Ctrl+C to stop.");
 
     var counter: u64 = 0;
     while (true) {
         // Check if shutdown was requested
         if (shutdown.load(.acquire)) {
-            std.log.info("Server shutting down gracefully...", .{});
+            std.log.info("Server shutting down gracefully...");
             break;
         }
 
@@ -37,7 +37,7 @@ fn signalHandler(rt: *zio.Runtime, shutdown: *std.atomic.Value(bool)) !void {
     // Wait for SIGINT (Ctrl+C)
     try sig.wait(rt);
 
-    std.log.info("Received signal, initiating shutdown...", .{});
+    std.log.info("Received signal, initiating shutdown...");
     shutdown.store(true, .release);
 }
 
@@ -45,24 +45,24 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var runtime = try zio.Runtime.init(gpa.allocator(), .{});
+    var runtime = try zio.Runtime.init(gpa.allocator());
     defer runtime.deinit();
 
     // Create shutdown flag
     var shutdown = std.atomic.Value(bool).init(false);
 
-    std.log.info("Starting demo (press Ctrl+C to stop gracefully)...", .{});
+    std.log.info("Starting demo (press Ctrl+C to stop gracefully)...");
 
     // Spawn server task
-    var server_task = try runtime.spawn(serverTask, .{ runtime, &shutdown }, .{});
+    var server_task = try runtime.spawn(serverTask, .{ runtime, &shutdown });
     defer server_task.cancel(runtime);
 
     // Spawn signal handler task
-    var signal_task = try runtime.spawn(signalHandler, .{ runtime, &shutdown }, .{});
+    var signal_task = try runtime.spawn(signalHandler, .{ runtime, &shutdown });
     defer signal_task.cancel(runtime);
 
     // Run until all tasks complete
     try runtime.run();
 
-    std.log.info("Demo completed.", .{});
+    std.log.info("Demo completed.");
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -6,7 +6,7 @@ const zio = @import("zio");
 
 fn sleepTask(rt: *zio.Runtime) !void {
     for (0..10) |_| {
-        std.log.info("Sleeping...", .{});
+        std.log.info("Sleeping...");
         try rt.sleep(1000);
     }
 }
@@ -16,9 +16,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
+    var runtime = try zio.Runtime.init(allocator);
     defer runtime.deinit();
 
-    var task = try runtime.spawn(sleepTask, .{runtime}, .{});
+    var task = try runtime.spawn(sleepTask, .{runtime});
     try task.join(runtime);
 }

--- a/examples/tcp_client.zig
+++ b/examples/tcp_client.zig
@@ -6,7 +6,7 @@ const print = std.debug.print;
 const zio = @import("zio");
 
 fn clientTask(rt: *zio.Runtime) !void {
-    std.log.info("Connecting to 127.0.0.1:8080...", .{});
+    std.log.info("Connecting to 127.0.0.1:8080...");
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
     var stream = try addr.connect(rt);
     defer stream.close(rt);
@@ -43,7 +43,7 @@ pub fn main() !void {
     });
     defer runtime.deinit();
 
-    var task = try runtime.spawn(clientTask, .{runtime}, .{});
+    var task = try runtime.spawn(clientTask, .{runtime});
     defer task.cancel(runtime);
 
     try runtime.run();

--- a/examples/tcp_echo_server.zig
+++ b/examples/tcp_echo_server.zig
@@ -31,23 +31,23 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
         try writer.interface.flush();
     }
 
-    std.log.info("Client disconnected", .{});
+    std.log.info("Client disconnected");
 }
 
 fn serverTask(rt: *zio.Runtime) !void {
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
 
-    const server = try addr.listen(rt, .{});
+    const server = try addr.listen(rt);
     defer server.close(rt);
 
     std.log.info("TCP echo server listening on {f}", .{server.socket.address});
-    std.log.info("Press Ctrl+C to stop the server", .{});
+    std.log.info("Press Ctrl+C to stop the server");
 
     while (true) {
         const stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.detach(rt);
     }
 }
@@ -57,10 +57,10 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const runtime = try zio.Runtime.init(allocator, .{});
+    const runtime = try zio.Runtime.init(allocator);
     defer runtime.deinit();
 
-    var server = try runtime.spawn(serverTask, .{runtime}, .{});
+    var server = try runtime.spawn(serverTask, .{runtime});
     defer server.cancel(runtime);
 
     try runtime.run();

--- a/examples/tls_demo.zig
+++ b/examples/tls_demo.zig
@@ -5,18 +5,18 @@ const std = @import("std");
 const zio = @import("zio");
 
 fn runTlsTask(rt: *zio.Runtime) !void {
-    std.log.info("Starting TLS connection...", .{});
+    std.log.info("Starting TLS connection...");
 
     // Connect to httpbin.org (reliable HTTPS API)
     // TODO: Add DNS resolution support instead of hardcoded IP address
     const addr = try zio.net.IpAddress.parseIp4("52.2.107.230", 443); // httpbin.org
-    std.log.info("Attempting TCP connection to httpbin.org:443...", .{});
+    std.log.info("Attempting TCP connection to httpbin.org:443...");
 
     var stream = try addr.connect(rt);
     defer stream.close(rt);
 
-    std.log.info("TCP connected to httpbin.org:443 successfully!", .{});
-    std.log.info("Starting TLS handshake...", .{});
+    std.log.info("TCP connected to httpbin.org:443 successfully!");
+    std.log.info("Starting TLS handshake...");
 
     // Create buffers for TCP stream I/O
     var tcp_read_buffer: [32 * 1024]u8 = undefined;
@@ -40,12 +40,12 @@ fn runTlsTask(rt: *zio.Runtime) !void {
         return;
     };
 
-    std.log.info("TLS handshake completed successfully!", .{});
+    std.log.info("TLS handshake completed successfully!");
 
     // Send HTTPS request
     const request = "GET /get HTTP/1.1\r\nHost: httpbin.org\r\nUser-Agent: zio.tls-demo\r\nConnection: close\r\n\r\n";
 
-    std.log.info("Sending HTTPS request...", .{});
+    std.log.info("Sending HTTPS request...");
     try tls_client.writer.writeAll(request);
     // Need to flush both TLS layer (encrypts data to TCP buffer) and TCP layer (sends over network)
     try tls_client.writer.flush();
@@ -58,7 +58,7 @@ fn runTlsTask(rt: *zio.Runtime) !void {
     std.log.info("Received {} bytes over TLS", .{bytes_read});
 
     // Print first part of response
-    std.log.info("HTTPS Response:", .{});
+    std.log.info("HTTPS Response:");
     std.log.info("{s}", .{buffer[0..@min(500, bytes_read)]});
 }
 
@@ -67,10 +67,10 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
+    var runtime = try zio.Runtime.init(allocator);
     defer runtime.deinit();
 
-    var tls_task = try runtime.spawn(runTlsTask, .{runtime}, .{});
+    var tls_task = try runtime.spawn(runTlsTask, .{runtime});
     defer tls_task.cancel(runtime);
 
     try runtime.run();

--- a/src/core/group.zig
+++ b/src/core/group.zig
@@ -227,7 +227,7 @@ fn testFn(arg: usize) usize {
 }
 
 test "Group: spawn" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
@@ -241,12 +241,12 @@ test "Group: spawn" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }
 
 test "Group: wait for multiple tasks" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
@@ -272,12 +272,12 @@ test "Group: wait for multiple tasks" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }
 
 test "Group: cancellation while waiting" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
@@ -316,10 +316,10 @@ test "Group: cancellation while waiting" {
             canceled = 0;
 
             // Spawn the group task
-            var group_handle = try runtime.spawn(groupTask, .{runtime}, .{});
+            var group_handle = try runtime.spawn(groupTask, .{runtime});
 
             // Spawn a task that will cancel the group task
-            var canceller = try runtime.spawn(cancellerTask, .{ runtime, &group_handle }, .{});
+            var canceller = try runtime.spawn(cancellerTask, .{ runtime, &group_handle });
             defer canceller.cancel(runtime);
 
             // Wait for group task to complete (should be canceled)
@@ -331,6 +331,6 @@ test "Group: cancellation while waiting" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }

--- a/src/core/timeout.zig
+++ b/src/core/timeout.zig
@@ -77,7 +77,7 @@ const Cancelable = @import("../common.zig").Cancelable;
 const Timeoutable = @import("../common.zig").Timeoutable;
 
 test "Timeout: smoke test" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout = Timeout.init;
@@ -87,7 +87,7 @@ test "Timeout: smoke test" {
 }
 
 test "Timeout: fires and returns error.Timeout" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout = Timeout.init;
@@ -109,7 +109,7 @@ test "Timeout: fires and returns error.Timeout" {
 }
 
 test "Timeout: nested timeouts - earliest fires first" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout1 = Timeout.init;
@@ -136,7 +136,7 @@ test "Timeout: nested timeouts - earliest fires first" {
 }
 
 test "Timeout: cleared before firing" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout = Timeout.init;
@@ -168,7 +168,7 @@ test "Timeout: user cancel has priority over timeout" {
         }
 
         fn main(rt: *Runtime) !void {
-            var handle = try rt.spawn(worker, .{rt}, .{});
+            var handle = try rt.spawn(worker, .{rt});
 
             // Let worker start and set timeout
             try rt.sleep(5);
@@ -186,15 +186,15 @@ test "Timeout: user cancel has priority over timeout" {
         }
     };
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
-    var handle = try rt.spawn(Test.main, .{rt}, .{});
+    var handle = try rt.spawn(Test.main, .{rt});
     try handle.join(rt);
 }
 
 test "Timeout: multiple timeouts with different deadlines" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout1 = Timeout.init;
@@ -227,7 +227,7 @@ test "Timeout: multiple timeouts with different deadlines" {
 }
 
 test "Timeout: set, clear, and re-set" {
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     var timeout = Timeout.init;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -15,13 +15,13 @@ test "fs: openFile and createFile with different modes" {
     const testing = std.testing;
     const allocator = testing.allocator;
 
-    const rt = try Runtime.init(allocator, .{});
+    const rt = try Runtime.init(allocator);
     defer rt.deinit();
 
     const dir = cwd();
     const file_path = "test_fs_demo.txt";
 
-    var file = try dir.createFile(rt, file_path, .{});
+    var file = try dir.createFile(rt, file_path);
 
     const write_data = "Hello, zio fs!";
     _ = try file.write(rt, write_data, 0);

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -322,12 +322,12 @@ pub const FileWriter = struct {
 test "File: basic read and write" {
     const fs = @import("../fs.zig");
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const dir = fs.cwd();
     const file_path = "test_file_basic.txt";
-    var zio_file = try dir.createFile(rt, file_path, .{});
+    var zio_file = try dir.createFile(rt, file_path);
 
     // Write test
     const write_data = "Hello, zio!";
@@ -351,7 +351,7 @@ test "File: basic read and write" {
 test "File: positional read and write" {
     const fs = @import("../fs.zig");
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const dir = fs.cwd();
@@ -381,12 +381,12 @@ test "File: positional read and write" {
 test "File: close operation" {
     const fs = @import("../fs.zig");
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const dir = fs.cwd();
     const file_path = "test_file_close.txt";
-    var zio_file = try dir.createFile(rt, file_path, .{});
+    var zio_file = try dir.createFile(rt, file_path);
 
     // Write some data
     const bytes_written = try zio_file.write(rt, "test data", 0);
@@ -401,7 +401,7 @@ test "File: close operation" {
 test "File: reader and writer interface" {
     const fs = @import("../fs.zig");
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const dir = fs.cwd();
@@ -409,7 +409,7 @@ test "File: reader and writer interface" {
 
     // Write using writer interface
     {
-        var file = try dir.createFile(rt, file_path, .{});
+        var file = try dir.createFile(rt, file_path);
 
         var write_buffer: [256]u8 = undefined;
         var writer = file.writer(rt, &write_buffer);
@@ -424,7 +424,7 @@ test "File: reader and writer interface" {
 
     // Read using reader interface
     {
-        var file = try dir.openFile(rt, file_path, .{});
+        var file = try dir.openFile(rt, file_path);
 
         var read_buffer: [256]u8 = undefined;
         var reader = file.reader(rt, &read_buffer);

--- a/src/net/test.zig
+++ b/src/net/test.zig
@@ -115,10 +115,10 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
             const server = try addr_inner.listen(rt, options_inner);
             defer server.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, server }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, server });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, server, write_buffer_inner }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, server, write_buffer_inner });
             defer client_task.cancel(rt);
 
             // TODO use TaskGroup
@@ -156,20 +156,20 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options, write_buffer }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options, write_buffer });
     try handle.join(runtime);
 }
 
 pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
     const Test = struct {
         pub fn mainFn(rt: *Runtime, server_addr_inner: @TypeOf(server_addr), client_addr_inner: @TypeOf(client_addr)) !void {
-            const socket = try server_addr_inner.bind(rt, .{});
+            const socket = try server_addr_inner.bind(rt);
             defer socket.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, socket }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, socket });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, socket, client_addr_inner }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, socket, client_addr_inner });
             defer client_task.cancel(rt);
 
             try server_task.join(rt);
@@ -187,7 +187,7 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
         }
 
         pub fn clientFn(rt: *Runtime, server_socket: Socket, client_addr_inner: @TypeOf(client_addr)) !void {
-            const client_socket = try client_addr_inner.bind(rt, .{});
+            const client_socket = try client_addr_inner.bind(rt);
             defer client_socket.close(rt);
 
             const test_data = "hello";
@@ -200,10 +200,10 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator);
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, server_addr, client_addr }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, server_addr, client_addr });
     try handle.join(runtime);
 }
 
@@ -213,10 +213,10 @@ pub fn checkShutdown(addr: anytype, options: anytype) !void {
             const server = try addr_inner.listen(rt, options_inner);
             defer server.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, server }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, server });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, server }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, server });
             defer client_task.cancel(rt);
 
             // TODO use TaskGroup
@@ -247,7 +247,7 @@ pub fn checkShutdown(addr: anytype, options: anytype) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options });
     try handle.join(runtime);
 }
 

--- a/src/select.zig
+++ b/src/select.zig
@@ -98,7 +98,7 @@ fn checkSelfWait(task: *AnyTask, future: anytype) void {
         if (std.meta.hasMethod(@TypeOf(future), "toAwaitable")) {
             const awaitable_ptr = future.toAwaitable();
             if (awaitable_ptr == &task.awaitable) {
-                std.debug.panic("cannot wait on self (would deadlock)", .{});
+                std.debug.panic("cannot wait on self (would deadlock)");
             }
         }
     }
@@ -252,8 +252,8 @@ pub const SelectWaiter = struct {
 ///
 /// Example:
 /// ```
-/// var h1 = try rt.spawn(task1, .{}, .{});
-/// var h2 = try rt.spawn(task2, .{}, .{});
+/// var h1 = try rt.spawn(task1);
+/// var h2 = try rt.spawn(task2);
 /// const result = rt.select(.{ .first = &h1, .second = &h2 });
 /// switch (result) {
 ///     .first => |val| ...,
@@ -510,7 +510,7 @@ pub fn waitUntilComplete(rt: *Runtime, future: anytype) FutureResult(@TypeOf(fut
 test "select: basic - first completes" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -525,9 +525,9 @@ test "select: basic - first completes" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
-            var fast = try rt.spawn(fastTask, .{rt}, .{});
+            var fast = try rt.spawn(fastTask, .{rt});
             defer fast.cancel(rt);
 
             const result = try select(rt, .{ .fast = &fast, .slow = &slow });
@@ -540,14 +540,14 @@ test "select: basic - first completes" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: already complete - fast path" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -561,14 +561,14 @@ test "select: already complete - fast path" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var immediate = try rt.spawn(immediateTask, .{}, .{});
+            var immediate = try rt.spawn(immediateTask);
             defer immediate.cancel(rt);
 
             // Give immediate task a chance to complete
             try rt.yield();
             try rt.yield();
 
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
 
             // immediate should already be complete, select should return immediately
@@ -580,14 +580,14 @@ test "select: already complete - fast path" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: heterogeneous types" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -607,11 +607,11 @@ test "select: heterogeneous types" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var int_handle = try rt.spawn(intTask, .{rt}, .{});
+            var int_handle = try rt.spawn(intTask, .{rt});
             defer int_handle.cancel(rt);
-            var string_handle = try rt.spawn(stringTask, .{rt}, .{});
+            var string_handle = try rt.spawn(stringTask, .{rt});
             defer string_handle.cancel(rt);
-            var bool_handle = try rt.spawn(boolTask, .{rt}, .{});
+            var bool_handle = try rt.spawn(boolTask, .{rt});
             defer bool_handle.cancel(rt);
 
             const result = try select(rt, .{
@@ -637,14 +637,14 @@ test "select: heterogeneous types" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: with cancellation" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -659,9 +659,9 @@ test "select: with cancellation" {
         }
 
         fn selectTask(rt: *Runtime) !i32 {
-            var h1 = try rt.spawn(slowTask1, .{rt}, .{});
+            var h1 = try rt.spawn(slowTask1, .{rt});
             defer h1.cancel(rt);
-            var h2 = try rt.spawn(slowTask2, .{rt}, .{});
+            var h2 = try rt.spawn(slowTask2, .{rt});
             defer h2.cancel(rt);
 
             const result = try select(rt, .{ .first = &h1, .second = &h2 });
@@ -672,7 +672,7 @@ test "select: with cancellation" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var select_handle = try rt.spawn(selectTask, .{rt}, .{});
+            var select_handle = try rt.spawn(selectTask, .{rt});
             defer select_handle.cancel(rt);
 
             // Give it a chance to start waiting
@@ -688,14 +688,14 @@ test "select: with cancellation" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: with error unions - success case" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -713,9 +713,9 @@ test "select: with error unions - success case" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var parse_handle = try rt.spawn(parseTask, .{rt}, .{});
+            var parse_handle = try rt.spawn(parseTask, .{rt});
             defer parse_handle.cancel(rt);
-            var validate_handle = try rt.spawn(validateTask, .{rt}, .{});
+            var validate_handle = try rt.spawn(validateTask, .{rt});
             defer validate_handle.cancel(rt);
 
             const result = try select(rt, .{
@@ -747,14 +747,14 @@ test "select: with error unions - success case" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: with error unions - error case" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -771,9 +771,9 @@ test "select: with error unions - error case" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var failing = try rt.spawn(failingTask, .{rt}, .{});
+            var failing = try rt.spawn(failingTask, .{rt});
             defer failing.cancel(rt);
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
 
             const result = try select(rt, .{ .failing = &failing, .slow = &slow });
@@ -796,14 +796,14 @@ test "select: with error unions - error case" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: with mixed error types" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -826,11 +826,11 @@ test "select: with mixed error types" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var h1 = try rt.spawn(task1, .{rt}, .{});
+            var h1 = try rt.spawn(task1, .{rt});
             defer h1.cancel(rt);
-            var h2 = try rt.spawn(task2, .{rt}, .{});
+            var h2 = try rt.spawn(task2, .{rt});
             defer h2.cancel(rt);
-            var h3 = try rt.spawn(task3, .{rt}, .{});
+            var h3 = try rt.spawn(task3, .{rt});
             defer h3.cancel(rt);
 
             // select returns Cancelable!SelectUnion(...)
@@ -859,7 +859,7 @@ test "select: with mixed error types" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -867,7 +867,7 @@ test "wait: plain type" {
     const testing = std.testing;
     const Future = @import("sync/future.zig").Future;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -879,7 +879,7 @@ test "wait: plain type" {
                 fn run(f: *Future(i32)) !void {
                     f.set(42);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -888,7 +888,7 @@ test "wait: plain type" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -896,7 +896,7 @@ test "wait: error union" {
     const testing = std.testing;
     const Future = @import("sync/future.zig").Future;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -910,7 +910,7 @@ test "wait: error union" {
                 fn run(f: *Future(MyError!i32)) !void {
                     f.set(123);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -920,7 +920,7 @@ test "wait: error union" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -928,7 +928,7 @@ test "wait: error union with error" {
     const testing = std.testing;
     const Future = @import("sync/future.zig").Future;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -942,7 +942,7 @@ test "wait: error union with error" {
                 fn run(f: *Future(MyError!i32)) !void {
                     f.set(MyError.Foo);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -951,7 +951,7 @@ test "wait: error union with error" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -959,7 +959,7 @@ test "wait: already complete (fast path)" {
     const testing = std.testing;
     const Future = @import("sync/future.zig").Future;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -973,14 +973,14 @@ test "wait: already complete (fast path)" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "select: wait on JoinHandle from spawned task" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -991,10 +991,10 @@ test "select: wait on JoinHandle from spawned task" {
 
         fn asyncTask(rt: *Runtime) !void {
             // Spawn a task and get a JoinHandle
-            var handle1 = try rt.spawn(workerTask, .{ rt, 21 }, .{});
+            var handle1 = try rt.spawn(workerTask, .{ rt, 21 });
             defer handle1.cancel(rt);
 
-            var handle2 = try rt.spawn(workerTask, .{ rt, 100 }, .{});
+            var handle2 = try rt.spawn(workerTask, .{ rt, 100 });
             defer handle2.cancel(rt);
 
             // Wait on JoinHandles using select
@@ -1018,6 +1018,6 @@ test "select: wait on JoinHandle from spawned task" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -377,16 +377,16 @@ pub const Signal = struct {
 test "Signal: basic signal handling" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
         signal_received: bool = false,
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignal, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -408,7 +408,7 @@ test "Signal: basic signal handling" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -417,20 +417,20 @@ test "Signal: basic signal handling" {
 test "Signal: multiple handlers for same signal" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
         count: std.atomic.Value(usize) = .init(0),
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignal, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h2 = try r.spawn(waitForSignal, .{ self, r });
             defer h2.cancel(r);
-            var h3 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h3 = try r.spawn(waitForSignal, .{ self, r });
             defer h3.cancel(r);
-            var h4 = try r.spawn(sendSignal, .{r}, .{});
+            var h4 = try r.spawn(sendSignal, .{r});
             defer h4.cancel(r);
 
             try h1.join(r);
@@ -454,7 +454,7 @@ test "Signal: multiple handlers for same signal" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(@as(usize, 3), ctx.count.load(.monotonic));
@@ -463,7 +463,7 @@ test "Signal: multiple handlers for same signal" {
 test "Signal: timedWait timeout" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
@@ -484,7 +484,7 @@ test "Signal: timedWait timeout" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.timed_out);
@@ -493,16 +493,16 @@ test "Signal: timedWait timeout" {
 test "Signal: timedWait receives signal before timeout" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const TestContext = struct {
         signal_received: bool = false,
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignalTimed, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignalTimed, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -524,7 +524,7 @@ test "Signal: timedWait receives signal before timeout" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -533,7 +533,7 @@ test "Signal: timedWait receives signal before timeout" {
 test "Signal: select on multiple signals" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const select = @import("select.zig").select;
@@ -542,9 +542,9 @@ test "Signal: select on multiple signals" {
         signal_received: std.atomic.Value(u8) = .init(0),
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignals, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignals, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -571,7 +571,7 @@ test "Signal: select on multiple signals" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(@intFromEnum(SignalKind.user2), ctx.signal_received.load(.monotonic));
@@ -580,7 +580,7 @@ test "Signal: select on multiple signals" {
 test "Signal: select with signal already received (fast path)" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const select = @import("select.zig").select;
@@ -607,7 +607,7 @@ test "Signal: select with signal already received (fast path)" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -616,7 +616,7 @@ test "Signal: select with signal already received (fast path)" {
 test "Signal: select with signal and task" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var rt = try Runtime.init(std.testing.allocator, .{});
+    var rt = try Runtime.init(std.testing.allocator);
     defer rt.deinit();
 
     const select = @import("select.zig").select;
@@ -633,10 +633,10 @@ test "Signal: select with signal and task" {
             var sig = try Signal.init(.user1);
             defer sig.deinit();
 
-            var task = try r.spawn(slowTask, .{r}, .{});
+            var task = try r.spawn(slowTask, .{r});
             defer task.cancel(r);
 
-            var sender = try r.spawn(sendSignal, .{r}, .{});
+            var sender = try r.spawn(sendSignal, .{r});
             defer sender.cancel(r);
 
             // Signal should win (arrives much sooner)
@@ -659,7 +659,7 @@ test "Signal: select with signal and task" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(.signal, ctx.winner);

--- a/src/sync/Barrier.zig
+++ b/src/sync/Barrier.zig
@@ -34,16 +34,16 @@
 //!
 //!     // Phase 2: all workers proceed together
 //!     if (is_leader) {
-//!         std.debug.print("All workers reached barrier\n", .{});
+//!         std.debug.print("All workers reached barrier\n");
 //!     }
 //!     std.debug.print("Worker {} starting phase 2\n", .{id});
 //! }
 //!
 //! var barrier = zio.Barrier.init(3);
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &barrier, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &barrier, 2 }, .{});
-//! var task3 = try runtime.spawn(worker, .{runtime, &barrier, 3 }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &barrier, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &barrier, 2 });
+//! var task3 = try runtime.spawn(worker, .{runtime, &barrier, 3 });
 //! ```
 
 const std = @import("std");
@@ -129,7 +129,7 @@ pub fn wait(self: *Barrier, runtime: *Runtime) (Cancelable || error{BrokenBarrie
 test "Barrier: basic synchronization" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -149,11 +149,11 @@ test "Barrier: basic synchronization" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[0] }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[0] });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[1] }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[1] });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[2] }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[2] });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -167,7 +167,7 @@ test "Barrier: basic synchronization" {
 test "Barrier: leader detection" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -182,11 +182,11 @@ test "Barrier: leader detection" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -198,7 +198,7 @@ test "Barrier: leader detection" {
 test "Barrier: reusable for multiple cycles" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(2);
@@ -222,9 +222,9 @@ test "Barrier: reusable for multiple cycles" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done });
     defer task2.cancel(runtime);
 
     try runtime.run();
@@ -237,7 +237,7 @@ test "Barrier: reusable for multiple cycles" {
 test "Barrier: single coroutine barrier" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(1);
@@ -250,7 +250,7 @@ test "Barrier: single coroutine barrier" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &is_leader_result }, .{});
+    var handle = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &is_leader_result });
     try handle.join(runtime);
 
     try testing.expect(is_leader_result);
@@ -259,7 +259,7 @@ test "Barrier: single coroutine barrier" {
 test "Barrier: ordering test" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -281,11 +281,11 @@ test "Barrier: ordering test" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[0], &final_order }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[0], &final_order });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[1], &final_order }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[1], &final_order });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[2], &final_order }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[2], &final_order });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -305,7 +305,7 @@ test "Barrier: ordering test" {
 test "Barrier: many coroutines" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var barrier = Barrier.init(5);
@@ -320,15 +320,15 @@ test "Barrier: many coroutines" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[0] }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[0] });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[1] }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[1] });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[2] }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[2] });
     defer task3.cancel(runtime);
-    var task4 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[3] }, .{});
+    var task4 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[3] });
     defer task4.cancel(runtime);
-    var task5 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[4] }, .{});
+    var task5 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[4] });
     defer task5.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -258,7 +258,7 @@ pub fn broadcast(self: *Condition, runtime: *Runtime) void {
 test "Condition basic wait/signal" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var mutex = Mutex.init;
@@ -286,9 +286,9 @@ test "Condition basic wait/signal" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &mutex, &condition, &ready }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &mutex, &condition, &ready });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -299,7 +299,7 @@ test "Condition basic wait/signal" {
 test "Condition timedWait timeout" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var mutex = Mutex.init;
@@ -320,7 +320,7 @@ test "Condition timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &timed_out });
     try handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -329,7 +329,7 @@ test "Condition timedWait timeout" {
 test "Condition broadcast" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var mutex = Mutex.init;
@@ -362,13 +362,13 @@ test "Condition broadcast" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter3.cancel(runtime);
-    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &mutex, &condition, &ready }, .{});
+    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &mutex, &condition, &ready });
     defer broadcaster_task.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -142,7 +142,7 @@ pub fn unlock(self: *Mutex, runtime: *Runtime) void {
 test "Mutex basic lock/unlock" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var shared_counter: u32 = 0;
@@ -158,9 +158,9 @@ test "Mutex basic lock/unlock" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex });
     defer task2.cancel(runtime);
 
     try runtime.run();
@@ -171,7 +171,7 @@ test "Mutex basic lock/unlock" {
 test "Mutex tryLock" {
     const testing = std.testing;
 
-    const rt = try Runtime.init(testing.allocator, .{});
+    const rt = try Runtime.init(testing.allocator);
     defer rt.deinit();
 
     var mutex = Mutex.init;

--- a/src/sync/Notify.zig
+++ b/src/sync/Notify.zig
@@ -41,9 +41,9 @@
 //!
 //! var notify = zio.Notify.init;
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &notify, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &notify, 2 }, .{});
-//! var task3 = try runtime.spawn(notifier, .{runtime, &notify }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &notify, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &notify, 2 });
+//! var task3 = try runtime.spawn(notifier, .{runtime, &notify });
 //! ```
 
 const std = @import("std");
@@ -231,7 +231,7 @@ pub fn asyncCancelWait(self: *Notify, _: *Runtime, wait_node: *WaitNode) void {
 test "Notify basic signal/wait" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -249,9 +249,9 @@ test "Notify basic signal/wait" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_finished }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_finished });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -262,7 +262,7 @@ test "Notify basic signal/wait" {
 test "Notify signal with no waiters" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -278,7 +278,7 @@ test "Notify signal with no waiters" {
 test "Notify broadcast to multiple waiters" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -299,13 +299,13 @@ test "Notify broadcast to multiple waiters" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter3.cancel(runtime);
-    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &notify }, .{});
+    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &notify });
     defer broadcaster_task.cancel(runtime);
 
     try runtime.run();
@@ -316,7 +316,7 @@ test "Notify broadcast to multiple waiters" {
 test "Notify multiple signals to multiple waiters" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -340,13 +340,13 @@ test "Notify multiple signals to multiple waiters" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter3.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -357,7 +357,7 @@ test "Notify multiple signals to multiple waiters" {
 test "Notify timedWait timeout" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -374,7 +374,7 @@ test "Notify timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &timed_out });
     try handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -383,7 +383,7 @@ test "Notify timedWait timeout" {
 test "Notify timedWait success" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var notify = Notify.init;
@@ -402,9 +402,9 @@ test "Notify timedWait success" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &wait_succeeded }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &wait_succeeded });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -431,7 +431,7 @@ test "Notify: select" {
         fn asyncTask(rt: *Runtime) !void {
             var notify = Notify.init;
 
-            var task = try rt.spawn(signalerTask, .{ rt, &notify }, .{});
+            var task = try rt.spawn(signalerTask, .{ rt, &notify });
             defer task.cancel(rt);
 
             const result = try select(rt, .{ .notify = &notify, .task = &task });
@@ -439,9 +439,9 @@ test "Notify: select" {
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator);
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -38,9 +38,9 @@
 //!
 //! var event = zio.ResetEvent.init;
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &event, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &event, 2 }, .{});
-//! var task3 = try runtime.spawn(coordinator, .{runtime, &event }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &event, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &event, 2 });
+//! var task3 = try runtime.spawn(coordinator, .{runtime, &event });
 //! ```
 
 const std = @import("std");
@@ -247,7 +247,7 @@ pub fn asyncCancelWait(self: *ResetEvent, _: *Runtime, wait_node: *WaitNode) voi
 test "ResetEvent basic set/reset/isSet" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var reset_event = ResetEvent.init;
@@ -271,7 +271,7 @@ test "ResetEvent basic set/reset/isSet" {
 test "ResetEvent wait/set signaling" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var reset_event = ResetEvent.init;
@@ -289,9 +289,9 @@ test "ResetEvent wait/set signaling" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_finished }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_finished });
     defer waiter_task.cancel(runtime);
-    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event }, .{});
+    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event });
     defer setter_task.cancel(runtime);
 
     try runtime.run();
@@ -303,7 +303,7 @@ test "ResetEvent wait/set signaling" {
 test "ResetEvent timedWait timeout" {
     const testing = std.testing;
 
-    const rt = try Runtime.init(testing.allocator, .{});
+    const rt = try Runtime.init(testing.allocator);
     defer rt.deinit();
 
     var reset_event = ResetEvent.init;
@@ -316,7 +316,7 @@ test "ResetEvent timedWait timeout" {
 test "ResetEvent multiple waiters broadcast" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var reset_event = ResetEvent.init;
@@ -337,13 +337,13 @@ test "ResetEvent multiple waiters broadcast" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter3.cancel(runtime);
-    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event }, .{});
+    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event });
     defer setter_task.cancel(runtime);
 
     try runtime.run();
@@ -355,7 +355,7 @@ test "ResetEvent multiple waiters broadcast" {
 test "ResetEvent wait on already set event" {
     const testing = std.testing;
 
-    const rt = try Runtime.init(testing.allocator, .{});
+    const rt = try Runtime.init(testing.allocator);
     defer rt.deinit();
 
     var reset_event = ResetEvent.init;
@@ -388,7 +388,7 @@ test "ResetEvent: select" {
         fn asyncTask(rt: *Runtime) !void {
             var reset_event = ResetEvent.init;
 
-            var task = try rt.spawn(setterTask, .{ rt, &reset_event }, .{});
+            var task = try rt.spawn(setterTask, .{ rt, &reset_event });
             defer task.cancel(rt);
 
             const result = try select(rt, .{ .event = &reset_event, .task = &task });
@@ -396,9 +396,9 @@ test "ResetEvent: select" {
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator);
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -33,11 +33,11 @@
 //! // Allow up to 3 concurrent workers
 //! var semaphore = zio.Semaphore{ .permits = 3 };
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &semaphore, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &semaphore, 2 }, .{});
-//! var task3 = try runtime.spawn(worker, .{runtime, &semaphore, 3 }, .{});
-//! var task4 = try runtime.spawn(worker, .{runtime, &semaphore, 4 }, .{});
-//! var task5 = try runtime.spawn(worker, .{runtime, &semaphore, 5 }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &semaphore, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &semaphore, 2 });
+//! var task3 = try runtime.spawn(worker, .{runtime, &semaphore, 3 });
+//! var task4 = try runtime.spawn(worker, .{runtime, &semaphore, 4 });
+//! var task5 = try runtime.spawn(worker, .{runtime, &semaphore, 5 });
 //! ```
 
 const std = @import("std");
@@ -159,7 +159,7 @@ pub fn post(self: *Semaphore, rt: *Runtime) void {
 test "Semaphore: basic wait/post" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var sem = Semaphore{ .permits = 1 };
@@ -173,11 +173,11 @@ test "Semaphore: basic wait/post" {
     };
 
     var n: i32 = 0;
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -188,7 +188,7 @@ test "Semaphore: basic wait/post" {
 test "Semaphore: timedWait timeout" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var sem = Semaphore{};
@@ -204,7 +204,7 @@ test "Semaphore: timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &timed_out });
     handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -214,7 +214,7 @@ test "Semaphore: timedWait timeout" {
 test "Semaphore: timedWait success" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var sem = Semaphore{};
@@ -232,9 +232,9 @@ test "Semaphore: timedWait success" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &got_permit }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &got_permit });
     defer waiter_task.cancel(runtime);
-    var poster_task = try runtime.spawn(TestFn.poster, .{ runtime, &sem }, .{});
+    var poster_task = try runtime.spawn(TestFn.poster, .{ runtime, &sem });
     defer poster_task.cancel(runtime);
 
     try runtime.run();
@@ -246,7 +246,7 @@ test "Semaphore: timedWait success" {
 test "Semaphore: multiple permits" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var sem = Semaphore{ .permits = 3 };
@@ -258,11 +258,11 @@ test "Semaphore: multiple permits" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task3.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -54,9 +54,9 @@ const select = @import("../select.zig").select;
 /// var buffer: [5]u32 = undefined;
 /// var channel = BroadcastChannel(u32).init(&buffer);
 ///
-/// var task1 = try runtime.spawn(broadcaster, .{runtime, &channel }, .{});
-/// var task2 = try runtime.spawn(listener, .{runtime, &channel }, .{});
-/// var task3 = try runtime.spawn(listener, .{runtime, &channel }, .{});
+/// var task1 = try runtime.spawn(broadcaster, .{runtime, &channel });
+/// var task2 = try runtime.spawn(listener, .{runtime, &channel });
+/// var task3 = try runtime.spawn(listener, .{runtime, &channel });
 /// ```
 pub fn BroadcastChannel(comptime T: type) type {
     return struct {
@@ -479,7 +479,7 @@ pub fn AsyncReceive(comptime T: type) type {
 test "BroadcastChannel: basic send and receive" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -508,9 +508,9 @@ test "BroadcastChannel: basic send and receive" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var results: [3]u32 = undefined;
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -523,7 +523,7 @@ test "BroadcastChannel: basic send and receive" {
 test "BroadcastChannel: multiple consumers receive same messages" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -556,13 +556,13 @@ test "BroadcastChannel: multiple consumers receive same messages" {
     var sum2: u32 = 0;
     var sum3: u32 = 0;
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver1_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer1, &sum1, &barrier }, .{});
+    var receiver1_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer1, &sum1, &barrier });
     defer receiver1_task.cancel(runtime);
-    var receiver2_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer2, &sum2, &barrier }, .{});
+    var receiver2_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer2, &sum2, &barrier });
     defer receiver2_task.cancel(runtime);
-    var receiver3_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer3, &sum3, &barrier }, .{});
+    var receiver3_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer3, &sum3, &barrier });
     defer receiver3_task.cancel(runtime);
 
     try runtime.run();
@@ -576,7 +576,7 @@ test "BroadcastChannel: multiple consumers receive same messages" {
 test "BroadcastChannel: lagged consumer" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [3]u32 = undefined;
@@ -611,14 +611,14 @@ test "BroadcastChannel: lagged consumer" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lag, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_lag, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: tryReceive" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -652,14 +652,14 @@ test "BroadcastChannel: tryReceive" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_try, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: new subscriber doesn't receive old messages" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -690,14 +690,14 @@ test "BroadcastChannel: new subscriber doesn't receive old messages" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_new_subscriber, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_new_subscriber, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: unsubscribe doesn't affect other consumers" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -728,14 +728,14 @@ test "BroadcastChannel: unsubscribe doesn't affect other consumers" {
 
     var consumer1 = BroadcastChannel(u32).Consumer{};
     var consumer2 = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_unsubscribe, .{ runtime, &channel, &consumer1, &consumer2 }, .{});
+    var handle = try runtime.spawn(TestFn.test_unsubscribe, .{ runtime, &channel, &consumer1, &consumer2 });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: close prevents new sends" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -756,14 +756,14 @@ test "BroadcastChannel: close prevents new sends" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_close, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_close, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: consumers can drain after close" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -796,9 +796,9 @@ test "BroadcastChannel: consumers can drain after close" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var results: [4]?u32 = .{ null, null, null, null };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -812,7 +812,7 @@ test "BroadcastChannel: consumers can drain after close" {
 test "BroadcastChannel: waiting consumers wake on close" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -845,9 +845,9 @@ test "BroadcastChannel: waiting consumers wake on close" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var got_closed = false;
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &channel, &consumer, &got_closed, &barrier }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &channel, &consumer, &got_closed, &barrier });
     defer waiter_task.cancel(runtime);
-    var closer_task = try runtime.spawn(TestFn.closer, .{ runtime, &channel, &barrier }, .{});
+    var closer_task = try runtime.spawn(TestFn.closer, .{ runtime, &channel, &barrier });
     defer closer_task.cancel(runtime);
 
     try runtime.run();
@@ -858,7 +858,7 @@ test "BroadcastChannel: waiting consumers wake on close" {
 test "BroadcastChannel: tryReceive returns Closed when channel closed and empty" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -880,14 +880,14 @@ test "BroadcastChannel: tryReceive returns Closed when channel closed and empty"
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try_closed, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_try_closed, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: asyncReceive with select - basic" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -917,9 +917,9 @@ test "BroadcastChannel: asyncReceive with select - basic" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -928,7 +928,7 @@ test "BroadcastChannel: asyncReceive with select - basic" {
 test "BroadcastChannel: asyncReceive with select - already ready" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -953,14 +953,14 @@ test "BroadcastChannel: asyncReceive with select - already ready" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: asyncReceive with select - closed channel" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -984,14 +984,14 @@ test "BroadcastChannel: asyncReceive with select - closed channel" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: asyncReceive with select - lagged consumer" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [3]u32 = undefined;
@@ -1021,14 +1021,14 @@ test "BroadcastChannel: asyncReceive with select - lagged consumer" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lagged, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_lagged, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
 test "BroadcastChannel: select with multiple broadcast channels" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;
@@ -1069,9 +1069,9 @@ test "BroadcastChannel: select with multiple broadcast channels" {
     var consumer1 = BroadcastChannel(u32).Consumer{};
     var consumer2 = BroadcastChannel(u32).Consumer{};
     var which: u8 = 0;
-    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &consumer1, &consumer2, &which }, .{});
+    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &consumer1, &consumer2, &which });
     defer select_task.cancel(runtime);
-    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 });
     defer sender_task.cancel(runtime);
 
     try runtime.run();
@@ -1083,7 +1083,7 @@ test "BroadcastChannel: select with multiple broadcast channels" {
 test "BroadcastChannel: position counter overflow handling" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [3]u32 = undefined;
@@ -1154,6 +1154,6 @@ test "BroadcastChannel: position counter overflow handling" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_overflow, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_overflow, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -44,8 +44,8 @@ const select = @import("../select.zig").select;
 /// var buffer: [5]u32 = undefined;
 /// var channel = Channel(u32).init(&buffer);
 ///
-/// var task1 = try runtime.spawn(producer, .{runtime, &channel }, .{});
-/// var task2 = try runtime.spawn(consumer, .{runtime, &channel }, .{});
+/// var task1 = try runtime.spawn(producer, .{runtime, &channel });
+/// var task2 = try runtime.spawn(consumer, .{runtime, &channel });
 /// ```
 pub fn Channel(comptime T: type) type {
     return struct {
@@ -644,7 +644,7 @@ pub fn AsyncSend(comptime T: type) type {
 test "Channel: basic send and receive" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -665,9 +665,9 @@ test "Channel: basic send and receive" {
     };
 
     var results: [3]u32 = undefined;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -680,7 +680,7 @@ test "Channel: basic send and receive" {
 test "Channel: trySend and tryReceive" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [2]u32 = undefined;
@@ -714,14 +714,14 @@ test "Channel: trySend and tryReceive" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testTry, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testTry, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: blocking behavior when empty" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -739,9 +739,9 @@ test "Channel: blocking behavior when empty" {
     };
 
     var result: u32 = 0;
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result });
     defer consumer_task.cancel(runtime);
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
 
     try runtime.run();
@@ -752,7 +752,7 @@ test "Channel: blocking behavior when empty" {
 test "Channel: blocking behavior when full" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [2]u32 = undefined;
@@ -774,9 +774,9 @@ test "Channel: blocking behavior when full" {
     };
 
     var count: u32 = 0;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel, &count }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel, &count });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -787,7 +787,7 @@ test "Channel: blocking behavior when full" {
 test "Channel: multiple producers and consumers" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -809,13 +809,13 @@ test "Channel: multiple producers and consumers" {
     };
 
     var sum: u32 = 0;
-    var producer1 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 0) }, .{});
+    var producer1 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 0) });
     defer producer1.cancel(runtime);
-    var producer2 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 100) }, .{});
+    var producer2 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 100) });
     defer producer2.cancel(runtime);
-    var consumer1 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum }, .{});
+    var consumer1 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum });
     defer consumer1.cancel(runtime);
-    var consumer2 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum }, .{});
+    var consumer2 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum });
     defer consumer2.cancel(runtime);
 
     try runtime.run();
@@ -827,7 +827,7 @@ test "Channel: multiple producers and consumers" {
 test "Channel: close graceful" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -849,9 +849,9 @@ test "Channel: close graceful" {
     };
 
     var results: [3]?u32 = .{ null, null, null };
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -864,7 +864,7 @@ test "Channel: close graceful" {
 test "Channel: close immediate" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -885,9 +885,9 @@ test "Channel: close immediate" {
     };
 
     var result: ?u32 = null;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -898,7 +898,7 @@ test "Channel: close immediate" {
 test "Channel: send on closed channel" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -916,14 +916,14 @@ test "Channel: send on closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testClosed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testClosed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: ring buffer wrapping" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [3]u32 = undefined;
@@ -957,14 +957,14 @@ test "Channel: ring buffer wrapping" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testWrap, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testWrap, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: asyncReceive with select - basic" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -987,9 +987,9 @@ test "Channel: asyncReceive with select - basic" {
         }
     };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -998,7 +998,7 @@ test "Channel: asyncReceive with select - basic" {
 test "Channel: asyncReceive with select - already ready" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -1019,14 +1019,14 @@ test "Channel: asyncReceive with select - already ready" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: asyncReceive with select - closed channel" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -1046,14 +1046,14 @@ test "Channel: asyncReceive with select - closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: asyncSend with select - basic" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [2]u32 = undefined;
@@ -1079,9 +1079,9 @@ test "Channel: asyncSend with select - basic" {
         }
     };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -1090,7 +1090,7 @@ test "Channel: asyncSend with select - basic" {
 test "Channel: asyncSend with select - already ready" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -1113,14 +1113,14 @@ test "Channel: asyncSend with select - already ready" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: asyncSend with select - closed channel" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -1140,14 +1140,14 @@ test "Channel: asyncSend with select - closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
 test "Channel: select on both send and receive" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;
@@ -1164,9 +1164,9 @@ test "Channel: select on both send and receive" {
             try ch2.send(rt, 2);
 
             var which: u8 = 0;
-            var select_task = try rt.spawn(selectTask, .{ rt, ch1, ch2, &which }, .{});
+            var select_task = try rt.spawn(selectTask, .{ rt, ch1, ch2, &which });
             defer select_task.cancel(rt);
-            var sender_task = try rt.spawn(sender, .{ rt, ch1 }, .{});
+            var sender_task = try rt.spawn(sender, .{ rt, ch1 });
             defer sender_task.cancel(rt);
 
             _ = try select_task.join(rt);
@@ -1199,14 +1199,14 @@ test "Channel: select on both send and receive" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testMain, .{ runtime, &channel1, &channel2 }, .{});
+    var handle = try runtime.spawn(TestFn.testMain, .{ runtime, &channel1, &channel2 });
     try handle.join(runtime);
 }
 
 test "Channel: select with multiple receivers" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;
@@ -1240,9 +1240,9 @@ test "Channel: select with multiple receivers" {
     };
 
     var which: u8 = 0;
-    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &which }, .{});
+    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &which });
     defer select_task.cancel(runtime);
-    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 });
     defer sender_task.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -142,7 +142,7 @@ pub fn Future(comptime T: type) type {
 test "Future: basic set and get" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -158,14 +158,14 @@ test "Future: basic set and get" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "Future: await from coroutine" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -186,11 +186,11 @@ test "Future: await from coroutine" {
             var future = Future(i32).init;
 
             // Spawn setter coroutine
-            var setter_handle = try rt.spawn(setterTask, .{ rt, &future }, .{});
+            var setter_handle = try rt.spawn(setterTask, .{ rt, &future });
             defer setter_handle.cancel(rt);
 
             // Spawn getter coroutine
-            var getter_handle = try rt.spawn(getterTask, .{ rt, &future }, .{});
+            var getter_handle = try rt.spawn(getterTask, .{ rt, &future });
             defer getter_handle.cancel(rt);
 
             const result = try getter_handle.join(rt);
@@ -198,14 +198,14 @@ test "Future: await from coroutine" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
 test "Future: multiple waiters" {
     const testing = std.testing;
 
-    const runtime = try Runtime.init(testing.allocator, .{});
+    const runtime = try Runtime.init(testing.allocator);
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -225,15 +225,15 @@ test "Future: multiple waiters" {
             var future = Future(i32).init;
 
             // Spawn multiple waiters
-            var waiter1 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter1 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter1.cancel(rt);
-            var waiter2 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter2 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter2.cancel(rt);
-            var waiter3 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter3 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter3.cancel(rt);
 
             // Spawn setter
-            var setter = try rt.spawn(setterTask, .{ rt, &future }, .{});
+            var setter = try rt.spawn(setterTask, .{ rt, &future });
             defer setter.cancel(rt);
 
             // Wait for all to complete
@@ -244,6 +244,6 @@ test "Future: multiple waiters" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -6,7 +6,6 @@ const std = @import("std");
 // Re-export runtime functionality
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
-pub const SpawnOptions = runtime.SpawnOptions;
 pub const JoinHandle = runtime.JoinHandle;
 
 // Re-export timeout functionality

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -91,7 +91,7 @@ pub fn main() !void {
     var log_buffer: std.Io.Writer.Allocating = .init(allocator);
     defer log_buffer.deinit();
 
-    Printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
+    Printer.fmt("\r\x1b[0K"); // beginning of line and clear to end of line
 
     for (builtin.test_functions) |t| {
         if (isSetup(t)) {
@@ -192,7 +192,7 @@ pub fn main() !void {
             const ms = @as(f64, @floatFromInt(ns_taken)) / 1_000_000.0;
             Printer.status(status, "{s} ({d:.2}ms)\n", .{ friendly_name, ms });
         } else {
-            Printer.status(status, ".", .{});
+            Printer.status(status, ".");
         }
     }
 
@@ -214,9 +214,9 @@ pub fn main() !void {
     if (leak > 0) {
         Printer.status(.fail, "{d} test{s} leaked\n", .{ leak, if (leak != 1) "s" else "" });
     }
-    Printer.fmt("\n", .{});
+    Printer.fmt("\n");
     try slowest.display();
-    Printer.fmt("\n", .{});
+    Printer.fmt("\n");
     std.posix.exit(if (fail == 0) 0 else 1);
 }
 
@@ -227,9 +227,9 @@ const Printer = struct {
 
     fn status(s: Status, comptime format: []const u8, args: anytype) void {
         switch (s) {
-            .pass => std.debug.print("\x1b[32m", .{}),
-            .fail => std.debug.print("\x1b[31m", .{}),
-            .skip => std.debug.print("\x1b[33m", .{}),
+            .pass => std.debug.print("\x1b[32m"),
+            .fail => std.debug.print("\x1b[31m"),
+            .skip => std.debug.print("\x1b[33m"),
             else => {},
         }
         std.debug.print(format ++ "\x1b[0m", args);


### PR DESCRIPTION
- Remove 'pinned' field from SpawnOptions and CreateOptions
- Remove pin_count field from AnyTask struct
- Remove beginPin() and endPin() methods from Executor and Runtime
- Update canMigrate() to only check cancellation status
- Remove SpawnOptions struct entirely as it's now empty
- Update all spawn() call sites to remove options parameter

This simplifies the API and removes unused functionality.