### PR TITLE
Remove WaitNode vtable, turn Waiter into tagged union

### DIFF
--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -836,7 +836,7 @@ pub const MutexNotify = struct {
 
         fn init() Waiter {
             return .{
-                .wait_node = .{ .vtable = &.{} },
+                .wait_node = .{},
                 .notify = Notify.init(),
             };
         }
@@ -1011,7 +1011,7 @@ const ConditionNotify = struct {
 
         fn init() Waiter {
             return .{
-                .wait_node = .{ .vtable = &.{} },
+                .wait_node = .{},
                 .notify = Notify.init(),
             };
         }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -130,22 +130,22 @@ pub fn JoinHandle(comptime T: type) type {
             return self.result;
         }
 
-        /// Registers a wait node to be notified when the task completes.
+        /// Registers a waiter to be notified when the task completes.
         /// This is part of the Future protocol for select().
         /// Returns false if the task is already complete (no wait needed), true if added to queue.
-        pub fn asyncWait(self: Self, wait_node: *WaitNode) bool {
+        pub fn asyncWait(self: Self, waiter: *Waiter) bool {
             if (self.awaitable) |awaitable| {
-                return awaitable.asyncWait(wait_node);
+                return awaitable.asyncWait(waiter);
             }
             return false; // Already complete
         }
 
-        /// Cancels a pending wait operation by removing the wait node.
+        /// Cancels a pending wait operation by removing the waiter.
         /// This is part of the Future protocol for select().
         /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: Self, wait_node: *WaitNode) bool {
+        pub fn asyncCancelWait(self: Self, waiter: *Waiter) bool {
             if (self.awaitable) |awaitable| {
-                return awaitable.asyncCancelWait(wait_node);
+                return awaitable.asyncCancelWait(waiter);
             }
             return true; // No awaitable means already completed, no wake in-flight
         }
@@ -321,9 +321,7 @@ pub const Executor = struct {
             .state = std.atomic.Value(AnyTask.State).init(.ready),
             .awaitable = .{
                 .kind = .task,
-                .wait_node = .{
-                    .vtable = &AnyTask.wait_node_vtable,
-                },
+                .wait_node = .{},
             },
             .coro = .{
                 .context = std.mem.zeroes(Context),

--- a/src/runtime/WaitNode.zig
+++ b/src/runtime/WaitNode.zig
@@ -5,8 +5,6 @@ const std = @import("std");
 
 const WaitNode = @This();
 
-vtable: *const VTable,
-
 // For participation in wait queues
 prev: ?*WaitNode = null,
 next: ?*WaitNode = null,
@@ -14,18 +12,3 @@ in_list: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_sa
 
 // User data associated with this wait node
 userdata: usize = undefined,
-
-pub const VTable = struct {
-    // Called when this node should be woken
-    wake: *const fn (self: *WaitNode) void = defaultWake,
-};
-
-fn defaultWake(self: *WaitNode) void {
-    // Default wake implementation does nothing
-    _ = self;
-}
-
-/// Wake this wait node
-pub fn wake(self: *WaitNode) void {
-    self.vtable.wake(self);
-}

--- a/src/runtime/awaitable.zig
+++ b/src/runtime/awaitable.zig
@@ -6,6 +6,7 @@ const builtin = @import("builtin");
 
 const RefCounter = @import("../utils/ref_counter.zig").RefCounter;
 const WaitNode = @import("WaitNode.zig");
+const Waiter = @import("../common.zig").Waiter;
 const GroupNode = @import("group.zig").GroupNode;
 const WaitQueue = @import("../utils/wait_queue.zig").WaitQueue;
 const SimpleQueue = @import("../utils/wait_queue.zig").SimpleWaitQueue;
@@ -29,11 +30,11 @@ pub const Awaitable = struct {
 
     wait_node: WaitNode,
 
-    // WaitNodes waiting for the completion of this awaitable
+    // Waiters waiting for the completion of this awaitable
     // Uses WaitQueue flag to track completion:
     // - flag clear = not complete
     // - flag set = complete
-    waiting_list: WaitQueue(WaitNode) = .empty,
+    waiting_list: WaitQueue(Waiter) = .empty,
 
     // Group membership - group_node.group is null if standalone
     group_node: GroupNode = .{},
@@ -53,20 +54,20 @@ pub const Awaitable = struct {
     /// Registers a wait node to be notified when the awaitable completes.
     /// This is part of the Future protocol for select().
     /// Returns false if the awaitable is already complete (no wait needed), true if added to queue.
-    pub fn asyncWait(self: *Awaitable, wait_node: *WaitNode) bool {
+    pub fn asyncWait(self: *Awaitable, waiter: *Waiter) bool {
         // Fast path: check if already complete
         if (self.waiting_list.isFlagSet()) {
             return false;
         }
         // Try to push to queue - only succeeds if awaitable is not complete (flag not set)
-        return self.waiting_list.pushUnlessFlag(wait_node);
+        return self.waiting_list.pushUnlessFlag(waiter);
     }
 
     /// Cancels a pending wait operation by removing the wait node.
     /// This is part of the Future protocol for select().
     /// Returns true if removed, false if already removed by completion (wake in-flight).
-    pub fn asyncCancelWait(self: *Awaitable, wait_node: *WaitNode) bool {
-        return self.waiting_list.remove(wait_node);
+    pub fn asyncCancelWait(self: *Awaitable, waiter: *Waiter) bool {
+        return self.waiting_list.remove(waiter);
     }
 
     /// Mark this awaitable as complete and wake all waiters (both coroutines and threads).
@@ -74,8 +75,8 @@ pub const Awaitable = struct {
     /// Can be called from any context.
     pub fn markComplete(self: *Awaitable) void {
         // Pop and wake all waiters while setting the flag
-        while (self.waiting_list.popAndSetFlag()) |wait_node| {
-            wait_node.wake();
+        while (self.waiting_list.popAndSetFlag()) |waiter| {
+            waiter.wake();
         }
     }
 

--- a/src/runtime/blocking_task.zig
+++ b/src/runtime/blocking_task.zig
@@ -7,7 +7,6 @@ const ev = @import("../ev/root.zig");
 
 const Runtime = @import("../runtime.zig").Runtime;
 const Awaitable = @import("awaitable.zig").Awaitable;
-const WaitNode = @import("WaitNode.zig");
 const Closure = @import("task.zig").Closure;
 const finishTask = @import("task.zig").finishTask;
 const Group = @import("group.zig").Group;
@@ -24,8 +23,6 @@ pub const AnyBlockingTask = struct {
 
     // Simple cancellation flag for blocking tasks
     user_canceled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
-
-    pub const wait_node_vtable = WaitNode.VTable{};
 
     pub inline fn fromAwaitable(awaitable: *Awaitable) *AnyBlockingTask {
         assert(awaitable.kind == .blocking_task);
@@ -84,9 +81,7 @@ pub const AnyBlockingTask = struct {
         self.* = .{
             .awaitable = .{
                 .kind = .blocking_task,
-                .wait_node = .{
-                    .vtable = &AnyBlockingTask.wait_node_vtable,
-                },
+                .wait_node = .{},
             },
             .work = ev.Work.init(workFunc, self),
             .runtime = runtime,

--- a/src/runtime/task.zig
+++ b/src/runtime/task.zig
@@ -173,15 +173,6 @@ pub const AnyTask = struct {
         finished,
     };
 
-    pub const wait_node_vtable = WaitNode.VTable{
-        .wake = waitNodeWake,
-    };
-
-    fn waitNodeWake(wait_node: *WaitNode) void {
-        const awaitable: *Awaitable = @fieldParentPtr("wait_node", wait_node);
-        AnyTask.fromAwaitable(awaitable).wake();
-    }
-
     pub inline fn fromAwaitable(awaitable: *Awaitable) *AnyTask {
         std.debug.assert(awaitable.kind == .task);
         return @fieldParentPtr("awaitable", awaitable);
@@ -477,9 +468,7 @@ pub const AnyTask = struct {
             .state = .init(.new),
             .awaitable = .{
                 .kind = .task,
-                .wait_node = .{
-                    .vtable = &AnyTask.wait_node_vtable,
-                },
+                .wait_node = .{},
             },
             .coro = .{
                 .parent_context_ptr = .init(&executor.main_task.coro.context),

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -60,10 +60,9 @@ const Timeoutable = @import("../common.zig").Timeoutable;
 const Timeout = @import("../time.zig").Timeout;
 const Mutex = @import("Mutex.zig");
 const WaitQueue = @import("../utils/wait_queue.zig").WaitQueue;
-const WaitNode = @import("../runtime/WaitNode.zig");
 const Waiter = @import("../common.zig").Waiter;
 
-wait_queue: WaitQueue(WaitNode) = .empty,
+wait_queue: WaitQueue(Waiter) = .empty,
 
 const Condition = @This();
 
@@ -94,7 +93,7 @@ pub fn wait(self: *Condition, mutex: *Mutex) Cancelable!void {
     var waiter: Waiter = .init();
 
     // Add to wait queue before releasing mutex
-    self.wait_queue.push(&waiter.wait_node);
+    self.wait_queue.push(&waiter);
 
     // Atomically release mutex
     mutex.unlock();
@@ -102,14 +101,14 @@ pub fn wait(self: *Condition, mutex: *Mutex) Cancelable!void {
     // Wait for signal, handling spurious wakeups internally
     waiter.wait(1, .allow_cancel) catch |err| {
         // On cancellation, try to remove from queue
-        const was_in_queue = self.wait_queue.remove(&waiter.wait_node);
+        const was_in_queue = self.wait_queue.remove(&waiter);
         if (!was_in_queue) {
             // We were already removed by signal() - wait for signal to complete
             waiter.wait(1, .no_cancel);
             // Since we're being cancelled and won't process the signal,
             // wake another waiter to receive the signal instead.
             if (self.wait_queue.pop()) |next_waiter| {
-                Waiter.fromWaitNode(next_waiter).signal();
+                next_waiter.signal();
             }
         }
         // Must reacquire mutex before returning
@@ -160,7 +159,7 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
     // Stack-allocated waiter - separates operation wait node from task wait node
     var waiter: Waiter = .init();
 
-    self.wait_queue.push(&waiter.wait_node);
+    self.wait_queue.push(&waiter);
 
     // Atomically release mutex
     mutex.unlock();
@@ -168,14 +167,14 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
     // Wait for signal or timeout, handling spurious wakeups internally
     waiter.timedWait(1, timeout, .allow_cancel) catch |err| {
         // On cancellation, try to remove from queue
-        const was_in_queue = self.wait_queue.remove(&waiter.wait_node);
+        const was_in_queue = self.wait_queue.remove(&waiter);
         if (!was_in_queue) {
             // Removed by signal() - wait for signal to complete before destroying waiter
             waiter.wait(1, .no_cancel);
             // Since we're being cancelled and won't process the signal,
             // wake another waiter to receive the signal instead.
             if (self.wait_queue.pop()) |next_waiter| {
-                Waiter.fromWaitNode(next_waiter).signal();
+                next_waiter.signal();
             }
         }
 
@@ -186,7 +185,7 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
     };
 
     // Determine winner: can we remove ourselves from queue?
-    const timed_out = self.wait_queue.remove(&waiter.wait_node);
+    const timed_out = self.wait_queue.remove(&waiter);
 
     // Re-acquire mutex after waking - propagate cancellation if it occurred during lock
     mutex.lockUncancelable();
@@ -213,8 +212,8 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
 /// condition.signal();
 /// ```
 pub fn signal(self: *Condition) void {
-    if (self.wait_queue.pop()) |wait_node| {
-        Waiter.fromWaitNode(wait_node).signal();
+    if (self.wait_queue.pop()) |waiter| {
+        waiter.signal();
     }
 }
 
@@ -234,8 +233,8 @@ pub fn signal(self: *Condition) void {
 /// condition.broadcast();
 /// ```
 pub fn broadcast(self: *Condition) void {
-    while (self.wait_queue.pop()) |wait_node| {
-        Waiter.fromWaitNode(wait_node).signal();
+    while (self.wait_queue.pop()) |waiter| {
+        waiter.signal();
     }
 }
 

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -129,7 +129,7 @@ pub fn timedWait(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable ||
     const address = @intFromPtr(ptr);
     const bucket = getBucket(address);
 
-    // Use a stack-allocated waiter with its own WaitNode
+    // Use a stack-allocated waiter
     var futex_waiter = FutexWaiter{
         .waiter = Waiter.init(),
         .address = address,

--- a/src/time.zig
+++ b/src/time.zig
@@ -12,7 +12,7 @@ const os = @import("os/root.zig");
 const ev = @import("ev/root.zig");
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
-const WaitNode = @import("runtime/WaitNode.zig");
+const Waiter = @import("common.zig").Waiter;
 
 // Time configuration - adjust these for different platforms
 const TimePrecision = enum { nanoseconds, microseconds, milliseconds };
@@ -453,17 +453,17 @@ pub const Timeout = union(enum) {
 
     pub const WaitContext = struct {
         timer: ev.Timer = ev.Timer.init(.{ .duration = .zero }),
-        wait_node: ?*WaitNode = null,
+        waiter: ?*Waiter = null,
     };
 
-    pub fn asyncWait(self: *const Timeout, wait_node: *WaitNode, ctx: *WaitContext) bool {
+    pub fn asyncWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
         // Timeout.none means wait forever - never completes
         if (self.* == .none) {
             return true;
         }
 
         ctx.timer = ev.Timer.init(self.*);
-        ctx.wait_node = wait_node;
+        ctx.waiter = waiter;
         ctx.timer.c.userdata = ctx;
         ctx.timer.c.callback = timerCallback;
 
@@ -474,16 +474,16 @@ pub const Timeout = union(enum) {
 
     fn timerCallback(_: *ev.Loop, c: *ev.Completion) void {
         const ctx: *WaitContext = @ptrCast(@alignCast(c.userdata.?));
-        if (ctx.wait_node) |node| {
-            node.wake();
+        if (ctx.waiter) |w| {
+            w.wake();
         }
     }
 
-    pub fn asyncCancelWait(self: *const Timeout, wait_node: *WaitNode, ctx: *WaitContext) bool {
+    pub fn asyncCancelWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
         _ = self;
-        _ = wait_node;
+        _ = waiter;
         const loop = ctx.timer.c.loop orelse return true;
-        ctx.wait_node = null; // Prevent callback from waking a stale/reused wait node
+        ctx.waiter = null; // Prevent callback from waking a stale/reused waiter
         loop.clearTimer(&ctx.timer);
         return true; // Timer operations don't have values to re-add if we lost the race
     }


### PR DESCRIPTION
Replace the WaitNode vtable-based polymorphic dispatch with a simpler
design where Waiter is a struct with queue linkage fields and a tagged
union (thread/task/select) for variant-specific data.

Previously, sync primitive queues were WaitQueue(WaitNode) and could
contain both Waiter and SelectWaiter nodes, using vtable dispatch for
wake(). The SelectWaiter vtable was already a leaky abstraction (channel
code compared vtable pointers for tryClaim/didWin).

Now all sync primitive queues are WaitQueue(Waiter) and wake/signal/
tryClaim/didWin are explicit switch statements on the tagged union.
WaitNode is retained only for the executor's ready queues (task
scheduling), stripped of its vtable.

https://claude.ai/code/session_017PbnUNCuvptrXdPpQthBX9