### PR TITLE
Revert awaken bit, restore preparing_to_wait state

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Install QEMU and Wine
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y qemu-user-static wine
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         done
       timeout-minutes: 10
       env:
-        TEST_VERBOSE: true
+        TEST_VERBOSE: 2
 
     - name: Run tests (FreeBSD VM)
       if: matrix.config.vm == 'freebsd'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, revert-awaken-bit ]
     tags:
   pull_request:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,64 +7,7 @@ on:
   pull_request:
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      extended: ${{ steps.filter.outputs.extended || steps.keyword.outputs.extended }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            extended:
-              - 'src/coro/**'
-              - 'src/ev/**'
-              - 'src/os/**'
-              - '.github/workflows/test.yml'
-      - name: Check for [ci:extended] in PR body
-        id: keyword
-        if: github.event_name == 'pull_request'
-        run: |
-          if echo "$PR_BODY" | grep -qF '[ci:extended]'; then
-            echo "extended=true" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-
-  basic:
-    needs: changes
-    if: needs.changes.outputs.extended != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: macos-latest
-          - os: windows-latest
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Zig
-      uses: mlugg/setup-zig@v2
-      with:
-        version: 0.15.2
-
-    - name: Apply Zig stdlib patches
-      run: ./patches/apply-zig-patches.sh
-
-    - name: Run check script
-      run: ./check.sh --full
-      timeout-minutes: 10
-      env:
-        TEST_VERBOSE: true
-
-  extended:
-    needs: changes
-    if: needs.changes.outputs.extended == 'true'
+  test:
     strategy:
       fail-fast: false
       matrix:

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -450,10 +450,17 @@ pub const Executor = struct {
         self.loop.wake();
     }
 
-    /// Schedule a task for execution. Called on the task's home executor (self).
+    /// Schedule a task for execution.
     /// Atomically transitions task state to .ready and schedules it for execution.
     /// May migrate the task to the current executor for cache locality.
-    pub fn scheduleTask(self: *Executor, task: *AnyTask) void {
+    ///
+    /// IMPORTANT: The task's home executor (from parent_context_ptr) is read AFTER
+    /// the state CAS, not before. The CAS on task.state provides the synchronization
+    /// point — reading parent_context_ptr before the CAS could see a stale value
+    /// on weakly-ordered architectures, because the store to parent_context_ptr
+    /// (during migration) is only ordered before the subsequent task.state CAS,
+    /// not before an unrelated load on another thread.
+    pub fn scheduleTask(task: *AnyTask) void {
         var old_state = task.state.load(.acquire);
         while (true) {
             switch (old_state) {
@@ -474,11 +481,14 @@ pub const Executor = struct {
         // Task hasn't yielded yet - it will see .ready and skip the yield
         if (old_state == .preparing_to_wait) return;
 
+        // CAS succeeded — now safe to read parent_context_ptr.
+        const home_executor = Executor.fromCoroutine(&task.coro);
+
         // main_task is never queued - it just checks state in run()
-        if (task == &self.main_task) {
+        if (task == &home_executor.main_task) {
             // Wake the loop if called from another thread
-            if (getCurrentExecutorOrNull() != self) {
-                self.loop.wake();
+            if (getCurrentExecutorOrNull() != home_executor) {
+                home_executor.loop.wake();
             }
             return;
         }
@@ -488,8 +498,8 @@ pub const Executor = struct {
             // TODO: for now, we are forcing .new tasks to be remotely scheduled
             //       to distribute them across executors, until we have work stealing
             //       for re-balancing them
-            if (current_exec.runtime == self.runtime and old_state != .new) {
-                if (current_exec != self) {
+            if (current_exec.runtime == home_executor.runtime and old_state != .new) {
+                if (current_exec != home_executor) {
                     task.coro.parent_context_ptr.store(&current_exec.main_task.coro.context, .release);
                     task.last_run_tick = 0; // Allow immediate execution on new executor
                 }
@@ -499,7 +509,7 @@ pub const Executor = struct {
         }
 
         // No current executor or different runtime
-        self.scheduleTaskRemote(task);
+        home_executor.scheduleTaskRemote(task);
     }
 
     const TaskCleanup = union(enum) {

--- a/src/sync/Notify.zig
+++ b/src/sync/Notify.zig
@@ -273,6 +273,10 @@ test "Notify broadcast to multiple waiters" {
             while (ready_flag.load(.acquire) < 3) {
                 try yield();
             }
+            // Wait for waiters to actually enter wait() and push to the queue.
+            // The ready_flag only indicates they're about to wait, not that
+            // they've pushed to the queue yet.
+            try sleep(.fromMilliseconds(1));
             n.broadcast();
         }
     };
@@ -310,6 +314,8 @@ test "Notify multiple signals to multiple waiters" {
             while (ready_flag.load(.acquire) < 3) {
                 try yield();
             }
+            // Wait for waiters to actually enter wait() and push to the queue.
+            try sleep(.fromMilliseconds(1));
             // Signal three times to wake all three waiters one by one (FIFO)
             n.signal();
             n.signal();

--- a/src/task.zig
+++ b/src/task.zig
@@ -418,8 +418,7 @@ pub const AnyTask = struct {
 
     /// Wake this task (mark it as ready and schedule for execution).
     pub fn wake(self: *AnyTask) void {
-        const executor = Executor.fromCoroutine(&self.coro);
-        executor.scheduleTask(self);
+        Executor.scheduleTask(self);
     }
 
     pub fn destroy(self: *AnyTask) void {
@@ -509,11 +508,10 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
 
     _ = rt.task_count.fetchAdd(1, .acq_rel);
 
-    const executor = Executor.fromCoroutine(&task.coro);
-    executor.scheduleTask(task);
+    Executor.scheduleTask(task);
 
     if (getCurrentExecutorOrNull()) |current_executor| {
-        if (current_executor == executor) {
+        if (current_executor == Executor.fromCoroutine(&task.coro)) {
             current_executor.maybeYield(.reschedule, .no_cancel);
         }
     }

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -127,7 +127,7 @@ pub fn main() !void {
         break :blk count;
     };
 
-    const root_node = if (!env.verbose) std.Progress.start(.{
+    const root_node = if (env.verbose == .off) std.Progress.start(.{
         .root_name = "Running tests",
         .estimated_total_items = test_count,
     }) else std.Progress.Node.none;
@@ -183,8 +183,10 @@ pub fn main() !void {
         }
 
         // Print test name before running (for debugging hangs)
-        if (env.verbose) {
-            Printer.fmt("{s} .. ", .{friendly_name});
+        switch (env.verbose) {
+            .naming => Printer.fmt("{s} .. ", .{friendly_name}),
+            .tracing => Printer.fmt("{s}\n", .{friendly_name}),
+            .off => {},
         }
 
         const result = t.func();
@@ -225,9 +227,17 @@ pub fn main() !void {
             .skip => "SKIP",
             .text => "",
         };
-        if (env.verbose) {
-            Printer.status(status, "{s}", .{status_str});
-            Printer.fmt(" ({d:.2}ms)\n", .{ms});
+        switch (env.verbose) {
+            .naming => {
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .tracing => {
+                Printer.fmt("  ", .{});
+                Printer.status(status, "{s}", .{status_str});
+                Printer.fmt(" ({d:.2}ms)\n", .{ms});
+            },
+            .off => {},
         }
 
         // Print error details for failures (in non-verbose mode, progress will show above this)
@@ -389,7 +399,9 @@ const SlowTracker = struct {
 };
 
 const Env = struct {
-    verbose: bool,
+    const Verbose = enum { off, naming, tracing };
+
+    verbose: Verbose,
     fail_first: bool,
     filters: std.ArrayList([]const u8),
     do_log_capture: bool,
@@ -411,7 +423,7 @@ const Env = struct {
         }
 
         return .{
-            .verbose = readEnvBool(allocator, "TEST_VERBOSE", false),
+            .verbose = readEnvVerbose(allocator),
             .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
             .filters = filters,
             .do_log_capture = readEnvBool(allocator, "TEST_LOG_CAPTURE", true),
@@ -440,6 +452,14 @@ const Env = struct {
         const value = readEnv(allocator, key) orelse return deflt;
         defer allocator.free(value);
         return std.ascii.eqlIgnoreCase(value, "true");
+    }
+
+    fn readEnvVerbose(allocator: Allocator) Verbose {
+        const value = readEnv(allocator, "TEST_VERBOSE") orelse return .off;
+        defer allocator.free(value);
+        if (std.ascii.eqlIgnoreCase(value, "2")) return .tracing;
+        if (std.ascii.eqlIgnoreCase(value, "true") or std.ascii.eqlIgnoreCase(value, "1")) return .naming;
+        return .off;
     }
 };
 


### PR DESCRIPTION
## Summary
- Reverts commit aede9e7d ("Remove preparing_to_wait state, use awaken bit instead (#344)") and all subsequent fixes built on top of it
- Restores the original `preparing_to_wait` task state approach for handling the race window between wait arming and context switch
- Cherry-picks CI-only commits (extended CI matrix, QEMU install, test runner verbose mode)