### PR TITLE
Remove pinning support and SpawnOptions

### DIFF
--- a/benchmarks/echo_server.zig
+++ b/benchmarks/echo_server.zig
@@ -34,7 +34,7 @@ fn serverTask(rt: *zio.Runtime, ready: *zio.ResetEvent, done: *zio.ResetEvent) !
         var stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.detach(rt);
     }
 
@@ -85,7 +85,7 @@ fn benchmarkTask(
     const total_messages = NUM_CLIENTS * MESSAGES_PER_CLIENT;
 
     // Spawn server
-    var server = try rt.spawn(serverTask, .{ rt, &server_ready, &server_done }, .{});
+    var server = try rt.spawn(serverTask, .{ rt, &server_ready, &server_done });
     defer server.cancel(rt);
 
     // Wait for server to be ready
@@ -98,7 +98,7 @@ fn benchmarkTask(
     defer allocator.free(client_tasks);
 
     for (client_tasks) |*task| {
-        const handle = try rt.spawn(clientTask, .{ rt, &server_ready }, .{});
+        const handle = try rt.spawn(clientTask, .{ rt, &server_ready });
         task.* = handle.cast(anyerror!void);
     }
 
@@ -141,6 +141,6 @@ pub fn main() !void {
     var runtime = try zio.Runtime.init(allocator, .{ .num_executors = 0 });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(benchmarkTask, .{ runtime, allocator }, .{});
+    var handle = try runtime.spawn(benchmarkTask, .{ runtime, allocator });
     try handle.join(runtime);
 }

--- a/benchmarks/ping_pong.zig
+++ b/benchmarks/ping_pong.zig
@@ -41,10 +41,10 @@ pub fn main() !void {
     var timer = try std.time.Timer.start();
 
     // Spawn pinger and ponger tasks
-    var pinger_task = try runtime.spawn(pinger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS }, .{});
+    var pinger_task = try runtime.spawn(pinger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS });
     defer pinger_task.cancel(runtime);
 
-    var ponger_task = try runtime.spawn(ponger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS }, .{});
+    var ponger_task = try runtime.spawn(ponger, .{ runtime, &ping_channel, &pong_channel, NUM_ROUNDS });
     defer ponger_task.cancel(runtime);
 
     // Run until both tasks complete

--- a/benchmarks/spawn_throughput.zig
+++ b/benchmarks/spawn_throughput.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
     var timer = try std.time.Timer.start();
 
     for (0..NUM_SPAWNS) |_| {
-        var t = try runtime.spawn(task, .{runtime}, .{});
+        var t = try runtime.spawn(task, .{runtime});
         t.detach(runtime);
     }
 

--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -75,7 +75,7 @@ fn serverTask(rt: *zio.Runtime) !void {
         const stream = try server.accept(rt);
         errdefer stream.close(rt);
 
-        var task = try rt.spawn(handleClient, .{ rt, stream }, .{});
+        var task = try rt.spawn(handleClient, .{ rt, stream });
         task.detach(rt);
     }
 }
@@ -88,6 +88,6 @@ pub fn main() !void {
     var rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var handle = try rt.spawn(serverTask, .{rt}, .{});
+    var handle = try rt.spawn(serverTask, .{rt});
     try handle.join(rt);
 }

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -36,13 +36,13 @@ pub fn main() !void {
     };
 
     // Spawn multiple tasks that increment shared counter
-    var task0 = try rt.spawn(incrementTask, .{ rt, &shared_data, 0 }, .{});
+    var task0 = try rt.spawn(incrementTask, .{ rt, &shared_data, 0 });
     defer task0.cancel(rt);
-    var task1 = try rt.spawn(incrementTask, .{ rt, &shared_data, 1 }, .{});
+    var task1 = try rt.spawn(incrementTask, .{ rt, &shared_data, 1 });
     defer task1.cancel(rt);
-    var task2 = try rt.spawn(incrementTask, .{ rt, &shared_data, 2 }, .{});
+    var task2 = try rt.spawn(incrementTask, .{ rt, &shared_data, 2 });
     defer task2.cancel(rt);
-    var task3 = try rt.spawn(incrementTask, .{ rt, &shared_data, 3 }, .{});
+    var task3 = try rt.spawn(incrementTask, .{ rt, &shared_data, 3 });
     defer task3.cancel(rt);
 
     try rt.run();

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -63,9 +63,9 @@ pub fn main() !void {
     }
 
     for (0..2) |i| {
-        producers[i] = try rt.spawn(producer, .{ rt, &channel, @as(u32, @intCast(i)) }, .{});
+        producers[i] = try rt.spawn(producer, .{ rt, &channel, @as(u32, @intCast(i)) });
         producer_count += 1;
-        consumers[i] = try rt.spawn(consumer, .{ rt, &channel, @as(u32, @intCast(i)) }, .{});
+        consumers[i] = try rt.spawn(consumer, .{ rt, &channel, @as(u32, @intCast(i)) });
         consumer_count += 1;
     }
 

--- a/examples/signal_demo.zig
+++ b/examples/signal_demo.zig
@@ -54,11 +54,11 @@ pub fn main() !void {
     std.log.info("Starting demo (press Ctrl+C to stop gracefully)...", .{});
 
     // Spawn server task
-    var server_task = try rt.spawn(serverTask, .{ rt, &shutdown }, .{});
+    var server_task = try rt.spawn(serverTask, .{ rt, &shutdown });
     defer server_task.cancel(rt);
 
     // Spawn signal handler task
-    var signal_task = try rt.spawn(signalHandler, .{ rt, &shutdown }, .{});
+    var signal_task = try rt.spawn(signalHandler, .{ rt, &shutdown });
     defer signal_task.cancel(rt);
 
     // Run until all tasks complete

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -19,6 +19,6 @@ pub fn main() !void {
     var rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var task = try rt.spawn(sleepTask, .{rt}, .{});
+    var task = try rt.spawn(sleepTask, .{rt});
     try task.join(rt);
 }

--- a/examples/tcp_client.zig
+++ b/examples/tcp_client.zig
@@ -43,7 +43,7 @@ pub fn main() !void {
     });
     defer rt.deinit();
 
