### PR TITLE
Remove unused rt parameter from unregisterGroupTask

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1079,7 +1079,7 @@ pub const Runtime = struct {
 
         // For group tasks, decrement counter and release group's reference
         if (awaitable.group_node.group) |group| {
-            unregisterGroupTask(self, group, awaitable);
+            unregisterGroupTask(group, awaitable);
         }
 
         // Decref for task completion

--- a/src/runtime/blocking_task.zig
+++ b/src/runtime/blocking_task.zig
@@ -162,7 +162,7 @@ pub fn spawnBlockingTask(
     errdefer task.destroy();
 
     if (group) |g| try registerGroupTask(g, &task.awaitable);
-    errdefer if (group) |g| unregisterGroupTask(rt, g, &task.awaitable);
+    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
 
     // +1 ref for the caller (JoinHandle) before scheduling, to prevent
     // race where task completes before caller can take ownership

--- a/src/runtime/group.zig
+++ b/src/runtime/group.zig
@@ -244,8 +244,7 @@ pub fn registerGroupTask(group: *Group, awaitable: *Awaitable) error{Closed}!voi
 
 /// Unregister an awaitable from a group.
 /// Removes from task list, releases ref, decrements counter, and wakes waiters if last task.
-pub fn unregisterGroupTask(rt: *Runtime, group: *Group, awaitable: *Awaitable) void {
-    _ = rt;
+pub fn unregisterGroupTask(group: *Group, awaitable: *Awaitable) void {
     // Only release if we successfully removed it (cancel might have popped it first)
     if (group.getTasks().remove(&awaitable.group_node)) {
         awaitable.release();

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -485,7 +485,7 @@ pub fn spawnTask(
     errdefer task.destroy();
 
     if (group) |g| try registerGroupTask(g, &task.awaitable);
-    errdefer if (group) |g| unregisterGroupTask(rt, g, &task.awaitable);
+    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
 
     // +1 ref for the caller (JoinHandle) before scheduling, to prevent
     // race where task completes before caller can take ownership


### PR DESCRIPTION
## Summary
- Remove unused `rt` parameter from `unregisterGroupTask` function
- Update all call sites in `runtime.zig`, `blocking_task.zig`, and `task.zig`

## Test plan
- All 340 tests pass
- Full check including examples and benchmarks succeeds