### PR TITLE
Change CompletionQueue to not clobber userdata

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -66,9 +66,9 @@ pub const CompletionQueue = struct {
     }
 
     /// Submit a completion to the queue and event loop.
-    /// Note: this claims `c.userdata` and `c.callback` for internal use.
+    /// Note: this claims `c.group.owner` and `c.callback` for internal use.
     pub fn submit(self: *CompletionQueue, c: *Completion) void {
-        c.userdata = self;
+        c.group.owner = self;
         c.callback = completionCallback;
 
         self.mutex.lock();
@@ -231,7 +231,7 @@ pub const CompletionQueue = struct {
     }
 
     fn completionCallback(_: *ev.Loop, c: *Completion) void {
-        const self: *CompletionQueue = @ptrCast(@alignCast(c.userdata.?));
+        const self: *CompletionQueue = @ptrCast(@alignCast(c.group.owner.?));
 
         self.mutex.lock();
         const removed = self.pending.remove(&c.group);

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -256,7 +256,7 @@ pub const Completion = struct {
     group: struct {
         next: ?*@This() = null,
         prev: ?*@This() = null,
-        owner: ?*Group = null,
+        owner: ?*anyopaque = null,
         userdata: usize = 0,
         in_list: if (std.debug.runtime_safety) bool else void =
             if (std.debug.runtime_safety) false else {},

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -180,7 +180,8 @@ pub const LoopState = struct {
         self.active -= 1;
 
         // Notify group owner if this completion belongs to one
-        if (completion.group.owner) |group| {
+        if (completion.group.owner) |owner| {
+            const group: *Group = @ptrCast(@alignCast(owner));
             const prev = group.remaining.fetchSub(1, .acq_rel);
 
             // Race mode: first to clear the flag wins, cancels siblings


### PR DESCRIPTION
Instead of using c.userdata to store the CompletionQueue pointer, store it in c.group.owner. This required changing group.owner from ?*Group to ?*anyopaque to allow both Group and CompletionQueue pointers.

Changes:
- Changed group.owner type to ?*anyopaque in Completion struct
- Updated loop.zig to cast the opaque pointer back to *Group
- Updated CompletionQueue to use group.owner instead of userdata
- Updated documentation to reflect the change

Fixes #292
