### PR TITLE
Run sync tests with multiple executors

### DIFF
--- a/src/sync/Barrier.zig
+++ b/src/sync/Barrier.zig
@@ -128,7 +128,7 @@ pub fn wait(self: *Barrier) (Cancelable || error{BrokenBarrier})!bool {
 }
 
 test "Barrier: basic synchronization" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -138,13 +138,13 @@ test "Barrier: basic synchronization" {
     const TestFn = struct {
         fn worker(b: *Barrier, cnt: *u32, result: *u32) !void {
             // Increment counter before barrier
-            cnt.* += 1;
+            _ = @atomicRmw(u32, cnt, .Add, 1, .monotonic);
 
             // Wait at barrier - all should see counter == 3 after this
             _ = try b.wait();
 
             // All coroutines should see the same final counter value
-            result.* = cnt.*;
+            result.* = @atomicLoad(u32, cnt, .monotonic);
         }
     };
 
@@ -165,7 +165,7 @@ test "Barrier: basic synchronization" {
 }
 
 test "Barrier: leader detection" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -175,7 +175,7 @@ test "Barrier: leader detection" {
         fn worker(b: *Barrier, leader_cnt: *u32) !void {
             const is_leader = try b.wait();
             if (is_leader) {
-                leader_cnt.* += 1;
+                _ = @atomicRmw(u32, leader_cnt, .Add, 1, .monotonic);
             }
         }
     };
@@ -195,7 +195,7 @@ test "Barrier: leader detection" {
 }
 
 test "Barrier: reusable for multiple cycles" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var barrier = Barrier.init(2);
@@ -206,15 +206,15 @@ test "Barrier: reusable for multiple cycles" {
     const TestFn = struct {
         fn worker(b: *Barrier, p1: *u32, p2: *u32, p3: *u32) !void {
             // Phase 1
-            p1.* += 1;
+            _ = @atomicRmw(u32, p1, .Add, 1, .monotonic);
             _ = try b.wait();
 
             // Phase 2
-            p2.* += 1;
+            _ = @atomicRmw(u32, p2, .Add, 1, .monotonic);
             _ = try b.wait();
 
             // Phase 3
-            p3.* += 1;
+            _ = @atomicRmw(u32, p3, .Add, 1, .monotonic);
             _ = try b.wait();
         }
     };
@@ -254,7 +254,7 @@ test "Barrier: single coroutine barrier" {
 }
 
 test "Barrier: ordering test" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var barrier = Barrier.init(3);
@@ -264,15 +264,14 @@ test "Barrier: ordering test" {
 
     const TestFn = struct {
         fn worker(b: *Barrier, order: *u32, my_arrival: *u32, final: *u32) !void {
-            // Record arrival order
-            my_arrival.* = order.*;
-            order.* += 1;
+            // Record arrival order atomically
+            my_arrival.* = @atomicRmw(u32, order, .Add, 1, .monotonic);
 
             // Wait at barrier
             _ = try b.wait();
 
             // After barrier, store final order value
-            final.* = order.*;
+            @atomicStore(u32, final, @atomicLoad(u32, order, .monotonic), .monotonic);
         }
     };
 
@@ -299,7 +298,7 @@ test "Barrier: ordering test" {
 }
 
 test "Barrier: many coroutines" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     var barrier = Barrier.init(5);
@@ -308,9 +307,9 @@ test "Barrier: many coroutines" {
 
     const TestFn = struct {
         fn worker(b: *Barrier, cnt: *u32, result: *u32) !void {
-            cnt.* += 1;
+            _ = @atomicRmw(u32, cnt, .Add, 1, .monotonic);
             _ = try b.wait();
-            result.* = cnt.*;
+            result.* = @atomicLoad(u32, cnt, .monotonic);
         }
     };
 

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -240,7 +240,7 @@ pub fn broadcast(self: *Condition) void {
 }
 
 test "Condition basic wait/signal" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var mutex = Mutex.init;
@@ -309,7 +309,7 @@ test "Condition timedWait timeout" {
 }
 
 test "Condition broadcast" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     var mutex = Mutex.init;

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -249,7 +249,7 @@ test "Futex: basic wait/wake" {
         }
     };
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
     var task = try rt.spawn(Main.run, .{rt});
@@ -319,7 +319,7 @@ test "Futex: multiple waiters same address" {
         }
     };
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
     var task = try rt.spawn(Main.run, .{rt});
@@ -365,7 +365,7 @@ test "Futex: multiple waiters different addresses" {
         }
     };
 
-    const rt = try Runtime.init(std.testing.allocator, .{});
+    const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
     var woken: u32 = 0;

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -150,7 +150,7 @@ pub fn unlock(self: *Mutex) void {
 }
 
 test "Mutex basic lock/unlock" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var shared_counter: u32 = 0;

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -163,7 +163,7 @@ pub fn post(self: *Semaphore) void {
 }
 
 test "Semaphore: basic wait/post" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var sem = Semaphore{ .permits = 1 };
@@ -216,7 +216,7 @@ test "Semaphore: timedWait timeout" {
 }
 
 test "Semaphore: timedWait success" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var sem = Semaphore{};
@@ -248,7 +248,7 @@ test "Semaphore: timedWait success" {
 }
 
 test "Semaphore: multiple permits" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var sem = Semaphore{ .permits = 3 };

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -479,7 +479,7 @@ pub fn AsyncReceive(comptime T: type) type {
 }
 
 test "BroadcastChannel: basic send and receive" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -523,7 +523,7 @@ test "BroadcastChannel: basic send and receive" {
 }
 
 test "BroadcastChannel: multiple consumers receive same messages" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -749,7 +749,7 @@ test "BroadcastChannel: close prevents new sends" {
 }
 
 test "BroadcastChannel: consumers can drain after close" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -798,7 +798,7 @@ test "BroadcastChannel: consumers can drain after close" {
 }
 
 test "BroadcastChannel: waiting consumers wake on close" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -870,7 +870,7 @@ test "BroadcastChannel: tryReceive returns Closed when channel closed and empty"
 }
 
 test "BroadcastChannel: asyncReceive with select - basic" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -1005,7 +1005,7 @@ test "BroadcastChannel: asyncReceive with select - lagged consumer" {
 }
 
 test "BroadcastChannel: select with multiple broadcast channels" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -621,7 +621,7 @@ pub fn AsyncSend(comptime T: type) type {
 }
 
 test "Channel: basic send and receive" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -696,7 +696,7 @@ test "Channel: trySend and tryReceive" {
 }
 
 test "Channel: blocking behavior when empty" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -728,7 +728,7 @@ test "Channel: blocking behavior when empty" {
 }
 
 test "Channel: blocking behavior when full" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [2]u32 = undefined;
