### PR TITLE
Change timedWait functions to accept Timeout parameter

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -54,7 +54,7 @@ defer sigint.deinit();
 while (true) {
     // some other work
 
-    sigint.timedWait(rt, 100 * std.time.ns_per_ms) catch |err| {
+    sigint.timedWait(rt, .{ .duration = .fromMilliseconds(100) }) catch |err| {
         if (err == error.Timeout) {
             continue;
         }

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -54,6 +54,7 @@ const Group = @import("../runtime/group.zig").Group;
 const Cancelable = @import("../common.zig").Cancelable;
 const Timeoutable = @import("../common.zig").Timeoutable;
 const Duration = @import("../time.zig").Duration;
+const Timeout = @import("../time.zig").Timeout;
 const Mutex = @import("Mutex.zig");
 const CompactWaitQueue = @import("../utils/wait_queue.zig").CompactWaitQueue;
 const WaitNode = @import("../runtime/WaitNode.zig");
@@ -152,7 +153,7 @@ pub fn waitUncancelable(self: *Condition, runtime: *Runtime, mutex: *Mutex) void
 /// Returns `error.Canceled` if the task is cancelled while waiting. Cancellation
 /// takes priority over timeout - if both occur, `error.Canceled` is returned.
 /// The mutex will be held when returning with any error.
-pub fn timedWait(self: *Condition, runtime: *Runtime, mutex: *Mutex, timeout: Duration) (Timeoutable || Cancelable)!void {
+pub fn timedWait(self: *Condition, runtime: *Runtime, mutex: *Mutex, timeout: Timeout) (Timeoutable || Cancelable)!void {
     // Stack-allocated waiter - separates operation wait node from task wait node
     var waiter: Waiter = .init(runtime);
 
@@ -292,7 +293,7 @@ test "Condition timedWait timeout" {
             defer mtx.unlock(rt);
 
             // Should timeout after 10ms
-            cond.timedWait(rt, mtx, .fromMilliseconds(10)) catch |err| {
+            cond.timedWait(rt, mtx, .{ .duration = .fromMilliseconds(10) }) catch |err| {
                 if (err == error.Timeout) {
                     timeout_flag.* = true;
                 }

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -51,6 +51,7 @@ const Executor = @import("../runtime.zig").Executor;
 const Cancelable = @import("../common.zig").Cancelable;
 const Timeoutable = @import("../common.zig").Timeoutable;
 const Duration = @import("../time.zig").Duration;
+const Timeout = @import("../time.zig").Timeout;
 const Awaitable = @import("../runtime.zig").Awaitable;
 const AnyTask = @import("../runtime.zig").AnyTask;
 const CompactWaitQueue = @import("../utils/wait_queue.zig").CompactWaitQueue;
@@ -155,7 +156,7 @@ pub fn wait(self: *ResetEvent, runtime: *Runtime) Cancelable!void {
 ///
 /// Returns `error.Timeout` if the timeout expires before the event is set.
 /// Returns `error.Canceled` if the task is cancelled while waiting.
-pub fn timedWait(self: *ResetEvent, runtime: *Runtime, timeout: Duration) (Timeoutable || Cancelable)!void {
+pub fn timedWait(self: *ResetEvent, runtime: *Runtime, timeout: Timeout) (Timeoutable || Cancelable)!void {
     const state = self.wait_queue.getState();
 
     // Fast path: already set
@@ -292,7 +293,7 @@ test "ResetEvent timedWait timeout" {
     var reset_event = ResetEvent.init;
 
     // Should timeout after 10ms
-    try std.testing.expectError(error.Timeout, reset_event.timedWait(rt, .fromMilliseconds(10)));
+    try std.testing.expectError(error.Timeout, reset_event.timedWait(rt, .{ .duration = .fromMilliseconds(10) }));
     try std.testing.expect(!reset_event.isSet());
 }
 

--- a/src/time.zig
+++ b/src/time.zig
@@ -336,6 +336,16 @@ pub const Timeout = union(enum) {
     duration: Duration,
     deadline: Timestamp,
 
+    /// Converts this timeout to a deadline-based timeout.
+    /// If already a deadline or none, returns self unchanged.
+    /// If a duration, converts to deadline using the current monotonic time.
+    pub fn toDeadline(self: Timeout) Timeout {
+        return switch (self) {
+            .none, .deadline => self,
+            .duration => |d| .{ .deadline = os.time.now(.monotonic).addDuration(d) },
+        };
+    }
+
     // Future protocol implementation for use with select()
 
     pub const Result = void;


### PR DESCRIPTION
## Summary

All `timedWait` functions now accept the `Timeout` union type instead of `Duration`, providing consistent support for:
- Duration-based timeouts (`.{ .duration = .fromMilliseconds(100) }`)
- Deadline-based timeouts (`.{ .deadline = timestamp }`)
- No timeout (`.none`)

## Changes

- Added `Timeout.toDeadline()` helper method for converting duration-based timeouts to deadline-based ones
- Updated `Waiter.timedWait` to accept `Timeout` parameter
- Updated `AutoCancel.set` to accept `Timeout` parameter
- Updated all sync primitives: `Condition`, `Semaphore`, `Notify`, `ResetEvent`, `Signal`, and `Futex`
- Added basic test for `Futex.timedWait` (was previously untested)
- Updated all tests and documentation to use new `Timeout` syntax

## Test plan

- [x] All 327 tests pass
- [x] Added new test for `Futex.timedWait`
- [x] Existing timedWait tests verify the new API works correctly