### PR TITLE
Refactor spawnBlockingTask to bypass event loop

### DIFF
--- a/src/runtime/blocking_task.zig
+++ b/src/runtime/blocking_task.zig
@@ -119,11 +119,11 @@ fn threadPoolCompletion(ctx: *anyopaque, _: *ev.Work) void {
 }
 
 /// Register a blocking task with the runtime and submit it for execution.
-/// Adds the task to the runtime's task list, increments its reference count,
+/// Increments its reference count, adds the task to the runtime's task list,
 /// and submits it directly to the thread pool.
 fn registerBlockingTask(rt: *Runtime, task: *AnyBlockingTask) void {
-    rt.tasks.add(&task.awaitable);
     task.awaitable.ref_count.incr();
+    rt.tasks.add(&task.awaitable);
     rt.thread_pool.submit(&task.work);
 }
 

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -412,11 +412,11 @@ const getNextExecutor = @import("../runtime.zig").getNextExecutor;
 const SpawnOptions = @import("../runtime.zig").SpawnOptions;
 
 /// Register a task with the runtime and schedule it for execution.
-/// Adds the task to the runtime's task list, increments its reference count,
+/// Increments its reference count, adds the task to the runtime's task list,
 /// and schedules it on its executor.
 pub fn registerTask(rt: *Runtime, task: *AnyTask) void {
-    rt.tasks.add(&task.awaitable);
     task.awaitable.ref_count.incr();
+    rt.tasks.add(&task.awaitable);
     const executor = Executor.fromCoroutine(&task.coro);
     executor.scheduleTask(task, .maybe_remote);
 }


### PR DESCRIPTION
## Summary
- Submit blocking tasks directly to the thread pool instead of going through the executor's event loop
- Fixes thread-safety issue where `spawnBlocking()` could be called from any thread but `loop.add()` was not designed for concurrent calls
- Completion callback now runs on thread pool worker thread using thread-safe operations

Fixes #190