@@ -764,7 +764,7 @@ test "Channel: blocking behavior when full" {
 }
 
 test "Channel: multiple producers and consumers" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     var buffer: [10]u32 = undefined;
@@ -780,7 +780,7 @@ test "Channel: multiple producers and consumers" {
         fn consumer(ch: *Channel(u32), sum: *u32) !void {
             for (0..5) |_| {
                 const val = try ch.receive();
-                sum.* += val;
+                _ = @atomicRmw(u32, sum, .Add, val, .monotonic);
             }
         }
     };
@@ -803,7 +803,7 @@ test "Channel: multiple producers and consumers" {
 }
 
 test "Channel: close graceful" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -841,7 +841,7 @@ test "Channel: close graceful" {
 }
 
 test "Channel: close immediate" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -938,7 +938,7 @@ test "Channel: ring buffer wrapping" {
 }
 
 test "Channel: asyncReceive with select - basic" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [5]u32 = undefined;
@@ -972,7 +972,7 @@ test "Channel: asyncReceive with select - basic" {
 }
 
 test "Channel: asyncReceive with select - value types" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     // Unbuffered channel - sender blocks until receiver ready
@@ -1056,7 +1056,7 @@ test "Channel: asyncReceive with select - closed channel" {
 }
 
 test "Channel: asyncSend with select - basic" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer: [2]u32 = undefined;
@@ -1146,7 +1146,7 @@ test "Channel: asyncSend with select - closed channel" {
 }
 
 test "Channel: select on both send and receive" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;
@@ -1203,7 +1203,7 @@ test "Channel: select on both send and receive" {
 }
 
 test "Channel: select with multiple receivers" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var buffer1: [5]u32 = undefined;
@@ -1252,7 +1252,7 @@ test "Channel: select with multiple receivers" {
 }
 
 test "Channel: unbuffered - basic synchronous transfer" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     // Unbuffered channel - sender and receiver must rendezvous
@@ -1388,7 +1388,7 @@ test "Channel: unbuffered - receiver blocks until sender ready" {
 }
 
 test "Channel: unbuffered - multiple senders and receivers" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     var channel = Channel(u32).init(&.{});
@@ -1400,7 +1400,7 @@ test "Channel: unbuffered - multiple senders and receivers" {
 
         fn receiver(ch: *Channel(u32), sum: *u32) !void {
             const val = try ch.receive();
-            sum.* += val;
+            _ = @atomicRmw(u32, sum, .Add, val, .monotonic);
         }
     };
 
@@ -1425,7 +1425,7 @@ test "Channel: unbuffered - multiple senders and receivers" {
 }
 
 test "Channel: unbuffered - close wakes blocked sender" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var channel = Channel(u32).init(&.{});
@@ -1460,7 +1460,7 @@ test "Channel: unbuffered - close wakes blocked sender" {
 }
 
 test "Channel: unbuffered - close wakes blocked receiver" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var channel = Channel(u32).init(&.{});
@@ -1495,7 +1495,7 @@ test "Channel: unbuffered - close wakes blocked receiver" {
 }
 
 test "Channel: unbuffered - select with direct transfer" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var channel = Channel(u32).init(&.{});

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -163,7 +163,7 @@ test "Future: basic set and get" {
 }
 
 test "Future: await from coroutine" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     const TestContext = struct {
@@ -201,7 +201,7 @@ test "Future: await from coroutine" {
 }
 
 test "Future: multiple waiters" {
-    const runtime = try Runtime.init(std.testing.allocator, .{});
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
     const TestContext = struct {


### PR DESCRIPTION
## Summary

- Configure all sync tests that spawn multiple tasks to use 2-4 executors, enabling true parallel execution to catch synchronization bugs hidden by single-threaded cooperative scheduling
- Use atomic operations for shared counters that are now concurrently modified by multiple executor threads
- Replace yield-based timing in Notify multi-waiter tests with an atomic ready counter to avoid lost signals

## Test plan

- [x] All 352 tests pass with `./check.sh`
- [ ] Run repeatedly to check for flaky failures under contention