### PR TITLE
Add native DNS resolver

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,9 +13,16 @@ pub fn build(b: *std.Build) void {
         "Override the default event loop backend (io_uring, epoll, kqueue, iocp, poll)",
     );
 
+    const dns_resolver = b.option(
+        []const u8,
+        "dns-resolver",
+        "Override the default DNS resolver (system, native)",
+    );
+
     // Create options for backend selection
     var options = b.addOptions();
     options.addOption(?[]const u8, "backend", backend);
+    options.addOption(?[]const u8, "dns_resolver", dns_resolver);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),

--- a/src/dns/native/config.zig
+++ b/src/dns/native/config.zig
@@ -130,8 +130,15 @@ pub const Config = struct {
         } else if (std.mem.eql(u8, keyword, "domain")) {
             // "domain" is like "search" but with a single domain
             self.search.len = 0;
-            if (tokens.next()) |domain| {
-                self.addSearchDomain(domain);
+            if (tokens.next()) |token| {
+                if (token[0] == '#') return;
+                const domain = if (std.mem.indexOfScalar(u8, token, '#')) |idx|
+                    token[0..idx]
+                else
+                    token;
+                if (domain.len > 0) {
+                    self.addSearchDomain(domain);
+                }
             }
         } else if (std.mem.eql(u8, keyword, "options")) {
             self.parseOptions(&tokens);
@@ -180,14 +187,14 @@ pub const Config = struct {
     fn parseOptions(self: *Config, tokens: *std.mem.TokenIterator(u8, .any)) void {
         while (tokens.next()) |opt| {
             if (std.mem.startsWith(u8, opt, "ndots:")) {
-                const ndots = std.fmt.parseInt(u8, opt[6..], 10) catch 1;
-                self.ndots = @intCast(@min(ndots, @as(u8, std.math.maxInt(u4))));
+                const ndots = std.fmt.parseInt(u16, opt[6..], 10) catch continue;
+                self.ndots = @intCast(@min(ndots, @as(u16, std.math.maxInt(u4))));
             } else if (std.mem.startsWith(u8, opt, "timeout:")) {
                 self.timeout = std.fmt.parseInt(u8, opt[8..], 10) catch 5;
                 if (self.timeout < 1) self.timeout = 1;
             } else if (std.mem.startsWith(u8, opt, "attempts:")) {
-                const attempts = std.fmt.parseInt(u8, opt[9..], 10) catch 2;
-                self.attempts = @intCast(@max(@as(u8, 1), @min(attempts, @as(u8, std.math.maxInt(u4)))));
+                const attempts = std.fmt.parseInt(u16, opt[9..], 10) catch continue;
+                self.attempts = @intCast(@max(@as(u16, 1), @min(attempts, @as(u16, std.math.maxInt(u4)))));
             } else if (std.mem.eql(u8, opt, "rotate")) {
                 self.rotate = true;
             } else if (std.mem.eql(u8, opt, "use-vc") or

--- a/src/dns/native/config.zig
+++ b/src/dns/native/config.zig
@@ -38,9 +38,6 @@ pub const Config = struct {
     /// Force TCP instead of UDP.
     use_tcp: bool = false,
 
-    /// Send A and AAAA queries sequentially instead of in parallel.
-    single_request: bool = false,
-
     pub const Server = struct {
         addr: net.IpAddress,
 
@@ -197,11 +194,9 @@ pub const Config = struct {
                 std.mem.eql(u8, opt, "tcp"))
             {
                 self.use_tcp = true;
-            } else if (std.mem.eql(u8, opt, "single-request") or
-                std.mem.eql(u8, opt, "single-request-reopen"))
-            {
-                self.single_request = true;
             }
+            // Note: single-request and single-request-reopen are intentionally
+            // not supported - queries are always sequential in this implementation.
         }
     }
 

--- a/src/dns/native/config.zig
+++ b/src/dns/native/config.zig
@@ -180,13 +180,14 @@ pub const Config = struct {
     fn parseOptions(self: *Config, tokens: *std.mem.TokenIterator(u8, .any)) void {
         while (tokens.next()) |opt| {
             if (std.mem.startsWith(u8, opt, "ndots:")) {
-                self.ndots = std.fmt.parseInt(u4, opt[6..], 10) catch 1;
+                const ndots = std.fmt.parseInt(u8, opt[6..], 10) catch 1;
+                self.ndots = @intCast(@min(ndots, @as(u8, std.math.maxInt(u4))));
             } else if (std.mem.startsWith(u8, opt, "timeout:")) {
                 self.timeout = std.fmt.parseInt(u8, opt[8..], 10) catch 5;
                 if (self.timeout < 1) self.timeout = 1;
             } else if (std.mem.startsWith(u8, opt, "attempts:")) {
-                self.attempts = std.fmt.parseInt(u4, opt[9..], 10) catch 2;
-                if (self.attempts < 1) self.attempts = 1;
+                const attempts = std.fmt.parseInt(u8, opt[9..], 10) catch 2;
+                self.attempts = @intCast(@max(@as(u8, 1), @min(attempts, @as(u8, std.math.maxInt(u4)))));
             } else if (std.mem.eql(u8, opt, "rotate")) {
                 self.rotate = true;
             } else if (std.mem.eql(u8, opt, "use-vc") or

--- a/src/dns/native/config.zig
+++ b/src/dns/native/config.zig
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Parser for /etc/resolv.conf and DNS resolver configuration.
+
+const std = @import("std");
+const net = @import("../../net.zig");
+
+/// Maximum number of nameservers (per resolv.conf man page).
+pub const max_servers = 3;
+
+/// Maximum number of search domains.
+pub const max_search = 6;
+
+/// Maximum length of a search domain.
+pub const max_search_len = 256;
+
+/// DNS resolver configuration.
+pub const Config = struct {
+    /// Nameserver addresses (host:port format).
+    servers: Servers = .{},
+
+    /// Search domains (rooted, with trailing dot).
+    search: SearchDomains = .{},
+
+    /// Number of dots in name to trigger absolute lookup first.
+    ndots: u4 = 1,
+
+    /// Timeout for each query attempt (seconds).
+    timeout: u8 = 5,
+
+    /// Number of attempts per server.
+    attempts: u4 = 2,
+
+    /// Rotate through nameservers.
+    rotate: bool = false,
+
+    /// Force TCP instead of UDP.
+    use_tcp: bool = false,
+
+    /// Send A and AAAA queries sequentially instead of in parallel.
+    single_request: bool = false,
+
+    pub const Server = struct {
+        addr: net.IpAddress,
+
+        pub fn format(self: Server, writer: anytype) !void {
+            try self.addr.format(writer);
+        }
+    };
+
+    pub const SearchDomain = struct {
+        data: [max_search_len]u8 = undefined,
+        len: u16 = 0,
+
+        pub fn init(domain: []const u8) SearchDomain {
+            var sd: SearchDomain = .{};
+            const copy_len: u16 = @intCast(@min(domain.len, max_search_len));
+            @memcpy(sd.data[0..copy_len], domain[0..copy_len]);
+            sd.len = copy_len;
+            return sd;
+        }
+
+        pub fn slice(self: *const SearchDomain) []const u8 {
+            return self.data[0..self.len];
+        }
+    };
+
+    pub const Servers = struct {
+        buffer: [max_servers]Server = undefined,
+        len: usize = 0,
+
+        pub fn appendAssumeCapacity(self: *Servers, server: Server) void {
+            self.buffer[self.len] = server;
+            self.len += 1;
+        }
+
+        pub fn slice(self: *const Servers) []const Server {
+            return self.buffer[0..self.len];
+        }
+    };
+
+    pub const SearchDomains = struct {
+        buffer: [max_search]SearchDomain = undefined,
+        len: usize = 0,
+
+        pub fn appendAssumeCapacity(self: *SearchDomains, domain: SearchDomain) void {
+            self.buffer[self.len] = domain;
+            self.len += 1;
+        }
+
+        pub fn slice(self: *const SearchDomains) []const SearchDomain {
+            return self.buffer[0..self.len];
+        }
+    };
+
+    /// Create default configuration (localhost resolvers).
+    pub fn default() Config {
+        var config: Config = .{};
+        config.servers.appendAssumeCapacity(.{ .addr = net.IpAddress.initIp4(.{ 127, 0, 0, 1 }, 53) });
+        return config;
+    }
+
+    /// Parse resolv.conf content.
+    pub fn parse(content: []const u8) Config {
+        var config: Config = .{};
+
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            config.parseLine(line);
+        }
+
+        // Apply defaults if nothing configured
+        if (config.servers.len == 0) {
+            config.servers.appendAssumeCapacity(.{ .addr = net.IpAddress.initIp4(.{ 127, 0, 0, 1 }, 53) });
+        }
+
+        return config;
+    }
+
+    fn parseLine(self: *Config, line: []const u8) void {
+        // Skip comments and empty lines
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0 or trimmed[0] == '#' or trimmed[0] == ';') return;
+
+        var tokens = std.mem.tokenizeAny(u8, trimmed, " \t");
+        const keyword = tokens.next() orelse return;
+
+        if (std.mem.eql(u8, keyword, "nameserver")) {
+            self.parseNameserver(tokens.next() orelse return);
+        } else if (std.mem.eql(u8, keyword, "search")) {
+            self.parseSearch(&tokens);
+        } else if (std.mem.eql(u8, keyword, "domain")) {
+            // "domain" is like "search" but with a single domain
+            self.search.len = 0;
+            if (tokens.next()) |domain| {
+                self.addSearchDomain(domain);
+            }
+        } else if (std.mem.eql(u8, keyword, "options")) {
+            self.parseOptions(&tokens);
+        }
+    }
+
+    fn parseNameserver(self: *Config, addr_str: []const u8) void {
+        if (self.servers.len >= max_servers) return;
+
+        // Parse IP address, default port 53
+        const addr = net.IpAddress.parseIp(addr_str, 53) catch return;
+        self.servers.appendAssumeCapacity(.{ .addr = addr });
+    }
+
+    fn parseSearch(self: *Config, tokens: *std.mem.TokenIterator(u8, .any)) void {
+        self.search.len = 0;
+        while (tokens.next()) |token| {
+            // Stop at comment
+            if (token[0] == '#') break;
+            // Handle inline comment (trim at #)
+            const domain = if (std.mem.indexOfScalar(u8, token, '#')) |idx|
+                token[0..idx]
+            else
+                token;
+            if (domain.len > 0) {
+                self.addSearchDomain(domain);
+            }
+        }
+    }
+
+    fn addSearchDomain(self: *Config, domain: []const u8) void {
+        if (self.search.len >= max_search) return;
+        if (domain.len == 0 or domain.len > max_search_len - 1) return;
+
+        // Ensure domain is rooted (has trailing dot)
+        var sd = SearchDomain.init(domain);
+        if (domain[domain.len - 1] != '.') {
+            if (sd.len < max_search_len) {
+                sd.data[sd.len] = '.';
+                sd.len += 1;
+            }
+        }
+        self.search.appendAssumeCapacity(sd);
+    }
+
+    fn parseOptions(self: *Config, tokens: *std.mem.TokenIterator(u8, .any)) void {
+        while (tokens.next()) |opt| {
+            if (std.mem.startsWith(u8, opt, "ndots:")) {
+                self.ndots = std.fmt.parseInt(u4, opt[6..], 10) catch 1;
+            } else if (std.mem.startsWith(u8, opt, "timeout:")) {
+                self.timeout = std.fmt.parseInt(u8, opt[8..], 10) catch 5;
+                if (self.timeout < 1) self.timeout = 1;
+            } else if (std.mem.startsWith(u8, opt, "attempts:")) {
+                self.attempts = std.fmt.parseInt(u4, opt[9..], 10) catch 2;
+                if (self.attempts < 1) self.attempts = 1;
+            } else if (std.mem.eql(u8, opt, "rotate")) {
+                self.rotate = true;
+            } else if (std.mem.eql(u8, opt, "use-vc") or
+                std.mem.eql(u8, opt, "usevc") or
+                std.mem.eql(u8, opt, "tcp"))
+            {
+                self.use_tcp = true;
+            } else if (std.mem.eql(u8, opt, "single-request") or
+                std.mem.eql(u8, opt, "single-request-reopen"))
+            {
+                self.single_request = true;
+            }
+        }
+    }
+
+    /// Generate the list of FQDNs to try for a given hostname.
+    /// Returns an iterator over names to query.
+    pub fn nameList(self: *const Config, name: []const u8) NameListIterator {
+        return NameListIterator.init(self, name);
+    }
+};
+
+/// Iterator over FQDNs to try for a lookup.
+pub const NameListIterator = struct {
+    config: *const Config,
+    name: []const u8,
+    state: State,
+    search_idx: usize,
+    tried_absolute: bool,
+    rooted: bool,
+
+    const State = enum {
+        absolute_first, // Try absolute name first (if enough dots or rooted)
+        search, // Try search domains
+        absolute_last, // Try absolute name last (if not enough dots)
+        done,
+    };
+
+    pub fn init(config: *const Config, name: []const u8) NameListIterator {
+        // Count dots in name
+        var dots: usize = 0;
+        for (name) |c| {
+            if (c == '.') dots += 1;
+        }
+
+        // If name is rooted (ends with dot), only try that name
+        const rooted = name.len > 0 and name[name.len - 1] == '.';
+        if (rooted) {
+            return .{
+                .config = config,
+                .name = name,
+                .state = .absolute_first,
+                .search_idx = 0,
+                .tried_absolute = false,
+                .rooted = true,
+            };
+        }
+
+        // If enough dots, try absolute first
+        const has_ndots = dots >= config.ndots;
+        return .{
+            .config = config,
+            .name = name,
+            .state = if (has_ndots) .absolute_first else .search,
+            .search_idx = 0,
+            .tried_absolute = false,
+            .rooted = false,
+        };
+    }
+
+    /// Get the next FQDN to try. Writes to the provided buffer.
+    /// Returns null when no more names to try.
+    pub fn next(self: *NameListIterator, buf: []u8) ?[]const u8 {
+        switch (self.state) {
+            .absolute_first => {
+                self.tried_absolute = true;
+                // For rooted names, go directly to done after returning the name
+                self.state = if (self.rooted) .done else .search;
+                return self.formatAbsolute(buf);
+            },
+            .search => {
+                if (self.search_idx < self.config.search.len) {
+                    const suffix = self.config.search.buffer[self.search_idx].slice();
+                    self.search_idx += 1;
+                    return self.formatWithSuffix(buf, suffix);
+                }
+                self.state = .absolute_last;
+                return self.next(buf);
+            },
+            .absolute_last => {
+                self.state = .done;
+                // Only try absolute if we didn't already try it
+                if (!self.tried_absolute) {
+                    return self.formatAbsolute(buf);
+                }
+                return null;
+            },
+            .done => return null,
+        }
+    }
+
+    fn formatAbsolute(self: *NameListIterator, buf: []u8) ?[]const u8 {
+        // Name without trailing dot - add one
+        const name = std.mem.trimRight(u8, self.name, ".");
+        if (name.len + 1 > buf.len) return null;
+        @memcpy(buf[0..name.len], name);
+        buf[name.len] = '.';
+        return buf[0 .. name.len + 1];
+    }
+
+    fn formatWithSuffix(self: *NameListIterator, buf: []u8, suffix: []const u8) ?[]const u8 {
+        const name = std.mem.trimRight(u8, self.name, ".");
+        const total = name.len + 1 + suffix.len;
+        if (total > buf.len) return null;
+        @memcpy(buf[0..name.len], name);
+        buf[name.len] = '.';
+        @memcpy(buf[name.len + 1 ..][0..suffix.len], suffix);
+        return buf[0..total];
+    }
+};
+
+// Tests
+
+test "Config.parse basic" {
+    const content =
+        \\# Comment
+        \\nameserver 8.8.8.8
+        \\nameserver 8.8.4.4
+        \\search example.com local.
+        \\options ndots:2 timeout:3 rotate
+    ;
+
+    const config = Config.parse(content);
+
+    try std.testing.expectEqual(@as(usize, 2), config.servers.len);
+    try std.testing.expectEqual(@as(usize, 2), config.search.len);
+    try std.testing.expectEqual(@as(u4, 2), config.ndots);
+    try std.testing.expectEqual(@as(u8, 3), config.timeout);
+    try std.testing.expect(config.rotate);
+}
+
+test "Config.parse IPv6" {
+    const content =
+        \\nameserver 2001:4860:4860::8888
+        \\nameserver ::1
+    ;
+
+    const config = Config.parse(content);
+    try std.testing.expectEqual(@as(usize, 2), config.servers.len);
+}
+
+test "Config.parse default" {
+    const config = Config.parse("");
+    try std.testing.expectEqual(@as(usize, 1), config.servers.len);
+}
+
+test "Config.nameList with ndots" {
+    var config: Config = .{};
+    config.ndots = 1;
+    config.search.appendAssumeCapacity(Config.SearchDomain.init("example.com."));
+
+    var buf: [256]u8 = undefined;
+    var iter = config.nameList("host");
+
+    // Not enough dots - search first
+    try std.testing.expectEqualStrings("host.example.com.", iter.next(&buf).?);
+    try std.testing.expectEqualStrings("host.", iter.next(&buf).?);
+    try std.testing.expect(iter.next(&buf) == null);
+}
+
+test "Config.nameList with enough dots" {
+    var config: Config = .{};
+    config.ndots = 1;
+    config.search.appendAssumeCapacity(Config.SearchDomain.init("example.com."));
+
+    var buf: [256]u8 = undefined;
+    var iter = config.nameList("www.host");
+
+    // Enough dots - absolute first
+    try std.testing.expectEqualStrings("www.host.", iter.next(&buf).?);
+    try std.testing.expectEqualStrings("www.host.example.com.", iter.next(&buf).?);
+    try std.testing.expect(iter.next(&buf) == null);
+}
+
+test "Config.nameList rooted name" {
+    var config: Config = .{};
+    config.search.appendAssumeCapacity(Config.SearchDomain.init("example.com."));
+
+    var buf: [256]u8 = undefined;
+    var iter = config.nameList("www.example.org.");
+
+    // Rooted name - only try that
+    try std.testing.expectEqualStrings("www.example.org.", iter.next(&buf).?);
+    try std.testing.expect(iter.next(&buf) == null);
+}

--- a/src/dns/native/hosts.zig
+++ b/src/dns/native/hosts.zig
@@ -4,6 +4,7 @@
 //! Parser for /etc/hosts file.
 
 const std = @import("std");
+const fs = @import("../../fs.zig");
 const net = @import("../../net.zig");
 
 /// Maximum number of addresses from hosts file per lookup.
@@ -26,17 +27,32 @@ pub const HostsResult = struct {
     }
 };
 
+const hosts_path = "/etc/hosts";
+
 /// Look up a hostname in /etc/hosts.
 /// Returns null if the hostname is not found.
-pub fn lookup(hostname: []const u8, family: ?net.IpAddress.Family) ?HostsResult {
-    const content = std.fs.cwd().readFileAlloc(
-        std.heap.page_allocator,
-        "/etc/hosts",
-        256 * 1024,
-    ) catch return null;
-    defer std.heap.page_allocator.free(content);
+pub fn lookup(hostname: []const u8, family: ?net.IpAddress.Family) error{Canceled}!?HostsResult {
+    const file = fs.openFile(hosts_path) catch |err| {
+        if (err == error.Canceled) return error.Canceled;
+        return null;
+    };
+    defer file.close();
 
-    return lookupInContent(content, hostname, family);
+    var read_buf: [512]u8 = undefined;
+    var reader = file.reader(&read_buf);
+
+    var buf: [65536]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&buf);
+    const len = reader.interface.streamRemaining(&writer) catch |err| {
+        if (err == error.ReadFailed) {
+            if (reader.err) |e| {
+                if (e == error.Canceled) return error.Canceled;
+            }
+        }
+        return null;
+    };
+
+    return lookupInContent(buf[0..len], hostname, family);
 }
 
 /// Look up a hostname in hosts file content (for testing).

--- a/src/dns/native/hosts.zig
+++ b/src/dns/native/hosts.zig
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Parser for /etc/hosts file.
+
+const std = @import("std");
+const net = @import("../../net.zig");
+
+/// Maximum number of addresses from hosts file per lookup.
+const max_hosts_addresses = 8;
+
+/// Hosts file lookup result.
+pub const HostsResult = struct {
+    addresses: [max_hosts_addresses]net.IpAddress = undefined,
+    len: usize = 0,
+
+    pub fn appendAssumeCapacity(self: *HostsResult, addr: net.IpAddress) void {
+        if (self.len < max_hosts_addresses) {
+            self.addresses[self.len] = addr;
+            self.len += 1;
+        }
+    }
+
+    pub fn slice(self: *const HostsResult) []const net.IpAddress {
+        return self.addresses[0..self.len];
+    }
+};
+
+/// Look up a hostname in /etc/hosts.
+/// Returns null if the hostname is not found.
+pub fn lookup(hostname: []const u8, family: ?net.IpAddress.Family) ?HostsResult {
+    const content = std.fs.cwd().readFileAlloc(
+        std.heap.page_allocator,
+        "/etc/hosts",
+        256 * 1024,
+    ) catch return null;
+    defer std.heap.page_allocator.free(content);
+
+    return lookupInContent(content, hostname, family);
+}
+
+/// Look up a hostname in hosts file content (for testing).
+pub fn lookupInContent(content: []const u8, hostname: []const u8, family: ?net.IpAddress.Family) ?HostsResult {
+    var result: HostsResult = .{};
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        // Skip comments and empty lines
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0 or trimmed[0] == '#') continue;
+
+        // Parse: IP_ADDRESS HOSTNAME [ALIASES...]
+        var tokens = std.mem.tokenizeAny(u8, trimmed, " \t");
+        const addr_str = tokens.next() orelse continue;
+
+        // Parse IP address (with dummy port 0)
+        const addr = net.IpAddress.parseIp(addr_str, 0) catch continue;
+
+        // Check family filter
+        if (family) |f| {
+            if (addr.getFamily() != f) continue;
+        }
+
+        // Check each hostname/alias
+        while (tokens.next()) |name| {
+            // Stop at comments
+            if (name[0] == '#') break;
+
+            if (std.ascii.eqlIgnoreCase(name, hostname)) {
+                result.appendAssumeCapacity(addr);
+                break;
+            }
+        }
+    }
+
+    return if (result.len > 0) result else null;
+}
+
+test "hosts.lookupInContent basic" {
+    const content =
+        \\# Comment
+        \\127.0.0.1 localhost localhost.localdomain
+        \\::1 localhost ip6-localhost
+        \\192.168.1.1 myhost
+    ;
+
+    // Lookup localhost - should get both IPv4 and IPv6
+    const result1 = lookupInContent(content, "localhost", null).?;
+    try std.testing.expectEqual(@as(usize, 2), result1.len);
+
+    // Lookup localhost - IPv4 only
+    const result2 = lookupInContent(content, "localhost", .ipv4).?;
+    try std.testing.expectEqual(@as(usize, 1), result2.len);
+
+    // Lookup localhost - IPv6 only
+    const result3 = lookupInContent(content, "localhost", .ipv6).?;
+    try std.testing.expectEqual(@as(usize, 1), result3.len);
+
+    // Lookup alias
+    const result4 = lookupInContent(content, "localhost.localdomain", null).?;
+    try std.testing.expectEqual(@as(usize, 1), result4.len);
+
+    // Lookup unknown host
+    const result5 = lookupInContent(content, "unknown", null);
+    try std.testing.expect(result5 == null);
+}
+
+test "hosts.lookupInContent case insensitive" {
+    const content = "127.0.0.1 LocalHost\n";
+
+    const result = lookupInContent(content, "LOCALHOST", null).?;
+    try std.testing.expectEqual(@as(usize, 1), result.len);
+}

--- a/src/dns/native/message.zig
+++ b/src/dns/native/message.zig
@@ -160,7 +160,7 @@ pub const Name = struct {
         var name: Name = .{};
         var pos: usize = 0;
 
-        if (s.len == 0) {
+        if (s.len == 0 or (s.len == 1 and s[0] == '.')) {
             // Root domain
             name.data[0] = 0;
             name.len = 1;

--- a/src/dns/native/message.zig
+++ b/src/dns/native/message.zig
@@ -1,0 +1,527 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! DNS message encoding and decoding per RFC 1035.
+//! Supports EDNS0 (RFC 6891) for larger packet sizes.
+
+const std = @import("std");
+
+/// Maximum DNS packet size with EDNS0.
+/// Value from https://dnsflagday.net/2020/
+pub const max_packet_size = 1232;
+
+/// Maximum domain name length (255 bytes per RFC 1035).
+pub const max_name_len = 255;
+
+/// Maximum label length (63 bytes per RFC 1035).
+pub const max_label_len = 63;
+
+/// DNS record types.
+pub const Type = enum(u16) {
+    A = 1,
+    NS = 2,
+    CNAME = 5,
+    SOA = 6,
+    PTR = 12,
+    MX = 15,
+    TXT = 16,
+    AAAA = 28,
+    SRV = 33,
+    OPT = 41, // EDNS0
+    _,
+};
+
+/// DNS record classes.
+pub const Class = enum(u16) {
+    IN = 1, // Internet
+    CS = 2, // CSNET (obsolete)
+    CH = 3, // CHAOS
+    HS = 4, // Hesiod
+    ANY = 255,
+    _,
+};
+
+/// DNS response codes.
+pub const RCode = enum(u4) {
+    success = 0, // No error
+    format_error = 1, // Format error
+    server_failure = 2, // Server failure
+    name_error = 3, // Non-existent domain (NXDOMAIN)
+    not_implemented = 4, // Not implemented
+    refused = 5, // Query refused
+    _,
+};
+
+/// DNS message header (12 bytes).
+pub const Header = struct {
+    id: u16,
+    flags: Flags,
+    qd_count: u16, // Question count
+    an_count: u16, // Answer count
+    ns_count: u16, // Authority count
+    ar_count: u16, // Additional count
+
+    pub const Flags = packed struct(u16) {
+        rcode: RCode = .success,
+        z: u3 = 0, // Reserved
+        ra: bool = false, // Recursion available
+        rd: bool = true, // Recursion desired
+        tc: bool = false, // Truncated
+        aa: bool = false, // Authoritative answer
+        opcode: u4 = 0, // Standard query
+        qr: bool = false, // Query (false) or Response (true)
+    };
+
+    pub fn encode(self: Header, buf: []u8) []u8 {
+        std.debug.assert(buf.len >= 12);
+        std.mem.writeInt(u16, buf[0..2], self.id, .big);
+        std.mem.writeInt(u16, buf[2..4], @bitCast(self.flags), .big);
+        std.mem.writeInt(u16, buf[4..6], self.qd_count, .big);
+        std.mem.writeInt(u16, buf[6..8], self.an_count, .big);
+        std.mem.writeInt(u16, buf[8..10], self.ns_count, .big);
+        std.mem.writeInt(u16, buf[10..12], self.ar_count, .big);
+        return buf[0..12];
+    }
+
+    pub fn decode(buf: []const u8) error{Truncated}!Header {
+        if (buf.len < 12) return error.Truncated;
+        return .{
+            .id = std.mem.readInt(u16, buf[0..2], .big),
+            .flags = @bitCast(std.mem.readInt(u16, buf[2..4], .big)),
+            .qd_count = std.mem.readInt(u16, buf[4..6], .big),
+            .an_count = std.mem.readInt(u16, buf[6..8], .big),
+            .ns_count = std.mem.readInt(u16, buf[8..10], .big),
+            .ar_count = std.mem.readInt(u16, buf[10..12], .big),
+        };
+    }
+};
+
+/// DNS question.
+pub const Question = struct {
+    name: Name,
+    qtype: Type,
+    qclass: Class,
+
+    pub fn encode(self: Question, buf: []u8) error{BufferTooSmall}![]u8 {
+        var pos: usize = 0;
+
+        // Encode name
+        const name_bytes = try self.name.encode(buf);
+        pos += name_bytes.len;
+
+        if (buf.len < pos + 4) return error.BufferTooSmall;
+
+        // Encode type and class
+        std.mem.writeInt(u16, buf[pos..][0..2], @intFromEnum(self.qtype), .big);
+        pos += 2;
+        std.mem.writeInt(u16, buf[pos..][0..2], @intFromEnum(self.qclass), .big);
+        pos += 2;
+
+        return buf[0..pos];
+    }
+};
+
+/// Decoded resource record.
+pub const ResourceRecord = struct {
+    name: Name,
+    rtype: Type,
+    class: Class,
+    ttl: u32,
+    rdata: []const u8,
+
+    /// Parse A record (IPv4 address).
+    pub fn parseA(self: ResourceRecord) ?[4]u8 {
+        if (self.rtype != .A or self.rdata.len != 4) return null;
+        return self.rdata[0..4].*;
+    }
+
+    /// Parse AAAA record (IPv6 address).
+    pub fn parseAAAA(self: ResourceRecord) ?[16]u8 {
+        if (self.rtype != .AAAA or self.rdata.len != 16) return null;
+        return self.rdata[0..16].*;
+    }
+
+    /// Parse CNAME record. Returns the target name.
+    pub fn parseCNAME(self: ResourceRecord, msg: []const u8) ?Name {
+        if (self.rtype != .CNAME) return null;
+        // CNAME rdata is a compressed name, need the full message for decompression
+        return Name.decode(msg, @intFromPtr(self.rdata.ptr) - @intFromPtr(msg.ptr)) catch null;
+    }
+};
+
+/// DNS domain name with support for compression.
+pub const Name = struct {
+    /// Raw label data (without compression).
+    data: [max_name_len]u8 = undefined,
+    len: u8 = 0,
+
+    /// Create a Name from a dotted string (e.g., "example.com").
+    pub fn fromString(s: []const u8) error{ NameTooLong, InvalidName }!Name {
+        var name: Name = .{};
+        var pos: usize = 0;
+
+        if (s.len == 0) {
+            // Root domain
+            name.data[0] = 0;
+            name.len = 1;
+            return name;
+        }
+
+        var iter = std.mem.splitScalar(u8, s, '.');
+        while (iter.next()) |label| {
+            if (label.len == 0) {
+                // Empty label - only allow as trailing root label
+                if (iter.peek() != null) return error.InvalidName; // Interior empty label
+                continue; // Trailing dot, skip (we add root terminator anyway)
+            }
+            if (label.len > max_label_len) return error.InvalidName;
+            if (pos + 1 + label.len > max_name_len) return error.NameTooLong;
+
+            name.data[pos] = @intCast(label.len);
+            pos += 1;
+            @memcpy(name.data[pos..][0..label.len], label);
+            pos += label.len;
+        }
+
+        if (pos + 1 > max_name_len) return error.NameTooLong;
+        name.data[pos] = 0; // Terminating zero-length label
+        pos += 1;
+        name.len = @intCast(pos);
+
+        return name;
+    }
+
+    /// Encode the name into wire format (already in wire format internally).
+    pub fn encode(self: Name, buf: []u8) error{BufferTooSmall}![]u8 {
+        if (buf.len < self.len) return error.BufferTooSmall;
+        @memcpy(buf[0..self.len], self.data[0..self.len]);
+        return buf[0..self.len];
+    }
+
+    /// Decode a name from wire format, handling compression pointers.
+    pub fn decode(msg: []const u8, start: usize) error{ Truncated, InvalidName }!Name {
+        var name: Name = .{};
+        var pos = start;
+        var out: usize = 0;
+        var jumps: usize = 0;
+        var end_pos: ?usize = null;
+
+        while (true) {
+            if (pos >= msg.len) return error.Truncated;
+
+            const len = msg[pos];
+
+            // Check for compression pointer (top 2 bits set)
+            if (len & 0xC0 == 0xC0) {
+                if (pos + 1 >= msg.len) return error.Truncated;
+
+                // Save the position after the pointer (for returning)
+                if (end_pos == null) {
+                    end_pos = pos + 2;
+                }
+
+                // Follow the pointer
+                const offset = (@as(u16, len & 0x3F) << 8) | msg[pos + 1];
+                pos = offset;
+
+                // Prevent infinite loops
+                jumps += 1;
+                if (jumps > max_name_len) return error.InvalidName;
+                continue;
+            }
+
+            // Zero length = end of name
+            if (len == 0) {
+                if (out + 1 > max_name_len) return error.InvalidName;
+                name.data[out] = 0;
+                out += 1;
+                break;
+            }
+
+            // Regular label
+            if (len > max_label_len) return error.InvalidName;
+            if (pos + 1 + len > msg.len) return error.Truncated;
+            if (out + 1 + len > max_name_len) return error.InvalidName;
+
+            name.data[out] = len;
+            out += 1;
+            @memcpy(name.data[out..][0..len], msg[pos + 1 ..][0..len]);
+            out += len;
+            pos += 1 + len;
+        }
+
+        name.len = @intCast(out);
+        return name;
+    }
+
+    /// Get the wire format length (for skipping in message parsing).
+    pub fn wireLen(msg: []const u8, start: usize) error{Truncated}!usize {
+        var pos = start;
+        while (true) {
+            if (pos >= msg.len) return error.Truncated;
+            const len = msg[pos];
+            if (len & 0xC0 == 0xC0) {
+                // Compression pointer - 2 bytes
+                return pos + 2 - start;
+            }
+            if (len == 0) {
+                return pos + 1 - start;
+            }
+            pos += 1 + len;
+        }
+    }
+
+    /// Convert to a dotted string representation.
+    pub fn toString(self: Name, buf: []u8) []u8 {
+        var pos: usize = 0;
+        var out: usize = 0;
+
+        while (pos < self.len) {
+            const label_len = self.data[pos];
+            if (label_len == 0) break;
+
+            if (out > 0 and out < buf.len) {
+                buf[out] = '.';
+                out += 1;
+            }
+
+            const end = @min(out + label_len, buf.len);
+            const copy_len = end - out;
+            if (copy_len > 0) {
+                @memcpy(buf[out..end], self.data[pos + 1 ..][0..copy_len]);
+                out = end;
+            }
+            pos += 1 + label_len;
+        }
+
+        return buf[0..out];
+    }
+
+    /// Check if two names are equal (case-insensitive per RFC 1035).
+    pub fn eql(a: Name, b: Name) bool {
+        if (a.len != b.len) return false;
+        return std.ascii.eqlIgnoreCase(a.data[0..a.len], b.data[0..b.len]);
+    }
+};
+
+/// EDNS0 OPT pseudo-record for advertising larger buffer sizes.
+pub const EdnsOpt = struct {
+    udp_size: u16 = max_packet_size,
+
+    pub fn encode(self: EdnsOpt, buf: []u8) error{BufferTooSmall}![]u8 {
+        // OPT record format:
+        // - Name: root (1 byte, 0x00)
+        // - Type: OPT (2 bytes)
+        // - Class: UDP payload size (2 bytes)
+        // - TTL: extended RCODE and flags (4 bytes)
+        // - RDLENGTH: 0 (2 bytes)
+        if (buf.len < 11) return error.BufferTooSmall;
+
+        buf[0] = 0; // Root name
+        std.mem.writeInt(u16, buf[1..3], @intFromEnum(Type.OPT), .big);
+        std.mem.writeInt(u16, buf[3..5], self.udp_size, .big);
+        std.mem.writeInt(u32, buf[5..9], 0, .big); // Extended RCODE + flags
+        std.mem.writeInt(u16, buf[9..11], 0, .big); // RDLENGTH
+
+        return buf[0..11];
+    }
+};
+
+/// Build a DNS query message.
+pub fn buildQuery(
+    buf: []u8,
+    id: u16,
+    name: Name,
+    qtype: Type,
+    with_edns: bool,
+) error{BufferTooSmall}![]u8 {
+    var pos: usize = 0;
+
+    // Header
+    const header = Header{
+        .id = id,
+        .flags = .{ .rd = true },
+        .qd_count = 1,
+        .an_count = 0,
+        .ns_count = 0,
+        .ar_count = if (with_edns) 1 else 0,
+    };
+    _ = header.encode(buf[pos..]);
+    pos += 12;
+
+    // Question
+    const question = Question{
+        .name = name,
+        .qtype = qtype,
+        .qclass = .IN,
+    };
+    const q_bytes = try question.encode(buf[pos..]);
+    pos += q_bytes.len;
+
+    // EDNS0 OPT record
+    if (with_edns) {
+        const opt = EdnsOpt{};
+        const opt_bytes = try opt.encode(buf[pos..]);
+        pos += opt_bytes.len;
+    }
+
+    return buf[0..pos];
+}
+
+/// Parser for DNS response messages.
+pub const ResponseParser = struct {
+    msg: []const u8,
+    pos: usize,
+    header: Header,
+
+    pub const ParseError = error{ Truncated, InvalidName, InvalidResponse };
+
+    pub fn init(msg: []const u8) ParseError!ResponseParser {
+        const header = Header.decode(msg) catch return error.Truncated;
+
+        // Basic validation
+        if (!header.flags.qr) return error.InvalidResponse; // Must be a response
+
+        return .{
+            .msg = msg,
+            .pos = 12,
+            .header = header,
+        };
+    }
+
+    /// Skip the question section.
+    pub fn skipQuestions(self: *ResponseParser) ParseError!void {
+        var count = self.header.qd_count;
+        while (count > 0) : (count -= 1) {
+            // Skip name
+            const name_len = Name.wireLen(self.msg, self.pos) catch return error.Truncated;
+            self.pos += name_len;
+
+            // Skip type and class
+            if (self.pos + 4 > self.msg.len) return error.Truncated;
+            self.pos += 4;
+        }
+    }
+
+    /// Read the next resource record from the answer section.
+    pub fn nextAnswer(self: *ResponseParser, remaining: *u16) ParseError!?ResourceRecord {
+        if (remaining.* == 0) return null;
+        remaining.* -= 1;
+
+        const rr = try self.readResourceRecord();
+        return rr;
+    }
+
+    fn readResourceRecord(self: *ResponseParser) ParseError!ResourceRecord {
+        // Name
+        const name = Name.decode(self.msg, self.pos) catch return error.InvalidName;
+        const name_len = Name.wireLen(self.msg, self.pos) catch return error.Truncated;
+        self.pos += name_len;
+
+        // Type, Class, TTL, RDLENGTH
+        if (self.pos + 10 > self.msg.len) return error.Truncated;
+
+        const rtype: Type = @enumFromInt(std.mem.readInt(u16, self.msg[self.pos..][0..2], .big));
+        self.pos += 2;
+        const class: Class = @enumFromInt(std.mem.readInt(u16, self.msg[self.pos..][0..2], .big));
+        self.pos += 2;
+        const ttl = std.mem.readInt(u32, self.msg[self.pos..][0..4], .big);
+        self.pos += 4;
+        const rdlength = std.mem.readInt(u16, self.msg[self.pos..][0..2], .big);
+        self.pos += 2;
+
+        if (self.pos + rdlength > self.msg.len) return error.Truncated;
+        const rdata = self.msg[self.pos..][0..rdlength];
+        self.pos += rdlength;
+
+        return .{
+            .name = name,
+            .rtype = rtype,
+            .class = class,
+            .ttl = ttl,
+            .rdata = rdata,
+        };
+    }
+};
+
+// Tests
+
+test "Name.fromString" {
+    const name = try Name.fromString("example.com");
+    var buf: [256]u8 = undefined;
+    const s = name.toString(&buf);
+    try std.testing.expectEqualStrings("example.com", s);
+}
+
+test "Name.fromString root" {
+    const name = try Name.fromString("");
+    try std.testing.expectEqual(@as(u8, 1), name.len);
+    try std.testing.expectEqual(@as(u8, 0), name.data[0]);
+}
+
+test "Name.fromString trailing dot" {
+    const name = try Name.fromString("example.com.");
+    var buf: [256]u8 = undefined;
+    const s = name.toString(&buf);
+    try std.testing.expectEqualStrings("example.com", s);
+}
+
+test "Name wire encoding roundtrip" {
+    const original = try Name.fromString("www.example.com");
+
+    var wire_buf: [256]u8 = undefined;
+    const wire = try original.encode(&wire_buf);
+
+    const decoded = try Name.decode(wire, 0);
+    try std.testing.expect(original.eql(decoded));
+}
+
+test "Name compression decoding" {
+    // Simulate a compressed name: pointer to offset 0
+    const msg = [_]u8{
+        // Name "example.com" at offset 0
+        7, 'e', 'x', 'a', 'm', 'p',  'l',  'e',
+        3, 'c', 'o', 'm', 0,
+        // Pointer to offset 0
+          0xC0, 0x00,
+    };
+
+    const name1 = try Name.decode(&msg, 0);
+    const name2 = try Name.decode(&msg, 13); // Should decompress to same name
+
+    try std.testing.expect(name1.eql(name2));
+}
+
+test "buildQuery" {
+    var buf: [512]u8 = undefined;
+    const name = try Name.fromString("example.com");
+    const query = try buildQuery(&buf, 0x1234, name, .A, true);
+
+    // Parse it back
+    const header = try Header.decode(query);
+    try std.testing.expectEqual(@as(u16, 0x1234), header.id);
+    try std.testing.expectEqual(@as(u16, 1), header.qd_count);
+    try std.testing.expectEqual(@as(u16, 1), header.ar_count); // EDNS0
+    try std.testing.expect(header.flags.rd);
+    try std.testing.expect(!header.flags.qr);
+}
+
+test "Header encode/decode roundtrip" {
+    const original = Header{
+        .id = 0xABCD,
+        .flags = .{ .rd = true, .aa = true },
+        .qd_count = 1,
+        .an_count = 2,
+        .ns_count = 3,
+        .ar_count = 4,
+    };
+
+    var buf: [12]u8 = undefined;
+    _ = original.encode(&buf);
+
+    const decoded = try Header.decode(&buf);
+    try std.testing.expectEqual(original.id, decoded.id);
+    try std.testing.expectEqual(original.flags, decoded.flags);
+    try std.testing.expectEqual(original.qd_count, decoded.qd_count);
+    try std.testing.expectEqual(original.an_count, decoded.an_count);
+}

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -37,8 +37,8 @@ pub const LookupError = error{
 pub const LookupOptions = struct {
     /// Address family filter.
     family: ?net.IpAddress.Family = null,
-    /// Query timeout per attempt.
-    timeout_ms: u32 = 5000,
+    /// Query timeout per attempt (overrides config timeout if set).
+    timeout_ms: ?u32 = null,
 };
 
 pub const LookupResult = struct {
@@ -303,17 +303,20 @@ pub const Resolver = struct {
         const query = message.buildQuery(&query_buf, id, name, qtype, !self.config.use_tcp) catch
             return error.Unexpected;
 
+        // Use explicit timeout if provided, otherwise use config timeout
+        const timeout_ms = options.timeout_ms orelse @as(u32, self.config.timeout) * 1000;
+
         if (self.config.use_tcp) {
-            return queryTcp(server, id, name, qtype, options, recv_buf);
+            return queryTcp(server, id, name, qtype, timeout_ms, recv_buf);
         }
 
         // Try UDP first
-        const udp_result = queryUdp(server, id, query, options, recv_buf);
+        const udp_result = queryUdp(server, id, query, timeout_ms, recv_buf);
         if (udp_result) |response| {
             // Check if truncated - fall back to TCP
             const header = Header.decode(response) catch return error.InvalidResponse;
             if (header.flags.tc) {
-                return queryTcp(server, id, name, qtype, options, recv_buf);
+                return queryTcp(server, id, name, qtype, timeout_ms, recv_buf);
             }
             return response;
         } else |err| {
@@ -326,13 +329,13 @@ pub const Resolver = struct {
         server: net.IpAddress,
         id: u16,
         query: []const u8,
-        options: LookupOptions,
+        timeout_ms: u32,
         recv_buf: *[message.max_packet_size]u8,
     ) LookupError![]const u8 {
         var socket = net.Socket.open(.dgram, os.net.Domain.fromPosix(server.any.family), .udp) catch return error.Unexpected;
         defer socket.close();
 
-        const timeout = time.Timeout.fromMilliseconds(options.timeout_ms);
+        const timeout = time.Timeout.fromMilliseconds(timeout_ms);
 
         // Send query
         _ = socket.sendTo(.{ .ip = server }, query, timeout) catch |err| {
@@ -375,7 +378,7 @@ pub const Resolver = struct {
         id: u16,
         name: Name,
         qtype: Type,
-        options: LookupOptions,
+        timeout_ms: u32,
         recv_buf: *[message.max_packet_size]u8,
     ) LookupError![]const u8 {
         // Rebuild query for TCP (with length prefix)
@@ -387,7 +390,7 @@ pub const Resolver = struct {
         std.mem.writeInt(u16, query_buf[0..2], @intCast(query_body.len), .big);
         const full_query = query_buf[0 .. 2 + query_body.len];
 
-        const timeout = time.Timeout.fromMilliseconds(options.timeout_ms);
+        const timeout = time.Timeout.fromMilliseconds(timeout_ms);
 
         var stream = server.connect(.{ .timeout = timeout }) catch |err| {
             return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -446,21 +446,37 @@ pub const Resolver = struct {
 
         // Parse answers into temporary result to avoid partial data on error
         var tmp: LookupResult = .{};
+        var current_name = expected_name;
         var remaining = parser.header.an_count;
         while (true) {
             const rr = parser.nextAnswer(&remaining) catch return error.InvalidResponse;
             if (rr == null) break;
             const record = rr.?;
-            if (record.parseA()) |ipv4| {
-                if (tmp.addresses.len < LookupResult.max_addresses) {
-                    tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
+            if (record.class != .IN) continue;
+
+            // Follow CNAME chain: update current_name when we see a CNAME for the active name
+            if (record.rtype == .CNAME and record.name.eql(current_name)) {
+                const cname = record.parseCNAME(response) orelse return error.InvalidResponse;
+                if (tmp.canonical_name == null) tmp.canonical_name = cname;
+                current_name = cname;
+                continue;
+            }
+
+            // Only accept records for the active name (original or CNAME target)
+            if (!record.name.eql(current_name)) continue;
+
+            if (expected_qtype == .A) {
+                if (record.parseA()) |ipv4| {
+                    if (tmp.addresses.len < LookupResult.max_addresses) {
+                        tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
+                    }
                 }
-            } else if (record.parseAAAA()) |ipv6| {
-                if (tmp.addresses.len < LookupResult.max_addresses) {
-                    tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
+            } else if (expected_qtype == .AAAA) {
+                if (record.parseAAAA()) |ipv6| {
+                    if (tmp.addresses.len < LookupResult.max_addresses) {
+                        tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
+                    }
                 }
-            } else if (record.rtype == .CNAME and tmp.canonical_name == null) {
-                tmp.canonical_name = record.parseCNAME(response);
             }
         }
 

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -52,6 +52,7 @@ pub const LookupResult = struct {
         len: usize = 0,
 
         pub fn appendAssumeCapacity(self: *Addresses, addr: net.IpAddress) void {
+            std.debug.assert(self.len < max_addresses);
             self.buffer[self.len] = addr;
             self.len += 1;
         }
@@ -344,6 +345,15 @@ pub const Resolver = struct {
             else => return error.Unexpected,
         };
 
+        // Validate response came from expected server (ignore port)
+        const from = recv_result.from.ip;
+        if (from.any.family != server.any.family) return error.InvalidResponse;
+        switch (from.any.family) {
+            os.net.AF.INET => if (from.in.addr != server.in.addr) return error.InvalidResponse,
+            os.net.AF.INET6 => if (!std.mem.eql(u8, &from.in6.addr, &server.in6.addr)) return error.InvalidResponse,
+            else => return error.InvalidResponse,
+        }
+
         // Validate response ID matches
         if (recv_result.len < 12) return error.InvalidResponse;
         const resp_id = std.mem.readInt(u16, recv_buf[0..2], .big);
@@ -422,17 +432,20 @@ pub const Resolver = struct {
 
         // Parse answers
         var remaining = parser.header.an_count;
-        while (parser.nextAnswer(&remaining) catch null) |rr| {
-            if (rr.parseA()) |ipv4| {
+        while (true) {
+            const rr = parser.nextAnswer(&remaining) catch return error.InvalidResponse;
+            if (rr == null) break;
+            const record = rr.?;
+            if (record.parseA()) |ipv4| {
                 if (result.addresses.len < LookupResult.max_addresses) {
                     result.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
                 }
-            } else if (rr.parseAAAA()) |ipv6| {
+            } else if (record.parseAAAA()) |ipv6| {
                 if (result.addresses.len < LookupResult.max_addresses) {
                     result.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
                 }
-            } else if (rr.rtype == .CNAME and result.canonical_name == null) {
-                result.canonical_name = rr.parseCNAME(response);
+            } else if (record.rtype == .CNAME and result.canonical_name == null) {
+                result.canonical_name = record.parseCNAME(response);
             }
         }
     }

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -230,7 +230,8 @@ pub const Resolver = struct {
         return last_err orelse error.UnknownHostName;
     }
 
-    /// Query for both A and AAAA records sequentially.
+    /// Query for both A and AAAA records.
+    /// Note: Queries are always sequential (matching single-request behavior).
     fn queryBoth(self: *Resolver, result: *LookupResult, name: Name, options: LookupOptions) ?LookupError {
         const err_a = self.queryOne(result, name, .A, options);
         if (err_a) |e| if (e == error.Canceled) return e;

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Native DNS resolver using UDP/TCP sockets directly.
+
+const std = @import("std");
+const fs = @import("../../fs.zig");
+const net = @import("../../net.zig");
+const os = @import("../../os/root.zig");
+const time = @import("../../time.zig");
+const message = @import("message.zig");
+const config_mod = @import("config.zig");
+const hosts = @import("hosts.zig");
+
+const Config = config_mod.Config;
+const Name = message.Name;
+const Type = message.Type;
+const Header = message.Header;
+const RCode = message.RCode;
+const ResponseParser = message.ResponseParser;
+
+pub const LookupError = error{
+    UnknownHostName,
+    TemporaryNameServerFailure,
+    NameServerFailure,
+    HostLacksNetworkAddresses,
+    InvalidResponse,
+    Truncated,
+    Timeout,
+    NetworkUnreachable,
+    ConnectionRefused,
+    Canceled,
+    OutOfMemory,
+    Unexpected,
+};
+
+pub const LookupOptions = struct {
+    /// Address family filter.
+    family: ?net.IpAddress.Family = null,
+    /// Query timeout per attempt.
+    timeout_ms: u32 = 5000,
+};
+
+pub const LookupResult = struct {
+    addresses: Addresses = .{},
+    canonical_name: ?Name = null,
+
+    pub const max_addresses = 32;
+
+    pub const Addresses = struct {
+        buffer: [max_addresses]net.IpAddress = undefined,
+        len: usize = 0,
+
+        pub fn appendAssumeCapacity(self: *Addresses, addr: net.IpAddress) void {
+            self.buffer[self.len] = addr;
+            self.len += 1;
+        }
+
+        pub fn slice(self: *Addresses) []net.IpAddress {
+            return self.buffer[0..self.len];
+        }
+
+        pub fn constSlice(self: *const Addresses) []const net.IpAddress {
+            return self.buffer[0..self.len];
+        }
+
+        pub fn capacity(self: *const Addresses) usize {
+            _ = self;
+            return max_addresses;
+        }
+    };
+};
+
+const resolv_conf_path = "/etc/resolv.conf";
+
+/// How often to check if resolv.conf has changed (in seconds).
+const config_reload_interval_s = 5;
+
+/// Native DNS resolver.
+pub const Resolver = struct {
+    config: Config,
+    /// Server rotation offset for load balancing.
+    server_offset: usize = 0,
+    /// Random state for query IDs.
+    prng: std.Random.DefaultPrng,
+    /// Last time we checked resolv.conf for changes.
+    last_checked: time.Timestamp = .zero,
+    /// Modification time of resolv.conf when we last loaded it.
+    mtime: i64 = 0,
+
+    pub fn init(cfg: Config) Resolver {
+        var seed: u64 = undefined;
+        std.posix.getrandom(std.mem.asBytes(&seed)) catch {
+            seed = @truncate(@as(u128, @bitCast(std.time.nanoTimestamp())));
+        };
+        return .{
+            .config = cfg,
+            .prng = std.Random.DefaultPrng.init(seed),
+        };
+    }
+
+    /// Load configuration from /etc/resolv.conf.
+    pub fn initFromSystem() error{Canceled}!Resolver {
+        var resolver = try loadConfig();
+        resolver.last_checked = time.Timestamp.now(.monotonic);
+        resolver.mtime = try getResolvConfMtime();
+        return resolver;
+    }
+
+    fn loadConfig() error{Canceled}!Resolver {
+        const file = fs.openFile(resolv_conf_path) catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            return init(Config.default());
+        };
+        defer file.close();
+
+        var read_buf: [512]u8 = undefined;
+        var reader = file.reader(&read_buf);
+
+        var buf: [4096]u8 = undefined;
+        var writer = std.Io.Writer.fixed(&buf);
+        const len = reader.interface.streamRemaining(&writer) catch |err| {
+            if (err == error.ReadFailed) {
+                if (reader.err) |e| {
+                    if (e == error.Canceled) return error.Canceled;
+                }
+            }
+            return init(Config.default());
+        };
+        return init(Config.parse(buf[0..len]));
+    }
+
+    fn getResolvConfMtime() error{Canceled}!i64 {
+        const stat_info = fs.stat(resolv_conf_path) catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            return 0;
+        };
+        return stat_info.mtime;
+    }
+
+    /// Check if resolv.conf has changed and reload if necessary.
+    fn tryReloadConfig(self: *Resolver) error{Canceled}!void {
+        const now = time.Timestamp.now(.monotonic);
+        if (self.last_checked.durationTo(now).toSeconds() < config_reload_interval_s) {
+            return;
+        }
+        self.last_checked = now;
+
+        const new_mtime = try getResolvConfMtime();
+        if (new_mtime == self.mtime) {
+            return;
+        }
+
+        // Config changed, reload it
+        const new_resolver = try loadConfig();
+        self.config = new_resolver.config;
+        self.mtime = new_mtime;
+        // Keep server_offset and prng state
+    }
+
+    /// Look up IP addresses for a hostname.
+    pub fn lookup(self: *Resolver, hostname: []const u8, port: u16, options: LookupOptions) LookupError!LookupResult {
+        try self.tryReloadConfig();
+
+        var result: LookupResult = .{};
+
+        // Check if hostname is a numeric IP address - return directly without DNS
+        if (net.IpAddress.parseIp(hostname, port)) |addr| {
+            const family = addr.getFamily();
+            if (options.family == null or options.family == family) {
+                result.addresses.appendAssumeCapacity(addr);
+                return result;
+            }
+            // Family mismatch - no addresses match the filter
+            return error.HostLacksNetworkAddresses;
+        } else |_| {}
+
+        // Check /etc/hosts before DNS query
+        if (hosts.lookup(hostname, options.family)) |hosts_result| {
+            for (hosts_result.slice()) |addr| {
+                var addr_with_port = addr;
+                addr_with_port.setPort(port);
+                if (result.addresses.len < LookupResult.max_addresses) {
+                    result.addresses.appendAssumeCapacity(addr_with_port);
+                }
+            }
+            if (result.addresses.len > 0) {
+                // Set canonical name to the hostname itself for hosts file entries
+                result.canonical_name = Name.fromString(hostname) catch null;
+                return result;
+            }
+        }
+
+        var last_err: ?LookupError = null;
+
+        // Try each name in the search list
+        var name_buf: [message.max_name_len + config_mod.max_search_len + 2]u8 = undefined;
+        var name_iter = self.config.nameList(hostname);
+
+        while (name_iter.next(&name_buf)) |fqdn| {
+            const name = Name.fromString(fqdn) catch continue;
+
+            // Query based on family filter
+            const query_err = if (options.family) |family| switch (family) {
+                .ipv4 => self.queryOne(&result, name, .A, options),
+                .ipv6 => self.queryOne(&result, name, .AAAA, options),
+            } else self.queryBoth(&result, name, options);
+
+            if (query_err) |err| {
+                last_err = err;
+                // For NXDOMAIN, don't try other search suffixes
+                if (err == error.UnknownHostName) {
+                    continue;
+                }
+                // For temporary errors, try next name
+                continue;
+            }
+
+            // Got results
+            if (result.addresses.len > 0) {
+                // Set port on all addresses
+                for (result.addresses.slice()) |*addr| {
+                    addr.setPort(port);
+                }
+                return result;
+            }
+        }
+
+        return last_err orelse error.UnknownHostName;
+    }
+
+    /// Query for both A and AAAA records sequentially.
+    fn queryBoth(self: *Resolver, result: *LookupResult, name: Name, options: LookupOptions) ?LookupError {
+        const err_a = self.queryOne(result, name, .A, options);
+        if (err_a) |e| if (e == error.Canceled) return e;
+
+        const err_aaaa = self.queryOne(result, name, .AAAA, options);
+        if (err_aaaa) |e| if (e == error.Canceled) return e;
+
+        // Return error only if both failed
+        if (result.addresses.len > 0) return null;
+        return err_a orelse err_aaaa;
+    }
+
+    /// Query for a single record type.
+    fn queryOne(self: *Resolver, result: *LookupResult, name: Name, qtype: Type, options: LookupOptions) ?LookupError {
+        var recv_buf: [message.max_packet_size]u8 = undefined;
+        var attempt: usize = 0;
+        const max_attempts = self.config.attempts;
+
+        while (attempt < max_attempts) : (attempt += 1) {
+            // Try each server
+            const server_count = self.config.servers.len;
+            var server_idx: usize = 0;
+
+            while (server_idx < server_count) : (server_idx += 1) {
+                const idx = if (self.config.rotate)
+                    (self.server_offset + server_idx) % server_count
+                else
+                    server_idx;
+
+                const server = self.config.servers.buffer[idx];
+
+                const query_result = self.queryServer(server.addr, name, qtype, options, &recv_buf);
+
+                if (query_result) |response| {
+                    parseResponse(result, response) catch |err| {
+                        // Propagate definitive errors, retry on parse failures
+                        if (err == error.UnknownHostName) return err;
+                        if (err == error.NameServerFailure) return err;
+                        if (err == error.TemporaryNameServerFailure) return err;
+                        continue; // Try next server on InvalidResponse
+                    };
+
+                    if (self.config.rotate) {
+                        self.server_offset = (self.server_offset + 1) % server_count;
+                    }
+
+                    return null; // Success
+                } else |err| {
+                    if (err == error.Canceled) return err;
+                    continue; // For any transport error, try next server
+                }
+            }
+        }
+
+        return error.TemporaryNameServerFailure;
+    }
+
+    /// Send query to a specific server.
+    fn queryServer(
+        self: *Resolver,
+        server: net.IpAddress,
+        name: Name,
+        qtype: Type,
+        options: LookupOptions,
+        recv_buf: *[message.max_packet_size]u8,
+    ) LookupError![]const u8 {
+        const id = self.prng.random().int(u16);
+        var query_buf: [512]u8 = undefined;
+        const query = message.buildQuery(&query_buf, id, name, qtype, !self.config.use_tcp) catch
+            return error.Unexpected;
+
+        if (self.config.use_tcp) {
+            return queryTcp(server, id, name, qtype, options, recv_buf);
+        }
+
+        // Try UDP first
+        const udp_result = queryUdp(server, id, query, options, recv_buf);
+        if (udp_result) |response| {
+            // Check if truncated - fall back to TCP
+            const header = Header.decode(response) catch return error.InvalidResponse;
+            if (header.flags.tc) {
+                return queryTcp(server, id, name, qtype, options, recv_buf);
+            }
+            return response;
+        } else |err| {
+            return err;
+        }
+    }
+
+    /// Send query over UDP.
+    fn queryUdp(
+        server: net.IpAddress,
+        id: u16,
+        query: []const u8,
+        options: LookupOptions,
+        recv_buf: *[message.max_packet_size]u8,
+    ) LookupError![]const u8 {
+        var socket = net.Socket.open(.dgram, os.net.Domain.fromPosix(server.any.family), .udp) catch return error.Unexpected;
+        defer socket.close();
+
+        const timeout = time.Timeout.fromMilliseconds(options.timeout_ms);
+
+        // Send query
+        _ = socket.sendTo(.{ .ip = server }, query, timeout) catch |err| {
+            return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;
+        };
+
+        // Receive response
+        const recv_result = socket.receiveFrom(recv_buf, timeout) catch |err| switch (err) {
+            error.Canceled => return error.Canceled,
+            error.Timeout => return error.Timeout,
+            else => return error.Unexpected,
+        };
+
+        // Validate response ID matches
+        if (recv_result.len < 12) return error.InvalidResponse;
+        const resp_id = std.mem.readInt(u16, recv_buf[0..2], .big);
+        if (resp_id != id) return error.InvalidResponse;
+
+        return recv_buf[0..recv_result.len];
+    }
+
+    /// Send query over TCP (for large responses).
+    fn queryTcp(
+        server: net.IpAddress,
+        id: u16,
+        name: Name,
+        qtype: Type,
+        options: LookupOptions,
+        recv_buf: *[message.max_packet_size]u8,
+    ) LookupError![]const u8 {
+        // Rebuild query for TCP (with length prefix)
+        var query_buf: [514]u8 = undefined;
+        const query_body = message.buildQuery(query_buf[2..], id, name, qtype, true) catch
+            return error.Unexpected;
+
+        // Add length prefix
+        std.mem.writeInt(u16, query_buf[0..2], @intCast(query_body.len), .big);
+        const full_query = query_buf[0 .. 2 + query_body.len];
+
+        const timeout = time.Timeout.fromMilliseconds(options.timeout_ms);
+
+        var stream = server.connect(.{ .timeout = timeout }) catch |err| {
+            return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;
+        };
+        defer stream.close();
+
+        // Send query
+        stream.writeAll(full_query, timeout) catch |err| {
+            return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;
+        };
+
+        // Read response length
+        var len_buf: [2]u8 = undefined;
+        stream.readAll(&len_buf, timeout) catch |err| {
+            return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;
+        };
+        const resp_len = std.mem.readInt(u16, &len_buf, .big);
+
+        if (resp_len < 12 or resp_len > message.max_packet_size) {
+            return error.InvalidResponse;
+        }
+
+        // Read response body
+        stream.readAll(recv_buf[0..resp_len], timeout) catch |err| {
+            return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;
+        };
+
+        // Validate response ID
+        const resp_id = std.mem.readInt(u16, recv_buf[0..2], .big);
+        if (resp_id != id) return error.InvalidResponse;
+
+        return recv_buf[0..resp_len];
+    }
+
+    /// Parse DNS response and extract addresses.
+    fn parseResponse(result: *LookupResult, response: []const u8) !void {
+        var parser = ResponseParser.init(response) catch return error.InvalidResponse;
+
+        // Check response code
+        switch (parser.header.flags.rcode) {
+            .success => {},
+            .name_error => return error.UnknownHostName,
+            .server_failure => return error.TemporaryNameServerFailure,
+            else => return error.NameServerFailure,
+        }
+
+        // Skip questions
+        parser.skipQuestions() catch return error.InvalidResponse;
+
+        // Parse answers
+        var remaining = parser.header.an_count;
+        while (parser.nextAnswer(&remaining) catch null) |rr| {
+            if (rr.parseA()) |ipv4| {
+                if (result.addresses.len < LookupResult.max_addresses) {
+                    result.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
+                }
+            } else if (rr.parseAAAA()) |ipv6| {
+                if (result.addresses.len < LookupResult.max_addresses) {
+                    result.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
+                }
+            } else if (rr.rtype == .CNAME and result.canonical_name == null) {
+                result.canonical_name = rr.parseCNAME(response);
+            }
+        }
+    }
+};
+
+// Tests (these require network access, so they're integration tests)
+
+test "Resolver.init" {
+    const resolver = Resolver.init(Config.default());
+    try std.testing.expectEqual(@as(usize, 1), resolver.config.servers.len);
+}

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -73,8 +73,9 @@ pub const LookupResult = struct {
 };
 
 const resolv_conf_path = "/etc/resolv.conf";
+const hosts_path = "/etc/hosts";
 
-/// How often to check if resolv.conf has changed (in seconds).
+/// How often to check if resolv.conf or /etc/hosts has changed (in seconds).
 const config_reload_interval_s = 5;
 
 /// Native DNS resolver.
@@ -88,6 +89,14 @@ pub const Resolver = struct {
     last_checked: time.Timestamp = .zero,
     /// Modification time of resolv.conf when we last loaded it.
     mtime: i64 = 0,
+    /// Cached /etc/hosts file content.
+    hosts_content: [65536]u8 = undefined,
+    /// Length of valid data in hosts_content.
+    hosts_content_len: usize = 0,
+    /// Last time we checked /etc/hosts for changes.
+    hosts_last_checked: time.Timestamp = .zero,
+    /// Modification time of /etc/hosts when we last loaded it.
+    hosts_mtime: i64 = 0,
 
     pub fn init(cfg: Config) Resolver {
         var seed: u64 = undefined;
@@ -105,6 +114,9 @@ pub const Resolver = struct {
         var resolver = try loadConfig();
         resolver.last_checked = time.Timestamp.now(.monotonic);
         resolver.mtime = try getResolvConfMtime();
+        resolver.hosts_last_checked = time.Timestamp.now(.monotonic);
+        resolver.hosts_mtime = try getHostsMtime();
+        try resolver.loadHosts();
         return resolver;
     }
 
@@ -139,6 +151,38 @@ pub const Resolver = struct {
         return stat_info.mtime;
     }
 
+    fn getHostsMtime() error{Canceled}!i64 {
+        const stat_info = fs.stat(hosts_path) catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            return 0;
+        };
+        return stat_info.mtime;
+    }
+
+    fn loadHosts(self: *Resolver) error{Canceled}!void {
+        const file = fs.openFile(hosts_path) catch |err| {
+            if (err == error.Canceled) return error.Canceled;
+            self.hosts_content_len = 0;
+            return;
+        };
+        defer file.close();
+
+        var read_buf: [512]u8 = undefined;
+        var reader = file.reader(&read_buf);
+
+        var writer = std.Io.Writer.fixed(&self.hosts_content);
+        const len = reader.interface.streamRemaining(&writer) catch |err| {
+            if (err == error.ReadFailed) {
+                if (reader.err) |e| {
+                    if (e == error.Canceled) return error.Canceled;
+                }
+            }
+            self.hosts_content_len = 0;
+            return;
+        };
+        self.hosts_content_len = len;
+    }
+
     /// Check if resolv.conf has changed and reload if necessary.
     fn tryReloadConfig(self: *Resolver) error{Canceled}!void {
         const now = time.Timestamp.now(.monotonic);
@@ -159,9 +203,28 @@ pub const Resolver = struct {
         // Keep server_offset and prng state
     }
 
+    /// Check if /etc/hosts has changed and reload if necessary.
+    fn tryReloadHosts(self: *Resolver) error{Canceled}!void {
+        const now = time.Timestamp.now(.monotonic);
+        if (self.hosts_last_checked.durationTo(now).toSeconds() < config_reload_interval_s) {
+            return;
+        }
+        self.hosts_last_checked = now;
+
+        const new_mtime = try getHostsMtime();
+        if (new_mtime == self.hosts_mtime) {
+            return;
+        }
+
+        // Hosts changed, reload it
+        try self.loadHosts();
+        self.hosts_mtime = new_mtime;
+    }
+
     /// Look up IP addresses for a hostname.
     pub fn lookup(self: *Resolver, hostname: []const u8, port: u16, options: LookupOptions) LookupError!LookupResult {
         try self.tryReloadConfig();
+        try self.tryReloadHosts();
 
         var result: LookupResult = .{};
 
@@ -176,8 +239,8 @@ pub const Resolver = struct {
             return error.HostLacksNetworkAddresses;
         } else |_| {}
 
-        // Check /etc/hosts before DNS query
-        if (hosts.lookup(hostname, options.family)) |hosts_result| {
+        // Check /etc/hosts before DNS query (using cached content)
+        if (hosts.lookupInContent(self.hosts_content[0..self.hosts_content_len], hostname, options.family)) |hosts_result| {
             for (hosts_result.slice()) |addr| {
                 var addr_with_port = addr;
                 addr_with_port.setPort(port);

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -436,23 +436,34 @@ pub const Resolver = struct {
         // Skip questions
         parser.skipQuestions() catch return error.InvalidResponse;
 
-        // Parse answers
+        // Parse answers into temporary result to avoid partial data on error
+        var tmp: LookupResult = .{};
         var remaining = parser.header.an_count;
         while (true) {
             const rr = parser.nextAnswer(&remaining) catch return error.InvalidResponse;
             if (rr == null) break;
             const record = rr.?;
             if (record.parseA()) |ipv4| {
-                if (result.addresses.len < LookupResult.max_addresses) {
-                    result.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
+                if (tmp.addresses.len < LookupResult.max_addresses) {
+                    tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp4(ipv4, 0));
                 }
             } else if (record.parseAAAA()) |ipv6| {
-                if (result.addresses.len < LookupResult.max_addresses) {
-                    result.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
+                if (tmp.addresses.len < LookupResult.max_addresses) {
+                    tmp.addresses.appendAssumeCapacity(net.IpAddress.initIp6(ipv6, 0, 0, 0));
                 }
-            } else if (record.rtype == .CNAME and result.canonical_name == null) {
-                result.canonical_name = record.parseCNAME(response);
+            } else if (record.rtype == .CNAME and tmp.canonical_name == null) {
+                tmp.canonical_name = record.parseCNAME(response);
             }
+        }
+
+        // Merge successful results
+        for (tmp.addresses.constSlice()) |addr| {
+            if (result.addresses.len < LookupResult.max_addresses) {
+                result.addresses.appendAssumeCapacity(addr);
+            }
+        }
+        if (result.canonical_name == null) {
+            result.canonical_name = tmp.canonical_name;
         }
     }
 };

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -38,7 +38,7 @@ pub const LookupOptions = struct {
     /// Address family filter.
     family: ?net.IpAddress.Family = null,
     /// Query timeout per attempt (overrides config timeout if set).
-    timeout_ms: ?u32 = null,
+    timeout: ?time.Timeout = null,
 };
 
 pub const LookupResult = struct {
@@ -304,19 +304,19 @@ pub const Resolver = struct {
             return error.Unexpected;
 
         // Use explicit timeout if provided, otherwise use config timeout
-        const timeout_ms = options.timeout_ms orelse @as(u32, self.config.timeout) * 1000;
+        const timeout = options.timeout orelse time.Timeout.fromSeconds(self.config.timeout);
 
         if (self.config.use_tcp) {
-            return queryTcp(server, id, name, qtype, timeout_ms, recv_buf);
+            return queryTcp(server, id, name, qtype, timeout, recv_buf);
         }
 
         // Try UDP first
-        const udp_result = queryUdp(server, id, query, timeout_ms, recv_buf);
+        const udp_result = queryUdp(server, id, query, timeout, recv_buf);
         if (udp_result) |response| {
             // Check if truncated - fall back to TCP
             const header = Header.decode(response) catch return error.InvalidResponse;
             if (header.flags.tc) {
-                return queryTcp(server, id, name, qtype, timeout_ms, recv_buf);
+                return queryTcp(server, id, name, qtype, timeout, recv_buf);
             }
             return response;
         } else |err| {
@@ -329,13 +329,11 @@ pub const Resolver = struct {
         server: net.IpAddress,
         id: u16,
         query: []const u8,
-        timeout_ms: u32,
+        timeout: time.Timeout,
         recv_buf: *[message.max_packet_size]u8,
     ) LookupError![]const u8 {
         var socket = net.Socket.open(.dgram, os.net.Domain.fromPosix(server.any.family), .udp) catch return error.Unexpected;
         defer socket.close();
-
-        const timeout = time.Timeout.fromMilliseconds(timeout_ms);
 
         // Send query
         _ = socket.sendTo(.{ .ip = server }, query, timeout) catch |err| {
@@ -378,7 +376,7 @@ pub const Resolver = struct {
         id: u16,
         name: Name,
         qtype: Type,
-        timeout_ms: u32,
+        timeout: time.Timeout,
         recv_buf: *[message.max_packet_size]u8,
     ) LookupError![]const u8 {
         // Rebuild query for TCP (with length prefix)
@@ -389,8 +387,6 @@ pub const Resolver = struct {
         // Add length prefix
         std.mem.writeInt(u16, query_buf[0..2], @intCast(query_body.len), .big);
         const full_query = query_buf[0 .. 2 + query_body.len];
-
-        const timeout = time.Timeout.fromMilliseconds(timeout_ms);
 
         var stream = server.connect(.{ .timeout = timeout }) catch |err| {
             return if (err == error.Canceled) error.Canceled else if (err == error.Timeout) error.Timeout else error.Unexpected;

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -345,12 +345,18 @@ pub const Resolver = struct {
             else => return error.Unexpected,
         };
 
-        // Validate response came from expected server (ignore port)
+        // Validate response came from expected server (IP and port)
         const from = recv_result.from.ip;
         if (from.any.family != server.any.family) return error.InvalidResponse;
         switch (from.any.family) {
-            os.net.AF.INET => if (from.in.addr != server.in.addr) return error.InvalidResponse,
-            os.net.AF.INET6 => if (!std.mem.eql(u8, &from.in6.addr, &server.in6.addr)) return error.InvalidResponse,
+            os.net.AF.INET => {
+                if (from.in.addr != server.in.addr) return error.InvalidResponse;
+                if (from.in.port != server.in.port) return error.InvalidResponse;
+            },
+            os.net.AF.INET6 => {
+                if (!std.mem.eql(u8, &from.in6.addr, &server.in6.addr)) return error.InvalidResponse;
+                if (from.in6.port != server.in6.port) return error.InvalidResponse;
+            },
             else => return error.InvalidResponse,
         }
 

--- a/src/dns/native/resolver.zig
+++ b/src/dns/native/resolver.zig
@@ -266,11 +266,12 @@ pub const Resolver = struct {
                 const query_result = self.queryServer(server.addr, name, qtype, options, &recv_buf);
 
                 if (query_result) |response| {
-                    parseResponse(result, response) catch |err| {
+                    parseResponse(result, response, name, qtype) catch |err| {
                         // Propagate definitive errors, retry on parse failures
                         if (err == error.UnknownHostName) return err;
                         if (err == error.NameServerFailure) return err;
                         if (err == error.TemporaryNameServerFailure) return err;
+                        if (err == error.HostLacksNetworkAddresses) return err;
                         continue; // Try next server on InvalidResponse
                     };
 
@@ -422,7 +423,7 @@ pub const Resolver = struct {
     }
 
     /// Parse DNS response and extract addresses.
-    fn parseResponse(result: *LookupResult, response: []const u8) !void {
+    fn parseResponse(result: *LookupResult, response: []const u8, expected_name: Name, expected_qtype: Type) !void {
         var parser = ResponseParser.init(response) catch return error.InvalidResponse;
 
         // Check response code
@@ -433,8 +434,15 @@ pub const Resolver = struct {
             else => return error.NameServerFailure,
         }
 
-        // Skip questions
-        parser.skipQuestions() catch return error.InvalidResponse;
+        // Validate question section matches our query
+        if (parser.header.qd_count != 1) return error.InvalidResponse;
+        const q_name = Name.decode(response, parser.pos) catch return error.InvalidResponse;
+        const q_name_len = Name.wireLen(response, parser.pos) catch return error.InvalidResponse;
+        parser.pos += q_name_len;
+        if (parser.pos + 4 > response.len) return error.InvalidResponse;
+        const q_type: Type = @enumFromInt(std.mem.readInt(u16, response[parser.pos..][0..2], .big));
+        parser.pos += 4; // skip type and class
+        if (!q_name.eql(expected_name) or q_type != expected_qtype) return error.InvalidResponse;
 
         // Parse answers into temporary result to avoid partial data on error
         var tmp: LookupResult = .{};
@@ -454,6 +462,11 @@ pub const Resolver = struct {
             } else if (record.rtype == .CNAME and tmp.canonical_name == null) {
                 tmp.canonical_name = record.parseCNAME(response);
             }
+        }
+
+        // NOERROR with no addresses means host exists but lacks records of this type
+        if (tmp.addresses.len == 0) {
+            return error.HostLacksNetworkAddresses;
         }
 
         // Merge successful results

--- a/src/dns/native/root.zig
+++ b/src/dns/native/root.zig
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Native DNS resolver implementation.
+//!
+//! This module provides a pure-Zig DNS resolver that communicates directly
+//! with DNS servers over UDP/TCP, similar to Go's native resolver.
+//!
+//! Benefits over getaddrinfo:
+//! - Truly async (no thread pool slot consumed)
+//! - Better cancellation support
+//! - Can query additional record types (SRV, MX, TXT)
+//! - No cgo/libc dependency
+//!
+//! Limitations:
+//! - Does not support mDNS (.local domains)
+//! - Does not support LLMNR
+//! - May not respect systemd-resolved or VPN split-DNS configurations
+
+pub const message = @import("message.zig");
+pub const config = @import("config.zig");
+pub const hosts = @import("hosts.zig");
+pub const resolver = @import("resolver.zig");
+
+pub const Config = config.Config;
+pub const Resolver = resolver.Resolver;
+pub const LookupError = resolver.LookupError;
+pub const LookupResult = resolver.LookupResult;
+pub const LookupOptions = resolver.LookupOptions;
+
+pub const Name = message.Name;
+pub const Type = message.Type;
+pub const Header = message.Header;
+
+test {
+    _ = message;
+    _ = config;
+    _ = hosts;
+    _ = resolver;
+}

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -132,7 +132,8 @@ const native_wrapper = struct {
         try mutex.lock();
         defer mutex.unlock();
 
-        // Lazy init under lock
+        // Lazy init under lock. Mutex is held during lookup because
+        // Resolver has mutable state (server_offset, prng, config reload).
         if (resolver_init_error) return error.Unexpected;
         if (resolver == null) {
             resolver = native.Resolver.initFromSystem() catch |err| {

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -3,7 +3,9 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const options = @import("zio_options");
 const net = @import("../net.zig");
+const Mutex = @import("../sync/Mutex.zig");
 
 pub const IpAddress = net.IpAddress;
 pub const HostName = net.HostName;
@@ -37,14 +39,133 @@ pub const LookupError = error{
     NoThreadPool,
 } || std.posix.UnexpectedError;
 
-const backend = @import("../ev/backend.zig");
+/// DNS resolver backend type.
+pub const ResolverType = enum {
+    /// Use system resolver (getaddrinfo or platform-specific async API).
+    system,
+    /// Use native Zig DNS resolver (pure Zig, no libc for DNS).
+    native,
+};
 
-pub const impl = if (builtin.os.tag == .windows)
+const ev_backend = @import("../ev/backend.zig");
+
+/// The selected DNS resolver backend.
+pub const resolver_type: ResolverType = blk: {
+    if (options.dns_resolver) |resolver_name| {
+        if (std.mem.eql(u8, resolver_name, "system")) {
+            break :blk .system;
+        } else if (std.mem.eql(u8, resolver_name, "native")) {
+            break :blk .native;
+        } else {
+            @compileError("Unknown DNS resolver: " ++ resolver_name);
+        }
+    }
+
+    // Default: use system resolver
+    // Native resolver doesn't support all configurations (mDNS, systemd-resolved, etc.)
+    break :blk .system;
+};
+
+/// System resolver implementation (getaddrinfo-based).
+pub const system = if (builtin.os.tag == .windows)
     @import("windows.zig")
-else if (builtin.os.tag.isDarwin() and backend.backend == .kqueue)
+else if (builtin.os.tag.isDarwin() and ev_backend.backend == .kqueue)
     @import("darwin.zig")
 else
     @import("posix.zig");
 
+/// Native DNS resolver (pure Zig, no libc for DNS).
+pub const native = @import("native/root.zig");
+
+/// The selected implementation.
+pub const impl = switch (resolver_type) {
+    .system => system,
+    .native => native_wrapper,
+};
+
 pub const Result = impl.Result;
 pub const lookup = impl.lookup;
+
+/// Wrapper to adapt native resolver to the same interface as system resolvers.
+const native_wrapper = struct {
+    pub const Result = struct {
+        inner: native.LookupResult,
+        current_idx: usize = 0,
+        returned_canonical: bool = false,
+        return_canonical_name: bool,
+        canonical_name_buf: [HostName.max_len]u8 = undefined,
+
+        pub fn deinit(self: *@This()) void {
+            _ = self;
+            // Native resolver doesn't allocate
+        }
+
+        pub fn next(self: *@This()) ?LookupResult {
+            // Return canonical name first if requested
+            if (self.return_canonical_name and !self.returned_canonical) {
+                self.returned_canonical = true;
+                if (self.inner.canonical_name) |cname| {
+                    const name_str = cname.toString(&self.canonical_name_buf);
+                    if (name_str.len > 0) {
+                        return .{ .canonical_name = .{ .bytes = self.canonical_name_buf[0..name_str.len] } };
+                    }
+                }
+            }
+
+            // Return addresses
+            if (self.current_idx < self.inner.addresses.len) {
+                const addr = self.inner.addresses.buffer[self.current_idx];
+                self.current_idx += 1;
+                return .{ .address = addr };
+            }
+
+            return null;
+        }
+    };
+
+    // Shared resolver instance (lazy initialized, protected by mutex)
+    var resolver: ?native.Resolver = null;
+    var resolver_init_error: bool = false;
+    var mutex: Mutex = .{};
+
+    pub fn lookup(opts: LookupOptions) LookupError!@This().Result {
+        try mutex.lock();
+        defer mutex.unlock();
+
+        // Lazy init under lock
+        if (resolver_init_error) return error.Unexpected;
+        if (resolver == null) {
+            resolver = native.Resolver.initFromSystem() catch |err| {
+                // Don't latch cancellation as permanent failure
+                if (err == error.Canceled) return error.Canceled;
+                resolver_init_error = true;
+                return error.Unexpected;
+            };
+        }
+
+        const native_result = resolver.?.lookup(opts.name, opts.port, .{
+            .family = opts.family,
+        }) catch |err| return switch (err) {
+            error.UnknownHostName => error.UnknownHostName,
+            error.TemporaryNameServerFailure => error.TemporaryNameServerFailure,
+            error.NameServerFailure => error.NameServerFailure,
+            error.HostLacksNetworkAddresses => error.HostLacksNetworkAddresses,
+            error.Canceled => error.Canceled,
+            error.OutOfMemory => error.OutOfMemory,
+            // Map native-specific errors to existing types
+            error.InvalidResponse, error.Truncated => error.NameServerFailure,
+            error.Timeout, error.NetworkUnreachable, error.ConnectionRefused => error.TemporaryNameServerFailure,
+            error.Unexpected => error.Unexpected,
+        };
+
+        return .{
+            .inner = native_result,
+            .return_canonical_name = opts.canonical_name,
+        };
+    }
+};
+
+test {
+    _ = native;
+    _ = system;
+}

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -45,6 +45,7 @@ pub const stdout = fs.stdout;
 pub const stderr = fs.stderr;
 
 pub const net = @import("net.zig");
+pub const dns = @import("dns/root.zig");
 
 pub const Mutex = @import("sync/Mutex.zig");
 pub const Condition = @import("sync/Condition.zig");


### PR DESCRIPTION
## Summary

- Pure Zig DNS resolver that doesn't depend on libc for name resolution
- Supports UDP/TCP queries with automatic TCP fallback for truncated responses
- Parses /etc/resolv.conf with automatic reload (checks mtime every 5 seconds)
- Supports /etc/hosts lookup before DNS queries
- Handles search domains, multiple nameservers, and server rotation
- Build option `-Ddns-resolver=native` to select resolver backend

## Test plan

- [x] `./check.sh` passes
- [ ] Manual testing with `-Ddns-resolver=native`