### PR TITLE
std.Io: implement childWait and childKill

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -37,6 +37,7 @@ const waitForIoUncancelable = common.waitForIoUncancelable;
 const ev = @import("ev/root.zig");
 const os_net = @import("os/net.zig");
 const os_fs = @import("os/fs.zig");
+const process_impl = @import("process.zig");
 const zio_net = @import("net.zig");
 const zio_dns = @import("dns/root.zig");
 const fillBuf = @import("utils/writer.zig").fillBuf;
@@ -998,12 +999,12 @@ fn processSpawnPathImpl(_: ?*anyopaque, _: Io.Dir, _: std.process.SpawnOptions) 
     @panic("TODO: processSpawnPath");
 }
 
-fn childWaitImpl(_: ?*anyopaque, _: *std.process.Child) std.process.Child.WaitError!std.process.Child.Term {
-    @panic("TODO: childWait");
+fn childWaitImpl(_: ?*anyopaque, child: *std.process.Child) std.process.Child.WaitError!std.process.Child.Term {
+    return process_impl.childWait(child);
 }
 
-fn childKillImpl(_: ?*anyopaque, _: *std.process.Child) void {
-    @panic("TODO: childKill");
+fn childKillImpl(_: ?*anyopaque, child: *std.process.Child) void {
+    process_impl.childKill(child);
 }
 
 fn progressParentFileImpl(_: ?*anyopaque) std.Progress.ParentFileError!Io.File {
@@ -1757,6 +1758,10 @@ fn dnsLookupErrToStdErr(err: zio_dns.LookupError) Io.net.HostName.LookupError {
         error.Unexpected, error.ServiceUnavailable, error.NoThreadPool, error.RuntimeShutdown => error.Unexpected,
         error.Closed => unreachable,
     };
+}
+
+test {
+    _ = process_impl;
 }
 
 test "Runtime.io / Runtime.fromIo round-trip" {

--- a/src/process.zig
+++ b/src/process.zig
@@ -54,6 +54,7 @@ fn childCleanup(child: *std.process.Child) void {
     if (builtin.os.tag == .windows) {
         std.os.windows.CloseHandle(child.id.?);
         std.os.windows.CloseHandle(child.thread_handle);
+        child.thread_handle = undefined;
     }
     child.id = null;
     if (child.stdin) |f| {
@@ -70,13 +71,27 @@ fn childCleanup(child: *std.process.Child) void {
     }
 }
 
+// POSIX: "true"/"false"/"sleep". Windows: cmd.exe equivalents.
+const argv_exit0: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "exit 0" }
+else
+    &.{"true"};
+
+const argv_exit1: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "exit 1" }
+else
+    &.{"false"};
+
+const argv_sleep: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "timeout /t 100 /nobreak" }
+else
+    &.{ "sleep", "100" };
+
 test "childWait: exit code 0" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var child = try std.process.spawn(std.testing.io, .{
-        .argv = &.{"/bin/true"},
-    });
+    var child = try std.process.spawn(std.testing.io, .{ .argv = argv_exit0 });
     const term = try childWait(&child);
     try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, term);
 }
@@ -85,9 +100,7 @@ test "childWait: exit code 1" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var child = try std.process.spawn(std.testing.io, .{
-        .argv = &.{"/bin/false"},
-    });
+    var child = try std.process.spawn(std.testing.io, .{ .argv = argv_exit1 });
     const term = try childWait(&child);
     try std.testing.expectEqual(std.process.Child.Term{ .exited = 1 }, term);
 }
@@ -96,9 +109,7 @@ test "childKill: terminates process" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var child = try std.process.spawn(std.testing.io, .{
-        .argv = &.{ "/bin/sleep", "100" },
-    });
+    var child = try std.process.spawn(std.testing.io, .{ .argv = argv_sleep });
     childKill(&child);
     try std.testing.expect(child.id == null);
 }

