### PR TITLE
Extract DNS lookup into src/dns/ with async Windows support

### DIFF
--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const os_net = @import("../os/net.zig");
+const common = @import("../common.zig");
+const blockInPlace = common.blockInPlace;
+const dns = @import("root.zig");
+
+pub const Result = struct {
+    head: ?*os_net.addrinfo,
+    current: ?*os_net.addrinfo,
+    return_canonical_name: bool,
+
+    pub fn deinit(self: *Result) void {
+        if (self.head) |head| {
+            os_net.freeaddrinfo(head);
+        }
+    }
+
+    pub fn next(self: *Result) ?dns.LookupResult {
+        if (self.return_canonical_name) {
+            self.return_canonical_name = false;
+            if (self.head) |head| {
+                if (head.canonname) |name| {
+                    return .{ .canonical_name = .{ .bytes = std.mem.sliceTo(name, 0) } };
+                }
+            }
+        }
+
+        while (self.current) |info| {
+            self.current = @ptrCast(info.next);
+            const addr = info.addr orelse continue;
+            if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
+            return .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.addrlen)) };
+        }
+        return null;
+    }
+};
+
+/// Resolves a hostname to addresses. Dispatches to the thread pool and
+/// suspends the current task until the blocking getaddrinfo call completes.
+pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
+    const head = try blockInPlace(lookupBlocking, .{options});
+    return .{
+        .head = head,
+        .current = head,
+        .return_canonical_name = options.canonical_name,
+    };
+}
+
+fn lookupBlocking(options: dns.LookupOptions) dns.LookupError!?*os_net.addrinfo {
+    var buf: [512]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    const allocator = fba.allocator();
+
+    const name_c = try allocator.dupeZ(u8, options.name);
+    const port_c = try std.fmt.allocPrintSentinel(allocator, "{d}", .{options.port}, 0);
+
+    var hints: os_net.addrinfo = std.mem.zeroes(os_net.addrinfo);
+    hints.family = if (options.family) |f| switch (f) {
+        .ipv4 => os_net.AF.INET,
+        .ipv6 => os_net.AF.INET6,
+    } else os_net.AF.UNSPEC;
+    hints.socktype = std.posix.SOCK.STREAM;
+    hints.protocol = std.posix.IPPROTO.TCP;
+    if (options.canonical_name) {
+        hints.flags.CANONNAME = true;
+    }
+
+    var res: ?*os_net.addrinfo = null;
+
+    os_net.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &res) catch |err| {
+        return switch (err) {
+            error.ServiceNotAvailable => error.ServiceUnavailable,
+            error.InvalidFlags => unreachable,
+            error.SocketTypeNotSupported => unreachable,
+            else => |e| e,
+        };
+    };
+
+    return res;
+}

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const builtin = @import("builtin");
+const net = @import("../net.zig");
+
+pub const IpAddress = net.IpAddress;
+pub const HostName = net.HostName;
+
+pub const LookupOptions = struct {
+    name: []const u8,
+    port: u16,
+    family: ?IpAddress.Family = null,
+    canonical_name: bool = false,
+};
+
+pub const LookupResult = union(enum) {
+    address: IpAddress,
+    canonical_name: HostName,
+};
+
+pub const LookupError = error{
+    HostLacksNetworkAddresses,
+    TemporaryNameServerFailure,
+    NameServerFailure,
+    AddressFamilyNotSupported,
+    OutOfMemory,
+    UnknownHostName,
+    ServiceUnavailable,
+    Unexpected,
+    ProcessFdQuotaExceeded,
+    SystemResources,
+    Canceled,
+    RuntimeShutdown,
+    Closed,
+    NoThreadPool,
+} || std.posix.UnexpectedError;
+
+pub const impl = switch (builtin.os.tag) {
+    .windows => @import("windows.zig"),
+    else => @import("posix.zig"),
+};
+
+pub const Result = impl.Result;
+pub const lookup = impl.lookup;

