### PR TITLE
Devirtualize wake() calls in Mutex and Condition

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -53,6 +53,15 @@ pub const Waiter = struct {
         };
     }
 
+    /// Recover Waiter pointer from embedded WaitNode.
+    /// Only valid for WaitNodes that are part of a Waiter.
+    pub inline fn fromWaitNode(wait_node: *WaitNode) *Waiter {
+        if (std.debug.runtime_safety) {
+            std.debug.assert(wait_node.vtable == &vtable);
+        }
+        return @alignCast(@fieldParentPtr("wait_node", wait_node));
+    }
+
     /// Signal this waiter and wake the task.
     /// Increments the signal count and wakes the task.
     pub fn signal(self: *Waiter) void {
@@ -66,8 +75,7 @@ pub const Waiter = struct {
     }
 
     fn wakeImpl(wait_node: *WaitNode) void {
-        const self: *Waiter = @fieldParentPtr("wait_node", wait_node);
-        self.signal();
+        fromWaitNode(wait_node).signal();
     }
 
     /// Wait for at least `expected` signals, handling spurious wakeups internally.

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -110,7 +110,7 @@ pub fn wait(self: *Condition, mutex: *Mutex) Cancelable!void {
             // Since we're being cancelled and won't process the signal,
             // wake another waiter to receive the signal instead.
             if (self.wait_queue.pop()) |next_waiter| {
-                next_waiter.wake();
+                Waiter.fromWaitNode(next_waiter).signal();
             }
         }
         // Must reacquire mutex before returning
@@ -176,7 +176,7 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
             // Since we're being cancelled and won't process the signal,
             // wake another waiter to receive the signal instead.
             if (self.wait_queue.pop()) |next_waiter| {
-                next_waiter.wake();
+                Waiter.fromWaitNode(next_waiter).signal();
             }
         }
 
@@ -215,7 +215,7 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
 /// ```
 pub fn signal(self: *Condition) void {
     if (self.wait_queue.pop()) |wait_node| {
-        wait_node.wake();
+        Waiter.fromWaitNode(wait_node).signal();
     }
 }
 
@@ -236,7 +236,7 @@ pub fn signal(self: *Condition) void {
 /// ```
 pub fn broadcast(self: *Condition) void {
     while (self.wait_queue.pop()) |wait_node| {
-        wait_node.wake();
+        Waiter.fromWaitNode(wait_node).signal();
     }
 }
 

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -147,7 +147,7 @@ pub fn unlock(self: *Mutex) void {
     // Pop one waiter or transition from locked_once to unlocked
     // Handles cancellation race by retrying internally
     if (self.queue.popOrTransition(locked_once, unlocked)) |wait_node| {
-        wait_node.wake();
+        Waiter.fromWaitNode(wait_node).signal();
     }
 }
 


### PR DESCRIPTION
## Summary

Replace indirect vtable dispatch with direct calls in Mutex and Condition for better performance. Since these primitives only use `Waiter` nodes (they don't implement `asyncWait` for select), we can safely devirtualize the wake() calls.

## Changes

- Add `Waiter.fromWaitNode()` helper with runtime safety vtable check
- Update `Waiter.wakeImpl()` to use `fromWaitNode()`
- Update `Mutex.unlock()` to use direct call instead of `wait_node.wake()`
- Update `Condition.signal()` and `broadcast()` to use direct calls

## Performance impact

Eliminates vtable indirection on the hot path:
- No indirect branch → better branch prediction
- Better inlining opportunities
- Simpler instruction stream
- Improved cache behavior

Since Mutex and Condition are core synchronization primitives used throughout the runtime, this optimization affects a significant fraction of all sync operations.

## Test plan

- [x] All Mutex tests pass
- [x] All Condition tests pass
- [x] Runtime safety check validates correct WaitNode type