-    var task = try rt.spawn(clientTask, .{rt}, .{});
+    var task = try rt.spawn(clientTask, .{rt});
     defer task.cancel(rt);
 
     try rt.run();

--- a/examples/tls_demo.zig
+++ b/examples/tls_demo.zig
@@ -70,7 +70,7 @@ pub fn main() !void {
     var rt = try zio.Runtime.init(allocator, .{});
     defer rt.deinit();
 
-    var tls_task = try rt.spawn(runTlsTask, .{rt}, .{});
+    var tls_task = try rt.spawn(runTlsTask, .{rt});
     defer tls_task.cancel(rt);
 
     try rt.run();

--- a/src/net.zig
+++ b/src/net.zig
@@ -1256,10 +1256,10 @@ test "tcpConnectToAddress: basic" {
     var server_port_buf: [1]u16 = undefined;
     var server_port_ch = Channel(u16).init(&server_port_buf);
 
-    var server_task = try runtime.spawn(ServerTask.run, .{ runtime, &server_port_ch }, .{});
+    var server_task = try runtime.spawn(ServerTask.run, .{ runtime, &server_port_ch });
     defer server_task.cancel(runtime);
 
-    var client_task = try runtime.spawn(ClientTask.run, .{ runtime, &server_port_ch }, .{});
+    var client_task = try runtime.spawn(ClientTask.run, .{ runtime, &server_port_ch });
     defer client_task.cancel(runtime);
 
     try runtime.run();
@@ -1316,10 +1316,10 @@ test "tcpConnectToHost: basic" {
     var server_port_buf: [1]u16 = undefined;
     var server_port_ch = Channel(u16).init(&server_port_buf);
 
-    var server_task = try runtime.spawn(ServerTask.run, .{ runtime, &server_port_ch }, .{});
+    var server_task = try runtime.spawn(ServerTask.run, .{ runtime, &server_port_ch });
     defer server_task.cancel(runtime);
 
-    var client_task = try runtime.spawn(ClientTask.run, .{ runtime, &server_port_ch }, .{});
+    var client_task = try runtime.spawn(ClientTask.run, .{ runtime, &server_port_ch });
     defer client_task.cancel(runtime);
 
     try runtime.run();
@@ -1631,10 +1631,10 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
             const server = try addr_inner.listen(rt, options_inner);
             defer server.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, server }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, server });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, server, write_buffer_inner }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, server, write_buffer_inner });
             defer client_task.cancel(rt);
 
             // TODO use TaskGroup
@@ -1672,7 +1672,7 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options, write_buffer }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options, write_buffer });
     try handle.join(runtime);
 }
 
@@ -1682,10 +1682,10 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
             const socket = try server_addr_inner.bind(rt, .{});
             defer socket.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, socket }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, socket });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, socket, client_addr_inner }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, socket, client_addr_inner });
             defer client_task.cancel(rt);
 
             try server_task.join(rt);
@@ -1719,7 +1719,7 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, server_addr, client_addr }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, server_addr, client_addr });
     try handle.join(runtime);
 }
 
@@ -1729,10 +1729,10 @@ pub fn checkShutdown(addr: anytype, options: anytype) !void {
             const server = try addr_inner.listen(rt, options_inner);
             defer server.close(rt);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, server }, .{});
+            var server_task = try rt.spawn(serverFn, .{ rt, server });
             defer server_task.cancel(rt);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, server }, .{});
+            var client_task = try rt.spawn(clientFn, .{ rt, server });
             defer client_task.cancel(rt);
 
             // TODO use TaskGroup
@@ -1763,7 +1763,7 @@ pub fn checkShutdown(addr: anytype, options: anytype) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options }, .{});
+    var handle = try runtime.spawn(Test.mainFn, .{ runtime, addr, options });
     try handle.join(runtime);
 }
 

--- a/src/runtime/autocancel.zig
+++ b/src/runtime/autocancel.zig
@@ -175,7 +175,7 @@ test "AutoCancel: user cancel has priority over timeout" {
         }
 
         fn main(rt: *Runtime) !void {
-            var handle = try rt.spawn(worker, .{rt}, .{});
+            var handle = try rt.spawn(worker, .{rt});
 
             // Let worker start and set timeout
             try rt.sleep(.fromMilliseconds(5));
@@ -191,7 +191,7 @@ test "AutoCancel: user cancel has priority over timeout" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var handle = try rt.spawn(Test.main, .{rt}, .{});
+    var handle = try rt.spawn(Test.main, .{rt});
     try handle.join(rt);
 }
 
@@ -277,7 +277,7 @@ test "AutoCancel: cancels spawned task via join" {
         }
 
         fn main(rt: *Runtime) !void {
-            var handle = try rt.spawn(blocker, .{rt}, .{});
+            var handle = try rt.spawn(blocker, .{rt});
             defer handle.cancel(rt);
 
             var timeout = AutoCancel.init;
@@ -297,6 +297,6 @@ test "AutoCancel: cancels spawned task via join" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var handle = try rt.spawn(Test.main, .{rt}, .{});
+    var handle = try rt.spawn(Test.main, .{rt});
     try handle.join(rt);
 }

--- a/src/runtime/group.zig
+++ b/src/runtime/group.zig
@@ -207,7 +207,7 @@ pub fn groupSpawnTask(
     context_alignment: std.mem.Alignment,
     start: *const fn (context: *const anyopaque) Cancelable!void,
 ) !void {
-    _ = try spawnTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, .{}, group);
+    _ = try spawnTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, group);
 }
 
 /// Spawn a blocking task in the group with raw context bytes and start function.
