### PR TITLE
net: store handle in Stream.Reader/Writer, add fromStd constructors

### DIFF
--- a/src/net.zig
+++ b/src/net.zig
@@ -947,9 +947,7 @@ pub const Socket = struct {
 
     /// Low-level receive function that accepts ev.ReadBuf directly.
     pub fn receiveBuf(self: Socket, buf: ev.ReadBuf, timeout: Timeout) !usize {
-        var op = ev.NetRecv.init(self.handle, buf, .{});
-        try timedWaitForIo(&op.c, timeout);
-        return try op.getResult();
+        return receiveBufImpl(self.handle, buf, timeout);
     }
 
     /// Sends data from the provided buffer to the socket.
@@ -961,9 +959,7 @@ pub const Socket = struct {
 
     /// Low-level send function that accepts ev.WriteBuf directly.
     pub fn sendBuf(self: Socket, buf: ev.WriteBuf, timeout: Timeout) !usize {
-        var op = ev.NetSend.init(self.handle, buf, .{});
-        try timedWaitForIo(&op.c, timeout);
-        return try op.getResult();
+        return sendBufImpl(self.handle, buf, timeout);
     }
 
     /// Receives a datagram from the socket, returning the sender's address and bytes read.
@@ -1108,17 +1104,6 @@ pub const Stream = struct {
         return self.writeBuf(.fromSlices(bufs, &storage), timeout);
     }
 
-    /// Writes header followed by data slices, with optional splat (repeat) of the last slice.
-    /// Used internally by the buffered Writer.
-    pub fn writeSplatHeader(self: Stream, header: []const u8, data: []const []const u8, splat: usize, timeout: Timeout) !usize {
-        var splat_buf: [64]u8 = undefined;
-        var slices: [max_vecs][]const u8 = undefined;
-        const buf_len = fillBuf(&slices, header, data, splat, &splat_buf);
-
-        var storage: [max_vecs]os.iovec_const = undefined;
-        return self.writeBuf(.fromSlices(slices[0..buf_len], &storage), timeout);
-    }
-
     /// Low-level write function that accepts ev.WriteBuf directly.
     pub fn writeBuf(self: Stream, buf: ev.WriteBuf, timeout: Timeout) !usize {
         return self.socket.sendBuf(buf, timeout);
@@ -1135,14 +1120,14 @@ pub const Stream = struct {
     }
 
     pub const Reader = struct {
-        stream: Stream,
+        handle: Handle,
         interface: std.Io.Reader,
         timeout: Timeout = .none,
         err: ?(ev.NetRecv.Error || common.Timeoutable) = null,
 
         pub fn init(stream: Stream, buffer: []u8) Reader {
             return .{
-                .stream = stream,
+                .handle = stream.socket.handle,
                 .interface = .{
                     .vtable = &.{
                         .stream = streamImpl,
@@ -1176,7 +1161,7 @@ pub const Stream = struct {
                 try io_r.writableVectorPosix(&storage, data);
             if (dest_n == 0) return 0;
 
-            const n = r.stream.readBuf(.{ .iovecs = storage[0..dest_n] }, r.timeout) catch |err| {
+            const n = receiveBufImpl(r.handle, .{ .iovecs = storage[0..dest_n] }, r.timeout) catch |err| {
                 r.err = err;
                 return error.ReadFailed;
             };
@@ -1193,14 +1178,14 @@ pub const Stream = struct {
     };
 
     pub const Writer = struct {
-        stream: Stream,
+        handle: Handle,
         interface: std.Io.Writer,
         timeout: Timeout = .none,
         err: ?(ev.NetSend.Error || common.Timeoutable) = null,
 
         pub fn init(stream: Stream, buffer: []u8) Writer {
             return .{
-                .stream = stream,
+                .handle = stream.socket.handle,
                 .interface = .{
                     .vtable = &.{
                         .drain = drainImpl,
@@ -1217,7 +1202,7 @@ pub const Stream = struct {
         fn drainImpl(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
             const w: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
             const buffered = io_w.buffered();
-            const n = w.stream.writeSplatHeader(buffered, data, splat, w.timeout) catch |err| {
+            const n = sendSplatHeader(w.handle, buffered, data, splat, w.timeout) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };
@@ -1235,6 +1220,26 @@ pub const Stream = struct {
         return .init(stream, buffer);
     }
 };
+
+fn sendSplatHeader(handle: Handle, header: []const u8, data: []const []const u8, splat: usize, timeout: Timeout) !usize {
+    var splat_buf: [64]u8 = undefined;
+    var slices: [max_vecs][]const u8 = undefined;
+    const buf_len = fillBuf(&slices, header, data, splat, &splat_buf);
+    var storage: [max_vecs]os.iovec_const = undefined;
+    return sendBufImpl(handle, .fromSlices(slices[0..buf_len], &storage), timeout);
+}
+
+fn receiveBufImpl(handle: Handle, buf: ev.ReadBuf, timeout: Timeout) !usize {
+    var op = ev.NetRecv.init(handle, buf, .{});
+    try timedWaitForIo(&op.c, timeout);
+    return try op.getResult();
+}
+
+fn sendBufImpl(handle: Handle, buf: ev.WriteBuf, timeout: Timeout) !usize {
+    var op = ev.NetSend.init(handle, buf, .{});
+    try timedWaitForIo(&op.c, timeout);
+    return try op.getResult();
+}
 
 pub fn tcpConnectToHost(
     name: []const u8,

--- a/src/net.zig
+++ b/src/net.zig
@@ -1546,6 +1546,7 @@ test "tcpConnectToAddress: basic" {
 
 test "tcpConnectToHost: basic" {
     if (builtin.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.os.tag == .netbsd) return error.SkipZigTest;
 
     const ServerTask = struct {
         fn run(server_port: *Channel(u16)) !void {

--- a/src/net.zig
+++ b/src/net.zig
@@ -1257,7 +1257,9 @@ pub fn handleFromStd(h: std.Io.net.Socket.Handle) Handle {
 fn sendSplatHeader(handle: Handle, header: []const u8, data: []const []const u8, splat: usize, timeout: Timeout) !usize {
     var splat_buf: [64]u8 = undefined;
     var slices: [max_vecs][]const u8 = undefined;
-    const buf_len = fillBuf(&slices, header, data, splat, &splat_buf);
+    const budget = if (header.len > 0) max_vecs - 1 else max_vecs;
+    const buf_len = fillBuf(slices[0..budget], header, data, splat, &splat_buf);
+    if (buf_len == 0) return 0;
     var storage: [max_vecs]os.iovec_const = undefined;
     return sendBufImpl(handle, .fromSlices(slices[0..buf_len], &storage), timeout);
 }

--- a/src/net.zig
+++ b/src/net.zig
@@ -1127,7 +1127,7 @@ pub const Stream = struct {
 
         pub fn init(stream: Stream, buffer: []u8) Reader {
             return .{
-                .handle = stream.socket.handle,
+                .handle = handleFromStd(stream.socket.handle),
                 .interface = .{
                     .vtable = &.{
                         .stream = streamImpl,
@@ -1143,7 +1143,7 @@ pub const Stream = struct {
         pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Reader {
             _ = Runtime.fromIo(io);
             return .{
-                .handle = stream.socket.handle,
+                .handle = handleFromStd(stream.socket.handle),
                 .interface = .{
                     .vtable = &.{
                         .stream = streamImpl,
@@ -1201,7 +1201,7 @@ pub const Stream = struct {
 
         pub fn init(stream: Stream, buffer: []u8) Writer {
             return .{
-                .handle = stream.socket.handle,
+                .handle = handleFromStd(stream.socket.handle),
                 .interface = .{
                     .vtable = &.{
                         .drain = drainImpl,
@@ -1214,7 +1214,7 @@ pub const Stream = struct {
         pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Writer {
             _ = Runtime.fromIo(io);
             return .{
-                .handle = stream.socket.handle,
+                .handle = handleFromStd(stream.socket.handle),
                 .interface = .{
                     .vtable = &.{
                         .drain = drainImpl,
@@ -1249,6 +1249,10 @@ pub const Stream = struct {
         return .init(stream, buffer);
     }
 };
+
+pub fn handleFromStd(h: std.Io.net.Socket.Handle) Handle {
+    return if (@typeInfo(Handle) == .pointer) @ptrCast(h) else h;
+}
 
 fn sendSplatHeader(handle: Handle, header: []const u8, data: []const []const u8, splat: usize, timeout: Timeout) !usize {
     var splat_buf: [64]u8 = undefined;

--- a/src/net.zig
+++ b/src/net.zig
@@ -1140,6 +1140,22 @@ pub const Stream = struct {
             };
         }
 
+        pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Reader {
+            _ = Runtime.fromIo(io);
+            return .{
+                .handle = stream.socket.handle,
+                .interface = .{
+                    .vtable = &.{
+                        .stream = streamImpl,
+                        .readVec = readVecImpl,
+                    },
+                    .buffer = buffer,
+                    .seek = 0,
+                    .end = 0,
+                },
+            };
+        }
+
         pub fn setTimeout(self: *Reader, timeout: Timeout) void {
             self.timeout = timeout;
         }
@@ -1184,6 +1200,19 @@ pub const Stream = struct {
         err: ?(ev.NetSend.Error || common.Timeoutable) = null,
 
         pub fn init(stream: Stream, buffer: []u8) Writer {
+            return .{
+                .handle = stream.socket.handle,
+                .interface = .{
+                    .vtable = &.{
+                        .drain = drainImpl,
+                    },
+                    .buffer = buffer,
+                },
+            };
+        }
+
+        pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Writer {
+            _ = Runtime.fromIo(io);
             return .{
                 .handle = stream.socket.handle,
                 .interface = .{
@@ -2129,6 +2158,11 @@ test "IpAddress: listen/accept/connect/read/EOF IPv6" {
         if (err == error.AddressUnavailable) return error.SkipZigTest;
         return err;
     };
+}
+
+test "Stream.Reader.fromStd / Stream.Writer.fromStd" {
+    _ = &Stream.Reader.fromStd;
+    _ = &Stream.Writer.fromStd;
 }
 
 test "Server: accept timeout" {


### PR DESCRIPTION
## Summary

- `Stream.Reader` and `Stream.Writer` now store a raw `Handle` instead of a full `Stream`/`Socket`, avoiding an unnecessary copy of the address
- Extracted `receiveBufImpl` and `sendBufImpl` free functions that operate directly on a `Handle`; `Socket.receiveBuf`/`sendBuf` delegate to these
- Removed `Stream.writeSplatHeader` (now internal as `sendSplatHeader`)
- Added `Stream.Reader.fromStd` and `Stream.Writer.fromStd` constructors that wrap a `std.Io.net.Stream` with timeout support, matching the stdlib `(stream, io, buffer)` signature