### PR TITLE
examples: Consistently use rt instead of runtime

### DIFF
--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -85,9 +85,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
-    defer runtime.deinit();
+    var rt = try zio.Runtime.init(allocator, .{});
+    defer rt.deinit();
 
-    var handle = try runtime.spawn(serverTask, .{runtime}, .{});
-    try handle.join(runtime);
+    var handle = try rt.spawn(serverTask, .{rt}, .{});
+    try handle.join(rt);
 }

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -28,24 +28,24 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var runtime = try zio.Runtime.init(gpa.allocator(), .{});
-    defer runtime.deinit();
+    var rt = try zio.Runtime.init(gpa.allocator(), .{});
+    defer rt.deinit();
 
     var shared_data = SharedData{
         .mutex = zio.Mutex.init,
     };
 
     // Spawn multiple tasks that increment shared counter
-    var task0 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 0 }, .{});
-    defer task0.cancel(runtime);
-    var task1 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 1 }, .{});
-    defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 2 }, .{});
-    defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(incrementTask, .{ runtime, &shared_data, 3 }, .{});
-    defer task3.cancel(runtime);
+    var task0 = try rt.spawn(incrementTask, .{ rt, &shared_data, 0 }, .{});
+    defer task0.cancel(rt);
+    var task1 = try rt.spawn(incrementTask, .{ rt, &shared_data, 1 }, .{});
+    defer task1.cancel(rt);
+    var task2 = try rt.spawn(incrementTask, .{ rt, &shared_data, 2 }, .{});
+    defer task2.cancel(rt);
+    var task3 = try rt.spawn(incrementTask, .{ rt, &shared_data, 3 }, .{});
+    defer task3.cancel(rt);
 
-    try runtime.run();
+    try rt.run();
 
     std.log.info("Final counter value: {} (expected: {})", .{ shared_data.counter, 4000 });
 }

--- a/examples/signal_demo.zig
+++ b/examples/signal_demo.zig
@@ -45,8 +45,8 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var runtime = try zio.Runtime.init(gpa.allocator(), .{});
-    defer runtime.deinit();
+    var rt = try zio.Runtime.init(gpa.allocator(), .{});
+    defer rt.deinit();
 
     // Create shutdown flag
     var shutdown = std.atomic.Value(bool).init(false);
@@ -54,15 +54,15 @@ pub fn main() !void {
     std.log.info("Starting demo (press Ctrl+C to stop gracefully)...", .{});
 
     // Spawn server task
-    var server_task = try runtime.spawn(serverTask, .{ runtime, &shutdown }, .{});
-    defer server_task.cancel(runtime);
+    var server_task = try rt.spawn(serverTask, .{ rt, &shutdown }, .{});
+    defer server_task.cancel(rt);
 
     // Spawn signal handler task
-    var signal_task = try runtime.spawn(signalHandler, .{ runtime, &shutdown }, .{});
-    defer signal_task.cancel(runtime);
+    var signal_task = try rt.spawn(signalHandler, .{ rt, &shutdown }, .{});
+    defer signal_task.cancel(rt);
 
     // Run until all tasks complete
-    try runtime.run();
+    try rt.run();
 
     std.log.info("Demo completed.", .{});
 }

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -16,9 +16,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
-    defer runtime.deinit();
+    var rt = try zio.Runtime.init(allocator, .{});
+    defer rt.deinit();
 
-    var task = try runtime.spawn(sleepTask, .{runtime}, .{});
-    try task.join(runtime);
+    var task = try rt.spawn(sleepTask, .{rt}, .{});
+    try task.join(rt);
 }

--- a/examples/tcp_client.zig
+++ b/examples/tcp_client.zig
@@ -38,13 +38,13 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Thread pool is always enabled for DNS resolution
-    var runtime = try zio.Runtime.init(allocator, .{
+    var rt = try zio.Runtime.init(allocator, .{
         .thread_pool = .{},
     });
-    defer runtime.deinit();
+    defer rt.deinit();
 
-    var task = try runtime.spawn(clientTask, .{runtime}, .{});
-    defer task.cancel(runtime);
+    var task = try rt.spawn(clientTask, .{rt}, .{});
+    defer task.cancel(rt);
 
-    try runtime.run();
+    try rt.run();
 }

--- a/examples/tls_demo.zig
+++ b/examples/tls_demo.zig
@@ -67,13 +67,13 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var runtime = try zio.Runtime.init(allocator, .{});
-    defer runtime.deinit();
+    var rt = try zio.Runtime.init(allocator, .{});
+    defer rt.deinit();
 
-    var tls_task = try runtime.spawn(runTlsTask, .{runtime}, .{});
-    defer tls_task.cancel(runtime);
+    var tls_task = try rt.spawn(runTlsTask, .{rt}, .{});
+    defer tls_task.cancel(rt);
 
-    try runtime.run();
+    try rt.run();
 
-    try tls_task.join(runtime);
+    try tls_task.join(rt);
 }


### PR DESCRIPTION
In the examples, the use of the runtime variable in the main function inconsistently use either `rt` or `runtime`.

In the docs, instead, the use is always `rt`.

This change will use `rt` consistently, but only for examples and documentation.