### PR TITLE
Fix NetBSD test failures

### DIFF
--- a/src/net.zig
+++ b/src/net.zig
@@ -2179,14 +2179,14 @@ test "Socket: buffer size get/set" {
     defer socket.close();
 
     // Test send buffer size
-    const desired_send_size: usize = 128 * 1024; // 128 KB
+    const desired_send_size: usize = 32 * 1024; // 32 KB
     try socket.setSendBufferSize(desired_send_size);
     const actual_send_size = try socket.getSendBufferSize();
     // The kernel may grant a different size, but it should be > 0
     try std.testing.expect(actual_send_size > 0);
 
     // Test receive buffer size
-    const desired_recv_size: usize = 256 * 1024; // 256 KB
+    const desired_recv_size: usize = 64 * 1024; // 64 KB
     try socket.setReceiveBufferSize(desired_recv_size);
     const actual_recv_size = try socket.getReceiveBufferSize();
     // The kernel may grant a different size, but it should be > 0
@@ -2194,7 +2194,7 @@ test "Socket: buffer size get/set" {
 
     // Verify that setting different sizes results in different values
     // (though kernel may adjust them)
-    const new_send_size: usize = 64 * 1024; // 64 KB
+    const new_send_size: usize = 16 * 1024; // 16 KB
     try socket.setSendBufferSize(new_send_size);
     const updated_send_size = try socket.getSendBufferSize();
     try std.testing.expect(updated_send_size > 0);


### PR DESCRIPTION
## Summary

Fixes three test failures on NetBSD discovered when cross-compiling and running tests via QEMU.

## Changes

### 1. Pipe error handling (fs.zig)
NetBSD returns `error.NotOpenForWriting` instead of `error.BrokenPipe` when writing to closed pipes. Added platform-specific error checking in two pipe tests:
- `test "Pipe: poll on closed read end"`
- `test "Pipe: half-close read end"`

### 2. Socket buffer size test (net.zig)
Reduced requested buffer sizes from 128KB/256KB to 32KB/64KB for all platforms. The larger sizes were hitting resource limits on NetBSD. The more conservative sizes work correctly across all platforms.

### 3. Event synchronization tests (os/thread_wait.zig)

**Event creation fix:**
NetBSD's `EventNetBSD` implementation captures `lwp_id` at init time and requires the Event to be created on the same thread that calls `wait()`. Modified `test "Event - timedWait success (signaled before timeout)"` to create the Event on the waiting thread using an atomic pointer.

**Timeout test robustness:**
Added retry loop in `test "Event - timeout"` to handle spurious wakeups. On NetBSD, multiple Events on the same thread can interfere via the per-thread unpark flag, causing stale `EALREADY` returns from `___lwp_park60`. The loop correctly handles these spurious wakeups while still verifying timeout behavior.

## Testing

- ✅ All 342 tests pass on Linux (native)
- ✅ All 342 tests pass on NetBSD 10.1 (x86_64, via QEMU)

## Compatibility

All changes maintain backward compatibility with existing platforms. The pipe error handling is platform-specific, socket buffer sizes are more conservative but work everywhere, and Event test changes handle spurious wakeups correctly on all platforms.