@@ -280,7 +280,7 @@ test "Group: spawn" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }
 
@@ -311,7 +311,7 @@ test "Group: wait for multiple tasks" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }
 
@@ -355,10 +355,10 @@ test "Group: cancellation while waiting" {
             canceled = 0;
 
             // Spawn the group task
-            var group_handle = try runtime.spawn(groupTask, .{runtime}, .{});
+            var group_handle = try runtime.spawn(groupTask, .{runtime});
 
             // Spawn a task that will cancel the group task
-            var canceller = try runtime.spawn(cancellerTask, .{ runtime, &group_handle }, .{});
+            var canceller = try runtime.spawn(cancellerTask, .{ runtime, &group_handle });
             defer canceller.cancel(runtime);
 
             // Wait for group task to complete (should be canceled)
@@ -370,6 +370,6 @@ test "Group: cancellation while waiting" {
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt}, .{});
+    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
     try handle.join(rt);
 }

--- a/src/select.zig
+++ b/src/select.zig
@@ -252,8 +252,8 @@ pub const SelectWaiter = struct {
 ///
 /// Example:
 /// ```
-/// var h1 = try rt.spawn(task1, .{}, .{});
-/// var h2 = try rt.spawn(task2, .{}, .{});
+/// var h1 = try rt.spawn(task1, .{});
+/// var h2 = try rt.spawn(task2, .{});
 /// const result = rt.select(.{ .first = &h1, .second = &h2 });
 /// switch (result) {
 ///     .first => |val| ...,
@@ -529,9 +529,9 @@ test "select: basic - first completes" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
-            var fast = try rt.spawn(fastTask, .{rt}, .{});
+            var fast = try rt.spawn(fastTask, .{rt});
             defer fast.cancel(rt);
 
             const result = try select(rt, .{ .fast = &fast, .slow = &slow });
@@ -544,7 +544,7 @@ test "select: basic - first completes" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -565,14 +565,14 @@ test "select: already complete - fast path" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var immediate = try rt.spawn(immediateTask, .{}, .{});
+            var immediate = try rt.spawn(immediateTask, .{});
             defer immediate.cancel(rt);
 
             // Give immediate task a chance to complete
             try rt.yield();
             try rt.yield();
 
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
 
             // immediate should already be complete, select should return immediately
@@ -584,7 +584,7 @@ test "select: already complete - fast path" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -611,11 +611,11 @@ test "select: heterogeneous types" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var int_handle = try rt.spawn(intTask, .{rt}, .{});
+            var int_handle = try rt.spawn(intTask, .{rt});
             defer int_handle.cancel(rt);
-            var string_handle = try rt.spawn(stringTask, .{rt}, .{});
+            var string_handle = try rt.spawn(stringTask, .{rt});
             defer string_handle.cancel(rt);
-            var bool_handle = try rt.spawn(boolTask, .{rt}, .{});
+            var bool_handle = try rt.spawn(boolTask, .{rt});
             defer bool_handle.cancel(rt);
 
             const result = try select(rt, .{
@@ -641,7 +641,7 @@ test "select: heterogeneous types" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -663,9 +663,9 @@ test "select: with cancellation" {
         }
 
         fn selectTask(rt: *Runtime) !i32 {
-            var h1 = try rt.spawn(slowTask1, .{rt}, .{});
+            var h1 = try rt.spawn(slowTask1, .{rt});
             defer h1.cancel(rt);
-            var h2 = try rt.spawn(slowTask2, .{rt}, .{});
+            var h2 = try rt.spawn(slowTask2, .{rt});
             defer h2.cancel(rt);
 
             const result = try select(rt, .{ .first = &h1, .second = &h2 });
@@ -676,7 +676,7 @@ test "select: with cancellation" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var select_handle = try rt.spawn(selectTask, .{rt}, .{});
+            var select_handle = try rt.spawn(selectTask, .{rt});
             defer select_handle.cancel(rt);
 
             // Give it a chance to start waiting
@@ -692,7 +692,7 @@ test "select: with cancellation" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -717,9 +717,9 @@ test "select: with error unions - success case" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var parse_handle = try rt.spawn(parseTask, .{rt}, .{});
+            var parse_handle = try rt.spawn(parseTask, .{rt});
             defer parse_handle.cancel(rt);
-            var validate_handle = try rt.spawn(validateTask, .{rt}, .{});
+            var validate_handle = try rt.spawn(validateTask, .{rt});
             defer validate_handle.cancel(rt);
 
             const result = try select(rt, .{
@@ -751,7 +751,7 @@ test "select: with error unions - success case" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -775,9 +775,9 @@ test "select: with error unions - error case" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var failing = try rt.spawn(failingTask, .{rt}, .{});
+            var failing = try rt.spawn(failingTask, .{rt});
             defer failing.cancel(rt);
-            var slow = try rt.spawn(slowTask, .{rt}, .{});
+            var slow = try rt.spawn(slowTask, .{rt});
             defer slow.cancel(rt);
 
             const result = try select(rt, .{ .failing = &failing, .slow = &slow });
@@ -800,7 +800,7 @@ test "select: with error unions - error case" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -830,11 +830,11 @@ test "select: with mixed error types" {
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var h1 = try rt.spawn(task1, .{rt}, .{});
+            var h1 = try rt.spawn(task1, .{rt});
             defer h1.cancel(rt);
-            var h2 = try rt.spawn(task2, .{rt}, .{});
+            var h2 = try rt.spawn(task2, .{rt});
             defer h2.cancel(rt);
-            var h3 = try rt.spawn(task3, .{rt}, .{});
+            var h3 = try rt.spawn(task3, .{rt});
             defer h3.cancel(rt);
 
             // select returns Cancelable!SelectUnion(...)
@@ -863,7 +863,7 @@ test "select: with mixed error types" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -883,7 +883,7 @@ test "wait: plain type" {
                 fn run(f: *Future(i32)) !void {
                     f.set(42);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -892,7 +892,7 @@ test "wait: plain type" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -914,7 +914,7 @@ test "wait: error union" {
                 fn run(f: *Future(MyError!i32)) !void {
                     f.set(123);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -924,7 +924,7 @@ test "wait: error union" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -946,7 +946,7 @@ test "wait: error union with error" {
                 fn run(f: *Future(MyError!i32)) !void {
                     f.set(MyError.Foo);
                 }
-            }.run, .{&future}, .{});
+            }.run, .{&future});
             defer task.cancel(rt);
 
             // Wait for the future
@@ -955,7 +955,7 @@ test "wait: error union with error" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -977,7 +977,7 @@ test "wait: already complete (fast path)" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -995,10 +995,10 @@ test "select: wait on JoinHandle from spawned task" {
 
         fn asyncTask(rt: *Runtime) !void {
             // Spawn a task and get a JoinHandle
-            var handle1 = try rt.spawn(workerTask, .{ rt, 21 }, .{});
+            var handle1 = try rt.spawn(workerTask, .{ rt, 21 });
             defer handle1.cancel(rt);
 
-            var handle2 = try rt.spawn(workerTask, .{ rt, 100 }, .{});
+            var handle2 = try rt.spawn(workerTask, .{ rt, 100 });
             defer handle2.cancel(rt);
 
             // Wait on JoinHandles using select
@@ -1022,6 +1022,6 @@ test "select: wait on JoinHandle from spawned task" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -394,9 +394,9 @@ test "Signal: basic signal handling" {
         signal_received: bool = false,
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignal, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -418,7 +418,7 @@ test "Signal: basic signal handling" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -434,13 +434,13 @@ test "Signal: multiple handlers for same signal" {
         count: std.atomic.Value(usize) = .init(0),
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignal, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h2 = try r.spawn(waitForSignal, .{ self, r });
             defer h2.cancel(r);
-            var h3 = try r.spawn(waitForSignal, .{ self, r }, .{});
+            var h3 = try r.spawn(waitForSignal, .{ self, r });
             defer h3.cancel(r);
-            var h4 = try r.spawn(sendSignal, .{r}, .{});
+            var h4 = try r.spawn(sendSignal, .{r});
             defer h4.cancel(r);
 
             try h1.join(r);
@@ -464,7 +464,7 @@ test "Signal: multiple handlers for same signal" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(@as(usize, 3), ctx.count.load(.monotonic));
@@ -494,7 +494,7 @@ test "Signal: timedWait timeout" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.timed_out);
@@ -510,9 +510,9 @@ test "Signal: timedWait receives signal before timeout" {
         signal_received: bool = false,
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignalTimed, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignalTimed, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -534,7 +534,7 @@ test "Signal: timedWait receives signal before timeout" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -552,9 +552,9 @@ test "Signal: select on multiple signals" {
         signal_received: std.atomic.Value(u8) = .init(0),
 
         fn mainTask(self: *@This(), r: *Runtime) !void {
-            var h1 = try r.spawn(waitForSignals, .{ self, r }, .{});
+            var h1 = try r.spawn(waitForSignals, .{ self, r });
             defer h1.cancel(r);
-            var h2 = try r.spawn(sendSignal, .{r}, .{});
+            var h2 = try r.spawn(sendSignal, .{r});
             defer h2.cancel(r);
 
             try h1.join(r);
@@ -581,7 +581,7 @@ test "Signal: select on multiple signals" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(@intFromEnum(SignalKind.user2), ctx.signal_received.load(.monotonic));
@@ -617,7 +617,7 @@ test "Signal: select with signal already received (fast path)" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expect(ctx.signal_received);
@@ -643,10 +643,10 @@ test "Signal: select with signal and task" {
             var sig = try Signal.init(.user1);
             defer sig.deinit();
 
-            var task = try r.spawn(slowTask, .{r}, .{});
+            var task = try r.spawn(slowTask, .{r});
             defer task.cancel(r);
 
-            var sender = try r.spawn(sendSignal, .{r}, .{});
+            var sender = try r.spawn(sendSignal, .{r});
             defer sender.cancel(r);
 
             // Signal should win (arrives much sooner)
@@ -669,7 +669,7 @@ test "Signal: select with signal and task" {
     };
 
     var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt }, .{});
+    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
     try handle.join(rt);
 
     try std.testing.expectEqual(.signal, ctx.winner);

--- a/src/sync/Barrier.zig
+++ b/src/sync/Barrier.zig
@@ -41,9 +41,9 @@
 //!
 //! var barrier = zio.Barrier.init(3);
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &barrier, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &barrier, 2 }, .{});
-//! var task3 = try runtime.spawn(worker, .{runtime, &barrier, 3 }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &barrier, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &barrier, 2 });
+//! var task3 = try runtime.spawn(worker, .{runtime, &barrier, 3 });
 //! ```
 
 const std = @import("std");
@@ -149,11 +149,11 @@ test "Barrier: basic synchronization" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[0] }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[0] });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[1] }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[1] });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[2] }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &results[2] });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -182,11 +182,11 @@ test "Barrier: leader detection" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &leader_count });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -222,9 +222,9 @@ test "Barrier: reusable for multiple cycles" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &phase1_done, &phase2_done, &phase3_done });
     defer task2.cancel(runtime);
 
     try runtime.run();
