### PR TITLE
Refactor group task callback signature for std.Io compatibility

### DIFF
--- a/src/runtime/blocking_task.zig
+++ b/src/runtime/blocking_task.zig
@@ -80,7 +80,7 @@ fn workFunc(work: *ev.Work) void {
 
     // Execute the user's blocking function
     // ev handles cancellation - if canceled, this won't be called
-    any_blocking_task.closure.call(AnyBlockingTask, any_blocking_task, any_blocking_task.awaitable.group_node.group);
+    any_blocking_task.closure.call(AnyBlockingTask, any_blocking_task);
 }
 
 // Completion callback - called by ev event loop when work finishes


### PR DESCRIPTION
Change Closure.Start.group from fn(group, context) -> void to fn(context) -> Cancelable!void. The group pointer is now packed into the context by Group.spawn.

Extract groupSpawnTask() as a standalone function that can be used by both Group.spawn and future std.Io vtable implementations.