### PR TITLE
Add NTP client tutorial and improve existing tutorials

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,6 +51,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "mutex-demo", .file = "examples/mutex_demo.zig" },
         .{ .name = "producer-consumer", .file = "examples/producer_consumer.zig" },
         .{ .name = "parallel-grep", .file = "examples/parallel_grep.zig" },
+        .{ .name = "ntp-client", .file = "examples/ntp_client.zig" },
         .{ .name = "signal-demo", .file = "examples/signal_demo.zig" },
         .{ .name = "udp-echo-server", .file = "examples/udp_echo_server.zig" },
         .{ .name = "ping", .file = "examples/ping.zig" },

--- a/docs/ntp-client.md
+++ b/docs/ntp-client.md
@@ -1,0 +1,170 @@
+# NTP Client
+
+In the previous tutorials, we've worked with TCP connections. Now let's explore UDP sockets and event-driven programming by building an NTP (Network Time Protocol) client that queries time servers.
+
+This tutorial covers:
+
+- **UDP sockets** - connectionless datagram communication
+- **DNS lookup** - resolving hostnames to IP addresses
+- **Timeouts** - setting time limits on I/O operations
+- **Select** - waiting on multiple events simultaneously
+
+## The Code
+
+Replace the contents of `src/main.zig` with this:
+
+```zig
+--8<-- "examples/ntp_client.zig"
+```
+
+Now build and run it:
+
+```sh
+$ zig build run
+info: NTP client starting. Press Ctrl+C to stop.
+info: Server: pool.ntp.org:123
+info: Update interval: 30s
+info: Request timeout: 5s
+info: Querying NTP server pool.ntp.org:123 (162.159.200.123:123)
+info: Current time: 2026-01-31 19:45:32.847 UTC
+info: Querying NTP server pool.ntp.org:123 (162.159.200.1:123)
+info: Current time: 2026-01-31 19:46:02.851 UTC
+^C
+info: NTP client stopped.
+```
+
+You can specify a different NTP server:
+
+```sh
+$ zig build run -- time.google.com
+```
+
+## How It Works
+
+This program demonstrates several networking concepts working together: DNS resolution, UDP communication, timeouts, and event multiplexing.
+
+### DNS Lookup
+
+Before we can contact an NTP server, we need to resolve its hostname to an IP address:
+
+```zig
+--8<-- "examples/ntp_client.zig:lookup"
+```
+
+[`HostName.lookup()`](../apidocs/#zio.net.HostName.lookup) returns an iterator that yields DNS results. The resolver may return multiple addresses (IPv4 and IPv6), and we take the first one. This happens asynchronously - the task suspends while DNS queries are performed.
+
+### UDP Sockets
+
+Unlike TCP which provides reliable, ordered, connection-oriented streams, UDP sends individual datagrams without establishing a connection:
+
+```zig
+const local_addr = try zio.net.IpAddress.parseIp4("0.0.0.0", 0);
+const socket = try local_addr.bind(rt, .{});
+defer socket.close(rt);
+```
+
+[`bind()`](../apidocs/#zio.net.IpAddress.bind) creates a UDP socket. Binding to `0.0.0.0:0` means "listen on any interface, on any available port" - the OS will assign a random port.
+
+With TCP, we called [`connect()`](../apidocs/#zio.net.Stream.connect) to establish a connection. With UDP, there's no connection - we just send datagrams to any address we want.
+
+### Sending and Receiving Datagrams
+
+To send a datagram:
+
+```zig
+const sent = try socket.sendTo(rt, addr, &buffer, timeout);
+```
+
+[`sendTo()`](../apidocs/#zio.net.Socket.sendTo) sends data to a specific address. UDP doesn't guarantee delivery - the datagram might get lost, arrive out of order, or be duplicated. For NTP, this is acceptable since we query periodically.
+
+To receive a datagram:
+
+```zig
+const result = socket.receiveFrom(rt, &buffer, timeout) catch |err| {
+    std.log.warn("Failed to receive NTP response: {}", .{err});
+    return err;
+};
+```
+
+[`receiveFrom()`](../apidocs/#zio.net.Socket.receiveFrom) returns both the data and the sender's address. This is important for UDP since we can receive datagrams from any address.
+
+### Timeouts
+
+Both [`sendTo()`](../apidocs/#zio.net.Socket.sendTo) and [`receiveFrom()`](../apidocs/#zio.net.Socket.receiveFrom) accept a [`Timeout`](../apidocs/#zio.Timeout) parameter:
+
+```zig
+const request_timeout: zio.Timeout = .{ .duration = .fromSeconds(5) };
+
+const result = socket.receiveFrom(rt, &buffer, request_timeout) catch |err| {
+    // Handle timeout or other error
+    return err;
+};
+```
+
+If the operation doesn't complete within 5 seconds, it returns `error.Timeout`. This prevents the program from hanging indefinitely if the server doesn't respond.
+
+You can also use `.none` for no timeout (wait indefinitely), or `.{ .deadline = timestamp }` to wait until a specific time.
+
+### The NTP Protocol
+
+NTP uses a simple binary protocol. We define the packet structure as an extern struct:
+
+```zig
+const NtpPacket = extern struct {
+    flags: packed struct(u8) {
+        mode: u3 = 3,      // Client mode
+        version: u3 = 3,   // NTP version 3
+        leap: u2 = 0,      // No leap second warning
+    } = .{},
+    stratum: u8 = 0,
+    poll: u8 = 0,
+    precision: u8 = 0,
+    root_delay: u32 = 0,
+    root_dispersion: u32 = 0,
+    reference_id: u32 = 0,
+    reference_timestamp: u64 = 0,
+    origin_timestamp: u64 = 0,
+    receive_timestamp: u64 = 0,
+    transmit_timestamp: u64 = 0,
+};
+```
+
+The `extern` keyword ensures the struct has C-compatible layout with no padding. We serialize it to bytes using [`writeStruct()`](https://ziglang.org/documentation/0.15.2/std/#std.Io.Writer.writeStruct):
+
+```zig
+const request: NtpPacket = .{};
+var buffer: [@sizeOf(NtpPacket)]u8 = undefined;
+var writer = std.Io.Writer.fixed(&buffer);
+try writer.writeStruct(request, .big);
+```
+
+The `.big` endianness ensures multi-byte fields are in network byte order (big-endian).
+
+When we receive the response, we deserialize it:
+
+```zig
+var reader = std.Io.Reader.fixed(buffer[0..result.len]);
+const response = try reader.takeStruct(NtpPacket, .big);
+```
+
+The timestamp is in NTP format (seconds since 1900-01-01), which we convert to Unix time and print in a human-readable format.
+
+### Select: Waiting on Multiple Events
+
+The main loop needs to handle two events: the periodic timer and the shutdown signal (Ctrl+C):
+
+```zig
+--8<-- "examples/ntp_client.zig:select"
+```
+
+[`select()`](../apidocs/#zio.select) suspends the task until one of the events occurs. You pass a struct where each field is a pointer to something that can be waited on:
+
+- [`JoinHandle`](../apidocs/#zio.JoinHandle) - fires when the task completes
+- [`Timeout`](../apidocs/#zio.Timeout) - fires when the duration elapses
+- [`Signal`](../apidocs/#zio.Signal) - fires when the signal is received
+- [`Channel`](../apidocs/#zio.Channel) - fires when data is available to receive
+- And more
+
+`select()` returns a union indicating which event fired, so you can handle each case appropriately.
+
+This is more efficient than spawning separate tasks and using channels. When you need to wait on multiple events in a single task, `select()` is the right tool.

--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -15,9 +15,12 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
     var write_buffer: [4096]u8 = undefined;
     var writer = stream.writer(rt, &write_buffer);
 
+    // --8<-- [start:init]
     // Initialize HTTP server for this connection
     var server = std.http.Server.init(&reader.interface, &writer.interface);
+    // --8<-- [end:init]
 
+    // --8<-- [start:loop]
     while (true) {
         // Receive HTTP request headers
         var request = server.receiveHead() catch |err| switch (err) {
@@ -51,6 +54,7 @@ fn handleClient(rt: *zio.Runtime, stream: zio.net.Stream) !void {
             break;
         }
     }
+    // --8<-- [end:loop]
 
     std.log.info("HTTP client disconnected", .{});
 }

--- a/examples/ntp_client.zig
+++ b/examples/ntp_client.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const zio = @import("zio");
+
+// --8<-- [start:lookup]
+fn lookupHost(rt: *zio.Runtime, hostname: []const u8, port: u16) !zio.net.Address {
+    const host = try zio.net.HostName.init(hostname);
+    var iter = try host.lookup(rt, .{ .port = port });
+    defer iter.deinit();
+
+    while (iter.next()) |result| {
+        switch (result) {
+            .address => |ip_addr| return .{ .ip = ip_addr },
+            else => continue,
+        }
+    }
+
+    return error.NoAddressFound;
+}
+// --8<-- [end:lookup]
+
+const NtpPacket = extern struct {
+    flags: packed struct(u8) {
+        mode: u3 = 3, // Client mode
+        version: u3 = 3, // NTP version 3
+        leap: u2 = 0, // No leap second warning
+    } = .{},
+    stratum: u8 = 0,
+    poll: u8 = 0,
+    precision: u8 = 0,
+    root_delay: u32 = 0,
+    root_dispersion: u32 = 0,
+    reference_id: u32 = 0,
+    reference_timestamp: u64 = 0,
+    origin_timestamp: u64 = 0,
+    receive_timestamp: u64 = 0,
+    transmit_timestamp: u64 = 0,
+};
+
+fn queryNtpServer(rt: *zio.Runtime, server: []const u8, port: u16, timeout: zio.Timeout) !void {
+    const addr = try lookupHost(rt, server, port);
+    std.log.info("Querying NTP server {s}:{d} ({f})", .{ server, port, addr });
+
+    // Create UDP socket (bind to any local port)
+    const local_addr = try zio.net.IpAddress.parseIp4("0.0.0.0", 0);
+    const socket = try local_addr.bind(rt, .{});
+    defer socket.close(rt);
+
+    // Prepare and send NTP request
+    const request: NtpPacket = .{};
+
+    var buffer: [@sizeOf(NtpPacket)]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&buffer);
+    try writer.writeStruct(request, .big);
+
+    const sent = try socket.sendTo(rt, addr, &buffer, timeout);
+    if (sent != @sizeOf(NtpPacket)) {
+        return error.IncompleteSend;
+    }
+
+    // Receive response
+    const result = socket.receiveFrom(rt, &buffer, timeout) catch |err| {
+        std.log.warn("Failed to receive NTP response: {}", .{err});
+        return err;
+    };
+
+    if (result.len < @sizeOf(NtpPacket)) {
+        std.log.warn("Received incomplete NTP packet: {} bytes", .{result.len});
+        return error.IncompletePacket;
+    }
+
+    var reader = std.Io.Reader.fixed(buffer[0..result.len]);
+    const response = try reader.takeStruct(NtpPacket, .big);
+
+    // Parse response (transmit_timestamp is already in native byte order)
+    const ntp_time = response.transmit_timestamp;
+
+    if (ntp_time == 0) {
+        std.log.warn("Invalid NTP response (zero timestamp)", .{});
+        return error.InvalidResponse;
+    }
+
+    // NTP timestamp: upper 32 bits = seconds, lower 32 bits = fractional seconds
+    const seconds: u32 = @truncate(ntp_time >> 32);
+    const milliseconds: u32 = @truncate((ntp_time & 0xFFFFFFFF) * 1000 >> 32);
+
+    // Format time using stdlib helpers (convert NTP epoch to Unix epoch)
+    const epoch_secs: std.time.epoch.EpochSeconds = .{ .secs = @intCast(@as(i64, seconds) + std.time.epoch.ntp) };
+    const day_seconds = epoch_secs.getDaySeconds();
+    const year_day = epoch_secs.getEpochDay().calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+
+    std.log.info("Current time: {d:0>4}-{d:0>2}-{d:0>2} {d:0>2}:{d:0>2}:{d:0>2}.{d:0>3} UTC", .{
+        year_day.year,
+        month_day.month.numeric(),
+        month_day.day_index + 1,
+        day_seconds.getHoursIntoDay(),
+        day_seconds.getMinutesIntoHour(),
+        day_seconds.getSecondsIntoMinute(),
+        milliseconds,
+    });
+}
+
+pub fn main() !void {
+    const gpa = std.heap.smp_allocator;
+
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+
+    const server = if (args.len > 1) args[1] else "pool.ntp.org";
+    const port: u16 = 123;
+
+    var rt = try zio.Runtime.init(gpa, .{});
+    defer rt.deinit();
+
+    // Setup SIGINT handler
+    var signal = try zio.Signal.init(.interrupt);
+    defer signal.deinit();
+
+    const interval: zio.Timeout = .{ .duration = .fromSeconds(30) };
+    const request_timeout: zio.Timeout = .{ .duration = .fromSeconds(5) };
+
+    std.log.info("NTP client starting. Press Ctrl+C to stop.", .{});
+    std.log.info("Server: {s}:{d}", .{ server, port });
+    std.log.info("Update interval: {f}", .{interval});
+    std.log.info("Request timeout: {f}", .{request_timeout});
+
+    while (true) {
+        // Query NTP server
+        queryNtpServer(rt, server, port, request_timeout) catch |err| {
+            std.log.err("NTP query failed: {}", .{err});
+        };
+
+        // --8<-- [start:select]
+        // Wait for next query or shutdown signal
+        const result = try zio.select(rt, .{
+            .interval = &interval,
+            .shutdown = &signal,
+        });
+
+        switch (result) {
+            .interval => continue, // Query again after interval
+            .shutdown => break, // Exit on Ctrl+C
+        }
+        // --8<-- [end:select]
+    }
+
+    std.log.info("NTP client stopped.", .{});
+}

--- a/examples/udp_echo_server.zig
+++ b/examples/udp_echo_server.zig
@@ -22,12 +22,13 @@ pub fn main() !void {
     std.log.info("UDP echo server listening on {f}", .{socket.address});
     std.log.info("Press Ctrl+C to stop the server", .{});
 
+    const timeout: zio.Timeout = .none;
     var buffer: [1024]u8 = undefined;
 
     while (true) {
-        const result = try socket.receiveFrom(rt, &buffer);
+        const result = try socket.receiveFrom(rt, &buffer, timeout);
         std.log.info("Received {d} bytes from {f}", .{ result.len, result.from });
-        const sent = try socket.sendTo(rt, result.from, buffer[0..result.len]);
+        const sent = try socket.sendTo(rt, result.from, buffer[0..result.len], timeout);
         std.debug.assert(sent == result.len);
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,8 +35,9 @@ nav:
   - Overview: index.md
   - Tutorial:
     - Getting Started: getting-started.md
-    - Simple TCP Server: tcp-server.md
-    - Simple HTTP Server: http-server.md
+    - TCP Server: tcp-server.md
+    - HTTP Server: http-server.md
+    - NTP Client: ntp-client.md
     - Parallel Grep: parallel-grep.md
   - Reference:
     - API Documentation: apidocs/

--- a/src/time.zig
+++ b/src/time.zig
@@ -422,6 +422,18 @@ pub const Timeout = union(enum) {
         };
     }
 
+    /// Formats the timeout for display.
+    pub fn format(self: Timeout, w: *std.Io.Writer) std.Io.Writer.Error!void {
+        switch (self) {
+            .none => try w.writeAll("none"),
+            .duration => |d| try d.format(w),
+            .deadline => |ts| {
+                try w.writeAll("deadline:");
+                try ts.format(w);
+            },
+        }
+    }
+
     // Future protocol implementation for use with select()
 
     pub const Result = void;


### PR DESCRIPTION
This PR adds a new NTP client tutorial and improves the existing tutorial documentation.

## Changes

### New NTP Client Tutorial
- Added NTP client example demonstrating UDP sockets, DNS lookup, timeouts, and select
- Added tutorial documentation explaining UDP networking and event-driven programming

### UDP Timeout Support
- Added timeout parameter to `Socket.sendTo()` and `Socket.receiveFrom()`
- Added `format()` method to `Timeout` type for display purposes

### Tutorial Improvements
- Improved tutorial intros with consistent but varied structure
- Converted all tutorial code snippets to use mkdocs-material snippet includes (--8<--)
- This ensures tutorials stay in sync with example code automatically
- Removed "Simple" prefix from TCP/HTTP server tutorial titles

### Code Organization
- Added snippet markers to example files (tcp_echo_server.zig, http_server.zig, ntp_client.zig)
- Renamed `sig` to `signal` for clarity in NTP client example

The new tutorial fits naturally between the HTTP Server and Parallel Grep tutorials, introducing UDP networking concepts before moving to advanced concurrency patterns.