@@ -250,7 +250,7 @@ test "Barrier: single coroutine barrier" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &is_leader_result }, .{});
+    var handle = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &is_leader_result });
     try handle.join(runtime);
 
     try testing.expect(is_leader_result);
@@ -281,11 +281,11 @@ test "Barrier: ordering test" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[0], &final_order }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[0], &final_order });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[1], &final_order }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[1], &final_order });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[2], &final_order }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &arrival_order, &arrivals[2], &final_order });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -320,15 +320,15 @@ test "Barrier: many coroutines" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[0] }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[0] });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[1] }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[1] });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[2] }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[2] });
     defer task3.cancel(runtime);
-    var task4 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[3] }, .{});
+    var task4 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[3] });
     defer task4.cancel(runtime);
-    var task5 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[4] }, .{});
+    var task5 = try runtime.spawn(TestFn.worker, .{ runtime, &barrier, &counter, &final_counts[4] });
     defer task5.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -295,9 +295,9 @@ test "Condition basic wait/signal" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &mutex, &condition, &ready }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &mutex, &condition, &ready });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -329,7 +329,7 @@ test "Condition timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &timed_out });
     try handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -371,13 +371,13 @@ test "Condition broadcast" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &mutex, &condition, &ready, &waiter_count });
     defer waiter3.cancel(runtime);
