### PR TITLE
Simplify Thumb context switch by folding Thumb bit into adr offset

### DIFF
--- a/src/coro/coroutines.zig
+++ b/src/coro/coroutines.zig
@@ -437,10 +437,8 @@ pub inline fn switchContext(
               .memory = true,
             }),
         .thumb => asm volatile (
-            // Calculate return address and set Thumb bit
-            // CRITICAL: adds r2, #1 sets LSB to indicate Thumb mode
-            \\ adr r2, 0f
-            \\ adds r2, #1
+            // Calculate return address with Thumb bit (LSB=1) set via adr offset
+            \\ adr r2, 0f + 1
             \\ mov r3, sp
             \\ str r3, [r0, #0]
             \\ str r7, [r0, #4]


### PR DESCRIPTION
## Summary
- Use `adr r2, 0f + 1` instead of separate `adr r2, 0f` + `adds r2, #1` to set the Thumb mode LSB in the return address
- Saves one instruction (2 bytes) in the Thumb context switch path

## Test plan
- [x] All coroutine tests pass on `thumb-linux`