### PR TITLE
Reduce Awaitable ref_count from u32 to u16 to save memory

### DIFF
--- a/src/runtime/awaitable.zig
+++ b/src/runtime/awaitable.zig
@@ -27,7 +27,7 @@ pub const AwaitableKind = enum {
 // Awaitable - base type for anything that can be waited on
 pub const Awaitable = struct {
     kind: AwaitableKind,
-    ref_count: RefCounter(u32) = RefCounter(u32).init(),
+    ref_count: RefCounter(u16) = RefCounter(u16).init(),
 
     wait_node: WaitNode,
 


### PR DESCRIPTION
The reference count only needs to track a small number of references
(typically 2-4), so u16 (max 65535) is more than sufficient.

On 32-bit architectures this saves 4 bytes per Awaitable due to
reduced alignment padding before wait_node.