-    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &mutex, &condition, &ready }, .{});
+    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &mutex, &condition, &ready });
     defer broadcaster_task.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -224,10 +224,10 @@ test "Futex: basic wait/wake" {
             var value: u32 = 0;
             var woken: bool = false;
 
-            var waiter = try io.spawn(waiterFunc, .{ io, &value, &woken }, .{});
+            var waiter = try io.spawn(waiterFunc, .{ io, &value, &woken });
             defer waiter.cancel(io);
 
-            var waker = try io.spawn(wakerFunc, .{ io, &value }, .{});
+            var waker = try io.spawn(wakerFunc, .{ io, &value });
             try waker.join(io);
 
             var timeout: AutoCancel = .init;
@@ -242,7 +242,7 @@ test "Futex: basic wait/wake" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var task = try rt.spawn(Main.run, .{rt}, .{});
+    var task = try rt.spawn(Main.run, .{rt});
     try task.join(rt);
 }
 
@@ -290,13 +290,13 @@ test "Futex: multiple waiters same address" {
             var value: u32 = 0;
             var woken: u32 = 0;
 
-            var waiter1 = try io.spawn(waiterFunc, .{ io, &value, &woken }, .{});
+            var waiter1 = try io.spawn(waiterFunc, .{ io, &value, &woken });
             defer waiter1.cancel(io);
 
-            var waiter2 = try io.spawn(waiterFunc, .{ io, &value, &woken }, .{});
+            var waiter2 = try io.spawn(waiterFunc, .{ io, &value, &woken });
             defer waiter2.cancel(io);
 
-            var waker = try io.spawn(wakerFunc, .{ io, &value }, .{});
+            var waker = try io.spawn(wakerFunc, .{ io, &value });
             try waker.join(io);
 
             var timeout: AutoCancel = .init;
@@ -312,7 +312,7 @@ test "Futex: multiple waiters same address" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var task = try rt.spawn(Main.run, .{rt}, .{});
+    var task = try rt.spawn(Main.run, .{rt});
     try task.join(rt);
 }
 
@@ -334,13 +334,13 @@ test "Futex: multiple waiters different addresses" {
             var value1: u32 = 0;
             var value2: u32 = 0;
 
-            var waiter1 = try io.spawn(waiterFunc, .{ io, &value1, w }, .{});
+            var waiter1 = try io.spawn(waiterFunc, .{ io, &value1, w });
             defer waiter1.cancel(io);
 
-            var waiter2 = try io.spawn(waiterFunc, .{ io, &value2, w }, .{});
+            var waiter2 = try io.spawn(waiterFunc, .{ io, &value2, w });
             defer waiter2.cancel(io);
 
-            var waker = try io.spawn(wakerFunc, .{ io, &value1 }, .{});
+            var waker = try io.spawn(wakerFunc, .{ io, &value1 });
             try waker.join(io);
 
             var timeout: AutoCancel = .init;
@@ -360,7 +360,7 @@ test "Futex: multiple waiters different addresses" {
 
     var woken: u32 = 0;
 
-    var task = try rt.spawn(Main.run, .{ rt, &woken }, .{});
+    var task = try rt.spawn(Main.run, .{ rt, &woken });
     task.join(rt) catch {};
 
     // Only waiter1 should have completed - waiter2 was on a different address

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -162,9 +162,9 @@ test "Mutex basic lock/unlock" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &shared_counter, &mutex });
     defer task2.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/Notify.zig
+++ b/src/sync/Notify.zig
@@ -41,9 +41,9 @@
 //!
 //! var notify = zio.Notify.init;
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &notify, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &notify, 2 }, .{});
-//! var task3 = try runtime.spawn(notifier, .{runtime, &notify }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &notify, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &notify, 2 });
+//! var task3 = try runtime.spawn(notifier, .{runtime, &notify });
 //! ```
 
 const std = @import("std");
@@ -247,9 +247,9 @@ test "Notify basic signal/wait" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_finished }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_finished });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -297,13 +297,13 @@ test "Notify broadcast to multiple waiters" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter3.cancel(runtime);
-    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &notify }, .{});
+    var broadcaster_task = try runtime.spawn(TestFn.broadcaster, .{ runtime, &notify });
     defer broadcaster_task.cancel(runtime);
 
     try runtime.run();
@@ -338,13 +338,13 @@ test "Notify multiple signals to multiple waiters" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &waiter_count });
     defer waiter3.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -372,7 +372,7 @@ test "Notify timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &timed_out });
     try handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -400,9 +400,9 @@ test "Notify timedWait success" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &wait_succeeded }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &notify, &wait_succeeded });
     defer waiter_task.cancel(runtime);
-    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify }, .{});
+    var signaler_task = try runtime.spawn(TestFn.signaler, .{ runtime, &notify });
     defer signaler_task.cancel(runtime);
 
     try runtime.run();
