### PR TITLE
Pass timestamp to StackPool.release() instead of getting current time

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -66,7 +66,7 @@ pub const RuntimeOptions = struct {
         .maximum_size = 8 * 1024 * 1024, // 8MB reserved
         .committed_size = 64 * 1024, // 64KB initial commit
         .max_unused_stacks = 16,
-        .max_age_ns = 60 * std.time.ns_per_s, // 60 seconds
+        .max_age_ms = 60 * std.time.ms_per_s, // 60 seconds
     },
     /// Number of executor threads to run.
     /// - null: auto-detect CPU count (multi-threaded)
@@ -548,7 +548,7 @@ pub const Executor = struct {
 
                         // Release stack immediately
                         if (current_coro.context.stack_info.allocation_len > 0) {
-                            self.runtime.stack_pool.release(current_coro.context.stack_info);
+                            self.runtime.stack_pool.release(current_coro.context.stack_info, self.loop.now());
                             current_coro.context.stack_info.allocation_len = 0;
                         }
 

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -312,7 +312,7 @@ pub const AnyTask = struct {
         const self = fromAwaitable(awaitable);
 
         if (self.coro.context.stack_info.allocation_len > 0) {
-            rt.stack_pool.release(self.coro.context.stack_info);
+            rt.stack_pool.release(self.coro.context.stack_info, rt.now());
         }
 
         self.closure.free(AnyTask, rt, self);


### PR DESCRIPTION
## Summary
- StackPool.release() now takes a `timestamp_ns` parameter instead of calling `std.time.Instant.now()` internally
- Runtime passes the event loop's cached monotonic time (`loop.now()`)
- Tests can pass mock timestamps, eliminating the need for 150ms sleep in the age-based expiration test

## Test plan
- [x] All existing StackPool tests pass
- [x] Full test suite passes