### PR TITLE
Add macOS Intel CI runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: macos-latest
+          - os: macos-15-intel
           - os: windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can see this as an alternative to the Go runtime, the Tokio project for Rust
 
 ## Features
 
-- Supports Linux (x86_64, aarch64, riscv64), Windows (x86_64, aarch64), macOS (aarch64), should also work on BSDs, but not tested
+- Supports Linux (x86_64, aarch64, riscv64), Windows (x86_64, aarch64), macOS (x86_64, aarch64), should also work on BSDs, but not tested
 - Single-threaded or multi-threaded runtime with one I/O event loop per executor thread
 - Spawning coroutines, one small allocation per spawn, stack memory is reused
 - Spawning blocking tasks in an auxiliary thread pool


### PR DESCRIPTION
## Summary
- Add macos-15-intel runner to CI matrix
- Update README to list macOS x86_64 as supported platform