### PR TITLE
Add os.ResetEvent and replace std.Thread.ResetEvent usage

### DIFF
--- a/src/ev/test/cancel.zig
+++ b/src/ev/test/cancel.zig
@@ -356,8 +356,8 @@ test "cancel: work after completion is no-op" {
 
 test "cancel: work before run" {
     // Use events to ensure the work is queued but not running when we cancel.
-    var started_event: std.Thread.ResetEvent = .{};
-    var blocker_event: std.Thread.ResetEvent = .{};
+    var started_event: os.ResetEvent = .init();
+    var blocker_event: os.ResetEvent = .init();
 
     var thread_pool: ev.ThreadPool = undefined;
     try thread_pool.init(std.testing.allocator, .{
@@ -372,8 +372,8 @@ test "cancel: work before run" {
     defer loop.deinit();
 
     const BlockingFn = struct {
-        started: *std.Thread.ResetEvent,
-        blocker: *std.Thread.ResetEvent,
+        started: *os.ResetEvent,
+        blocker: *os.ResetEvent,
 
         pub fn main(work: *Work) void {
             const self: *@This() = @ptrCast(@alignCast(work.userdata));
@@ -420,8 +420,8 @@ test "cancel: work before run" {
 
 test "cancel: work double cancel is idempotent" {
     // Use events to ensure the work is queued but not running when we cancel.
-    var started_event: std.Thread.ResetEvent = .{};
-    var blocker_event: std.Thread.ResetEvent = .{};
+    var started_event: os.ResetEvent = .init();
+    var blocker_event: os.ResetEvent = .init();
 
     var thread_pool: ev.ThreadPool = undefined;
     try thread_pool.init(std.testing.allocator, .{
@@ -436,8 +436,8 @@ test "cancel: work double cancel is idempotent" {
     defer loop.deinit();
 
     const BlockingFn = struct {
-        started: *std.Thread.ResetEvent,
-        blocker: *std.Thread.ResetEvent,
+        started: *os.ResetEvent,
+        blocker: *os.ResetEvent,
 
         pub fn main(work: *Work) void {
             const self: *@This() = @ptrCast(@alignCast(work.userdata));
@@ -484,8 +484,8 @@ test "cancel: work double cancel is idempotent" {
 test "cancel: queued work via thread pool cancel" {
     // Test that ThreadPool.cancel() correctly calls completion_fn when
     // it removes work from the queue (work never started running).
-    var started_event: std.Thread.ResetEvent = .{};
-    var blocker_event: std.Thread.ResetEvent = .{};
+    var started_event: os.ResetEvent = .init();
+    var blocker_event: os.ResetEvent = .init();
 
     var thread_pool: ThreadPool = undefined;
     try thread_pool.init(std.testing.allocator, .{
@@ -496,8 +496,8 @@ test "cancel: queued work via thread pool cancel" {
     defer blocker_event.set(); // Ensure thread unblocks before deinit
 
     const BlockingFn = struct {
-        started: *std.Thread.ResetEvent,
-        blocker: *std.Thread.ResetEvent,
+        started: *os.ResetEvent,
+        blocker: *os.ResetEvent,
 
         pub fn work(w: *Work) void {
             var self: *@This() = @ptrCast(@alignCast(w.userdata));

--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -11,6 +11,7 @@ pub const thread_wait = @import("thread_wait.zig");
 
 pub const Mutex = thread_wait.Mutex;
 pub const Condition = thread_wait.Condition;
+pub const ResetEvent = thread_wait.ResetEvent;
 
 pub const iovec = fs.iovec;
 pub const iovec_const = fs.iovec_const;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -801,7 +801,7 @@ pub const Runtime = struct {
 
     const Worker = struct {
         thread: std.Thread = undefined,
-        ready: std.Thread.ResetEvent = .{},
+        ready: os.ResetEvent = .init(),
         err: ?anyerror = null,
         executor: Executor = undefined,
     };


### PR DESCRIPTION
## Summary

- Implement `os.ResetEvent` in `src/os/thread_wait.zig` using existing `Mutex` and `Condition` primitives
- Export `ResetEvent` from `src/os/root.zig`
- Replace `std.Thread.ResetEvent` with `os.ResetEvent` in `src/runtime.zig` and `src/ev/test/cancel.zig`

This continues the work of replacing `std.Thread` synchronization primitives with `os` module equivalents. The implementation is simple and straightforward, using a mutex-protected boolean flag with a condition variable for signaling.

## Test plan

- All unit tests pass
- Existing tests that use ResetEvent continue to work correctly