### PR TITLE
Fix pipe read/write using wrong offset in io_uring backend

### DIFF
--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -764,7 +764,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                 state.markCompletedFromBackend(c);
                 return;
             };
-            sqe.prep_readv(data.handle, data.buffer.iovecs, 0);
+            sqe.prep_readv(data.handle, data.buffer.iovecs, @bitCast(@as(i64, -1)));
             sqe.user_data = @intFromPtr(c);
         },
         .pipe_write => {
@@ -775,7 +775,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                 state.markCompletedFromBackend(c);
                 return;
             };
-            sqe.prep_writev(data.handle, data.buffer.iovecs, 0);
+            sqe.prep_writev(data.handle, data.buffer.iovecs, @bitCast(@as(i64, -1)));
             sqe.user_data = @intFromPtr(c);
         },
         .pipe_close => {


### PR DESCRIPTION
## Summary
- PipeRead and PipeWrite in the io_uring backend used offset `0` for `prep_readv`/`prep_writev`, which translates to `preadv2`/`pwritev2` at file position 0
- This caused repeated writes to overwrite from the beginning when a pipe fd was actually a regular file (e.g. stdout redirected to a file with `> output.txt`)
- Changed to offset `-1` (`@bitCast(@as(i64, -1))`) which tells io_uring to use the current file position, matching regular `readv`/`writev` behavior