@@ -429,7 +429,7 @@ test "Notify: select" {
         fn asyncTask(rt: *Runtime) !void {
             var notify = Notify.init;
 
-            var task = try rt.spawn(signalerTask, .{ rt, &notify }, .{});
+            var task = try rt.spawn(signalerTask, .{ rt, &notify });
             defer task.cancel(rt);
 
             const result = try select(rt, .{ .notify = &notify, .task = &task });
@@ -440,6 +440,6 @@ test "Notify: select" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -38,9 +38,9 @@
 //!
 //! var event = zio.ResetEvent.init;
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &event, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &event, 2 }, .{});
-//! var task3 = try runtime.spawn(coordinator, .{runtime, &event }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &event, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &event, 2 });
+//! var task3 = try runtime.spawn(coordinator, .{runtime, &event });
 //! ```
 
 const std = @import("std");
@@ -288,9 +288,9 @@ test "ResetEvent wait/set signaling" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_finished }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_finished });
     defer waiter_task.cancel(runtime);
-    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event }, .{});
+    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event });
     defer setter_task.cancel(runtime);
 
     try runtime.run();
@@ -336,13 +336,13 @@ test "ResetEvent multiple waiters broadcast" {
         }
     };
 
-    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter1 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter1.cancel(runtime);
-    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter2 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter2.cancel(runtime);
-    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count }, .{});
+    var waiter3 = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &waiter_count });
     defer waiter3.cancel(runtime);
-    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event }, .{});
+    var setter_task = try runtime.spawn(TestFn.setter, .{ runtime, &reset_event });
     defer setter_task.cancel(runtime);
 
     try runtime.run();
@@ -391,7 +391,7 @@ test "ResetEvent: cancel waiting task" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &started }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &reset_event, &started });
     defer waiter_task.cancel(runtime);
 
     // Wait until waiter has actually started and is blocked
@@ -420,7 +420,7 @@ test "ResetEvent: select" {
         fn asyncTask(rt: *Runtime) !void {
             var reset_event = ResetEvent.init;
 
-            var task = try rt.spawn(setterTask, .{ rt, &reset_event }, .{});
+            var task = try rt.spawn(setterTask, .{ rt, &reset_event });
             defer task.cancel(rt);
 
             const result = try select(rt, .{ .event = &reset_event, .task = &task });
@@ -431,6 +431,6 @@ test "ResetEvent: select" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -33,11 +33,11 @@
 //! // Allow up to 3 concurrent workers
 //! var semaphore = zio.Semaphore{ .permits = 3 };
 //!
-//! var task1 = try runtime.spawn(worker, .{runtime, &semaphore, 1 }, .{});
-//! var task2 = try runtime.spawn(worker, .{runtime, &semaphore, 2 }, .{});
-//! var task3 = try runtime.spawn(worker, .{runtime, &semaphore, 3 }, .{});
-//! var task4 = try runtime.spawn(worker, .{runtime, &semaphore, 4 }, .{});
-//! var task5 = try runtime.spawn(worker, .{runtime, &semaphore, 5 }, .{});
+//! var task1 = try runtime.spawn(worker, .{runtime, &semaphore, 1 });
+//! var task2 = try runtime.spawn(worker, .{runtime, &semaphore, 2 });
+//! var task3 = try runtime.spawn(worker, .{runtime, &semaphore, 3 });
+//! var task4 = try runtime.spawn(worker, .{runtime, &semaphore, 4 });
+//! var task5 = try runtime.spawn(worker, .{runtime, &semaphore, 5 });
 //! ```
 
 const std = @import("std");
@@ -175,11 +175,11 @@ test "Semaphore: basic wait/post" {
     };
 
     var n: i32 = 0;
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem, &n });
     defer task3.cancel(runtime);
 
     try runtime.run();
@@ -206,7 +206,7 @@ test "Semaphore: timedWait timeout" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &timed_out }, .{});
+    var handle = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &timed_out });
     handle.join(runtime);
 
     try testing.expect(timed_out);
@@ -234,9 +234,9 @@ test "Semaphore: timedWait success" {
         }
     };
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &got_permit }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &sem, &got_permit });
     defer waiter_task.cancel(runtime);
-    var poster_task = try runtime.spawn(TestFn.poster, .{ runtime, &sem }, .{});
+    var poster_task = try runtime.spawn(TestFn.poster, .{ runtime, &sem });
     defer poster_task.cancel(runtime);
 
     try runtime.run();
@@ -260,11 +260,11 @@ test "Semaphore: multiple permits" {
         }
     };
 
-    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task1 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task1.cancel(runtime);
-    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task2 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task2.cancel(runtime);
-    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem }, .{});
+    var task3 = try runtime.spawn(TestFn.worker, .{ runtime, &sem });
     defer task3.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -55,9 +55,9 @@ const Waiter = @import("common.zig").Waiter;
 /// var buffer: [5]u32 = undefined;
 /// var channel = BroadcastChannel(u32).init(&buffer);
 ///
-/// var task1 = try runtime.spawn(broadcaster, .{runtime, &channel }, .{});
-/// var task2 = try runtime.spawn(listener, .{runtime, &channel }, .{});
-/// var task3 = try runtime.spawn(listener, .{runtime, &channel }, .{});
+/// var task1 = try runtime.spawn(broadcaster, .{runtime, &channel });
+/// var task2 = try runtime.spawn(listener, .{runtime, &channel });
+/// var task3 = try runtime.spawn(listener, .{runtime, &channel });
 /// ```
 pub fn BroadcastChannel(comptime T: type) type {
     return struct {
@@ -512,9 +512,9 @@ test "BroadcastChannel: basic send and receive" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var results: [3]u32 = undefined;
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -560,13 +560,13 @@ test "BroadcastChannel: multiple consumers receive same messages" {
     var sum2: u32 = 0;
     var sum3: u32 = 0;
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver1_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer1, &sum1, &barrier }, .{});
+    var receiver1_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer1, &sum1, &barrier });
     defer receiver1_task.cancel(runtime);
