### PR TITLE
Add std.Io TCP echo server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ exe.root_module.addImport("zio", zio.module("zio"));
 
 ## Usage
 
-Basic TCP echo server:
+A minimal TCP echo server, using zio's native API:
 
 ```zig
 const std = @import("std");
@@ -89,26 +89,68 @@ fn handleClient(stream: zio.net.Stream) !void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    const rt = try zio.Runtime.init(gpa.allocator(), .{});
+    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
     defer rt.deinit();
 
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);
     const server = try addr.listen(.{});
     defer server.close();
 
-    std.log.info("Listening on {f}", .{server.socket.address});
-
     var group: zio.Group = .init;
     defer group.cancel();
 
     while (true) {
-        const stream = try server.accept();
+        const stream = try server.accept(.{});
         errdefer stream.close();
-
         try group.spawn(handleClient, .{stream});
+    }
+}
+```
+
+The same server written against the standard library's [`std.Io`] interface:
+
+```zig
+const std = @import("std");
+const zio = @import("zio");
+
+const Io = std.Io;
+
+fn handleClient(io: Io, stream: Io.net.Stream) Io.Cancelable!void {
+    defer stream.close(io);
+
+    var read_buffer: [1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+
+    var write_buffer: [1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+
+    while (true) {
+        const line = reader.interface.takeDelimiterInclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.ReadFailed => return if (reader.err.? == error.Canceled) error.Canceled else {},
+            else => return,
+        };
+        writer.interface.writeAll(line) catch return if (writer.err.? == error.Canceled) error.Canceled else {};
+        writer.interface.flush() catch return if (writer.err.? == error.Canceled) error.Canceled else {};
+    }
+}
+
+pub fn main() !void {
+    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const addr = try Io.net.IpAddress.parseIp4("127.0.0.1", 8080);
+    var server = try addr.listen(io, .{});
+    defer server.deinit(io);
+
+    var group: Io.Group = .init;
+    defer group.cancel(io);
+
+    while (true) {
+        const stream = try server.accept(io);
+        errdefer stream.close(io);
+        try group.concurrent(io, handleClient, .{ io, stream });
     }
 }
 ```

--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "hello-world", .file = "examples/hello_world.zig" },
         .{ .name = "sleep", .file = "examples/sleep.zig" },
         .{ .name = "tcp-echo-server", .file = "examples/tcp_echo_server.zig" },
+        .{ .name = "tcp-echo-server-stdio", .file = "examples/tcp_echo_server_stdio.zig" },
         .{ .name = "tcp-client", .file = "examples/tcp_client.zig" },
         .{ .name = "http-server", .file = "examples/http_server.zig" },
         .{ .name = "mutex-demo", .file = "examples/mutex_demo.zig" },

--- a/examples/tcp_echo_server.zig
+++ b/examples/tcp_echo_server.zig
@@ -5,6 +5,10 @@ const zio = @import("zio");
 fn handleClient(stream: zio.net.Stream) !void {
     defer stream.close();
 
+    defer stream.shutdown(.both) catch |err| {
+        std.log.err("Failed to shutdown client connection: {}", .{err});
+    };
+
     std.log.info("Client connected from {f}", .{stream.socket.address});
 
     var read_buffer: [1024]u8 = undefined;

--- a/examples/tcp_echo_server_stdio.zig
+++ b/examples/tcp_echo_server_stdio.zig
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+//
+// Test with: echo "hello" | nc -N 127.0.0.1 8080
+//
+// This example demonstrates using std.Io interface with zio Runtime.
+
+const std = @import("std");
+const zio = @import("zio");
+
+const Io = std.Io;
+
+fn handleClient(io: Io, stream: Io.net.Stream) Io.Cancelable!void {
+    defer stream.close(io);
+
+    defer stream.shutdown(io, .both) catch |err| {
+        std.log.err("Failed to shutdown client connection: {}", .{err});
+    };
+
+    std.log.info("Client connected from {f}", .{stream.socket.address});
+
+    var read_buffer: [1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+
+    var write_buffer: [1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+
+    while (true) {
+        const line = reader.interface.takeDelimiterInclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.ReadFailed => {
+                if (reader.err) |e| {
+                    if (e == error.Canceled) return error.Canceled;
+                    std.log.err("Read error: {}", .{e});
+                }
+                return;
+            },
+            else => {
+                std.log.err("Read error: {}", .{err});
+                return;
+            },
+        };
+
+        std.log.info("Received: {s}", .{line});
+
+        try io.sleep(.fromMilliseconds(1000), .awake);
+
+        writer.interface.writeAll(line) catch {
+            if (writer.err) |e| {
+                if (e == error.Canceled) return error.Canceled;
+                std.log.err("Write error: {}", .{e});
+            }
+            return;
+        };
+        writer.interface.flush() catch {
+            if (writer.err) |e| {
+                if (e == error.Canceled) return error.Canceled;
+                std.log.err("Flush error: {}", .{e});
+            }
+            return;
+        };
+    }
+
+    std.log.info("Client disconnected", .{});
+}
+
+pub fn main() !void {
+    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+    defer rt.deinit();
+
+    const io = rt.io();
+
+    const addr = try Io.net.IpAddress.parseIp4("127.0.0.1", 8080);
+
+    var server = try addr.listen(io, .{});
+    defer server.deinit(io);
+
+    std.log.info("TCP echo server listening on {f}", .{server.socket.address});
+    std.log.info("Press Ctrl+C to stop the server", .{});
+
+    var group: Io.Group = .init;
+    defer group.cancel(io);
+
+    while (true) {
+        const stream = try server.accept(io);
+        errdefer stream.close(io);
+
+        try group.concurrent(io, handleClient, .{ io, stream });
+    }
+}


### PR DESCRIPTION
## Summary
- Add `examples/tcp_echo_server_stdio.zig`, a std.Io version of the existing TCP echo server
- Wire it into `build.zig`
- Replace the single example in README.md with two minimal side-by-side versions (native API and std.Io)
- Add a matching `shutdown(.both)` defer to the native example so the two stay close in shape

## Test plan
- [x] `zig build examples`