### PR TITLE
Eliminate cross-thread reads of parent_context_ptr; fix related scheduling bugs

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -14,10 +14,11 @@ BACKEND=""
 USE_WINE=false
 USE_QEMU=false
 NO_EXEC=false
+TIMEOUT=""
 
 # Parse arguments
 usage() {
-  echo "Usage: $0 [--filter \"test name\"] [--target <target>] [--backend <backend>] [--wine] [--qemu] [--no-exec] [--ci] [--full] [--release] [--verbose]"
+  echo "Usage: $0 [--filter \"test name\"] [--target <target>] [--backend <backend>] [--wine] [--qemu] [--no-exec] [--ci] [--full] [--release] [--verbose] [--timeout <seconds>]"
 }
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -65,6 +66,10 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=true
             shift
             ;;
+        --timeout)
+            [[ $# -ge 2 ]] || { echo "--timeout requires an argument"; usage; exit 1; }
+            TIMEOUT="$2"; shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             usage
@@ -83,36 +88,40 @@ else
 fi
 
 echo "=== Running unit tests ==="
-BUILD_ARGS="test"
+BUILD_ARGS=(test)
 if [ -n "$TEST_FILTER" ]; then
     echo "Filter: $TEST_FILTER"
-    BUILD_ARGS="$BUILD_ARGS -Dtest-filter=\"$TEST_FILTER\""
+    BUILD_ARGS+=("-Dtest-filter=$TEST_FILTER")
 fi
 if [ -n "$TARGET" ]; then
     echo "Target: $TARGET"
-    BUILD_ARGS="$BUILD_ARGS -Dtarget=$TARGET"
+    BUILD_ARGS+=("-Dtarget=$TARGET")
 fi
 if [ -n "$BACKEND" ]; then
     echo "Backend: $BACKEND"
-    BUILD_ARGS="$BUILD_ARGS -Dbackend=$BACKEND"
+    BUILD_ARGS+=("-Dbackend=$BACKEND")
 fi
 if [ "$USE_WINE" = true ]; then
-    BUILD_ARGS="$BUILD_ARGS -Demit-test-bin"
+    BUILD_ARGS+=(-Demit-test-bin)
 fi
 if [ "$USE_QEMU" = true ]; then
-    BUILD_ARGS="$BUILD_ARGS -fqemu"
+    BUILD_ARGS+=(-fqemu)
 fi
 if [ "$NO_EXEC" = true ]; then
-    BUILD_ARGS="$BUILD_ARGS -Demit-test-bin"
+    BUILD_ARGS+=(-Demit-test-bin)
 fi
 if [ "$RELEASE_MODE" = true ]; then
     echo "Build mode: ReleaseSafe"
-    BUILD_ARGS="$BUILD_ARGS -Doptimize=ReleaseSafe"
+    BUILD_ARGS+=(-Doptimize=ReleaseSafe)
 fi
 if [ "$VERBOSE" = true ]; then
     export TEST_VERBOSE=true
 fi
-eval zig build $BUILD_ARGS --summary all
+if [ -n "$TIMEOUT" ]; then
+    timeout "$TIMEOUT" zig build "${BUILD_ARGS[@]}" --summary all
+else
+    zig build "${BUILD_ARGS[@]}" --summary all
+fi
 
 if [ "$USE_WINE" = true ]; then
     echo "=== Running tests with Wine ==="

--- a/examples/coro_demo.zig
+++ b/examples/coro_demo.zig
@@ -81,7 +81,7 @@ pub fn main() !void {
 
     // Create producer coroutine
     var producer_coro: coro.Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try coro.stackAlloc(&producer_coro.context.stack_info, 64 * 1024, 4096);
@@ -89,7 +89,7 @@ pub fn main() !void {
 
     // Create consumer coroutine
     var consumer_coro: coro.Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try coro.stackAlloc(&consumer_coro.context.stack_info, 64 * 1024, 4096);

--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -72,9 +72,12 @@ pub const Awaitable = struct {
     /// Waiting tasks may belong to different executors, so always uses `.maybe_remote` mode.
     /// Can be called from any context.
     pub fn markComplete(self: *Awaitable) void {
-        // Pop and wake all waiters while setting the flag
-        while (self.waiting_list.popAndSetFlag()) |node| {
-            Waiter.fromNode(node).signal();
+        // Pop and wake all waiters while setting the flag.
+        // Break as soon as we pop the last waiter - signaling it can free `self`
+        // if the awaitable is destroyed after being observed as complete.
+        while (self.waiting_list.popAndSetFlag()) |result| {
+            Waiter.fromNode(result.node).signal();
+            if (result.is_last) break;
         }
     }
 

--- a/src/coro/coroutines.zig
+++ b/src/coro/coroutines.zig
@@ -1082,7 +1082,7 @@ fn coroEntry() callconv(.naked) noreturn {
 
 pub const Coroutine = struct {
     context: Context = undefined,
-    parent_context_ptr: std.atomic.Value(*Context),
+    parent_context_ptr: *Context,
 
     /// Returns the current coroutine for this thread, or null if not in a coroutine.
     pub fn getCurrent() ?*Coroutine {
@@ -1104,12 +1104,12 @@ pub const Coroutine = struct {
 
     /// Step into the coroutine
     pub fn step(self: *Coroutine) void {
-        switchContext(self.parent_context_ptr.raw, &self.context);
+        switchContext(self.parent_context_ptr, &self.context);
     }
 
     /// Yield control back to the caller
     pub fn yield(self: *Coroutine) void {
-        switchContext(&self.context, self.parent_context_ptr.raw);
+        switchContext(&self.context, self.parent_context_ptr);
     }
 
     /// Yield control to another coroutine
@@ -1200,7 +1200,7 @@ test "Coroutine: basic" {
     var parent_context: Context = undefined;
 
     var coro: Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try stackAlloc(&coro.context.stack_info, 64 * 1024, 4096);
@@ -1227,7 +1227,7 @@ test "Coroutine: recursion" {
     var parent_context: Context = undefined;
 
     var coro: Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try stackAlloc(&coro.context.stack_info, 64 * 1024, 4096);
@@ -1255,14 +1255,14 @@ test "Coroutine: message passing" {
     var parent_context: Context = undefined;
 
     var coro1: Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try stackAlloc(&coro1.context.stack_info, 64 * 1024, 4096);
     defer stackFree(coro1.context.stack_info);
 
     var coro2: Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try stackAlloc(&coro2.context.stack_info, 64 * 1024, 4096);
@@ -1351,7 +1351,7 @@ test "Coroutine: allocator inside coroutine" {
     var parent_context: Context = undefined;
 
     var coro: Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
     try stackAlloc(&coro.context.stack_info, 8 * 1024 * 1024, 4096);
@@ -1389,7 +1389,7 @@ test "Coroutine: stack trace" {
 
     var parent_ctx: Context = undefined;
     var coro = Coroutine{
-        .parent_context_ptr = .init(&parent_ctx),
+        .parent_context_ptr = &parent_ctx,
         .context = undefined,
     };
 

--- a/src/coro/stack.zig
+++ b/src/coro/stack.zig
@@ -586,7 +586,7 @@ test "Stack: automatic growth" {
 
     var parent_context: coroutines.Context = undefined;
     var coro: coroutines.Coroutine = .{
-        .parent_context_ptr = .init(&parent_context),
+        .parent_context_ptr = &parent_context,
         .context = undefined,
     };
 

--- a/src/group.zig
+++ b/src/group.zig
@@ -196,11 +196,14 @@ pub const Group = struct {
 
         group.setCanceled();
 
-        // Pop all tasks to cancel them while setting the "canceled" flag
-        while (group.getTasks().popAndSetFlag()) |node| {
-            const awaitable: *Awaitable = @fieldParentPtr("group_node", node);
+        // Pop all tasks to cancel them while setting the "canceled" flag.
+        // Note: the group typically lives on the caller's stack so cancel()/release()
+        // don't free `self`, but we still break on is_last for consistency.
+        while (group.getTasks().popAndSetFlag()) |result| {
+            const awaitable: *Awaitable = @fieldParentPtr("group_node", result.node);
             awaitable.cancel();
             awaitable.release();
+            if (result.is_last) break;
         }
 
         // Wait for all tasks to complete

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -261,9 +261,10 @@ pub const Executor = struct {
 
     /// Get the Executor instance from any coroutine that belongs to it.
     /// Coroutines have parent_context_ptr pointing to main_task.coro.context,
-    /// so we navigate: context -> coro -> main_task -> executor
+    /// so we navigate: context -> coro -> main_task -> executor.
+    /// Only valid on the executor thread that is currently running the coroutine.
     pub fn fromCoroutine(coro: *Coroutine) *Executor {
-        const main_coro: *Coroutine = @fieldParentPtr("context", coro.parent_context_ptr.load(.acquire));
+        const main_coro: *Coroutine = @fieldParentPtr("context", coro.parent_context_ptr);
         const main_task: *AnyTask = @fieldParentPtr("coro", main_coro);
         return @alignCast(@fieldParentPtr("main_task", main_task));
     }
@@ -289,9 +290,10 @@ pub const Executor = struct {
                 .context = std.mem.zeroes(Context),
                 .parent_context_ptr = undefined,
             },
+            .runtime = runtime,
             .closure = undefined, // main_task has no closure
         };
-        self.main_task.coro.parent_context_ptr = .init(&self.main_task.coro.context);
+        self.main_task.coro.parent_context_ptr = &self.main_task.coro.context;
 
         try setupStackGrowth();
         errdefer cleanupStackGrowth();
@@ -355,7 +357,7 @@ pub const Executor = struct {
                 // Store parent_context_ptr just before stepping into the coroutine.
                 // Both the store and the subsequent load in fromCoroutine() happen on
                 // the same executor thread, so no cross-thread ordering is needed.
-                next_task.coro.parent_context_ptr.store(&self.main_task.coro.context, .monotonic);
+                next_task.coro.parent_context_ptr = &self.main_task.coro.context;
                 next_task.coro.step();
                 self.processCleanup();
             }
@@ -457,16 +459,6 @@ pub const Executor = struct {
     /// Schedule a task for execution.
     /// Atomically transitions task state to .ready and schedules it for execution.
     /// May migrate the task to the current executor for cache locality.
-    ///
-    /// IMPORTANT: The task's home executor (from parent_context_ptr) is read AFTER
-    /// the state CAS, not before. The CAS on task.state provides the synchronization
-    /// point — reading parent_context_ptr before the CAS could see a stale value
-    /// on weakly-ordered architectures.
-    ///
-    /// NOTE: parent_context_ptr is NOT updated here during migration. Instead, it is
-    /// stored immediately before the coroutine is stepped into (in run() and switchOut()),
-    /// ensuring the store and load are always on the same executor thread — no
-    /// cross-thread memory ordering concerns for parent_context_ptr at all.
     pub fn scheduleTask(task: *AnyTask) void {
         var old = task.state.load(.acquire);
         while (true) {
@@ -496,15 +488,10 @@ pub const Executor = struct {
             break;
         }
 
-        // CAS succeeded — now safe to read parent_context_ptr. Since parent_context_ptr
-        // is always stored just before the coroutine runs (on the same thread), the
-        // .acq_rel CAS above synchronizes-with the previous .waiting CAS, which
-        // happens-after the last time parent_context_ptr was written (before step/yieldTo).
-        const home_executor = Executor.fromCoroutine(&task.coro);
-
-        // main_task is never queued - it just checks state in run()
-        if (task == &home_executor.main_task) {
-            // Wake the loop if called from another thread
+        // Main task: parent_context_ptr points to its own context (self-referencing, immutable).
+        // main_task is never queued - it just checks state in run().
+        if (task.coro.parent_context_ptr == &task.coro.context) {
+            const home_executor: *Executor = @alignCast(@fieldParentPtr("main_task", task));
             if (getCurrentExecutorOrNull() != home_executor) {
                 home_executor.loop.wake();
             }
@@ -516,18 +503,17 @@ pub const Executor = struct {
             // TODO: for now, we are forcing .new tasks to be remotely scheduled
             //       to distribute them across executors, until we have work stealing
             //       for re-balancing them
-            if (current_exec.runtime == home_executor.runtime and old.tag != .new) {
-                if (current_exec != home_executor) {
-                    task.last_run_tick = 0; // Allow immediate execution on new executor
-                    // parent_context_ptr is updated just before the coroutine runs
-                }
+            if (current_exec.runtime == task.runtime and old.tag != .new) {
+                task.last_run_tick = 0; // Allow immediate execution on new executor
                 current_exec.scheduleTaskLocal(task);
                 return;
             }
         }
 
-        // No current executor or different runtime
-        home_executor.scheduleTaskRemote(task);
+        // No current executor or different runtime — pick an executor round-robin
+        const executors = task.runtime.executors.items;
+        const index = task.runtime.next_executor_index.fetchAdd(1, .monotonic);
+        executors[index % executors.len].scheduleTaskRemote(task);
     }
 
     const TaskCleanup = union(enum) {
@@ -596,7 +582,7 @@ pub const Executor = struct {
             // Store parent_context_ptr just before switching into the coroutine.
             // Both the store and the subsequent load in fromCoroutine() happen on
             // the same executor thread, so no cross-thread ordering is needed.
-            next_task.coro.parent_context_ptr.store(&self.main_task.coro.context, .monotonic);
+            next_task.coro.parent_context_ptr = &self.main_task.coro.context;
             coro.yieldTo(&next_task.coro);
         } else {
             coro.yield();

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -520,6 +520,13 @@ pub const Executor = struct {
             }
         }
 
+        // Non-migratable tasks must go home, even when scheduled from a foreign
+        // thread or a different runtime. Only .new tasks get round-robin distribution.
+        if (old.tag != .new and !task.canMigrate()) {
+            Executor.fromCoroutine(&task.coro).scheduleTaskRemote(task);
+            return;
+        }
+
         // No current executor or different runtime — pick an executor round-robin
         const executors = task.runtime.executors.items;
         const index = task.runtime.next_executor_index.fetchAdd(1, .monotonic);

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -259,6 +259,9 @@ pub const Executor = struct {
     // When notified, it calls loop.stop() to exit the event loop.
     shutdown: ev.Async = ev.Async.init(),
 
+    // Executor dedicated to this thread. Written once on init, never updated.
+    pub threadlocal var current: ?*Executor = null;
+
     /// Get the Executor instance from any coroutine that belongs to it.
     /// Coroutines have parent_context_ptr pointing to main_task.coro.context,
     /// so we navigate: context -> coro -> main_task -> executor.
@@ -310,9 +313,11 @@ pub const Executor = struct {
         self.loop.add(&self.shutdown.c);
 
         self.main_task.coro.setCurrent();
+        Executor.current = self;
     }
 
     pub fn deinit(self: *Executor) void {
+        Executor.current = null;
         Coroutine.clearCurrent();
 
         self.loop.deinit();
@@ -504,8 +509,13 @@ pub const Executor = struct {
             //       to distribute them across executors, until we have work stealing
             //       for re-balancing them
             if (current_exec.runtime == task.runtime and old.tag != .new) {
-                task.last_run_tick = 0; // Allow immediate execution on new executor
-                current_exec.scheduleTaskLocal(task);
+                const home_exec = Executor.fromCoroutine(&task.coro);
+                if (current_exec == home_exec or task.canMigrate()) {
+                    task.last_run_tick = 0; // Allow immediate execution on new executor
+                    current_exec.scheduleTaskLocal(task);
+                } else {
+                    home_exec.scheduleTaskRemote(task);
+                }
                 return;
             }
         }

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -78,9 +78,15 @@ pub fn isSet(self: *const ResetEvent) bool {
 /// The event remains set until `reset()` is called. Multiple calls to `set()` while
 /// already set have no effect.
 pub fn set(self: *ResetEvent) void {
-    // Pop and wake all waiters while setting the flag
-    while (self.wait_queue.popAndSetFlag()) |node| {
-        Waiter.fromNode(node).signal();
+    // Pop and wake all waiters while setting the flag.
+    //
+    // UAF safety: `self` may live on a coroutine stack belonging to a waiting task.
+    // Signaling the last waiter can resume that task on another executor, which may
+    // return and free its stack before we touch `self` again. Break out of the loop
+    // as soon as we've popped the last waiter so we never touch `self` afterwards.
+    while (self.wait_queue.popAndSetFlag()) |result| {
+        Waiter.fromNode(result.node).signal();
+        if (result.is_last) break;
     }
 }
 

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -88,9 +88,12 @@ pub fn Future(comptime T: type) type {
                 return;
             }
 
-            // Pop and wake all waiters while setting the flag
-            while (self.wait_queue.popAndSetFlag()) |node| {
-                Waiter.fromNode(node).signal();
+            // Pop and wake all waiters while setting the flag.
+            // Break as soon as we pop the last waiter - signaling it can free `self`
+            // if it lives on a coroutine stack.
+            while (self.wait_queue.popAndSetFlag()) |result| {
+                Waiter.fromNode(result.node).signal();
+                if (result.is_last) break;
             }
         }
 

--- a/src/task.zig
+++ b/src/task.zig
@@ -167,6 +167,9 @@ pub const AnyTask = struct {
     // Reset to 0 when stolen, allowing immediate execution on the thief.
     last_run_tick: u32 = 0,
 
+    // Runtime this task belongs to (set at creation, never changes)
+    runtime: *Runtime,
+
     // Closure for the task
     closure: Closure,
 
@@ -223,7 +226,7 @@ pub const AnyTask = struct {
     }
 
     pub inline fn getRuntime(self: *AnyTask) *Runtime {
-        return self.getExecutor().runtime;
+        return self.runtime;
     }
 
     pub inline fn getThreadPool(self: *AnyTask) *ev.ThreadPool {
@@ -487,8 +490,9 @@ pub const AnyTask = struct {
                 .wait_node = .{},
             },
             .coro = .{
-                .parent_context_ptr = .init(&executor.main_task.coro.context),
+                .parent_context_ptr = &executor.main_task.coro.context,
             },
+            .runtime = executor.runtime,
             .closure = alloc_result.closure,
         };
 
@@ -523,7 +527,7 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
     Executor.scheduleTask(task);
 
     if (getCurrentExecutorOrNull()) |current_executor| {
-        if (current_executor == Executor.fromCoroutine(&task.coro)) {
+        if (current_executor.runtime == task.runtime) {
             current_executor.maybeYield(.reschedule, .no_cancel);
         }
     }

--- a/src/task.zig
+++ b/src/task.zig
@@ -225,6 +225,13 @@ pub const AnyTask = struct {
         return Executor.fromCoroutine(&self.coro);
     }
 
+    /// Check if this task can be migrated to a different executor.
+    // TODO: Enable migration once we have work-stealing for re-balancing
+    pub inline fn canMigrate(self: *const AnyTask) bool {
+        _ = self;
+        return false;
+    }
+
     pub inline fn getRuntime(self: *AnyTask) *Runtime {
         return self.runtime;
     }

--- a/src/utils/wait_queue.zig
+++ b/src/utils/wait_queue.zig
@@ -429,12 +429,28 @@ pub fn WaitQueue(comptime T: type) type {
             return self.popInternal(old_state, old_head, false);
         }
 
+        /// Result of popAndSetFlag: the popped node plus whether the queue is now empty.
+        /// `is_last == true` means this node was the final waiter and callers must not
+        /// call popAndSetFlag again - it is safe to stop iterating without touching self.
+        ///
+        /// This matters for use cases like ResetEvent where `self` lives on a coroutine
+        /// stack: signaling the last waiter can resume the parent task on another
+        /// executor in parallel, which may return and free the stack before we get a
+        /// chance to touch `self` again.
+        pub const PopResult = struct {
+            node: *T,
+            is_last: bool,
+        };
+
         /// Pop a waiter while also setting the flag.
-        /// Returns the popped waiter, or null if no waiters (flag is still set).
+        /// Returns the popped waiter and whether it was the last one, or null if no
+        /// waiters (flag is still set).
         ///
         /// This is useful for ResetEvent.set() / Future.set() - set the flag and
-        /// wake all waiters. Call in a loop until null is returned.
-        pub fn popAndSetFlag(self: *Self) ?*T {
+        /// wake all waiters. Callers MUST break out of the loop once `is_last` is true
+        /// without calling popAndSetFlag again, because signaling the last waiter can
+        /// cause `self` to be freed.
+        pub fn popAndSetFlag(self: *Self) ?PopResult {
             const old_state = self.acquireMutationLock();
 
             const old_head = getHeadPtr(old_state) orelse {
@@ -443,7 +459,9 @@ pub fn WaitQueue(comptime T: type) type {
                 return null;
             };
 
-            return self.popInternal(old_state, old_head, true);
+            const is_last = old_head.next == null;
+            const node = self.popInternal(old_state, old_head, true);
+            return .{ .node = node, .is_last = is_last };
         }
     };
 }


### PR DESCRIPTION
## Summary

Originally just made `parent_context_ptr` non-atomic by eliminating cross-thread reads. While verifying this on CI (including riscv64) a couple of related task-scheduling correctness issues surfaced and are fixed here too.

### parent_context_ptr: non-atomic (ad8d24f1)
- Add `runtime: *Runtime` field to `AnyTask`, so `scheduleTask()` no longer needs to derive the executor from `parent_context_ptr` in cross-thread paths
- `scheduleTask()` uses `task.runtime` for same-runtime checks and round-robin executor selection
- Main task detection uses the self-referencing `parent_context_ptr` invariant (`parent_context_ptr == &context`) instead of comparing against `home_executor.main_task`
- `parent_context_ptr` changes from `std.atomic.Value(*Context)` to a plain `*Context` — all remaining reads are same-thread

### Task migration gating (6173a3e7, b7efdf20)
- Re-add `AnyTask.canMigrate()` (currently always false, pending work-stealing) and gate cross-executor migration in `scheduleTask()` behind it
- Fix the fallback branch in `scheduleTask()` which was unconditionally doing round-robin `scheduleTaskRemote`, causing foreign-thread wakes of non-migratable tasks to land on a random executor and defeat the `canMigrate()` guard. Non-migratable tasks now go back to their home executor via `fromCoroutine`; `.new` tasks still get round-robin distribution
- Add `Executor.current` threadlocal for direct per-thread access

### UAF fix in popAndSetFlag loop (9000d530)
`ResetEvent.set()` (and the same pattern in `Future.set()`, `Awaitable.markComplete()`, `Group.cancel()`) iterates `popAndSetFlag` until null. With task migration disabled, signaling the last waiter can resume the parent task on another executor in parallel. If that parent returns and its coroutine stack is released while the signaler is still in the loop, the next `popAndSetFlag` performs an atomic RMW on `self.head` — now on a freed/reused stack. Manifested as a `popInternal` assertion failure on riscv64 CI.

Fix: `popAndSetFlag` returns a struct indicating whether the popped waiter was the last one; callers break out of the loop in that case without touching `self` again.

### Misc
- Add `--timeout` arg to `check.sh` (26b3ab84)

## Test plan

- [x] `./check.sh` — all tests pass
- [x] `./check.sh --full` — examples and benchmarks build
- [x] riscv64 CI green (previously flaky with the popInternal assertion)
