### PR TITLE
Remove Awaitable.done field to save memory

### DIFF
--- a/src/runtime/blocking_task.zig
+++ b/src/runtime/blocking_task.zig
@@ -36,7 +36,7 @@ pub const AnyBlockingTask = struct {
     pub fn getResult(self: *AnyBlockingTask, comptime T: type) T {
         // Sanity checks before unsafe casting
         if (std.debug.runtime_safety) {
-            std.debug.assert(self.awaitable.done.load(.acquire)); // Task must be completed
+            std.debug.assert(self.awaitable.hasResult()); // Task must be completed
             std.debug.assert(@sizeOf(T) == self.closure.result_len); // Size must match
             std.debug.assert(@alignOf(T) <= Closure.max_result_alignment); // Alignment must fit
         }

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -196,7 +196,7 @@ pub const AnyTask = struct {
     pub fn getResult(self: *AnyTask, comptime T: type) T {
         // Sanity checks before unsafe casting
         if (std.debug.runtime_safety) {
-            std.debug.assert(self.awaitable.done.load(.acquire)); // Task must be completed
+            std.debug.assert(self.awaitable.hasResult()); // Task must be completed
             std.debug.assert(@sizeOf(T) == self.closure.result_len); // Size must match
             std.debug.assert(@alignOf(T) <= Closure.max_result_alignment); // Alignment must fit
         }


### PR DESCRIPTION
## Summary

Eliminate the redundant `done` field from `Awaitable` by using the `waiting_list` WaitQueue state to track completion, saving 1 byte per awaitable.

### Changes:

- **Removed `Awaitable.done` field** - The `waiting_list` already tracks completion via its sentinel states
- **Use `waiting_list.getState() == complete`** for all completion checks (`hasResult()`, `asyncWait()`)
- **Fixed race condition in `markComplete()`** - Now collects all waiters into a `SimpleQueue` before waking them, ensuring the queue transitions to `complete` state before any woken task calls `hasResult()`

### Race Condition Fix:

The old code had a subtle race:
1. `markComplete()` pops first waiter and wakes it immediately
2. That waiter runs and calls `hasResult()`
3. But `waiting_list` is still in "pointer" state (has more waiters), not `complete` yet
4. `hasResult()` returns false even though the task is done!

The new implementation collects all waiters first, transitions to `complete`, then wakes them.

### Benefits:

- **1 byte saved per awaitable** (atomic bool removed)
- Simpler implementation - one source of truth for completion state
- Fixed race condition where `hasResult()` could return false for completed tasks

All 328 tests pass.