### PR TITLE
Remove thread.yield() from WaitQueue spinlock

### DIFF
--- a/src/utils/wait_queue.zig
+++ b/src/utils/wait_queue.zig
@@ -9,7 +9,6 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const thread = @import("../os/thread.zig");
 
 /// Node for participation in wait queues.
 ///
@@ -187,7 +186,6 @@ pub fn WaitQueue(comptime T: type) type {
         /// Spins until mutation lock is acquired.
         /// Returns the state before mutation bit was set (with lock bit cleared).
         fn acquireMutationLock(self: *Self) usize {
-            var spin_count: u4 = 0;
             while (true) {
                 const old = self.head.fetchOr(lock_bit, .acquire);
 
@@ -195,10 +193,6 @@ pub fn WaitQueue(comptime T: type) type {
                     return old;
                 }
 
-                spin_count +%= 1;
-                if (spin_count == 0) {
-                    thread.yield();
-                }
                 std.atomic.spinLoopHint();
             }
         }


### PR DESCRIPTION
## Summary

- Remove `thread.yield()` syscall from the `WaitQueue` mutation spinlock
- The lock guards only a few pointer updates (constant-time, bounded critical section), so `spinLoopHint` (PAUSE) is sufficient
- The syscall overhead of yielding to the OS far exceeds the time any thread could hold this lock

## Test plan

- [x] All 24 WaitQueue tests pass, including concurrent stress tests