--- a/src/dns/windows.zig
+++ b/src/dns/windows.zig
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Windows DNS resolver using GetAddrInfoExW with async completion callback.
+//! Unlike the POSIX implementation which dispatches blocking getaddrinfo to the
+//! thread pool, this uses the native Windows async API: the completion callback
+//! signals the Waiter directly, avoiding a thread pool slot.
+
+const std = @import("std");
+const windows = @import("../os/windows.zig");
+const os_net = @import("../os/net.zig");
+const common = @import("../common.zig");
+const Waiter = common.Waiter;
+const dns = @import("root.zig");
+
+const ADDRINFOEXW = windows.ADDRINFOEXW;
+
+/// Context placed on the stack while the async lookup is in flight.
+const LookupContext = struct {
+    overlapped: windows.OVERLAPPED,
+    waiter: Waiter,
+    err: u32,
+};
+
+fn completionCallback(dwError: u32, _: u32, lpOverlapped: ?*windows.OVERLAPPED) callconv(.winapi) void {
+    const ctx: *LookupContext = @fieldParentPtr("overlapped", lpOverlapped.?);
+    ctx.err = dwError;
+    ctx.waiter.signal();
+}
+
+pub const Result = struct {
+    head: ?*ADDRINFOEXW,
+    current: ?*ADDRINFOEXW,
+    return_canonical_name: bool,
+    canonical_name_buf: [dns.HostName.max_len]u8,
+
+    pub fn deinit(self: *Result) void {
+        if (self.head) |head| {
+            windows.FreeAddrInfoExW(head);
+        }
+    }
+
+    pub fn next(self: *Result) ?dns.LookupResult {
+        if (self.return_canonical_name) {
+            self.return_canonical_name = false;
+            if (self.head) |head| {
+                if (head.ai_canonname) |name| {
+                    const len = std.unicode.utf16LeToUtf8(&self.canonical_name_buf, std.mem.sliceTo(name, 0)) catch 0;
+                    if (len > 0) {
+                        return .{ .canonical_name = .{ .bytes = self.canonical_name_buf[0..len] } };
+                    }
+                }
+            }
+        }
+
+        while (self.current) |info| {
+            self.current = info.ai_next;
+            const addr = info.ai_addr orelse continue;
+            if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
+            return .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.ai_addrlen)) };
+        }
+        return null;
+    }
+};
+
+pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
+    os_net.ensureWSAInitialized();
+
+    // Convert name to null-terminated UTF-16
+    var name_wide: [256:0]u16 = undefined;
+    const name_len = std.unicode.utf8ToUtf16Le(&name_wide, options.name) catch return error.UnknownHostName;
+    name_wide[name_len] = 0;
+
+    // Format port as null-terminated UTF-16
+    var port_wide: [8:0]u16 = undefined;
+    var port_buf: [8]u8 = undefined;
+    const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{options.port}) catch unreachable;
+    const port_len = std.unicode.utf8ToUtf16Le(&port_wide, port_str) catch unreachable;
+    port_wide[port_len] = 0;
+
+    var hints: ADDRINFOEXW = std.mem.zeroes(ADDRINFOEXW);
+    hints.ai_family = if (options.family) |f| switch (f) {
+        .ipv4 => @as(i32, os_net.AF.INET),
+        .ipv6 => @as(i32, os_net.AF.INET6),
+    } else @as(i32, os_net.AF.UNSPEC);
+    hints.ai_socktype = os_net.SOCK.STREAM;
+    hints.ai_protocol = os_net.IPPROTO.TCP;
+    if (options.canonical_name) {
+        hints.ai_flags = @bitCast(windows.AI{ .CANONNAME = true });
+    }
+
+    var result: ?*ADDRINFOEXW = null;
+    var ctx: LookupContext = .{
+        .overlapped = std.mem.zeroes(windows.OVERLAPPED),
+        .waiter = .init(),
+        .err = 0,
+    };
+    var cancel_handle: windows.HANDLE = undefined;
+
+    const rc = windows.GetAddrInfoExW(
+        @ptrCast(&name_wide),
+        @ptrCast(&port_wide),
+        windows.NS_DNS,
+        null,
+        &hints,
+        &result,
+        null,
+        &ctx.overlapped,
+        completionCallback,
+        &cancel_handle,
+    );
+
+    if (rc == 0) {
+        return .{
+            .head = result,
+            .current = result,
+            .return_canonical_name = options.canonical_name,
+            .canonical_name_buf = undefined,
+        };
+    }
+
+    if (rc != windows.WSA_IO_PENDING) {
+        return winsockToLookupError(rc);
+    }
+
+    // Async path: wait for the completion callback to signal
+    ctx.waiter.wait(1, .allow_cancel) catch {
+        // Cancelled — ask Windows to cancel, then wait for the callback
+        _ = windows.GetAddrInfoExCancel(&cancel_handle);
+        ctx.waiter.wait(1, .no_cancel);
+
+        if (result) |r| windows.FreeAddrInfoExW(r);
+        return error.Canceled;
+    };
+
+    if (ctx.err != 0) {
+        if (result) |r| windows.FreeAddrInfoExW(r);
+        return winsockToLookupError(@intCast(ctx.err));
+    }
+
+    return .{
+        .head = result,
+        .current = result,
+        .return_canonical_name = options.canonical_name,
+        .canonical_name_buf = undefined,
+    };
+}
+
+fn winsockToLookupError(err: i32) dns.LookupError {
+    const wsa_err: windows.WinsockError = @enumFromInt(@as(u16, @intCast(err)));
+    return switch (wsa_err) {
+        .EAFNOSUPPORT => error.AddressFamilyNotSupported,
+        .EINVAL => error.Unexpected,
+        .ESOCKTNOSUPPORT => error.Unexpected,
+        .NO_DATA => error.UnknownHostName,
+        .NO_RECOVERY => error.NameServerFailure,
+        .NOTINITIALISED => error.SystemResources,
+        .TRY_AGAIN => error.TemporaryNameServerFailure,
+        .TYPE_NOT_FOUND => error.ServiceUnavailable,
+        .NOT_ENOUGH_MEMORY => error.SystemResources,
+        .HOST_NOT_FOUND => error.UnknownHostName,
+        else => error.Unexpected,
+    };
+}

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -781,6 +781,47 @@ pub const AI = packed struct(u32) {
     EXTENDED: bool = false,
 };
 
