### PR TITLE
Add thread.yield() for cross-platform thread yielding

### DIFF
--- a/src/os/c.zig
+++ b/src/os/c.zig
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+/// Common libc declarations shared across POSIX platforms.
+
+// Thread yield
+pub extern "c" fn sched_yield() c_int;

--- a/src/os/darwin.zig
+++ b/src/os/darwin.zig
@@ -30,3 +30,5 @@ pub const OS_UNFAIR_LOCK_INIT: os_unfair_lock_s = .{ ._os_unfair_lock_opaque = 0
 pub extern "c" fn os_unfair_lock_lock(lock: os_unfair_lock_t) void;
 pub extern "c" fn os_unfair_lock_unlock(lock: os_unfair_lock_t) void;
 pub extern "c" fn os_unfair_lock_trylock(lock: os_unfair_lock_t) bool;
+
+pub const sched_yield = @import("c.zig").sched_yield;

--- a/src/os/dragonfly.zig
+++ b/src/os/dragonfly.zig
@@ -9,3 +9,5 @@
 // Reference: https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/umtx.h
 pub extern "c" fn umtx_sleep(addr: *const u32, value: c_int, timeout: c_int) c_int;
 pub extern "c" fn umtx_wakeup(addr: *const u32, count: c_int) c_int;
+
+pub const sched_yield = @import("c.zig").sched_yield;

--- a/src/os/freebsd.zig
+++ b/src/os/freebsd.zig
@@ -42,3 +42,5 @@ pub const ucond = extern struct {
 };
 
 pub extern "c" fn _umtx_op(obj: *const anyopaque, op: c_int, val: c_ulong, uaddr: ?*anyopaque, uaddr2: ?*anyopaque) c_int;
+
+pub const sched_yield = @import("c.zig").sched_yield;

--- a/src/os/linux.zig
+++ b/src/os/linux.zig
@@ -55,6 +55,8 @@ pub const io_uring_getevents_arg = extern struct {
 
 /// io_uring_enter2 syscall (kernel 5.11+)
 /// This version supports extended arguments including timeout
+pub const sched_yield = @import("c.zig").sched_yield;
+
 pub fn io_uring_enter2(
     fd: i32,
     to_submit: u32,

--- a/src/os/netbsd.zig
+++ b/src/os/netbsd.zig
@@ -27,3 +27,5 @@ pub const pthread_cond_wait = std.c.pthread_cond_wait;
 pub const pthread_cond_timedwait = std.c.pthread_cond_timedwait;
 pub const pthread_cond_signal = std.c.pthread_cond_signal;
 pub const pthread_cond_broadcast = std.c.pthread_cond_broadcast;
+
+pub const sched_yield = @import("c.zig").sched_yield;

--- a/src/os/openbsd.zig
+++ b/src/os/openbsd.zig
@@ -12,3 +12,5 @@ pub const FUTEX_WAKE: c_int = 2;
 pub const FUTEX_PRIVATE_FLAG: c_int = 128;
 
 pub extern "c" fn futex(uaddr: *const u32, op: c_int, val: c_int, timeout: ?*const std.posix.timespec, uaddr2: ?*u32) c_int;
+
+pub const sched_yield = @import("c.zig").sched_yield;

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -257,6 +257,8 @@ pub extern "kernel32" fn Sleep(
     dwMilliseconds: DWORD,
 ) callconv(.winapi) void;
 
+pub extern "kernel32" fn SwitchToThread() callconv(.winapi) BOOL;
+
 pub extern "kernel32" fn SleepEx(
     dwMilliseconds: DWORD,
     bAlertable: BOOL,

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -655,7 +655,7 @@ pub fn getCurrentTaskOrNull() ?*AnyTask {
 /// No-op if called from a thread without an executor (returns without error).
 pub fn yield() Cancelable!void {
     const task = getCurrentTaskOrNull() orelse {
-        std.Thread.yield() catch {};
+        os.thread.yield();
         return;
     };
     return task.yield(.reschedule, .allow_cancel);

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -46,6 +46,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Runtime = @import("../runtime.zig").Runtime;
+const os = @import("../os/root.zig");
 const yield = @import("../runtime.zig").yield;
 const Group = @import("../runtime/group.zig").Group;
 const Cancelable = @import("../common.zig").Cancelable;
@@ -433,7 +434,7 @@ test "ResetEvent: foreign thread signals async task" {
         fn threadSet(event: *ResetEvent, ready: *std.atomic.Value(bool)) void {
             // Wait for task to be ready
             while (!ready.load(.acquire)) {
-                std.Thread.yield() catch {};
+                os.thread.yield();
             }
             event.set();
         }

--- a/src/utils/queue.zig
+++ b/src/utils/queue.zig
@@ -18,6 +18,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const thread = @import("../os/thread.zig");
 
 /// Work-stealing queue for task scheduling.
 ///
@@ -419,7 +420,7 @@ test "WorkStealingQueue: concurrent push and steal" {
             var attempts: usize = 0;
             while (attempts < 20) : (attempts += 1) {
                 _ = victim.steal(dest);
-                std.Thread.yield() catch {};
+                thread.yield();
             }
         }
     }.stealItems, .{ &victim_queue, &stealer_queue });

--- a/src/utils/wait_queue.zig
+++ b/src/utils/wait_queue.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const thread = @import("../os/thread.zig");
 const SimpleStack = @import("simple_stack.zig").SimpleStack;
 
 /// Simple wait queue for use under external synchronization (e.g., mutex).
@@ -323,7 +324,7 @@ pub fn WaitQueue(comptime T: type) type {
 
                 spin_count +%= 1;
                 if (spin_count == 0) {
-                    std.Thread.yield() catch {};
+                    thread.yield();
                 }
                 std.atomic.spinLoopHint();
             }


### PR DESCRIPTION
## Summary

- Adds `os.thread.yield()` that uses direct syscalls/externs instead of `std.Thread.yield()`
- Linux/BSD/macOS: `sched_yield()` via shared `c.zig`
- Windows: `SwitchToThread()` via kernel32
- Replaces all `std.Thread.yield()` usages throughout the codebase

## Test plan

- [x] All 357 tests pass