-    var receiver2_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer2, &sum2, &barrier }, .{});
+    var receiver2_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer2, &sum2, &barrier });
     defer receiver2_task.cancel(runtime);
-    var receiver3_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer3, &sum3, &barrier }, .{});
+    var receiver3_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer3, &sum3, &barrier });
     defer receiver3_task.cancel(runtime);
 
     try runtime.run();
@@ -615,7 +615,7 @@ test "BroadcastChannel: lagged consumer" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lag, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_lag, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -656,7 +656,7 @@ test "BroadcastChannel: tryReceive" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_try, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -694,7 +694,7 @@ test "BroadcastChannel: new subscriber doesn't receive old messages" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_new_subscriber, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_new_subscriber, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -732,7 +732,7 @@ test "BroadcastChannel: unsubscribe doesn't affect other consumers" {
 
     var consumer1 = BroadcastChannel(u32).Consumer{};
     var consumer2 = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_unsubscribe, .{ runtime, &channel, &consumer1, &consumer2 }, .{});
+    var handle = try runtime.spawn(TestFn.test_unsubscribe, .{ runtime, &channel, &consumer1, &consumer2 });
     try handle.join(runtime);
 }
 
@@ -760,7 +760,7 @@ test "BroadcastChannel: close prevents new sends" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_close, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_close, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -800,9 +800,9 @@ test "BroadcastChannel: consumers can drain after close" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var results: [4]?u32 = .{ null, null, null, null };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &results, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -849,9 +849,9 @@ test "BroadcastChannel: waiting consumers wake on close" {
     var consumer = BroadcastChannel(u32).Consumer{};
     var got_closed = false;
 
-    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &channel, &consumer, &got_closed, &barrier }, .{});
+    var waiter_task = try runtime.spawn(TestFn.waiter, .{ runtime, &channel, &consumer, &got_closed, &barrier });
     defer waiter_task.cancel(runtime);
-    var closer_task = try runtime.spawn(TestFn.closer, .{ runtime, &channel, &barrier }, .{});
+    var closer_task = try runtime.spawn(TestFn.closer, .{ runtime, &channel, &barrier });
     defer closer_task.cancel(runtime);
 
     try runtime.run();
@@ -884,7 +884,7 @@ test "BroadcastChannel: tryReceive returns Closed when channel closed and empty"
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try_closed, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_try_closed, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -921,9 +921,9 @@ test "BroadcastChannel: asyncReceive with select - basic" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel, &barrier });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &barrier }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel, &consumer, &barrier });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -957,7 +957,7 @@ test "BroadcastChannel: asyncReceive with select - already ready" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -988,7 +988,7 @@ test "BroadcastChannel: asyncReceive with select - closed channel" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -1025,7 +1025,7 @@ test "BroadcastChannel: asyncReceive with select - lagged consumer" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lagged, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_lagged, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }
 
@@ -1073,9 +1073,9 @@ test "BroadcastChannel: select with multiple broadcast channels" {
     var consumer1 = BroadcastChannel(u32).Consumer{};
     var consumer2 = BroadcastChannel(u32).Consumer{};
     var which: u8 = 0;
-    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &consumer1, &consumer2, &which }, .{});
+    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &consumer1, &consumer2, &which });
     defer select_task.cancel(runtime);
-    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 });
     defer sender_task.cancel(runtime);
 
     try runtime.run();
@@ -1158,6 +1158,6 @@ test "BroadcastChannel: position counter overflow handling" {
     };
 
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_overflow, .{ runtime, &channel, &consumer }, .{});
+    var handle = try runtime.spawn(TestFn.test_overflow, .{ runtime, &channel, &consumer });
     try handle.join(runtime);
 }

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -53,8 +53,8 @@ pub const CloseMode = enum {
 /// var buffer: [5]u32 = undefined;
 /// var channel = Channel(u32).init(&buffer);
 ///
-/// var task1 = try runtime.spawn(producer, .{runtime, &channel }, .{});
-/// var task2 = try runtime.spawn(consumer, .{runtime, &channel }, .{});
+/// var task1 = try runtime.spawn(producer, .{runtime, &channel });
+/// var task2 = try runtime.spawn(consumer, .{runtime, &channel });
 /// ```
 pub fn Channel(comptime T: type) type {
     return struct {
@@ -681,9 +681,9 @@ test "Channel: basic send and receive" {
     };
 
     var results: [3]u32 = undefined;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -730,7 +730,7 @@ test "Channel: trySend and tryReceive" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testTry, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testTry, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -755,9 +755,9 @@ test "Channel: blocking behavior when empty" {
     };
 
     var result: u32 = 0;
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result });
     defer consumer_task.cancel(runtime);
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
 
     try runtime.run();
@@ -790,9 +790,9 @@ test "Channel: blocking behavior when full" {
     };
 
     var count: u32 = 0;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel, &count }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel, &count });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -825,13 +825,13 @@ test "Channel: multiple producers and consumers" {
     };
 
     var sum: u32 = 0;
-    var producer1 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 0) }, .{});
+    var producer1 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 0) });
     defer producer1.cancel(runtime);
-    var producer2 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 100) }, .{});
+    var producer2 = try runtime.spawn(TestFn.producer, .{ runtime, &channel, @as(u32, 100) });
     defer producer2.cancel(runtime);
-    var consumer1 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum }, .{});
+    var consumer1 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum });
     defer consumer1.cancel(runtime);
-    var consumer2 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum }, .{});
+    var consumer2 = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &sum });
     defer consumer2.cancel(runtime);
 
     try runtime.run();
@@ -865,9 +865,9 @@ test "Channel: close graceful" {
     };
 
     var results: [3]?u32 = .{ null, null, null };
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &results });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -901,9 +901,9 @@ test "Channel: close immediate" {
     };
 
     var result: ?u32 = null;
