### PR TITLE
std.Io: mark fileMemoryMap methods as not supported

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -913,23 +913,23 @@ fn fileHardLinkImpl(_: ?*anyopaque, file: Io.File, new_dir: Io.Dir, new_sub_path
 }
 
 fn fileMemoryMapCreateImpl(_: ?*anyopaque, _: Io.File, _: Io.File.MemoryMap.CreateOptions) Io.File.MemoryMap.CreateError!Io.File.MemoryMap {
-    @panic("TODO: fileMemoryMapCreate");
+    @panic("fileMemoryMapCreate: not supported");
 }
 
 fn fileMemoryMapDestroyImpl(_: ?*anyopaque, _: *Io.File.MemoryMap) void {
-    @panic("TODO: fileMemoryMapDestroy");
+    @panic("fileMemoryMapDestroy: not supported");
 }
 
 fn fileMemoryMapSetLengthImpl(_: ?*anyopaque, _: *Io.File.MemoryMap, _: usize) Io.File.MemoryMap.SetLengthError!void {
-    @panic("TODO: fileMemoryMapSetLength");
+    @panic("fileMemoryMapSetLength: not supported");
 }
 
 fn fileMemoryMapReadImpl(_: ?*anyopaque, _: *Io.File.MemoryMap) Io.File.ReadPositionalError!void {
-    @panic("TODO: fileMemoryMapRead");
+    @panic("fileMemoryMapRead: not supported");
 }
 
 fn fileMemoryMapWriteImpl(_: ?*anyopaque, _: *Io.File.MemoryMap) Io.File.WritePositionalError!void {
-    @panic("TODO: fileMemoryMapWrite");
+    @panic("fileMemoryMapWrite: not supported");
 }
 
 fn processExecutableOpenImpl(_: ?*anyopaque, _: Io.Dir.OpenFileOptions) std.process.OpenExecutableError!Io.File {


### PR DESCRIPTION
`MemoryMap.CreateError` has no unsupported variant, so there is no way to signal to callers that memory-mapped I/O is not available. Rather than leaving these as `TODO` panics, mark them explicitly as not supported.