### PR TITLE
Add timeout support to Socket and Stream I/O methods

### DIFF
--- a/benchmarks/echo_server.zig
+++ b/benchmarks/echo_server.zig
@@ -15,9 +15,9 @@ fn handleClient(rt: *zio.Runtime, in_stream: zio.net.Stream) !void {
     var buffer: [MESSAGE_SIZE]u8 = undefined;
 
     while (true) {
-        const n = try stream.read(rt, &buffer);
+        const n = try stream.read(rt, &buffer, .none);
         if (n == 0) break;
-        try stream.writeAll(rt, buffer[0..n]);
+        try stream.writeAll(rt, buffer[0..n], .none);
     }
 }
 
@@ -65,11 +65,11 @@ fn clientTask(
 
     var i: usize = 0;
     while (i < MESSAGES_PER_CLIENT) : (i += 1) {
-        try stream.writeAll(rt, &send_buffer);
+        try stream.writeAll(rt, &send_buffer, .none);
 
         var bytes_received: usize = 0;
         while (bytes_received < MESSAGE_SIZE) {
-            const n = try stream.read(rt, recv_buffer[bytes_received..]);
+            const n = try stream.read(rt, recv_buffer[bytes_received..], .none);
             if (n == 0) return error.UnexpectedEndOfStream;
             bytes_received += n;
         }

--- a/examples/tcp_echo_server_plain.zig
+++ b/examples/tcp_echo_server_plain.zig
@@ -18,11 +18,11 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
     var buffer: [1024]u8 = undefined;
 
     while (true) {
-        const n = try stream.read(rt, &buffer);
+        const n = try stream.read(rt, &buffer, .none);
         if (n == 0) break;
 
         std.log.info("Received: {s}", .{buffer[0..n]});
-        try stream.writeAll(rt, buffer[0..n]);
+        try stream.writeAll(rt, buffer[0..n], .none);
     }
 
     std.log.info("Client disconnected", .{});

--- a/src/net.zig
+++ b/src/net.zig
@@ -919,29 +919,29 @@ pub const Socket = struct {
     /// Receives data from the socket into the provided buffer.
     /// Returns the number of bytes received, which may be less than buf.len.
     /// A return value of 0 indicates the socket has been shut down.
-    pub fn receive(self: Socket, rt: *Runtime, buf: []u8) !usize {
+    pub fn receive(self: Socket, rt: *Runtime, buf: []u8, timeout: Timeout) !usize {
         var storage: [1]os.iovec = undefined;
-        return self.receiveBuf(rt, .fromSlice(buf, &storage));
+        return self.receiveBuf(rt, .fromSlice(buf, &storage), timeout);
     }
 
     /// Low-level receive function that accepts ev.ReadBuf directly.
-    pub fn receiveBuf(self: Socket, rt: *Runtime, buf: ev.ReadBuf) !usize {
+    pub fn receiveBuf(self: Socket, rt: *Runtime, buf: ev.ReadBuf, timeout: Timeout) !usize {
         var op = ev.NetRecv.init(self.handle, buf, .{});
-        try waitForIo(rt, &op.c);
+        try timedWaitForIo(rt, &op.c, timeout);
         return try op.getResult();
     }
 
     /// Sends data from the provided buffer to the socket.
     /// Returns the number of bytes sent, which may be less than buf.len.
-    pub fn send(self: Socket, rt: *Runtime, buf: []const u8) !usize {
+    pub fn send(self: Socket, rt: *Runtime, buf: []const u8, timeout: Timeout) !usize {
         var storage: [1]os.iovec_const = undefined;
-        return self.sendBuf(rt, .fromSlice(buf, &storage));
+        return self.sendBuf(rt, .fromSlice(buf, &storage), timeout);
     }
 
     /// Low-level send function that accepts ev.WriteBuf directly.
-    pub fn sendBuf(self: Socket, rt: *Runtime, buf: ev.WriteBuf) !usize {
+    pub fn sendBuf(self: Socket, rt: *Runtime, buf: ev.WriteBuf, timeout: Timeout) !usize {
         var op = ev.NetSend.init(self.handle, buf, .{});
-        try waitForIo(rt, &op.c);
+        try timedWaitForIo(rt, &op.c, timeout);
         return try op.getResult();
     }
 
@@ -1002,17 +1002,17 @@ pub const Stream = struct {
     /// Reads data from the stream into the provided buffer.
     /// Returns the number of bytes read, which may be less than buf.len.
     /// A return value of 0 indicates end-of-stream.
-    pub fn read(self: Stream, rt: *Runtime, buf: []u8) !usize {
+    pub fn read(self: Stream, rt: *Runtime, buf: []u8, timeout: Timeout) !usize {
         var storage: [1]os.iovec = undefined;
-        return self.readBuf(rt, .fromSlice(buf, &storage));
+        return self.readBuf(rt, .fromSlice(buf, &storage), timeout);
     }
 
     /// Reads data from the stream into the provided buffer until it is full or the stream is closed.
     /// A return value of 0 indicates end-of-stream.
-    pub fn readAll(self: Stream, rt: *Runtime, buf: []u8) !void {
+    pub fn readAll(self: Stream, rt: *Runtime, buf: []u8, timeout: Timeout) !void {
         var offset: usize = 0;
         while (offset < buf.len) {
-            const n = try self.read(rt, buf[offset..]);
+            const n = try self.read(rt, buf[offset..], timeout);
             if (n == 0) break;
             offset += n;
         }
@@ -1021,41 +1021,41 @@ pub const Stream = struct {
     /// Low-level read function that accepts ev.ReadBuf directly.
     /// Returns the number of bytes read, which may be less than requested.
     /// A return value of 0 indicates end-of-stream.
-    pub fn readBuf(self: Stream, rt: *Runtime, buf: ev.ReadBuf) !usize {
-        return self.socket.receiveBuf(rt, buf);
+    pub fn readBuf(self: Stream, rt: *Runtime, buf: ev.ReadBuf, timeout: Timeout) !usize {
+        return self.socket.receiveBuf(rt, buf, timeout);
     }
 
     /// Writes data from the provided buffer to the stream.
     /// Returns the number of bytes written, which may be less than buf.len.
-    pub fn write(self: Stream, rt: *Runtime, buf: []const u8) !usize {
+    pub fn write(self: Stream, rt: *Runtime, buf: []const u8, timeout: Timeout) !usize {
         var storage: [1]os.iovec_const = undefined;
-        return self.writeBuf(rt, .fromSlice(buf, &storage));
+        return self.writeBuf(rt, .fromSlice(buf, &storage), timeout);
     }
 
     /// Writes data from the provided buffer to the stream until it is empty.
     /// Returns an error if the stream is closed or if the write fails.
-    pub fn writeAll(self: Stream, rt: *Runtime, buf: []const u8) !void {
+    pub fn writeAll(self: Stream, rt: *Runtime, buf: []const u8, timeout: Timeout) !void {
         var offset: usize = 0;
         while (offset < buf.len) {
-            const n = try self.write(rt, buf[offset..]);
+            const n = try self.write(rt, buf[offset..], timeout);
             offset += n;
         }
     }
 
     /// Writes header followed by data slices, with optional splat (repeat) of the last slice.
     /// Used internally by the buffered Writer.
-    pub fn writeSplatHeader(self: Stream, rt: *Runtime, header: []const u8, data: []const []const u8, splat: usize) !usize {
+    pub fn writeSplatHeader(self: Stream, rt: *Runtime, header: []const u8, data: []const []const u8, splat: usize, timeout: Timeout) !usize {
         var splat_buf: [64]u8 = undefined;
         var slices: [max_vecs][]const u8 = undefined;
         const buf_len = fillBuf(&slices, header, data, splat, &splat_buf);
 
         var storage: [max_vecs]os.iovec_const = undefined;
-        return self.writeBuf(rt, .fromSlices(slices[0..buf_len], &storage));
+        return self.writeBuf(rt, .fromSlices(slices[0..buf_len], &storage), timeout);
     }
 
     /// Low-level write function that accepts ev.WriteBuf directly.
-    pub fn writeBuf(self: Stream, rt: *Runtime, buf: ev.WriteBuf) !usize {
-        return self.socket.sendBuf(rt, buf);
+    pub fn writeBuf(self: Stream, rt: *Runtime, buf: ev.WriteBuf, timeout: Timeout) !usize {
+        return self.socket.sendBuf(rt, buf, timeout);
     }
 
     /// Shuts down all or part of a full-duplex connection.
@@ -1072,7 +1072,8 @@ pub const Stream = struct {
         rt: *Runtime,
         stream: Stream,
         interface: std.Io.Reader,
-        err: ?ev.NetRecv.Error = null,
+        timeout: Timeout = .none,
+        err: ?(ev.NetRecv.Error || common.Timeoutable) = null,
 
         pub fn init(stream: Stream, rt: *Runtime, buffer: []u8) Reader {
             return .{
@@ -1088,6 +1089,10 @@ pub const Stream = struct {
                     .end = 0,
                 },
             };
+        }
+
+        pub fn setTimeout(self: *Reader, timeout: Timeout) void {
+            self.timeout = timeout;
         }
 
         fn streamImpl(io_r: *std.Io.Reader, io_w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
@@ -1107,7 +1112,7 @@ pub const Stream = struct {
                 try io_r.writableVectorPosix(&storage, data);
             if (dest_n == 0) return 0;
 
-            const n = r.stream.readBuf(r.rt, .{ .iovecs = storage[0..dest_n] }) catch |err| {
+            const n = r.stream.readBuf(r.rt, .{ .iovecs = storage[0..dest_n] }, r.timeout) catch |err| {
                 r.err = err;
                 return error.ReadFailed;
             };
@@ -1127,7 +1132,8 @@ pub const Stream = struct {
         rt: *Runtime,
         stream: Stream,
         interface: std.Io.Writer,
-        err: ?ev.NetSend.Error = null,
+        timeout: Timeout = .none,
+        err: ?(ev.NetSend.Error || common.Timeoutable) = null,
 
         pub fn init(stream: Stream, rt: *Runtime, buffer: []u8) Writer {
             return .{
@@ -1142,10 +1148,14 @@ pub const Stream = struct {
             };
         }
 
+        pub fn setTimeout(self: *Writer, timeout: Timeout) void {
+            self.timeout = timeout;
+        }
+
         fn drainImpl(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
             const w: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
             const buffered = io_w.buffered();
-            const n = w.stream.writeSplatHeader(w.rt, buffered, data, splat) catch |err| {
+            const n = w.stream.writeSplatHeader(w.rt, buffered, data, splat, w.timeout) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };
@@ -1361,7 +1371,7 @@ test "HostName: connect" {
             var stream = try host.connect(runtime, port, .{});
             defer stream.close(runtime);
 
-            try stream.writeAll(runtime, "hello");
+            try stream.writeAll(runtime, "hello", .none);
         }
     };
 


### PR DESCRIPTION
## Summary
- Refactor Socket/Stream I/O to use low-level `receiveBuf`/`sendBuf` methods
- Add timeout parameter to all Socket and Stream read/write methods
- Add `setTimeout` method to buffered Reader and Writer

## Test plan
- [x] All existing tests pass
- [ ] Manual testing with timeout scenarios