### PR TITLE
Fix lost wakeup race in waitTask re-arm loop

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -211,7 +211,16 @@ pub const Waiter = struct {
             if (current >= expected) {
                 return;
             }
+
             task.state.store(.preparing_to_wait, .release);
+
+            // Recheck after arming to close the race window where a signal
+            // between the check and the store sees .ready and is a no-op.
+            current = d.notify.state.load(.acquire);
+            if (current >= expected) {
+                task.state.store(.ready, .release);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
After resuming from a spurious wake (e.g. cancel on a no_cancel waiter),
waitTask checks the notify state and then stores .preparing_to_wait.
A signal arriving between the check and the store sees .ready and is a
no-op in scheduleTask, causing the task to park indefinitely.

Add a recheck of notify.state after storing .preparing_to_wait to close
this window, mirroring the arm-then-check pattern used on initial entry.