+// ADDRINFOEXW structure for GetAddrInfoExW
+pub const ADDRINFOEXW = extern struct {
+    ai_flags: i32,
+    ai_family: i32,
+    ai_socktype: i32,
+    ai_protocol: i32,
+    ai_addrlen: usize,
+    ai_canonname: ?[*:0]const u16,
+    ai_addr: ?*sockaddr,
+    ai_blob: ?*anyopaque,
+    ai_bloblen: usize,
+    ai_provider: ?*GUID,
+    ai_next: ?*ADDRINFOEXW,
+};
+
+pub const LPLOOKUPSERVICE_COMPLETION_ROUTINE = *const fn (DWORD, DWORD, ?*OVERLAPPED) callconv(.winapi) void;
+
+pub const NS_DNS: DWORD = 12;
+pub const WSA_IO_PENDING: i32 = 997;
+
+pub extern "ws2_32" fn GetAddrInfoExW(
+    pName: ?[*:0]const u16,
+    pServiceName: ?[*:0]const u16,
+    dwNameSpace: DWORD,
+    lpNspId: ?*anyopaque,
+    hints: ?*const ADDRINFOEXW,
+    ppResult: *?*ADDRINFOEXW,
+    timeout: ?*anyopaque,
+    lpOverlapped: ?*OVERLAPPED,
+    lpCompletionRoutine: ?LPLOOKUPSERVICE_COMPLETION_ROUTINE,
+    lpNameHandle: ?*HANDLE,
+) callconv(.winapi) i32;
+
+pub extern "ws2_32" fn GetAddrInfoExCancel(
+    lpHandle: *HANDLE,
+) callconv(.winapi) i32;
+
+pub extern "ws2_32" fn FreeAddrInfoExW(
+    pAddrInfoEx: *ADDRINFOEXW,
+) callconv(.winapi) void;
+
 // Winsock functions
 pub extern "ws2_32" fn WSAStartup(
     wVersionRequired: WORD,


### PR DESCRIPTION
## Summary
- Move DNS resolution logic from `net.zig` into a dedicated `src/dns/` module with platform-specific implementations
- POSIX: dispatches blocking `getaddrinfo` to the thread pool via `blockInPlace` (existing behavior)
- Windows: uses `GetAddrInfoExW` with async completion callback, signaling the Waiter directly without consuming a thread pool slot
- `dns.Result` serves as both iterator and resource owner (`next()` + `deinit()`)

## Test plan
- [x] All 366 tests pass (`./check.sh --full`)
- [x] Windows cross-compile + Wine tests pass (`./check.sh --target x86_64-windows --wine --filter HostName`)
- [x] NTP client example compiles with updated API

Fixes #247