### PR TITLE
Add per-request I/O priority (ioprio) support

### DIFF
--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -68,6 +68,7 @@ pub const capabilities: BackendCapabilities = .{
     .file_stat = true,
     .dir_open = true,
     .dir_close = true,
+    .ioprio = true,
 };
 
 pub const SharedState = struct {};
@@ -504,6 +505,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                 return;
             };
             sqe.prep_readv(data.handle, data.buffer.iovecs, data.offset);
+            sqe.ioprio = data.ioprio;
             sqe.user_data = @intFromPtr(c);
         },
         .file_write => {
@@ -515,6 +517,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                 return;
             };
             sqe.prep_writev(data.handle, data.buffer.iovecs, data.offset);
+            sqe.ioprio = data.ioprio;
             sqe.user_data = @intFromPtr(c);
         },
         .file_sync => {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -10,6 +10,8 @@ const fs = @import("../os/fs.zig");
 const Timestamp = @import("../time.zig").Timestamp;
 const Timeout = @import("../time.zig").Timeout;
 
+pub const IoPrio = if (Backend.capabilities.ioprio) u16 else void;
+
 pub const BackendCapabilities = struct {
     file_read: bool = false,
     file_write: bool = false,
@@ -46,6 +48,8 @@ pub const BackendCapabilities = struct {
     /// When true, completions submitted to one loop in a group may be completed
     /// on another loop's thread. Timer operations are protected by a mutex.
     is_multi_threaded: bool = false,
+
+    ioprio: bool = false,
 
     pub fn supportsNonBlockingFileIo(comptime self: BackendCapabilities) bool {
         return self.file_read or self.file_write;
@@ -948,6 +952,7 @@ pub const FileRead = struct {
     handle: fs.fd_t,
     buffer: ReadBuf,
     offset: u64,
+    ioprio: IoPrio = if (IoPrio == void) {} else 0,
 
     pub const Error = fs.FileReadError || Cancelable;
 
@@ -975,6 +980,7 @@ pub const FileWrite = struct {
     handle: fs.fd_t,
     buffer: WriteBuf,
     offset: u64,
+    ioprio: IoPrio = if (IoPrio == void) {} else 0,
 
     pub const Error = fs.FileWriteError || Cancelable;
 

--- a/src/ev/root.zig
+++ b/src/ev/root.zig
@@ -25,6 +25,7 @@ pub const executeBlocking = @import("blocking.zig").executeBlocking;
 
 const completion = @import("completion.zig");
 pub const Completion = completion.Completion;
+pub const IoPrio = completion.IoPrio;
 pub const Op = completion.Op;
 pub const Cancelable = completion.Cancelable;
 pub const Group = completion.Group;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -337,16 +337,26 @@ pub const File = struct {
         return try op.getResult();
     }
 
+    pub const ReadOptions = struct {
+        ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
+    };
+
+    pub const WriteOptions = struct {
+        ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
+    };
+
     /// Read from file using ReadBuf (vectored read).
-    pub fn readBuf(self: File, buf: ev.ReadBuf, offset: u64) ReadError!usize {
+    pub fn readBuf(self: File, buf: ev.ReadBuf, offset: u64, options: ReadOptions) ReadError!usize {
         var op = ev.FileRead.init(self.fd, buf, offset);
+        op.ioprio = options.ioprio;
         try waitForIo(&op.c);
         return try op.getResult();
     }
 
     /// Write to file using WriteBuf (vectored write).
-    pub fn writeBuf(self: File, buf: ev.WriteBuf, offset: u64) WriteError!usize {
+    pub fn writeBuf(self: File, buf: ev.WriteBuf, offset: u64, options: WriteOptions) WriteError!usize {
         var op = ev.FileWrite.init(self.fd, buf, offset);
+        op.ioprio = options.ioprio;
         try waitForIo(&op.c);
         return try op.getResult();
     }
@@ -426,6 +436,7 @@ pub const File = struct {
 pub const FileReader = struct {
     file: File,
     position: u64 = 0,
+    ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
     err: ?File.ReadError = null,
     interface: std.Io.Reader,
 
@@ -453,7 +464,8 @@ pub const FileReader = struct {
         const r: *FileReader = @alignCast(@fieldParentPtr("interface", io_reader));
         const dest = limit.slice(try w.writableSliceGreedy(1));
 
-        const n = r.file.read(dest, r.position) catch |err| {
+        var iovec_storage: [1]os.iovec = undefined;
+        const n = r.file.readBuf(.fromSlice(dest, &iovec_storage), r.position, .{ .ioprio = r.ioprio }) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -479,7 +491,8 @@ pub const FileReader = struct {
         // - 1 byte at position-1 (last byte we claim to have discarded)
         // - 1 byte at position (to verify there's more data or we're exactly at EOF)
         var buf: [2]u8 = undefined;
-        const n = r.file.read(&buf, r.position - 1) catch |err| {
+        var iovec_storage: [1]os.iovec = undefined;
+        const n = r.file.readBuf(.fromSlice(&buf, &iovec_storage), r.position - 1, .{ .ioprio = r.ioprio }) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -501,7 +514,7 @@ pub const FileReader = struct {
         if (dest_n == 0) return 0;
 
         const buf = ev.ReadBuf{ .iovecs = iovec_storage[0..dest_n] };
-        const n = r.file.readBuf(buf, r.position) catch |err| {
+        const n = r.file.readBuf(buf, r.position, .{ .ioprio = r.ioprio }) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -522,6 +535,7 @@ pub const FileReader = struct {
 pub const FileWriter = struct {
     file: File,
     position: u64 = 0,
+    ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
     err: ?File.WriteError = null,
     interface: std.Io.Writer,
 
@@ -553,7 +567,8 @@ pub const FileWriter = struct {
 
         if (buf_len == 0) return 0;
 
-        const n = w.file.writeVec(slices[0..buf_len], w.position) catch |err| {
+        var iovec_storage: [max_vecs]os.iovec_const = undefined;
+        const n = w.file.writeBuf(.fromSlices(slices[0..buf_len], &iovec_storage), w.position, .{ .ioprio = w.ioprio }) catch |err| {
             w.err = err;
             return error.WriteFailed;
         };
@@ -567,7 +582,8 @@ pub const FileWriter = struct {
 
         while (io_writer.end > 0) {
             const buffered = io_writer.buffered();
-            const n = w.file.write(buffered, w.position) catch |err| {
+            var iovec_storage: [1]os.iovec_const = undefined;
+            const n = w.file.writeBuf(.fromSlice(buffered, &iovec_storage), w.position, .{ .ioprio = w.ioprio }) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -337,26 +337,16 @@ pub const File = struct {
         return try op.getResult();
     }
 
-    pub const ReadOptions = struct {
-        ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
-    };
-
-    pub const WriteOptions = struct {
-        ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
-    };
-
     /// Read from file using ReadBuf (vectored read).
-    pub fn readBuf(self: File, buf: ev.ReadBuf, offset: u64, options: ReadOptions) ReadError!usize {
+    pub fn readBuf(self: File, buf: ev.ReadBuf, offset: u64) ReadError!usize {
         var op = ev.FileRead.init(self.fd, buf, offset);
-        op.ioprio = options.ioprio;
         try waitForIo(&op.c);
         return try op.getResult();
     }
 
     /// Write to file using WriteBuf (vectored write).
-    pub fn writeBuf(self: File, buf: ev.WriteBuf, offset: u64, options: WriteOptions) WriteError!usize {
+    pub fn writeBuf(self: File, buf: ev.WriteBuf, offset: u64) WriteError!usize {
         var op = ev.FileWrite.init(self.fd, buf, offset);
-        op.ioprio = options.ioprio;
         try waitForIo(&op.c);
         return try op.getResult();
     }
@@ -436,7 +426,6 @@ pub const File = struct {
 pub const FileReader = struct {
     file: File,
     position: u64 = 0,
-    ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
     err: ?File.ReadError = null,
     interface: std.Io.Reader,
 
@@ -464,8 +453,7 @@ pub const FileReader = struct {
         const r: *FileReader = @alignCast(@fieldParentPtr("interface", io_reader));
         const dest = limit.slice(try w.writableSliceGreedy(1));
 
-        var iovec_storage: [1]os.iovec = undefined;
-        const n = r.file.readBuf(.fromSlice(dest, &iovec_storage), r.position, .{ .ioprio = r.ioprio }) catch |err| {
+        const n = r.file.read(dest, r.position) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -491,8 +479,7 @@ pub const FileReader = struct {
         // - 1 byte at position-1 (last byte we claim to have discarded)
         // - 1 byte at position (to verify there's more data or we're exactly at EOF)
         var buf: [2]u8 = undefined;
-        var iovec_storage: [1]os.iovec = undefined;
-        const n = r.file.readBuf(.fromSlice(&buf, &iovec_storage), r.position - 1, .{ .ioprio = r.ioprio }) catch |err| {
+        const n = r.file.read(&buf, r.position - 1) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -514,7 +501,7 @@ pub const FileReader = struct {
         if (dest_n == 0) return 0;
 
         const buf = ev.ReadBuf{ .iovecs = iovec_storage[0..dest_n] };
-        const n = r.file.readBuf(buf, r.position, .{ .ioprio = r.ioprio }) catch |err| {
+        const n = r.file.readBuf(buf, r.position) catch |err| {
             r.err = err;
             return error.ReadFailed;
         };
@@ -535,7 +522,6 @@ pub const FileReader = struct {
 pub const FileWriter = struct {
     file: File,
     position: u64 = 0,
-    ioprio: ev.IoPrio = if (ev.IoPrio == void) {} else 0,
     err: ?File.WriteError = null,
     interface: std.Io.Writer,
 
@@ -567,8 +553,7 @@ pub const FileWriter = struct {
 
         if (buf_len == 0) return 0;
 
-        var iovec_storage: [max_vecs]os.iovec_const = undefined;
-        const n = w.file.writeBuf(.fromSlices(slices[0..buf_len], &iovec_storage), w.position, .{ .ioprio = w.ioprio }) catch |err| {
+        const n = w.file.writeVec(slices[0..buf_len], w.position) catch |err| {
             w.err = err;
             return error.WriteFailed;
         };
@@ -582,8 +567,7 @@ pub const FileWriter = struct {
 
         while (io_writer.end > 0) {
             const buffered = io_writer.buffered();
-            var iovec_storage: [1]os.iovec_const = undefined;
-            const n = w.file.writeBuf(.fromSlice(buffered, &iovec_storage), w.position, .{ .ioprio = w.ioprio }) catch |err| {
+            const n = w.file.write(buffered, w.position) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };


### PR DESCRIPTION
## Summary

- Add `IoPrio` type to the ev layer (`u16` on io_uring, `void` on other backends)
- Add `ioprio` field to `FileRead`/`FileWrite` completions, wired to `sqe.ioprio` in the io_uring backend
- Add `ReadOptions`/`WriteOptions` to `File.readBuf`/`File.writeBuf`
- Add `ioprio` field to `FileReader`/`FileWriter`, threaded through all vtable I/O operations

This allows setting per-request block I/O scheduling priority on Linux (respected by bfq and mq-deadline schedulers). Useful for prioritizing reads over background writes in database-style workloads.

Ref: #332