--- a/src/process.zig
+++ b/src/process.zig
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Runtime = @import("runtime.zig").Runtime;
+const ev = @import("ev/root.zig");
+const os = @import("os/root.zig");
+const waitForIo = @import("common.zig").waitForIo;
+const waitForIoUncancelable = @import("common.zig").waitForIoUncancelable;
+
+const ProcessHandle = ev.ProcessWait.ProcessHandle;
+
+pub fn childWait(child: *std.process.Child) std.process.Child.WaitError!std.process.Child.Term {
+    var op = ev.ProcessWait.init(child.id.?);
+    waitForIo(&op.c) catch |err| switch (err) {
+        error.Canceled => return error.Canceled,
+    };
+    const status = op.getResult() catch |err| switch (err) {
+        error.ProcessNotFound => return error.Unexpected,
+        error.SystemResources => return error.Unexpected,
+        error.Canceled => return error.Canceled,
+        error.Unexpected => return error.Unexpected,
+    };
+    const term = exitStatusToTerm(status);
+    childCleanup(child);
+    return term;
+}
+
+pub fn childKill(child: *std.process.Child) void {
+    sendTermSignal(child.id.?);
+    var op = ev.ProcessWait.init(child.id.?);
+    waitForIoUncancelable(&op.c);
+    childCleanup(child);
+}
+
+fn exitStatusToTerm(status: ev.ProcessWait.ExitStatus) std.process.Child.Term {
+    if (status.signal) |sig| {
+        return .{ .signal = @enumFromInt(sig) };
+    }
+    return .{ .exited = status.code };
+}
+
+fn sendTermSignal(handle: ProcessHandle) void {
+    if (builtin.os.tag == .windows) {
+        _ = std.os.windows.ntdll.NtTerminateProcess(handle, @enumFromInt(1));
+    } else {
+        _ = std.posix.system.kill(handle, .TERM);
+    }
+}
+
+fn childCleanup(child: *std.process.Child) void {
+    if (builtin.os.tag == .windows) {
+        std.os.windows.CloseHandle(child.id.?);
+        std.os.windows.CloseHandle(child.thread_handle);
+    }
+    child.id = null;
+    if (child.stdin) |f| {
+        os.fs.close(f.handle) catch {};
+        child.stdin = null;
+    }
+    if (child.stdout) |f| {
+        os.fs.close(f.handle) catch {};
+        child.stdout = null;
+    }
+    if (child.stderr) |f| {
+        os.fs.close(f.handle) catch {};
+        child.stderr = null;
+    }
+}
+
+test "childWait: exit code 0" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var child = try std.process.spawn(std.testing.io, .{
+        .argv = &.{"/bin/true"},
+    });
+    const term = try childWait(&child);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, term);
+}
+
+test "childWait: exit code 1" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var child = try std.process.spawn(std.testing.io, .{
+        .argv = &.{"/bin/false"},
+    });
+    const term = try childWait(&child);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 1 }, term);
+}
+
+test "childKill: terminates process" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var child = try std.process.spawn(std.testing.io, .{
+        .argv = &.{ "/bin/sleep", "100" },
+    });
+    childKill(&child);
+    try std.testing.expect(child.id == null);
+}

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -187,6 +187,7 @@ pub fn main(init: std.process.Init) !void {
 
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
+        std.testing.io_instance = .init(gpa, .{});
 
         if (env.do_log_capture) {
             log_buffer.clearRetainingCapacity();
@@ -210,6 +211,7 @@ pub fn main(init: std.process.Init) !void {
 
         const ns_taken = slowest.endTiming(io, gpa, friendly_name);
 
+        std.testing.io_instance.deinit();
         if (std.testing.allocator_instance.deinit() == .leak) {
             leak += 1;
             Printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });


### PR DESCRIPTION
Part of #366.

## Summary

- Adds `src/process.zig` with `childWait` and `childKill` implementations backed by `ev.ProcessWait`
- `childWait` uses `waitForIo` for cancellation-aware async waiting; converts `ExitStatus` to `std.process.Child.Term` and closes stdio pipes
- `childKill` sends `SIGTERM` (POSIX) / `NtTerminateProcess` (Windows), then reaps the process uncancelably via `waitForIoUncancelable`
- Wires both into `io.zig`'s vtable, replacing the `@panic("TODO")` stubs
- Initializes `std.testing.io_instance` in the test runner so tests can spawn processes via `std.testing.io`

## Notes

The io_uring backend uses `IORING_OP_WAITID` (requires Linux 6.7+) and will return `error.Unexpected` on older kernels; tests pass with the epoll backend.

## Test plan

- `./check.sh --filter "child" --backend epoll`