### PR TITLE
Add future protocol to Timeout for use with select()

### DIFF
--- a/src/time.zig
+++ b/src/time.zig
@@ -371,6 +371,7 @@ pub const Timeout = union(enum) {
     pub fn asyncCancelWait(self: *const Timeout, _: *Runtime, _: *WaitNode, ctx: *WaitContext) bool {
         _ = self;
         const loop = ctx.timer.c.loop orelse return true;
+        ctx.wait_node = null; // Prevent callback from waking a stale/reused wait node
         loop.clearTimer(&ctx.timer);
         return true; // Timer operations don't have values to re-add if we lost the race
     }


### PR DESCRIPTION
## Summary
- Adds future protocol methods (`asyncWait`, `asyncCancelWait`, `getResult`) to the `Timeout` type
- Enables `Timeout` to be used directly in `select()` calls for timeout races
- Includes test verifying timeout wins against a channel that never receives

## Test plan
- [x] `./check.sh --filter "Timeout future"` passes
- [x] `./check.sh --full` passes (320/320 tests)