-    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel }, .{});
+    var producer_task = try runtime.spawn(TestFn.producer, .{ runtime, &channel });
     defer producer_task.cancel(runtime);
-    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result }, .{});
+    var consumer_task = try runtime.spawn(TestFn.consumer, .{ runtime, &channel, &result });
     defer consumer_task.cancel(runtime);
 
     try runtime.run();
@@ -932,7 +932,7 @@ test "Channel: send on closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testClosed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testClosed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -973,7 +973,7 @@ test "Channel: ring buffer wrapping" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testWrap, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.testWrap, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -1003,9 +1003,9 @@ test "Channel: asyncReceive with select - basic" {
         }
     };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -1035,7 +1035,7 @@ test "Channel: asyncReceive with select - already ready" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -1062,7 +1062,7 @@ test "Channel: asyncReceive with select - closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -1095,9 +1095,9 @@ test "Channel: asyncSend with select - basic" {
         }
     };
 
-    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender, .{ runtime, &channel });
     defer sender_task.cancel(runtime);
-    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel }, .{});
+    var receiver_task = try runtime.spawn(TestFn.receiver, .{ runtime, &channel });
     defer receiver_task.cancel(runtime);
 
     try runtime.run();
@@ -1129,7 +1129,7 @@ test "Channel: asyncSend with select - already ready" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_ready, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -1156,7 +1156,7 @@ test "Channel: asyncSend with select - closed channel" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel }, .{});
+    var handle = try runtime.spawn(TestFn.test_closed, .{ runtime, &channel });
     try handle.join(runtime);
 }
 
@@ -1180,9 +1180,9 @@ test "Channel: select on both send and receive" {
             try ch2.send(rt, 2);
 
             var which: u8 = 0;
-            var select_task = try rt.spawn(selectTask, .{ rt, ch1, ch2, &which }, .{});
+            var select_task = try rt.spawn(selectTask, .{ rt, ch1, ch2, &which });
             defer select_task.cancel(rt);
-            var sender_task = try rt.spawn(sender, .{ rt, ch1 }, .{});
+            var sender_task = try rt.spawn(sender, .{ rt, ch1 });
             defer sender_task.cancel(rt);
 
             _ = try select_task.join(rt);
@@ -1215,7 +1215,7 @@ test "Channel: select on both send and receive" {
         }
     };
 
-    var handle = try runtime.spawn(TestFn.testMain, .{ runtime, &channel1, &channel2 }, .{});
+    var handle = try runtime.spawn(TestFn.testMain, .{ runtime, &channel1, &channel2 });
     try handle.join(runtime);
 }
 
@@ -1256,9 +1256,9 @@ test "Channel: select with multiple receivers" {
     };
 
     var which: u8 = 0;
-    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &which }, .{});
+    var select_task = try runtime.spawn(TestFn.selectTask, .{ runtime, &channel1, &channel2, &which });
     defer select_task.cancel(runtime);
-    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 }, .{});
+    var sender_task = try runtime.spawn(TestFn.sender2, .{ runtime, &channel2 });
     defer sender_task.cancel(runtime);
 
     try runtime.run();

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -158,7 +158,7 @@ test "Future: basic set and get" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -186,11 +186,11 @@ test "Future: await from coroutine" {
             var future = Future(i32).init;
 
             // Spawn setter coroutine
-            var setter_handle = try rt.spawn(setterTask, .{ rt, &future }, .{});
+            var setter_handle = try rt.spawn(setterTask, .{ rt, &future });
             defer setter_handle.cancel(rt);
 
             // Spawn getter coroutine
-            var getter_handle = try rt.spawn(getterTask, .{ rt, &future }, .{});
+            var getter_handle = try rt.spawn(getterTask, .{ rt, &future });
             defer getter_handle.cancel(rt);
 
             const result = try getter_handle.join(rt);
@@ -198,7 +198,7 @@ test "Future: await from coroutine" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }
 
@@ -225,15 +225,15 @@ test "Future: multiple waiters" {
             var future = Future(i32).init;
 
             // Spawn multiple waiters
-            var waiter1 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter1 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter1.cancel(rt);
-            var waiter2 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter2 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter2.cancel(rt);
-            var waiter3 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) }, .{});
+            var waiter3 = try rt.spawn(waiterTask, .{ rt, &future, @as(i32, 999) });
             defer waiter3.cancel(rt);
 
             // Spawn setter
-            var setter = try rt.spawn(setterTask, .{ rt, &future }, .{});
+            var setter = try rt.spawn(setterTask, .{ rt, &future });
             defer setter.cancel(rt);
 
             // Wait for all to complete
@@ -244,6 +244,6 @@ test "Future: multiple waiters" {
         }
     };
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime}, .{});
+    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
     try handle.join(runtime);
 }

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -6,7 +6,6 @@ const builtin = @import("builtin");
 
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
-pub const SpawnOptions = runtime.SpawnOptions;
 pub const JoinHandle = runtime.JoinHandle;
 
 pub const AutoCancel = @import("runtime/autocancel.zig").AutoCancel;


### PR DESCRIPTION
## Summary

- Remove pinning support - no longer needed now that cross-thread cancellation works correctly
- Tasks can now freely migrate between executors without needing to be pinned
- Net removal of 71 lines of code

## Changes

- Remove `SpawnOptions` struct (only had `pinned` field)
- Remove `pin_count` field from `AnyTask`
- Remove `canMigrate()` function
- Remove `CreateOptions` struct from `task.zig`
- Remove `beginPin()`/`endPin()` from `Executor` and `Runtime`
- Remove `options` parameter from `spawn()` and `spawnTask()`
- Update all spawn() call sites to remove empty options argument

## Test plan

- [x] All 273 unit tests pass