### PR TITLE
Add blockInPlace for zero-allocation blocking operations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Added `blockInPlace` for running blocking functions on the thread pool without allocations.
+
 ## [0.8.0] - 2026-02-09
 
 ### Added

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const MemoryPoolAligned = @import("../utils/memory_pool.zig").MemoryPoolAligned;
+const ev = @import("../ev/root.zig");
 
 const Runtime = @import("../runtime.zig").Runtime;
 const Executor = @import("../runtime.zig").Executor;
@@ -216,6 +217,10 @@ pub const AnyTask = struct {
 
     pub inline fn getRuntime(self: *AnyTask) *Runtime {
         return self.getExecutor().runtime;
+    }
+
+    pub inline fn getThreadPool(self: *AnyTask) *ev.ThreadPool {
+        return &self.getRuntime().thread_pool;
     }
 
     pub const YieldMode = enum { park, reschedule };

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -26,6 +26,7 @@ pub const CompletionQueue = @import("completion_queue.zig").CompletionQueue;
 const common = @import("common.zig");
 pub const Cancelable = common.Cancelable;
 pub const Timeoutable = common.Timeoutable;
+pub const blockInPlace = common.blockInPlace;
 
 pub const time = @import("time.zig"); // TODO: make non-pub
 pub const Duration = time.Duration;


### PR DESCRIPTION
## Summary

- Add `blockInPlace` function that runs blocking functions on the thread pool without allocations (all state kept on stack)
- Add `task.getThreadPool()` helper method
- Update `HostName.lookup` to use `blockInPlace` instead of `spawnBlocking`

## Test plan

- [x] Existing tests pass
- [x] New `blockInPlace: basic computation` test added