### PR TITLE
tests: remove wasteful spawn+join wrappers

### DIFF
--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -153,8 +153,8 @@ test "AutoCancel: cleared before firing" {
 }
 
 test "AutoCancel: user cancel has priority over timeout" {
-    const Test = struct {
-        fn worker(rt: *Runtime) !void {
+    const worker = struct {
+        fn call(rt: *Runtime) !void {
             var timeout = AutoCancel.init;
             defer timeout.clear();
 
@@ -169,25 +169,20 @@ test "AutoCancel: user cancel has priority over timeout" {
 
             return error.TestUnexpectedResult;
         }
-
-        fn main(rt: *Runtime) !void {
-            var handle = try rt.spawn(worker, .{rt});
-
-            // Let worker start and set timeout
-            try rt.sleep(.fromMilliseconds(5));
-
-            // User cancel before timeout fires
-            handle.cancel();
-
-            // Worker handles the cancellation gracefully, so join succeeds
-            try handle.join();
-        }
-    };
+    }.call;
 
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var handle = try rt.spawn(Test.main, .{rt});
+    var handle = try rt.spawn(worker, .{rt});
+
+    // Let worker start and set timeout
+    try rt.sleep(.fromMilliseconds(5));
+
+    // User cancel before timeout fires
+    handle.cancel();
+
+    // Worker handles the cancellation gracefully, so join succeeds
     try handle.join();
 }
 
@@ -266,33 +261,28 @@ test "AutoCancel: set with Duration.max clears prior timer" {
 }
 
 test "AutoCancel: cancels spawned task via join" {
-    const Test = struct {
-        fn blocker(rt: *Runtime) !void {
+    const blocker = struct {
+        fn call(rt: *Runtime) !void {
             // Block forever
             try rt.sleep(.fromMilliseconds(1000000));
         }
-
-        fn main(rt: *Runtime) !void {
-            var handle = try rt.spawn(blocker, .{rt});
-            defer handle.cancel();
-
-            var timeout = AutoCancel.init;
-            defer timeout.clear();
-            timeout.set(.fromMilliseconds(10));
-
-            // Join should be canceled by timeout
-            handle.join() catch |err| {
-                try std.testing.expect(timeout.check(err));
-                return; // Expected
-            };
-
-            return error.TestUnexpectedResult;
-        }
-    };
+    }.call;
 
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var handle = try rt.spawn(Test.main, .{rt});
-    try handle.join();
+    var handle = try rt.spawn(blocker, .{rt});
+    defer handle.cancel();
+
+    var timeout = AutoCancel.init;
+    defer timeout.clear();
+    timeout.set(.fromMilliseconds(10));
+
+    // Join should be canceled by timeout
+    handle.join() catch |err| {
+        try std.testing.expect(timeout.check(err));
+        return; // Expected
+    };
+
+    return error.TestUnexpectedResult;
 }

--- a/src/group.zig
+++ b/src/group.zig
@@ -299,57 +299,45 @@ test "Group: spawn" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        fn asyncTask() !void {
-            var group: Group = .init;
-            defer group.cancel();
+    var group: Group = .init;
+    defer group.cancel();
 
-            try group.spawn(testFn, .{0});
+    try group.spawn(testFn, .{0});
 
-            try group.wait();
-        }
-    };
-
-    var handle = try rt.spawn(TestContext.asyncTask, .{});
-    try handle.join();
+    try group.wait();
 }
 
 test "Group: wait for multiple tasks" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        var completed: usize = 0;
+    const completed = struct {
+        var value: usize = 0;
 
         fn task() void {
-            _ = @atomicRmw(usize, &completed, .Add, 1, .monotonic);
-        }
-
-        fn asyncTask() !void {
-            completed = 0;
-
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(task, .{});
-            try group.spawn(task, .{});
-            try group.spawn(task, .{});
-
-            try group.wait();
-
-            try std.testing.expectEqual(3, completed);
+            _ = @atomicRmw(usize, &value, .Add, 1, .monotonic);
         }
     };
 
-    var handle = try rt.spawn(TestContext.asyncTask, .{});
-    try handle.join();
+    completed.value = 0;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(completed.task, .{});
+    try group.spawn(completed.task, .{});
+    try group.spawn(completed.task, .{});
+
+    try group.wait();
+
+    try std.testing.expectEqual(3, completed.value);
 }
 
 test "Group: cancellation while waiting" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
+    const counts = struct {
         var started: usize = 0;
         var canceled: usize = 0;
 
@@ -359,49 +347,48 @@ test "Group: cancellation while waiting" {
                 _ = @atomicRmw(usize, &canceled, .Add, 1, .monotonic);
             };
         }
+    };
 
-        fn cancellerTask(runtime: *Runtime, group_handle: *JoinHandle(anyerror!void)) !void {
+    const cancellerTask = struct {
+        fn call(runtime: *Runtime, group_handle: *JoinHandle(anyerror!void)) !void {
             // Wait a bit for tasks to start
             try runtime.sleep(.fromMilliseconds(10));
             // Cancel the group waiter
             group_handle.awaitable.?.cancel();
         }
+    }.call;
 
-        fn groupTask() anyerror!void {
+    const groupTask = struct {
+        fn call() anyerror!void {
             var group: Group = .init;
             defer group.cancel();
 
             // Spawn multiple slow tasks
-            try group.spawn(slowTask, .{});
-            try group.spawn(slowTask, .{});
-            try group.spawn(slowTask, .{});
+            try group.spawn(counts.slowTask, .{});
+            try group.spawn(counts.slowTask, .{});
+            try group.spawn(counts.slowTask, .{});
 
             // This wait should be interrupted by cancellation
             group.wait() catch {};
         }
+    }.call;
 
-        fn asyncTask(runtime: *Runtime) !void {
-            started = 0;
-            canceled = 0;
+    counts.started = 0;
+    counts.canceled = 0;
 
-            // Spawn the group task
-            var group_handle = try runtime.spawn(groupTask, .{});
+    // Spawn the group task
+    var group_handle = try rt.spawn(groupTask, .{});
 
-            // Spawn a task that will cancel the group task
-            var canceller = try runtime.spawn(cancellerTask, .{ runtime, &group_handle });
-            defer canceller.cancel();
+    // Spawn a task that will cancel the group task
+    var canceller = try rt.spawn(cancellerTask, .{ rt, &group_handle });
+    defer canceller.cancel();
 
-            // Wait for group task to complete (should be canceled)
-            try group_handle.join();
+    // Wait for group task to complete (should be canceled)
+    try group_handle.join();
 
-            // All tasks should have been canceled
-            try std.testing.expectEqual(3, started);
-            try std.testing.expectEqual(3, canceled);
-        }
-    };
-
-    var handle = try rt.spawn(TestContext.asyncTask, .{rt});
-    try handle.join();
+    // All tasks should have been canceled
+    try std.testing.expectEqual(3, counts.started);
+    try std.testing.expectEqual(3, counts.canceled);
 }
 
 test "Group: failed task does not close group" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -1776,53 +1776,60 @@ test "Runtime.io / Runtime.fromIo round-trip" {
 test "io: async/await returns task result" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const doubleIt = struct {
-        fn call(x: i32) i32 {
+    const Worker = struct {
+        fn doubleIt(x: i32) i32 {
             return x * 2;
         }
-    }.call;
 
-    var future = io.async(doubleIt, .{21});
-    const value = future.await(io);
-    try std.testing.expectEqual(42, value);
+        fn run(io: Io) !void {
+            var future = io.async(doubleIt, .{21});
+            const value = future.await(io);
+            try std.testing.expectEqual(@as(i32, 42), value);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: Io.Mutex lock/unlock serializes tasks" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
     const State = struct {
         mutex: Io.Mutex = .init,
         counter: u32 = 0,
     };
 
-    const bump = struct {
-        fn call(io2: Io, s: *State) !void {
+    const Worker = struct {
+        fn bump(io: Io, s: *State) !void {
             var i: usize = 0;
             while (i < 100) : (i += 1) {
-                try s.mutex.lock(io2);
+                try s.mutex.lock(io);
                 s.counter += 1;
-                s.mutex.unlock(io2);
+                s.mutex.unlock(io);
             }
         }
-    }.call;
 
-    var s: State = .{};
-    var group: Io.Group = .init;
-    group.async(io, bump, .{ io, &s });
-    group.async(io, bump, .{ io, &s });
-    group.async(io, bump, .{ io, &s });
-    try group.await(io);
-    try std.testing.expectEqual(300, s.counter);
+        fn run(io: Io) !void {
+            var s: State = .{};
+            var group: Io.Group = .init;
+            group.async(io, bump, .{ io, &s });
+            group.async(io, bump, .{ io, &s });
+            group.async(io, bump, .{ io, &s });
+            try group.await(io);
+            try std.testing.expectEqual(@as(u32, 300), s.counter);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: Io.Condition wakes waiter after signal" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
     const State = struct {
         mutex: Io.Mutex = .init,
@@ -1830,37 +1837,39 @@ test "io: Io.Condition wakes waiter after signal" {
         ready: bool = false,
     };
 
-    const producer = struct {
-        fn call(io2: Io, s: *State) !void {
-            try s.mutex.lock(io2);
-            defer s.mutex.unlock(io2);
+    const Worker = struct {
+        fn producer(io: Io, s: *State) !void {
+            try s.mutex.lock(io);
+            defer s.mutex.unlock(io);
             s.ready = true;
-            s.cond.signal(io2);
+            s.cond.signal(io);
         }
-    }.call;
 
-    const consumer = struct {
-        fn call(io2: Io, s: *State, observed: *bool) !void {
-            try s.mutex.lock(io2);
-            defer s.mutex.unlock(io2);
-            while (!s.ready) try s.cond.wait(io2, &s.mutex);
+        fn consumer(io: Io, s: *State, observed: *bool) !void {
+            try s.mutex.lock(io);
+            defer s.mutex.unlock(io);
+            while (!s.ready) try s.cond.wait(io, &s.mutex);
             observed.* = true;
         }
-    }.call;
 
-    var s: State = .{};
-    var observed = false;
-    var group: Io.Group = .init;
-    group.async(io, consumer, .{ io, &s, &observed });
-    group.async(io, producer, .{ io, &s });
-    try group.await(io);
-    try std.testing.expect(observed);
+        fn run(io: Io) !void {
+            var s: State = .{};
+            var observed = false;
+            var group: Io.Group = .init;
+            group.async(io, consumer, .{ io, &s, &observed });
+            group.async(io, producer, .{ io, &s });
+            try group.await(io);
+            try std.testing.expect(observed);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: Io.Semaphore limits concurrent workers" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
     const Shared = struct {
         sem: Io.Semaphore = .{ .permits = 2 },
@@ -1868,10 +1877,10 @@ test "io: Io.Semaphore limits concurrent workers" {
         peak: std.atomic.Value(u32) = .init(0),
     };
 
-    const work = struct {
-        fn call(io2: Io, shared: *Shared) !void {
-            try shared.sem.wait(io2);
-            defer shared.sem.post(io2);
+    const Worker = struct {
+        fn work(io: Io, shared: *Shared) !void {
+            try shared.sem.wait(io);
+            defer shared.sem.post(io);
 
             const current = shared.active.fetchAdd(1, .acq_rel) + 1;
             // Track peak concurrency.
@@ -1881,16 +1890,21 @@ test "io: Io.Semaphore limits concurrent workers" {
             }
             _ = shared.active.fetchSub(1, .acq_rel);
         }
-    }.call;
 
-    var shared: Shared = .{};
-    var group: Io.Group = .init;
-    var i: usize = 0;
-    while (i < 8) : (i += 1) {
-        group.async(io, work, .{ io, &shared });
-    }
-    try group.await(io);
-    try std.testing.expect(shared.peak.load(.acquire) <= 2);
+        fn run(io: Io) !void {
+            var shared: Shared = .{};
+            var group: Io.Group = .init;
+            var i: usize = 0;
+            while (i < 8) : (i += 1) {
+                group.async(io, work, .{ io, &shared });
+            }
+            try group.await(io);
+            try std.testing.expect(shared.peak.load(.acquire) <= 2);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: processExecutablePath returns a non-empty path" {
@@ -1970,65 +1984,72 @@ test "io: sleep with duration returns after delay" {
 test "io: sleep is cancelable" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const sleeper = struct {
-        fn call(io2: Io, observed: *Io.Cancelable!void) void {
-            observed.* = io2.sleep(.fromSeconds(60), .awake);
+    const Worker = struct {
+        fn sleeper(io: Io, observed: *Io.Cancelable!void) void {
+            observed.* = io.sleep(.fromSeconds(60), .awake);
         }
-    }.call;
 
-    var observed: Io.Cancelable!void = {};
-    var future = io.async(sleeper, .{ io, &observed });
-    try io.sleep(.fromMilliseconds(10), .awake);
-    future.cancel(io);
-    try std.testing.expectError(error.Canceled, observed);
+        fn run(io: Io) !void {
+            var observed: Io.Cancelable!void = {};
+            var future = io.async(sleeper, .{ io, &observed });
+            try io.sleep(.fromMilliseconds(10), .awake);
+            future.cancel(io);
+            try std.testing.expectError(error.Canceled, observed);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: net TCP listen/connect/accept handshake" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const connector = struct {
-        fn call(io2: Io, address: *const Io.net.IpAddress, result: *Io.net.IpAddress.ConnectError!Io.net.Stream) void {
-            result.* = Io.net.IpAddress.connect(address, io2, .{ .mode = .stream });
+    const Worker = struct {
+        fn connector(io: Io, address: *const Io.net.IpAddress, result: *Io.net.IpAddress.ConnectError!Io.net.Stream) void {
+            result.* = Io.net.IpAddress.connect(address, io, .{ .mode = .stream });
         }
-    }.call;
 
-    var server = try Io.net.IpAddress.listen(
-        &.{ .ip4 = .loopback(0) },
-        io,
-        .{ .reuse_address = true },
-    );
-    defer server.deinit(io);
+        fn run(io: Io) !void {
+            var server = try Io.net.IpAddress.listen(
+                &.{ .ip4 = .loopback(0) },
+                io,
+                .{ .reuse_address = true },
+            );
+            defer server.deinit(io);
 
-    var connect_result: Io.net.IpAddress.ConnectError!Io.net.Stream = undefined;
-    var future = io.async(connector, .{ io, &server.socket.address, &connect_result });
-    defer future.cancel(io);
+            var connect_result: Io.net.IpAddress.ConnectError!Io.net.Stream = undefined;
+            var future = io.async(connector, .{ io, &server.socket.address, &connect_result });
+            defer future.cancel(io);
 
-    const accepted = try server.accept(io);
-    defer accepted.close(io);
+            const accepted = try server.accept(io);
+            defer accepted.close(io);
 
-    const client = try connect_result;
-    defer client.close(io);
+            const client = try connect_result;
+            defer client.close(io);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: net TCP read/write/shutdown round-trip" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const echoer = struct {
-        fn call(io2: Io, server: *Io.net.Server) !void {
-            const peer = try server.accept(io2);
-            defer peer.close(io2);
+    const Worker = struct {
+        fn echoer(io: Io, server: *Io.net.Server) !void {
+            const peer = try server.accept(io);
+            defer peer.close(io);
 
             var recv_buf: [256]u8 = undefined;
-            var reader = peer.reader(io2, &recv_buf);
+            var reader = peer.reader(io, &recv_buf);
 
             var send_buf: [256]u8 = undefined;
-            var writer = peer.writer(io2, &send_buf);
+            var writer = peer.writer(io, &send_buf);
 
             // Echo until EOF.
             while (true) {
@@ -2039,42 +2060,47 @@ test "io: net TCP read/write/shutdown round-trip" {
                 if (n == 0) break;
                 try writer.interface.flush();
             }
-            try peer.shutdown(io2, .send);
+            try peer.shutdown(io, .send);
         }
-    }.call;
 
-    var server = try Io.net.IpAddress.listen(
-        &.{ .ip4 = .loopback(0) },
-        io,
-        .{ .reuse_address = true },
-    );
-    defer server.deinit(io);
+        fn run(io: Io) !void {
+            var server = try Io.net.IpAddress.listen(
+                &.{ .ip4 = .loopback(0) },
+                io,
+                .{ .reuse_address = true },
+            );
+            defer server.deinit(io);
 
-    var echo_err: anyerror!void = {};
-    var future = io.async(struct {
-        fn call(io2: Io, s: *Io.net.Server, out: *anyerror!void) void {
-            out.* = echoer(io2, s);
+            var echo_err: anyerror!void = {};
+            var future = io.async(struct {
+                fn call(io2: Io, s: *Io.net.Server, out: *anyerror!void) void {
+                    out.* = echoer(io2, s);
+                }
+            }.call, .{ io, &server, &echo_err });
+
+            const client = try Io.net.IpAddress.connect(&server.socket.address, io, .{ .mode = .stream });
+            defer client.close(io);
+
+            var send_buf: [64]u8 = undefined;
+            var writer = client.writer(io, &send_buf);
+            try writer.interface.writeAll("hello ");
+            try writer.interface.writeAll("world");
+            try writer.interface.flush();
+            try client.shutdown(io, .send);
+
+            var recv_buf: [64]u8 = undefined;
+            var reader = client.reader(io, &recv_buf);
+            var out: [32]u8 = undefined;
+            const got = try reader.interface.readSliceShort(&out);
+            try std.testing.expectEqualStrings("hello world", out[0..got]);
+
+            future.await(io);
+            try echo_err;
         }
-    }.call, .{ io, &server, &echo_err });
+    };
 
-    const client = try Io.net.IpAddress.connect(&server.socket.address, io, .{ .mode = .stream });
-    defer client.close(io);
-
-    var send_buf: [64]u8 = undefined;
-    var writer = client.writer(io, &send_buf);
-    try writer.interface.writeAll("hello ");
-    try writer.interface.writeAll("world");
-    try writer.interface.flush();
-    try client.shutdown(io, .send);
-
-    var recv_buf: [64]u8 = undefined;
-    var reader = client.reader(io, &recv_buf);
-    var out: [32]u8 = undefined;
-    const got = try reader.interface.readSliceShort(&out);
-    try std.testing.expectEqualStrings("hello world", out[0..got]);
-
-    future.await(io);
-    try echo_err;
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: net Unix listen/connect/accept round-trip" {
@@ -2082,43 +2108,47 @@ test "io: net Unix listen/connect/accept round-trip" {
 
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const connector = struct {
-        fn call(io2: Io, address: *const Io.net.UnixAddress, result: *Io.net.UnixAddress.ConnectError!Io.net.Stream) void {
-            result.* = Io.net.UnixAddress.connect(address, io2);
+    const Worker = struct {
+        fn connector(io: Io, address: *const Io.net.UnixAddress, result: *Io.net.UnixAddress.ConnectError!Io.net.Stream) void {
+            result.* = Io.net.UnixAddress.connect(address, io);
         }
-    }.call;
 
-    const path = "test_io_net_unix.sock";
-    (Io.Dir.cwd()).deleteFile(io, path) catch {};
-    defer (Io.Dir.cwd()).deleteFile(io, path) catch {};
+        fn run(io: Io) !void {
+            const path = "test_io_net_unix.sock";
+            (Io.Dir.cwd()).deleteFile(io, path) catch {};
+            defer (Io.Dir.cwd()).deleteFile(io, path) catch {};
 
-    const address = try Io.net.UnixAddress.init(path);
-    var server = try address.listen(io, .{});
-    defer server.deinit(io);
+            const address = try Io.net.UnixAddress.init(path);
+            var server = try address.listen(io, .{});
+            defer server.deinit(io);
 
-    var connect_result: Io.net.UnixAddress.ConnectError!Io.net.Stream = undefined;
-    var future = io.async(connector, .{ io, &address, &connect_result });
-    defer future.cancel(io);
+            var connect_result: Io.net.UnixAddress.ConnectError!Io.net.Stream = undefined;
+            var future = io.async(connector, .{ io, &address, &connect_result });
+            defer future.cancel(io);
 
-    const accepted = try server.accept(io);
-    defer accepted.close(io);
+            const accepted = try server.accept(io);
+            defer accepted.close(io);
 
-    const client = try connect_result;
-    defer client.close(io);
+            const client = try connect_result;
+            defer client.close(io);
 
-    var send_buf: [32]u8 = undefined;
-    var writer = client.writer(io, &send_buf);
-    try writer.interface.writeAll("ping");
-    try writer.interface.flush();
-    try client.shutdown(io, .send);
+            var send_buf: [32]u8 = undefined;
+            var writer = client.writer(io, &send_buf);
+            try writer.interface.writeAll("ping");
+            try writer.interface.flush();
+            try client.shutdown(io, .send);
 
-    var recv_buf: [32]u8 = undefined;
-    var reader = accepted.reader(io, &recv_buf);
-    var out: [8]u8 = undefined;
-    const got = try reader.interface.readSliceShort(&out);
-    try std.testing.expectEqualStrings("ping", out[0..got]);
+            var recv_buf: [32]u8 = undefined;
+            var reader = accepted.reader(io, &recv_buf);
+            var out: [8]u8 = undefined;
+            const got = try reader.interface.readSliceShort(&out);
+            try std.testing.expectEqualStrings("ping", out[0..got]);
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }
 
 test "io: net UDP bind assigns ephemeral port" {
@@ -2706,19 +2736,23 @@ test "io: file hardLink" {
 test "io: group runs spawned tasks to completion" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
-    const io = rt.io();
 
-    const bump = struct {
-        fn call(counter: *std.atomic.Value(u32)) void {
+    const Worker = struct {
+        fn bump(counter: *std.atomic.Value(u32)) void {
             _ = counter.fetchAdd(1, .acq_rel);
         }
-    }.call;
 
-    var counter: std.atomic.Value(u32) = .init(0);
-    var group: Io.Group = .init;
-    group.async(io, bump, .{&counter});
-    group.async(io, bump, .{&counter});
-    group.async(io, bump, .{&counter});
-    try group.await(io);
-    try std.testing.expectEqual(3, counter.load(.acquire));
+        fn run(io: Io) !void {
+            var counter: std.atomic.Value(u32) = .init(0);
+            var group: Io.Group = .init;
+            group.async(io, bump, .{&counter});
+            group.async(io, bump, .{&counter});
+            group.async(io, bump, .{&counter});
+            try group.await(io);
+            try std.testing.expectEqual(@as(u32, 3), counter.load(.acquire));
+        }
+    };
+
+    var handle = try rt.spawn(Worker.run, .{rt.io()});
+    try handle.join();
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -1776,60 +1776,53 @@ test "Runtime.io / Runtime.fromIo round-trip" {
 test "io: async/await returns task result" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn doubleIt(x: i32) i32 {
+    const doubleIt = struct {
+        fn call(x: i32) i32 {
             return x * 2;
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var future = io.async(doubleIt, .{21});
-            const value = future.await(io);
-            try std.testing.expectEqual(@as(i32, 42), value);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var future = io.async(doubleIt, .{21});
+    const value = future.await(io);
+    try std.testing.expectEqual(42, value);
 }
 
 test "io: Io.Mutex lock/unlock serializes tasks" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
     const State = struct {
         mutex: Io.Mutex = .init,
         counter: u32 = 0,
     };
 
-    const Worker = struct {
-        fn bump(io: Io, s: *State) !void {
+    const bump = struct {
+        fn call(io2: Io, s: *State) !void {
             var i: usize = 0;
             while (i < 100) : (i += 1) {
-                try s.mutex.lock(io);
+                try s.mutex.lock(io2);
                 s.counter += 1;
-                s.mutex.unlock(io);
+                s.mutex.unlock(io2);
             }
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var s: State = .{};
-            var group: Io.Group = .init;
-            group.async(io, bump, .{ io, &s });
-            group.async(io, bump, .{ io, &s });
-            group.async(io, bump, .{ io, &s });
-            try group.await(io);
-            try std.testing.expectEqual(@as(u32, 300), s.counter);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var s: State = .{};
+    var group: Io.Group = .init;
+    group.async(io, bump, .{ io, &s });
+    group.async(io, bump, .{ io, &s });
+    group.async(io, bump, .{ io, &s });
+    try group.await(io);
+    try std.testing.expectEqual(300, s.counter);
 }
 
 test "io: Io.Condition wakes waiter after signal" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
     const State = struct {
         mutex: Io.Mutex = .init,
@@ -1837,39 +1830,37 @@ test "io: Io.Condition wakes waiter after signal" {
         ready: bool = false,
     };
 
-    const Worker = struct {
-        fn producer(io: Io, s: *State) !void {
-            try s.mutex.lock(io);
-            defer s.mutex.unlock(io);
+    const producer = struct {
+        fn call(io2: Io, s: *State) !void {
+            try s.mutex.lock(io2);
+            defer s.mutex.unlock(io2);
             s.ready = true;
-            s.cond.signal(io);
+            s.cond.signal(io2);
         }
+    }.call;
 
-        fn consumer(io: Io, s: *State, observed: *bool) !void {
-            try s.mutex.lock(io);
-            defer s.mutex.unlock(io);
-            while (!s.ready) try s.cond.wait(io, &s.mutex);
+    const consumer = struct {
+        fn call(io2: Io, s: *State, observed: *bool) !void {
+            try s.mutex.lock(io2);
+            defer s.mutex.unlock(io2);
+            while (!s.ready) try s.cond.wait(io2, &s.mutex);
             observed.* = true;
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var s: State = .{};
-            var observed = false;
-            var group: Io.Group = .init;
-            group.async(io, consumer, .{ io, &s, &observed });
-            group.async(io, producer, .{ io, &s });
-            try group.await(io);
-            try std.testing.expect(observed);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var s: State = .{};
+    var observed = false;
+    var group: Io.Group = .init;
+    group.async(io, consumer, .{ io, &s, &observed });
+    group.async(io, producer, .{ io, &s });
+    try group.await(io);
+    try std.testing.expect(observed);
 }
 
 test "io: Io.Semaphore limits concurrent workers" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
     const Shared = struct {
         sem: Io.Semaphore = .{ .permits = 2 },
@@ -1877,10 +1868,10 @@ test "io: Io.Semaphore limits concurrent workers" {
         peak: std.atomic.Value(u32) = .init(0),
     };
 
-    const Worker = struct {
-        fn work(io: Io, shared: *Shared) !void {
-            try shared.sem.wait(io);
-            defer shared.sem.post(io);
+    const work = struct {
+        fn call(io2: Io, shared: *Shared) !void {
+            try shared.sem.wait(io2);
+            defer shared.sem.post(io2);
 
             const current = shared.active.fetchAdd(1, .acq_rel) + 1;
             // Track peak concurrency.
@@ -1890,21 +1881,16 @@ test "io: Io.Semaphore limits concurrent workers" {
             }
             _ = shared.active.fetchSub(1, .acq_rel);
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var shared: Shared = .{};
-            var group: Io.Group = .init;
-            var i: usize = 0;
-            while (i < 8) : (i += 1) {
-                group.async(io, work, .{ io, &shared });
-            }
-            try group.await(io);
-            try std.testing.expect(shared.peak.load(.acquire) <= 2);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var shared: Shared = .{};
+    var group: Io.Group = .init;
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        group.async(io, work, .{ io, &shared });
+    }
+    try group.await(io);
+    try std.testing.expect(shared.peak.load(.acquire) <= 2);
 }
 
 test "io: processExecutablePath returns a non-empty path" {
@@ -1984,72 +1970,65 @@ test "io: sleep with duration returns after delay" {
 test "io: sleep is cancelable" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn sleeper(io: Io, observed: *Io.Cancelable!void) void {
-            observed.* = io.sleep(.fromSeconds(60), .awake);
+    const sleeper = struct {
+        fn call(io2: Io, observed: *Io.Cancelable!void) void {
+            observed.* = io2.sleep(.fromSeconds(60), .awake);
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var observed: Io.Cancelable!void = {};
-            var future = io.async(sleeper, .{ io, &observed });
-            try io.sleep(.fromMilliseconds(10), .awake);
-            future.cancel(io);
-            try std.testing.expectError(error.Canceled, observed);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var observed: Io.Cancelable!void = {};
+    var future = io.async(sleeper, .{ io, &observed });
+    try io.sleep(.fromMilliseconds(10), .awake);
+    future.cancel(io);
+    try std.testing.expectError(error.Canceled, observed);
 }
 
 test "io: net TCP listen/connect/accept handshake" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn connector(io: Io, address: *const Io.net.IpAddress, result: *Io.net.IpAddress.ConnectError!Io.net.Stream) void {
-            result.* = Io.net.IpAddress.connect(address, io, .{ .mode = .stream });
+    const connector = struct {
+        fn call(io2: Io, address: *const Io.net.IpAddress, result: *Io.net.IpAddress.ConnectError!Io.net.Stream) void {
+            result.* = Io.net.IpAddress.connect(address, io2, .{ .mode = .stream });
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var server = try Io.net.IpAddress.listen(
-                &.{ .ip4 = .loopback(0) },
-                io,
-                .{ .reuse_address = true },
-            );
-            defer server.deinit(io);
+    var server = try Io.net.IpAddress.listen(
+        &.{ .ip4 = .loopback(0) },
+        io,
+        .{ .reuse_address = true },
+    );
+    defer server.deinit(io);
 
-            var connect_result: Io.net.IpAddress.ConnectError!Io.net.Stream = undefined;
-            var future = io.async(connector, .{ io, &server.socket.address, &connect_result });
-            defer future.cancel(io);
+    var connect_result: Io.net.IpAddress.ConnectError!Io.net.Stream = undefined;
+    var future = io.async(connector, .{ io, &server.socket.address, &connect_result });
+    defer future.cancel(io);
 
-            const accepted = try server.accept(io);
-            defer accepted.close(io);
+    const accepted = try server.accept(io);
+    defer accepted.close(io);
 
-            const client = try connect_result;
-            defer client.close(io);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    const client = try connect_result;
+    defer client.close(io);
 }
 
 test "io: net TCP read/write/shutdown round-trip" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn echoer(io: Io, server: *Io.net.Server) !void {
-            const peer = try server.accept(io);
-            defer peer.close(io);
+    const echoer = struct {
+        fn call(io2: Io, server: *Io.net.Server) !void {
+            const peer = try server.accept(io2);
+            defer peer.close(io2);
 
             var recv_buf: [256]u8 = undefined;
-            var reader = peer.reader(io, &recv_buf);
+            var reader = peer.reader(io2, &recv_buf);
 
             var send_buf: [256]u8 = undefined;
-            var writer = peer.writer(io, &send_buf);
+            var writer = peer.writer(io2, &send_buf);
 
             // Echo until EOF.
             while (true) {
@@ -2060,47 +2039,42 @@ test "io: net TCP read/write/shutdown round-trip" {
                 if (n == 0) break;
                 try writer.interface.flush();
             }
-            try peer.shutdown(io, .send);
+            try peer.shutdown(io2, .send);
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var server = try Io.net.IpAddress.listen(
-                &.{ .ip4 = .loopback(0) },
-                io,
-                .{ .reuse_address = true },
-            );
-            defer server.deinit(io);
+    var server = try Io.net.IpAddress.listen(
+        &.{ .ip4 = .loopback(0) },
+        io,
+        .{ .reuse_address = true },
+    );
+    defer server.deinit(io);
 
-            var echo_err: anyerror!void = {};
-            var future = io.async(struct {
-                fn call(io2: Io, s: *Io.net.Server, out: *anyerror!void) void {
-                    out.* = echoer(io2, s);
-                }
-            }.call, .{ io, &server, &echo_err });
-
-            const client = try Io.net.IpAddress.connect(&server.socket.address, io, .{ .mode = .stream });
-            defer client.close(io);
-
-            var send_buf: [64]u8 = undefined;
-            var writer = client.writer(io, &send_buf);
-            try writer.interface.writeAll("hello ");
-            try writer.interface.writeAll("world");
-            try writer.interface.flush();
-            try client.shutdown(io, .send);
-
-            var recv_buf: [64]u8 = undefined;
-            var reader = client.reader(io, &recv_buf);
-            var out: [32]u8 = undefined;
-            const got = try reader.interface.readSliceShort(&out);
-            try std.testing.expectEqualStrings("hello world", out[0..got]);
-
-            future.await(io);
-            try echo_err;
+    var echo_err: anyerror!void = {};
+    var future = io.async(struct {
+        fn call(io2: Io, s: *Io.net.Server, out: *anyerror!void) void {
+            out.* = echoer(io2, s);
         }
-    };
+    }.call, .{ io, &server, &echo_err });
 
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    const client = try Io.net.IpAddress.connect(&server.socket.address, io, .{ .mode = .stream });
+    defer client.close(io);
+
+    var send_buf: [64]u8 = undefined;
+    var writer = client.writer(io, &send_buf);
+    try writer.interface.writeAll("hello ");
+    try writer.interface.writeAll("world");
+    try writer.interface.flush();
+    try client.shutdown(io, .send);
+
+    var recv_buf: [64]u8 = undefined;
+    var reader = client.reader(io, &recv_buf);
+    var out: [32]u8 = undefined;
+    const got = try reader.interface.readSliceShort(&out);
+    try std.testing.expectEqualStrings("hello world", out[0..got]);
+
+    future.await(io);
+    try echo_err;
 }
 
 test "io: net Unix listen/connect/accept round-trip" {
@@ -2108,47 +2082,43 @@ test "io: net Unix listen/connect/accept round-trip" {
 
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn connector(io: Io, address: *const Io.net.UnixAddress, result: *Io.net.UnixAddress.ConnectError!Io.net.Stream) void {
-            result.* = Io.net.UnixAddress.connect(address, io);
+    const connector = struct {
+        fn call(io2: Io, address: *const Io.net.UnixAddress, result: *Io.net.UnixAddress.ConnectError!Io.net.Stream) void {
+            result.* = Io.net.UnixAddress.connect(address, io2);
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            const path = "test_io_net_unix.sock";
-            (Io.Dir.cwd()).deleteFile(io, path) catch {};
-            defer (Io.Dir.cwd()).deleteFile(io, path) catch {};
+    const path = "test_io_net_unix.sock";
+    (Io.Dir.cwd()).deleteFile(io, path) catch {};
+    defer (Io.Dir.cwd()).deleteFile(io, path) catch {};
 
-            const address = try Io.net.UnixAddress.init(path);
-            var server = try address.listen(io, .{});
-            defer server.deinit(io);
+    const address = try Io.net.UnixAddress.init(path);
+    var server = try address.listen(io, .{});
+    defer server.deinit(io);
 
-            var connect_result: Io.net.UnixAddress.ConnectError!Io.net.Stream = undefined;
-            var future = io.async(connector, .{ io, &address, &connect_result });
-            defer future.cancel(io);
+    var connect_result: Io.net.UnixAddress.ConnectError!Io.net.Stream = undefined;
+    var future = io.async(connector, .{ io, &address, &connect_result });
+    defer future.cancel(io);
 
-            const accepted = try server.accept(io);
-            defer accepted.close(io);
+    const accepted = try server.accept(io);
+    defer accepted.close(io);
 
-            const client = try connect_result;
-            defer client.close(io);
+    const client = try connect_result;
+    defer client.close(io);
 
-            var send_buf: [32]u8 = undefined;
-            var writer = client.writer(io, &send_buf);
-            try writer.interface.writeAll("ping");
-            try writer.interface.flush();
-            try client.shutdown(io, .send);
+    var send_buf: [32]u8 = undefined;
+    var writer = client.writer(io, &send_buf);
+    try writer.interface.writeAll("ping");
+    try writer.interface.flush();
+    try client.shutdown(io, .send);
 
-            var recv_buf: [32]u8 = undefined;
-            var reader = accepted.reader(io, &recv_buf);
-            var out: [8]u8 = undefined;
-            const got = try reader.interface.readSliceShort(&out);
-            try std.testing.expectEqualStrings("ping", out[0..got]);
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var recv_buf: [32]u8 = undefined;
+    var reader = accepted.reader(io, &recv_buf);
+    var out: [8]u8 = undefined;
+    const got = try reader.interface.readSliceShort(&out);
+    try std.testing.expectEqualStrings("ping", out[0..got]);
 }
 
 test "io: net UDP bind assigns ephemeral port" {
@@ -2736,23 +2706,19 @@ test "io: file hardLink" {
 test "io: group runs spawned tasks to completion" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
+    const io = rt.io();
 
-    const Worker = struct {
-        fn bump(counter: *std.atomic.Value(u32)) void {
+    const bump = struct {
+        fn call(counter: *std.atomic.Value(u32)) void {
             _ = counter.fetchAdd(1, .acq_rel);
         }
+    }.call;
 
-        fn run(io: Io) !void {
-            var counter: std.atomic.Value(u32) = .init(0);
-            var group: Io.Group = .init;
-            group.async(io, bump, .{&counter});
-            group.async(io, bump, .{&counter});
-            group.async(io, bump, .{&counter});
-            try group.await(io);
-            try std.testing.expectEqual(@as(u32, 3), counter.load(.acquire));
-        }
-    };
-
-    var handle = try rt.spawn(Worker.run, .{rt.io()});
-    try handle.join();
+    var counter: std.atomic.Value(u32) = .init(0);
+    var group: Io.Group = .init;
+    group.async(io, bump, .{&counter});
+    group.async(io, bump, .{&counter});
+    group.async(io, bump, .{&counter});
+    try group.await(io);
+    try std.testing.expectEqual(3, counter.load(.acquire));
 }

--- a/src/net.zig
+++ b/src/net.zig
@@ -1347,27 +1347,19 @@ test "HostName: connect" {
     const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer rt.deinit();
 
-    const Test = struct {
-        fn run() !void {
-            // Start a server
-            const server_addr = try IpAddress.parseIp4("127.0.0.1", 0);
-            const server = try server_addr.listen(.{});
-            defer server.close();
+    // Start a server
+    const server_addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try server_addr.listen(.{});
+    defer server.close();
 
-            const port = server.socket.address.ip.getPort();
+    const port = server.socket.address.ip.getPort();
 
-            // Connect via HostName
-            const host = try HostName.init("localhost");
-            var stream = try host.connect(port, .{});
-            defer stream.close();
+    // Connect via HostName
+    const host = try HostName.init("localhost");
+    var stream = try host.connect(port, .{});
+    defer stream.close();
 
-            try stream.writeAll("hello", .none);
-        }
-    };
-
-    var task = try rt.spawn(Test.run, .{});
-    defer task.cancel();
-    try task.join();
+    try stream.writeAll("hello", .none);
 }
 
 test "IpAddress: getFamily" {
@@ -1846,19 +1838,6 @@ test "UnixAddress: init" {
 
 pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
     const Test = struct {
-        pub fn mainFn(addr_inner: @TypeOf(addr), options_inner: @TypeOf(options), write_buffer_inner: []u8) !void {
-            const server = try addr_inner.listen(options_inner);
-            defer server.close();
-
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(serverFn, .{server});
-            try group.spawn(clientFn, .{ server, write_buffer_inner });
-
-            try group.wait();
-        }
-
         pub fn serverFn(server: Server) !void {
             const client = try server.accept(.{});
             defer client.close();
@@ -1888,25 +1867,20 @@ pub fn checkListen(addr: anytype, options: anytype, write_buffer: []u8) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ addr, options, write_buffer });
-    try handle.join();
+    const server = try addr.listen(options);
+    defer server.close();
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(Test.serverFn, .{server});
+    try group.spawn(Test.clientFn, .{ server, write_buffer });
+
+    try group.wait();
 }
 
 pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
     const Test = struct {
-        pub fn mainFn(server_addr_inner: @TypeOf(server_addr), client_addr_inner: @TypeOf(client_addr)) !void {
-            const socket = try server_addr_inner.bind(.{});
-            defer socket.close();
-
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(serverFn, .{socket});
-            try group.spawn(clientFn, .{ socket, client_addr_inner });
-
-            try group.wait();
-        }
-
         pub fn serverFn(socket: Socket) !void {
             var buf: [1024]u8 = undefined;
             const result = try socket.receiveFrom(&buf, .none);
@@ -1934,25 +1908,20 @@ pub fn checkBind(server_addr: anytype, client_addr: anytype) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ server_addr, client_addr });
-    try handle.join();
+    const socket = try server_addr.bind(.{});
+    defer socket.close();
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(Test.serverFn, .{socket});
+    try group.spawn(Test.clientFn, .{ socket, client_addr });
+
+    try group.wait();
 }
 
 pub fn checkShutdown(addr: anytype, options: anytype) !void {
     const Test = struct {
-        pub fn mainFn(addr_inner: @TypeOf(addr), options_inner: @TypeOf(options)) !void {
-            const server = try addr_inner.listen(options_inner);
-            defer server.close();
-
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(serverFn, .{server});
-            try group.spawn(clientFn, .{server});
-
-            try group.wait();
-        }
-
         pub fn serverFn(server: Server) !void {
             const client = try server.accept(.{});
             defer client.close();
@@ -1975,8 +1944,16 @@ pub fn checkShutdown(addr: anytype, options: anytype) !void {
     const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(Test.mainFn, .{ addr, options });
-    try handle.join();
+    const server = try addr.listen(options);
+    defer server.close();
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(Test.serverFn, .{server});
+    try group.spawn(Test.clientFn, .{server});
+
+    try group.wait();
 }
 
 test "UnixAddress: listen/accept/connect/read/write" {
@@ -2114,15 +2091,10 @@ test "Server: accept timeout" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    var handle = try runtime.spawn(struct {
-        fn run() !void {
-            const addr = try IpAddress.parseIp4("127.0.0.1", 0);
-            const server = try addr.listen(.{});
-            defer server.close();
+    const addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try addr.listen(.{});
+    defer server.close();
 
-            const result = server.accept(.{ .timeout = Timeout.fromMilliseconds(10) });
-            try std.testing.expectError(error.Timeout, result);
-        }
-    }.run, .{});
-    try handle.join();
+    const result = server.accept(.{ .timeout = Timeout.fromMilliseconds(10) });
+    try std.testing.expectError(error.Timeout, result);
 }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -980,22 +980,14 @@ test "Runtime: implicit run" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn asyncTask(rt: *Runtime) !void {
-            const start = rt.now();
-            try std.testing.expect(start.value > 0);
+    const start = runtime.now();
+    try std.testing.expect(start.value > 0);
 
-            // Sleep to ensure time advances
-            try rt.sleep(.fromMilliseconds(10));
+    try runtime.sleep(.fromMilliseconds(10));
 
-            const end = rt.now();
-            try std.testing.expect(end.value > start.value);
-            try std.testing.expect(start.durationTo(end).toMilliseconds() >= 10);
-        }
-    };
-
-    var task = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try task.join();
+    const end = runtime.now();
+    try std.testing.expect(end.value > start.value);
+    try std.testing.expect(start.durationTo(end).toMilliseconds() >= 10);
 }
 
 test "Runtime: sleep from main" {
@@ -1015,14 +1007,7 @@ test "runtime: basic sleep" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const Sleeper = struct {
-        fn run(rt: *Runtime) !void {
-            try rt.sleep(.fromMilliseconds(1));
-        }
-    };
-
-    var task = try runtime.spawn(Sleeper.run, .{runtime});
-    try task.join();
+    try runtime.sleep(.fromMilliseconds(1));
 }
 
 test "runtime: now() returns monotonic time" {

--- a/src/select.zig
+++ b/src/select.zig
@@ -488,146 +488,143 @@ test "select: basic - first completes" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn slowTask(rt: *Runtime) !i32 {
+    const slowTask = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 42;
         }
+    }.call;
 
-        fn fastTask(rt: *Runtime) !i32 {
+    const fastTask = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(10));
             return 99;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var slow = try rt.spawn(slowTask, .{rt});
-            defer slow.cancel();
-            var fast = try rt.spawn(fastTask, .{rt});
-            defer fast.cancel();
+    var slow = try runtime.spawn(slowTask, .{runtime});
+    defer slow.cancel();
+    var fast = try runtime.spawn(fastTask, .{runtime});
+    defer fast.cancel();
 
-            const result = try select(.{ .fast = &fast, .slow = &slow });
-            switch (result) {
-                .slow => |val| try std.testing.expectEqual(42, val),
-                .fast => |val| try std.testing.expectEqual(99, val),
-            }
-            // Fast should win
-            try std.testing.expectEqual(std.meta.Tag(@TypeOf(result)).fast, std.meta.activeTag(result));
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    const result = try select(.{ .fast = &fast, .slow = &slow });
+    switch (result) {
+        .slow => |val| try std.testing.expectEqual(42, val),
+        .fast => |val| try std.testing.expectEqual(99, val),
+    }
+    // Fast should win
+    try std.testing.expectEqual(std.meta.Tag(@TypeOf(result)).fast, std.meta.activeTag(result));
 }
 
 test "select: already complete - fast path" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn immediateTask() i32 {
+    const immediateTask = struct {
+        fn call() i32 {
             return 123;
         }
+    }.call;
 
-        fn slowTask(rt: *Runtime) !i32 {
+    const slowTask = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 456;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var immediate = try rt.spawn(immediateTask, .{});
-            defer immediate.cancel();
+    var immediate = try runtime.spawn(immediateTask, .{});
+    defer immediate.cancel();
 
-            // Give immediate task a chance to complete
-            try yield();
-            try yield();
+    // Give immediate task a chance to complete
+    try yield();
+    try yield();
 
-            var slow = try rt.spawn(slowTask, .{rt});
-            defer slow.cancel();
+    var slow = try runtime.spawn(slowTask, .{runtime});
+    defer slow.cancel();
 
-            // immediate should already be complete, select should return immediately
-            const result = try select(.{ .immediate = &immediate, .slow = &slow });
-            switch (result) {
-                .immediate => |val| try std.testing.expectEqual(123, val),
-                .slow => return error.TestUnexpectedResult,
-            }
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // immediate should already be complete, select should return immediately
+    const result = try select(.{ .immediate = &immediate, .slow = &slow });
+    switch (result) {
+        .immediate => |val| try std.testing.expectEqual(123, val),
+        .slow => return error.TestUnexpectedResult,
+    }
 }
 
 test "select: heterogeneous types" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn intTask(rt: *Runtime) Cancelable!i32 {
+    const intTask = struct {
+        fn call(rt: *Runtime) Cancelable!i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 42;
         }
+    }.call;
 
-        fn stringTask(rt: *Runtime) Cancelable![]const u8 {
+    const stringTask = struct {
+        fn call(rt: *Runtime) Cancelable![]const u8 {
             try rt.sleep(.fromMilliseconds(10));
             return "hello";
         }
+    }.call;
 
-        fn boolTask(rt: *Runtime) Cancelable!bool {
+    const boolTask = struct {
+        fn call(rt: *Runtime) Cancelable!bool {
             try rt.sleep(.fromMilliseconds(150));
             return true;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var int_handle = try rt.spawn(intTask, .{rt});
-            defer int_handle.cancel();
-            var string_handle = try rt.spawn(stringTask, .{rt});
-            defer string_handle.cancel();
-            var bool_handle = try rt.spawn(boolTask, .{rt});
-            defer bool_handle.cancel();
+    var int_handle = try runtime.spawn(intTask, .{runtime});
+    defer int_handle.cancel();
+    var string_handle = try runtime.spawn(stringTask, .{runtime});
+    defer string_handle.cancel();
+    var bool_handle = try runtime.spawn(boolTask, .{runtime});
+    defer bool_handle.cancel();
 
-            const result = try select(.{
-                .string = &string_handle,
-                .int = &int_handle,
-                .bool = &bool_handle,
-            });
+    const result = try select(.{
+        .string = &string_handle,
+        .int = &int_handle,
+        .bool = &bool_handle,
+    });
 
-            switch (result) {
-                .int => |val| {
-                    try std.testing.expectEqual(42, try val);
-                    return error.TestUnexpectedResult; // Should not complete first
-                },
-                .string => |val| {
-                    try std.testing.expectEqualStrings("hello", try val);
-                    // This should win
-                },
-                .bool => |val| {
-                    try std.testing.expectEqual(true, try val);
-                    return error.TestUnexpectedResult; // Should not complete first
-                },
-            }
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    switch (result) {
+        .int => |val| {
+            try std.testing.expectEqual(42, try val);
+            return error.TestUnexpectedResult; // Should not complete first
+        },
+        .string => |val| {
+            try std.testing.expectEqualStrings("hello", try val);
+            // This should win
+        },
+        .bool => |val| {
+            try std.testing.expectEqual(true, try val);
+            return error.TestUnexpectedResult; // Should not complete first
+        },
+    }
 }
 
 test "select: with cancellation" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn slowTask1(rt: *Runtime) !i32 {
+    const slowTask1 = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(1000));
             return 1;
         }
+    }.call;
 
-        fn slowTask2(rt: *Runtime) !i32 {
+    const slowTask2 = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(1000));
             return 2;
         }
+    }.call;
 
-        fn selectTask(rt: *Runtime) !i32 {
+    const selectTask = struct {
+        fn call(rt: *Runtime) !i32 {
             var h1 = try rt.spawn(slowTask1, .{rt});
             defer h1.cancel();
             var h2 = try rt.spawn(slowTask2, .{rt});
@@ -639,191 +636,179 @@ test "select: with cancellation" {
                 .second => |v| v,
             };
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var select_handle = try rt.spawn(selectTask, .{rt});
-            defer select_handle.cancel();
+    var select_handle = try runtime.spawn(selectTask, .{runtime});
+    defer select_handle.cancel();
 
-            // Give it a chance to start waiting
-            try yield();
-            try yield();
+    // Give it a chance to start waiting
+    try yield();
+    try yield();
 
-            // Cancel the select operation
-            select_handle.cancel();
+    // Cancel the select operation
+    select_handle.cancel();
 
-            // Should return error.Canceled
-            const result = select_handle.join();
-            try std.testing.expectError(error.Canceled, result);
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Should return error.Canceled
+    const result = select_handle.join();
+    try std.testing.expectError(error.Canceled, result);
 }
 
 test "select: with error unions - success case" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        const ParseError = error{ InvalidFormat, OutOfRange };
-        const ValidationError = error{ TooShort, TooLong };
+    const ParseError = error{ InvalidFormat, OutOfRange };
+    const ValidationError = error{ TooShort, TooLong };
 
-        fn parseTask(rt: *Runtime) (ParseError || Cancelable)!i32 {
+    const parseTask = struct {
+        fn call(rt: *Runtime) (ParseError || Cancelable)!i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 42;
         }
+    }.call;
 
-        fn validateTask(rt: *Runtime) (ValidationError || Cancelable)![]const u8 {
+    const validateTask = struct {
+        fn call(rt: *Runtime) (ValidationError || Cancelable)![]const u8 {
             try rt.sleep(.fromMilliseconds(10));
             return "valid";
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var parse_handle = try rt.spawn(parseTask, .{rt});
-            defer parse_handle.cancel();
-            var validate_handle = try rt.spawn(validateTask, .{rt});
-            defer validate_handle.cancel();
+    var parse_handle = try runtime.spawn(parseTask, .{runtime});
+    defer parse_handle.cancel();
+    var validate_handle = try runtime.spawn(validateTask, .{runtime});
+    defer validate_handle.cancel();
 
-            const result = try select(.{
-                .validate = &validate_handle,
-                .parse = &parse_handle,
-            });
+    const result = try select(.{
+        .validate = &validate_handle,
+        .parse = &parse_handle,
+    });
 
-            // Result is a union where each field has the original error type
-            switch (result) {
-                .parse => |val_or_err| {
-                    // val_or_err is ParseError!i32
-                    const val = val_or_err catch |err| {
-                        try std.testing.expect(false); // Should not error
-                        return err;
-                    };
-                    try std.testing.expectEqual(42, val);
-                    return error.TestUnexpectedResult; // validate should win
-                },
-                .validate => |val_or_err| {
-                    // val_or_err is ValidationError![]const u8
-                    const val = val_or_err catch |err| {
-                        try std.testing.expect(false); // Should not error
-                        return err;
-                    };
-                    try std.testing.expectEqualStrings("valid", val);
-                    // This should win
-                },
-            }
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Result is a union where each field has the original error type
+    switch (result) {
+        .parse => |val_or_err| {
+            // val_or_err is ParseError!i32
+            const val = val_or_err catch |err| {
+                try std.testing.expect(false); // Should not error
+                return err;
+            };
+            try std.testing.expectEqual(42, val);
+            return error.TestUnexpectedResult; // validate should win
+        },
+        .validate => |val_or_err| {
+            // val_or_err is ValidationError![]const u8
+            const val = val_or_err catch |err| {
+                try std.testing.expect(false); // Should not error
+                return err;
+            };
+            try std.testing.expectEqualStrings("valid", val);
+            // This should win
+        },
+    }
 }
 
 test "select: with error unions - error case" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        const ParseError = error{ InvalidFormat, OutOfRange };
+    const ParseError = error{ InvalidFormat, OutOfRange };
 
-        fn failingTask(rt: *Runtime) (ParseError || Cancelable)!i32 {
+    const failingTask = struct {
+        fn call(rt: *Runtime) (ParseError || Cancelable)!i32 {
             try rt.sleep(.fromMilliseconds(10));
             return error.OutOfRange;
         }
+    }.call;
 
-        fn slowTask(rt: *Runtime) !i32 {
+    const slowTask = struct {
+        fn call(rt: *Runtime) !i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 99;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var failing = try rt.spawn(failingTask, .{rt});
-            defer failing.cancel();
-            var slow = try rt.spawn(slowTask, .{rt});
-            defer slow.cancel();
+    var failing = try runtime.spawn(failingTask, .{runtime});
+    defer failing.cancel();
+    var slow = try runtime.spawn(slowTask, .{runtime});
+    defer slow.cancel();
 
-            const result = try select(.{ .failing = &failing, .slow = &slow });
+    const result = try select(.{ .failing = &failing, .slow = &slow });
 
-            switch (result) {
-                .failing => |val_or_err| {
-                    // val_or_err is ParseError!i32
-                    _ = val_or_err catch |err| {
-                        // Should receive the original error
-                        try std.testing.expectEqual(ParseError.OutOfRange, err);
-                        return;
-                    };
-                    return error.TestUnexpectedResult; // Should have errored
-                },
-                .slow => |val| {
-                    try std.testing.expectEqual(99, val);
-                    return error.TestUnexpectedResult; // failing should win
-                },
-            }
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    switch (result) {
+        .failing => |val_or_err| {
+            // val_or_err is ParseError!i32
+            _ = val_or_err catch |err| {
+                // Should receive the original error
+                try std.testing.expectEqual(ParseError.OutOfRange, err);
+                return;
+            };
+            return error.TestUnexpectedResult; // Should have errored
+        },
+        .slow => |val| {
+            try std.testing.expectEqual(99, val);
+            return error.TestUnexpectedResult; // failing should win
+        },
+    }
 }
 
 test "select: with mixed error types" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        const ParseError = error{ InvalidFormat, OutOfRange };
-        const IOError = error{ FileNotFound, PermissionDenied };
+    const ParseError = error{ InvalidFormat, OutOfRange };
+    const IOError = error{ FileNotFound, PermissionDenied };
 
-        fn task1(rt: *Runtime) (ParseError || Cancelable)!i32 {
+    const task1 = struct {
+        fn call(rt: *Runtime) (ParseError || Cancelable)!i32 {
             try rt.sleep(.fromMilliseconds(100));
             return 100;
         }
+    }.call;
 
-        fn task2(rt: *Runtime) (IOError || Cancelable)![]const u8 {
+    const task2 = struct {
+        fn call(rt: *Runtime) (IOError || Cancelable)![]const u8 {
             try rt.sleep(.fromMilliseconds(10));
             return error.FileNotFound;
         }
+    }.call;
 
-        fn task3(rt: *Runtime) !bool {
+    const task3 = struct {
+        fn call(rt: *Runtime) !bool {
             try rt.sleep(.fromMilliseconds(150));
             return true;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var h1 = try rt.spawn(task1, .{rt});
-            defer h1.cancel();
-            var h2 = try rt.spawn(task2, .{rt});
-            defer h2.cancel();
-            var h3 = try rt.spawn(task3, .{rt});
-            defer h3.cancel();
+    var h1 = try runtime.spawn(task1, .{runtime});
+    defer h1.cancel();
+    var h2 = try runtime.spawn(task2, .{runtime});
+    defer h2.cancel();
+    var h3 = try runtime.spawn(task3, .{runtime});
+    defer h3.cancel();
 
-            // select returns Cancelable!SelectUnion(...)
-            // SelectUnion has: { .h2: IOError![]const u8, .h1: ParseError!i32, .h3: bool }
-            const result = try select(.{ .h2 = &h2, .h1 = &h1, .h3 = &h3 });
+    // select returns Cancelable!SelectUnion(...)
+    // SelectUnion has: { .h2: IOError![]const u8, .h1: ParseError!i32, .h3: bool }
+    const result = try select(.{ .h2 = &h2, .h1 = &h1, .h3 = &h3 });
 
-            switch (result) {
-                .h1 => |val_or_err| {
-                    _ = val_or_err catch return error.TestUnexpectedResult;
-                    return error.TestUnexpectedResult;
-                },
-                .h2 => |val_or_err| {
-                    // val_or_err is IOError![]const u8
-                    _ = val_or_err catch |err| {
-                        // Verify we got the original error type
-                        try std.testing.expectEqual(IOError.FileNotFound, err);
-                        return; // This is expected
-                    };
-                    return error.TestUnexpectedResult; // Should have errored
-                },
-                .h3 => |val| {
-                    try std.testing.expectEqual(true, val);
-                    return error.TestUnexpectedResult;
-                },
-            }
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    switch (result) {
+        .h1 => |val_or_err| {
+            _ = val_or_err catch return error.TestUnexpectedResult;
+            return error.TestUnexpectedResult;
+        },
+        .h2 => |val_or_err| {
+            // val_or_err is IOError![]const u8
+            _ = val_or_err catch |err| {
+                // Verify we got the original error type
+                try std.testing.expectEqual(IOError.FileNotFound, err);
+                return; // This is expected
+            };
+            return error.TestUnexpectedResult; // Should have errored
+        },
+        .h3 => |val| {
+            try std.testing.expectEqual(true, val);
+            return error.TestUnexpectedResult;
+        },
+    }
 }
 
 test "wait: plain type" {
@@ -832,87 +817,64 @@ test "wait: plain type" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn asyncTask(rt: *Runtime) !void {
-            var future = Future(i32).init;
+    var future = Future(i32).init;
 
-            // Spawn task to set the future
-            var task = try rt.spawn(struct {
-                fn run(f: *Future(i32)) !void {
-                    f.set(42);
-                }
-            }.run, .{&future});
-            defer task.cancel();
-
-            // Wait for the future
-            const result = try wait(&future);
-            try std.testing.expectEqual(42, result.value);
+    // Spawn task to set the future
+    var task = try runtime.spawn(struct {
+        fn run(f: *Future(i32)) !void {
+            f.set(42);
         }
-    };
+    }.run, .{&future});
+    defer task.cancel();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Wait for the future
+    const result = try wait(&future);
+    try std.testing.expectEqual(42, result.value);
 }
 
 test "wait: error union" {
     const Future = @import("sync/future.zig").Future;
+    const MyError = error{Foo};
 
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        const MyError = error{Foo};
+    var future = Future(MyError!i32).init;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var future = Future(MyError!i32).init;
-
-            // Spawn task to set the future with success
-            var task = try rt.spawn(struct {
-                fn run(f: *Future(MyError!i32)) !void {
-                    f.set(123);
-                }
-            }.run, .{&future});
-            defer task.cancel();
-
-            // Wait for the future
-            const result = try wait(&future);
-            const value = try result.value;
-            try std.testing.expectEqual(123, value);
+    // Spawn task to set the future with success
+    var task = try runtime.spawn(struct {
+        fn run(f: *Future(MyError!i32)) !void {
+            f.set(123);
         }
-    };
+    }.run, .{&future});
+    defer task.cancel();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Wait for the future
+    const result = try wait(&future);
+    const value = try result.value;
+    try std.testing.expectEqual(123, value);
 }
 
 test "wait: error union with error" {
     const Future = @import("sync/future.zig").Future;
+    const MyError = error{Foo};
 
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        const MyError = error{Foo};
+    var future = Future(MyError!i32).init;
 
-        fn asyncTask(rt: *Runtime) !void {
-            var future = Future(MyError!i32).init;
-
-            // Spawn task to set the future with error
-            var task = try rt.spawn(struct {
-                fn run(f: *Future(MyError!i32)) !void {
-                    f.set(MyError.Foo);
-                }
-            }.run, .{&future});
-            defer task.cancel();
-
-            // Wait for the future
-            const result = try wait(&future);
-            try std.testing.expectError(MyError.Foo, result.value);
+    // Spawn task to set the future with error
+    var task = try runtime.spawn(struct {
+        fn run(f: *Future(MyError!i32)) !void {
+            f.set(MyError.Foo);
         }
-    };
+    }.run, .{&future});
+    defer task.cancel();
 
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Wait for the future
+    const result = try wait(&future);
+    try std.testing.expectError(MyError.Foo, result.value);
 }
 
 test "wait: already complete (fast path)" {
@@ -921,60 +883,48 @@ test "wait: already complete (fast path)" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn asyncTask() !void {
-            var future = Future(i32).init;
-            future.set(99);
+    var future = Future(i32).init;
+    future.set(99);
 
-            // Wait should return immediately since already set
-            const result = try wait(&future);
-            try std.testing.expectEqual(99, result.value);
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{});
-    try handle.join();
+    // Wait should return immediately since already set
+    const result = try wait(&future);
+    try std.testing.expectEqual(99, result.value);
 }
 
 test "select: wait on JoinHandle from spawned task" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const TestContext = struct {
-        fn workerTask(rt: *Runtime, value: i32) !i32 {
+    const workerTask = struct {
+        fn call(rt: *Runtime, value: i32) !i32 {
             try rt.sleep(.fromMilliseconds(10));
             return value * 2;
         }
+    }.call;
 
-        fn asyncTask(rt: *Runtime) !void {
-            // Spawn a task and get a JoinHandle
-            var handle1 = try rt.spawn(workerTask, .{ rt, 21 });
-            defer handle1.cancel();
+    // Spawn a task and get a JoinHandle
+    var handle1 = try runtime.spawn(workerTask, .{ runtime, 21 });
+    defer handle1.cancel();
 
-            var handle2 = try rt.spawn(workerTask, .{ rt, 100 });
-            defer handle2.cancel();
+    var handle2 = try runtime.spawn(workerTask, .{ runtime, 100 });
+    defer handle2.cancel();
 
-            // Wait on JoinHandles using select
-            const result = try select(.{
-                .first = &handle1,
-                .second = &handle2,
-            });
+    // Wait on JoinHandles using select
+    const result = try select(.{
+        .first = &handle1,
+        .second = &handle2,
+    });
 
-            // Verify we got a result
-            switch (result) {
-                .first => |val| {
-                    try std.testing.expectEqual(42, val);
-                },
-                .second => |val| {
-                    try std.testing.expectEqual(200, val);
-                },
-            }
+    // Verify we got a result
+    switch (result) {
+        .first => |val| {
+            try std.testing.expectEqual(42, val);
+        },
+        .second => |val| {
+            try std.testing.expectEqual(200, val);
+        },
+    }
 
-            // Both should be valid results, though timing determines which completes first
-            try std.testing.expect(std.meta.activeTag(result) == .first or std.meta.activeTag(result) == .second);
-        }
-    };
-
-    var handle = try runtime.spawn(TestContext.asyncTask, .{runtime});
-    try handle.join();
+    // Both should be valid results, though timing determines which completes first
+    try std.testing.expect(std.meta.activeTag(result) == .first or std.meta.activeTag(result) == .second);
 }

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -386,39 +386,33 @@ test "Signal: basic signal handling" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        signal_received: bool = false,
+    var signal_received = false;
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(waitForSignal, .{ self, r });
-            try group.spawn(sendSignal, .{r});
-
-            try group.wait();
-        }
-
-        fn waitForSignal(self: *@This(), r: *Runtime) !void {
-            _ = r;
+    const waitForSignal = struct {
+        fn call(flag: *bool) !void {
             var sig = try Signal.init(.interrupt);
             defer sig.deinit();
-
             try sig.wait();
-            self.signal_received = true;
+            flag.* = true;
         }
+    }.call;
 
-        fn sendSignal(r: *Runtime) !void {
+    const sendSignal = struct {
+        fn call(r: *Runtime) !void {
             try r.sleep(.fromMilliseconds(10));
             try posix.raise(@intFromEnum(SignalKind.interrupt));
         }
-    };
+    }.call;
 
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
+    var group: Group = .init;
+    defer group.cancel();
 
-    try std.testing.expect(ctx.signal_received);
+    try group.spawn(waitForSignal, .{&signal_received});
+    try group.spawn(sendSignal, .{rt});
+
+    try group.wait();
+
+    try std.testing.expect(signal_received);
 }
 
 test "Signal: multiple handlers for same signal" {
@@ -427,41 +421,35 @@ test "Signal: multiple handlers for same signal" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        count: std.atomic.Value(usize) = .init(0),
+    var count = std.atomic.Value(usize).init(0);
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(waitForSignal, .{ self, r });
-            try group.spawn(waitForSignal, .{ self, r });
-            try group.spawn(waitForSignal, .{ self, r });
-            try group.spawn(sendSignal, .{r});
-
-            try group.wait();
-        }
-
-        fn waitForSignal(self: *@This(), r: *Runtime) !void {
-            _ = r;
+    const waitForSignal = struct {
+        fn call(cnt: *std.atomic.Value(usize)) !void {
             var sig = try Signal.init(.interrupt);
             defer sig.deinit();
-
             try sig.wait();
-            _ = self.count.fetchAdd(1, .monotonic);
+            _ = cnt.fetchAdd(1, .monotonic);
         }
+    }.call;
 
-        fn sendSignal(r: *Runtime) !void {
+    const sendSignal = struct {
+        fn call(r: *Runtime) !void {
             try r.sleep(.fromMilliseconds(10));
             try posix.raise(@intFromEnum(SignalKind.interrupt));
         }
-    };
+    }.call;
 
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
+    var group: Group = .init;
+    defer group.cancel();
 
-    try std.testing.expectEqual(3, ctx.count.load(.monotonic));
+    try group.spawn(waitForSignal, .{&count});
+    try group.spawn(waitForSignal, .{&count});
+    try group.spawn(waitForSignal, .{&count});
+    try group.spawn(sendSignal, .{rt});
+
+    try group.wait();
+
+    try std.testing.expectEqual(3, count.load(.monotonic));
 }
 
 test "Signal: timedWait timeout" {
@@ -470,29 +458,11 @@ test "Signal: timedWait timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        timed_out: bool = false,
+    var sig = try Signal.init(.interrupt);
+    defer sig.deinit();
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            _ = r;
-            var sig = try Signal.init(.interrupt);
-            defer sig.deinit();
-
-            sig.timedWait(.{ .duration = .fromMilliseconds(50) }) catch |err| {
-                if (err == error.Timeout) {
-                    self.timed_out = true;
-                    return;
-                }
-                return err;
-            };
-        }
-    };
-
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
-
-    try std.testing.expect(ctx.timed_out);
+    const result = sig.timedWait(.{ .duration = .fromMilliseconds(50) });
+    try std.testing.expectError(error.Timeout, result);
 }
 
 test "Signal: timedWait receives signal before timeout" {
@@ -501,39 +471,33 @@ test "Signal: timedWait receives signal before timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    const TestContext = struct {
-        signal_received: bool = false,
+    var signal_received = false;
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(waitForSignalTimed, .{ self, r });
-            try group.spawn(sendSignal, .{r});
-
-            try group.wait();
-        }
-
-        fn waitForSignalTimed(self: *@This(), r: *Runtime) !void {
-            _ = r;
+    const waitForSignalTimed = struct {
+        fn call(flag: *bool) !void {
             var sig = try Signal.init(.interrupt);
             defer sig.deinit();
-
             try sig.timedWait(.{ .duration = .fromSeconds(1) });
-            self.signal_received = true;
+            flag.* = true;
         }
+    }.call;
 
-        fn sendSignal(r: *Runtime) !void {
+    const sendSignal = struct {
+        fn call(r: *Runtime) !void {
             try r.sleep(.fromMilliseconds(10));
             try posix.raise(@intFromEnum(SignalKind.interrupt));
         }
-    };
+    }.call;
 
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
+    var group: Group = .init;
+    defer group.cancel();
 
-    try std.testing.expect(ctx.signal_received);
+    try group.spawn(waitForSignalTimed, .{&signal_received});
+    try group.spawn(sendSignal, .{rt});
+
+    try group.wait();
+
+    try std.testing.expect(signal_received);
 }
 
 test "Signal: select on multiple signals" {
@@ -544,21 +508,10 @@ test "Signal: select on multiple signals" {
 
     const select = @import("select.zig").select;
 
-    const TestContext = struct {
-        signal_received: std.atomic.Value(u8) = .init(0),
+    var signal_received = std.atomic.Value(u8).init(0);
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var group: Group = .init;
-            defer group.cancel();
-
-            try group.spawn(waitForSignals, .{ self, r });
-            try group.spawn(sendSignal, .{r});
-
-            try group.wait();
-        }
-
-        fn waitForSignals(self: *@This(), r: *Runtime) !void {
-            _ = r;
+    const waitForSignals = struct {
+        fn call(flag: *std.atomic.Value(u8)) !void {
             var sig1 = try Signal.init(.user1);
             defer sig1.deinit();
             var sig2 = try Signal.init(.user2);
@@ -566,22 +519,28 @@ test "Signal: select on multiple signals" {
 
             const result = try select(.{ .sig1 = &sig1, .sig2 = &sig2 });
             switch (result) {
-                .sig1 => self.signal_received.store(@intFromEnum(SignalKind.user1), .monotonic),
-                .sig2 => self.signal_received.store(@intFromEnum(SignalKind.user2), .monotonic),
+                .sig1 => flag.store(@intFromEnum(SignalKind.user1), .monotonic),
+                .sig2 => flag.store(@intFromEnum(SignalKind.user2), .monotonic),
             }
         }
+    }.call;
 
-        fn sendSignal(r: *Runtime) !void {
+    const sendSignal = struct {
+        fn call(r: *Runtime) !void {
             try r.sleep(.fromMilliseconds(10));
             try posix.raise(@intFromEnum(SignalKind.user2));
         }
-    };
+    }.call;
 
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
+    var group: Group = .init;
+    defer group.cancel();
 
-    try std.testing.expectEqual(@intFromEnum(SignalKind.user2), ctx.signal_received.load(.monotonic));
+    try group.spawn(waitForSignals, .{&signal_received});
+    try group.spawn(sendSignal, .{rt});
+
+    try group.wait();
+
+    try std.testing.expectEqual(@intFromEnum(SignalKind.user2), signal_received.load(.monotonic));
 }
 
 test "Signal: select with signal already received (fast path)" {
@@ -592,32 +551,23 @@ test "Signal: select with signal already received (fast path)" {
 
     const select = @import("select.zig").select;
 
-    const TestContext = struct {
-        signal_received: bool = false,
+    var sig = try Signal.init(.user1);
+    defer sig.deinit();
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var sig = try Signal.init(.user1);
-            defer sig.deinit();
+    // Send signal first
+    try posix.raise(@intFromEnum(SignalKind.user1));
 
-            // Send signal first
-            try posix.raise(@intFromEnum(SignalKind.user1));
+    // Small delay to ensure signal is processed
+    try rt.sleep(.fromMilliseconds(10));
 
-            // Small delay to ensure signal is processed
-            try r.sleep(.fromMilliseconds(10));
+    // Now select should return immediately (fast path)
+    const result = try select(.{ .sig = &sig });
+    var signal_received = false;
+    switch (result) {
+        .sig => signal_received = true,
+    }
 
-            // Now select should return immediately (fast path)
-            const result = try select(.{ .sig = &sig });
-            switch (result) {
-                .sig => self.signal_received = true,
-            }
-        }
-    };
-
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
-
-    try std.testing.expect(ctx.signal_received);
+    try std.testing.expect(signal_received);
 }
 
 test "Signal: select with signal and task" {
@@ -628,46 +578,41 @@ test "Signal: select with signal and task" {
 
     const select = @import("select.zig").select;
 
-    const TestContext = struct {
-        winner: enum { signal, task } = .task,
-
-        fn slowTask(r: *Runtime) !u32 {
+    const slowTask = struct {
+        fn call(r: *Runtime) !u32 {
             try r.sleep(.fromMilliseconds(100));
             return 42;
         }
+    }.call;
 
-        fn mainTask(self: *@This(), r: *Runtime) !void {
-            var sig = try Signal.init(.user1);
-            defer sig.deinit();
-
-            var task = try r.spawn(slowTask, .{r});
-            defer task.cancel();
-
-            var sender = try r.spawn(sendSignal, .{r});
-            defer sender.cancel();
-
-            // Signal should win (arrives much sooner)
-            const result = try select(.{ .sig = &sig, .task = &task });
-            switch (result) {
-                .sig => self.winner = .signal,
-                .task => |val| {
-                    _ = try val;
-                    self.winner = .task;
-                },
-            }
-
-            try sender.join();
-        }
-
-        fn sendSignal(r: *Runtime) !void {
+    const sendSignal = struct {
+        fn call(r: *Runtime) !void {
             try r.sleep(.fromMilliseconds(10));
             try posix.raise(@intFromEnum(SignalKind.user1));
         }
-    };
+    }.call;
 
-    var ctx = TestContext{};
-    var handle = try rt.spawn(TestContext.mainTask, .{ &ctx, rt });
-    try handle.join();
+    var sig = try Signal.init(.user1);
+    defer sig.deinit();
 
-    try std.testing.expectEqual(.signal, ctx.winner);
+    var task = try rt.spawn(slowTask, .{rt});
+    defer task.cancel();
+
+    var sender = try rt.spawn(sendSignal, .{rt});
+    defer sender.cancel();
+
+    // Signal should win (arrives much sooner)
+    const result = try select(.{ .sig = &sig, .task = &task });
+    var winner: enum { signal, task } = .task;
+    switch (result) {
+        .sig => winner = .signal,
+        .task => |val| {
+            _ = try val;
+            winner = .task;
+        },
+    }
+
+    try sender.join();
+
+    try std.testing.expectEqual(.signal, winner);
 }

--- a/src/sync/Barrier.zig
+++ b/src/sync/Barrier.zig
@@ -238,19 +238,9 @@ test "Barrier: single coroutine barrier" {
     defer runtime.deinit();
 
     var barrier = Barrier.init(1);
-    var is_leader_result = false;
 
-    const TestFn = struct {
-        fn worker(b: *Barrier, leader: *bool) !void {
-            const is_leader = try b.wait();
-            leader.* = is_leader;
-        }
-    };
-
-    var handle = try runtime.spawn(TestFn.worker, .{ &barrier, &is_leader_result });
-    try handle.join();
-
-    try std.testing.expect(is_leader_result);
+    const is_leader = try barrier.wait();
+    try std.testing.expect(is_leader);
 }
 
 test "Barrier: ordering test" {

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -291,26 +291,12 @@ test "Condition timedWait timeout" {
 
     var mutex = Mutex.init;
     var condition = Condition.init;
-    var timed_out = false;
 
-    const TestFn = struct {
-        fn waiter(mtx: *Mutex, cond: *Condition, timeout_flag: *bool) !void {
-            try mtx.lock();
-            defer mtx.unlock();
+    try mutex.lock();
+    defer mutex.unlock();
 
-            // Should timeout after 10ms
-            cond.timedWait(mtx, .{ .duration = .fromMilliseconds(10) }) catch |err| {
-                if (err == error.Timeout) {
-                    timeout_flag.* = true;
-                }
-            };
-        }
-    };
-
-    var handle = try runtime.spawn(TestFn.waiter, .{ &mutex, &condition, &timed_out });
-    try handle.join();
-
-    try std.testing.expect(timed_out);
+    const result = condition.timedWait(&mutex, .{ .duration = .fromMilliseconds(10) });
+    try std.testing.expectError(error.Timeout, result);
 }
 
 test "Condition broadcast" {

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -196,22 +196,9 @@ test "Semaphore: timedWait timeout" {
     defer runtime.deinit();
 
     var sem = Semaphore{};
-    var timed_out = false;
 
-    const TestFn = struct {
-        fn waiter(s: *Semaphore, timeout_flag: *bool) void {
-            s.timedWait(.{ .duration = .fromMilliseconds(10) }) catch |err| {
-                if (err == error.Timeout) {
-                    timeout_flag.* = true;
-                }
-            };
-        }
-    };
-
-    var handle = try runtime.spawn(TestFn.waiter, .{ &sem, &timed_out });
-    handle.join();
-
-    try std.testing.expect(timed_out);
+    const result = sem.timedWait(.{ .duration = .fromMilliseconds(10) });
+    try std.testing.expectError(error.Timeout, result);
     try std.testing.expectEqual(0, sem.permits);
 }
 

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -578,38 +578,31 @@ test "BroadcastChannel: lagged consumer" {
 
     var buffer: [3]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_lag(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Send more items than buffer capacity without consuming
-            try ch.send(1);
-            try ch.send(2);
-            try ch.send(3);
-            try ch.send(4); // This overwrites item 1
-            try ch.send(5); // This overwrites item 2
-
-            // First receive should return Lagged since we missed items 1 and 2
-            const err = ch.receive(consumer);
-            try std.testing.expectError(error.Lagged, err);
-
-            // After lag, we should be positioned at the oldest available (3)
-            const val1 = try ch.receive(consumer);
-            try std.testing.expectEqual(3, val1);
-
-            const val2 = try ch.receive(consumer);
-            try std.testing.expectEqual(4, val2);
-
-            const val3 = try ch.receive(consumer);
-            try std.testing.expectEqual(5, val3);
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lag, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Send more items than buffer capacity without consuming
+    try channel.send(1);
+    try channel.send(2);
+    try channel.send(3);
+    try channel.send(4); // This overwrites item 1
+    try channel.send(5); // This overwrites item 2
+
+    // First receive should return Lagged since we missed items 1 and 2
+    const err = channel.receive(&consumer);
+    try std.testing.expectError(error.Lagged, err);
+
+    // After lag, we should be positioned at the oldest available (3)
+    const val1 = try channel.receive(&consumer);
+    try std.testing.expectEqual(3, val1);
+
+    const val2 = try channel.receive(&consumer);
+    try std.testing.expectEqual(4, val2);
+
+    const val3 = try channel.receive(&consumer);
+    try std.testing.expectEqual(5, val3);
 }
 
 test "BroadcastChannel: tryReceive" {
@@ -618,36 +611,29 @@ test "BroadcastChannel: tryReceive" {
 
     var buffer: [5]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_try(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // tryReceive on empty channel should return WouldBlock
-            const err1 = ch.tryReceive(consumer);
-            try std.testing.expectError(error.WouldBlock, err1);
-
-            // Send some items
-            try ch.send(42);
-            try ch.send(43);
-
-            // tryReceive should succeed
-            const val1 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(42, val1);
-
-            const val2 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(43, val2);
-
-            // tryReceive on caught-up consumer should return WouldBlock
-            const err2 = ch.tryReceive(consumer);
-            try std.testing.expectError(error.WouldBlock, err2);
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // tryReceive on empty channel should return WouldBlock
+    const err1 = channel.tryReceive(&consumer);
+    try std.testing.expectError(error.WouldBlock, err1);
+
+    // Send some items
+    try channel.send(42);
+    try channel.send(43);
+
+    // tryReceive should succeed
+    const val1 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(42, val1);
+
+    const val2 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(43, val2);
+
+    // tryReceive on caught-up consumer should return WouldBlock
+    const err2 = channel.tryReceive(&consumer);
+    try std.testing.expectError(error.WouldBlock, err2);
 }
 
 test "BroadcastChannel: new subscriber doesn't receive old messages" {
@@ -656,34 +642,27 @@ test "BroadcastChannel: new subscriber doesn't receive old messages" {
 
     var buffer: [10]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_new_subscriber(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            // Send messages before subscribing
-            try ch.send(1);
-            try ch.send(2);
-            try ch.send(3);
-
-            // Now subscribe
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Send new message
-            try ch.send(4);
-
-            // Should only receive message 4, not 1, 2, 3
-            const val = try ch.receive(consumer);
-            try std.testing.expectEqual(4, val);
-
-            // tryReceive should return WouldBlock (no more messages)
-            const err = ch.tryReceive(consumer);
-            try std.testing.expectError(error.WouldBlock, err);
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_new_subscriber, .{ &channel, &consumer });
-    try handle.join();
+
+    // Send messages before subscribing
+    try channel.send(1);
+    try channel.send(2);
+    try channel.send(3);
+
+    // Now subscribe
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Send new message
+    try channel.send(4);
+
+    // Should only receive message 4, not 1, 2, 3
+    const val = try channel.receive(&consumer);
+    try std.testing.expectEqual(4, val);
+
+    // tryReceive should return WouldBlock (no more messages)
+    const err = channel.tryReceive(&consumer);
+    try std.testing.expectError(error.WouldBlock, err);
 }
 
 test "BroadcastChannel: unsubscribe doesn't affect other consumers" {
@@ -692,34 +671,27 @@ test "BroadcastChannel: unsubscribe doesn't affect other consumers" {
 
     var buffer: [10]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_unsubscribe(ch: *BroadcastChannel(u32), c1: *BroadcastChannel(u32).Consumer, c2: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(c1);
-            ch.subscribe(c2);
-
-            try ch.send(1);
-            try ch.send(2);
-
-            // Both should receive
-            try std.testing.expectEqual(1, try ch.receive(c1));
-            try std.testing.expectEqual(1, try ch.receive(c2));
-
-            // Unsubscribe c1
-            ch.unsubscribe(c1);
-
-            try ch.send(3);
-
-            // c2 should still receive
-            try std.testing.expectEqual(2, try ch.receive(c2));
-            try std.testing.expectEqual(3, try ch.receive(c2));
-        }
-    };
-
     var consumer1 = BroadcastChannel(u32).Consumer{};
     var consumer2 = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_unsubscribe, .{ &channel, &consumer1, &consumer2 });
-    try handle.join();
+
+    channel.subscribe(&consumer1);
+    channel.subscribe(&consumer2);
+
+    try channel.send(1);
+    try channel.send(2);
+
+    // Both should receive
+    try std.testing.expectEqual(1, try channel.receive(&consumer1));
+    try std.testing.expectEqual(1, try channel.receive(&consumer2));
+
+    // Unsubscribe consumer1
+    channel.unsubscribe(&consumer1);
+
+    try channel.send(3);
+
+    // consumer2 should still receive
+    try std.testing.expectEqual(2, try channel.receive(&consumer2));
+    try std.testing.expectEqual(3, try channel.receive(&consumer2));
 }
 
 test "BroadcastChannel: close prevents new sends" {
@@ -729,22 +701,15 @@ test "BroadcastChannel: close prevents new sends" {
     var buffer: [10]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
 
-    const TestFn = struct {
-        fn test_close(ch: *BroadcastChannel(u32)) !void {
-            // Send before closing
-            try ch.send(1);
+    // Send before closing
+    try channel.send(1);
 
-            // Close the channel
-            ch.close();
+    // Close the channel
+    channel.close();
 
-            // Try to send after closing should fail
-            const err = ch.send(2);
-            try std.testing.expectError(error.Closed, err);
-        }
-    };
-
-    var handle = try runtime.spawn(TestFn.test_close, .{&channel});
-    try handle.join();
+    // Try to send after closing should fail
+    const err = channel.send(2);
+    try std.testing.expectError(error.Closed, err);
 }
 
 test "BroadcastChannel: consumers can drain after close" {
@@ -848,24 +813,17 @@ test "BroadcastChannel: tryReceive returns Closed when channel closed and empty"
 
     var buffer: [10]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_try_closed(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Close the empty channel
-            ch.close();
-
-            // tryReceive should return Closed
-            const err = ch.tryReceive(consumer);
-            try std.testing.expectError(error.Closed, err);
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_try_closed, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Close the empty channel
+    channel.close();
+
+    // tryReceive should return Closed
+    const err = channel.tryReceive(&consumer);
+    try std.testing.expectError(error.Closed, err);
 }
 
 test "BroadcastChannel: asyncReceive with select - basic" {
@@ -915,28 +873,21 @@ test "BroadcastChannel: asyncReceive with select - already ready" {
 
     var buffer: [5]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_ready(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Send first, so receiver finds it ready
-            try ch.send(99);
-
-            var recv = ch.asyncReceive(consumer);
-            const result = try select(.{ .recv = &recv });
-            switch (result) {
-                .recv => |val| {
-                    try std.testing.expectEqual(99, try val);
-                },
-            }
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_ready, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Send first, so receiver finds it ready
+    try channel.send(99);
+
+    var recv = channel.asyncReceive(&consumer);
+    const result = try select(.{ .recv = &recv });
+    switch (result) {
+        .recv => |val| {
+            try std.testing.expectEqual(99, try val);
+        },
+    }
 }
 
 test "BroadcastChannel: asyncReceive with select - closed channel" {
@@ -945,27 +896,20 @@ test "BroadcastChannel: asyncReceive with select - closed channel" {
 
     var buffer: [5]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_closed(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            ch.close();
-
-            var recv = ch.asyncReceive(consumer);
-            const result = try select(.{ .recv = &recv });
-            switch (result) {
-                .recv => |val| {
-                    try std.testing.expectError(error.Closed, val);
-                },
-            }
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_closed, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    channel.close();
+
+    var recv = channel.asyncReceive(&consumer);
+    const result = try select(.{ .recv = &recv });
+    switch (result) {
+        .recv => |val| {
+            try std.testing.expectError(error.Closed, val);
+        },
+    }
 }
 
 test "BroadcastChannel: asyncReceive with select - lagged consumer" {
@@ -974,33 +918,26 @@ test "BroadcastChannel: asyncReceive with select - lagged consumer" {
 
     var buffer: [3]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_lagged(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Send more items than buffer capacity without consuming
-            try ch.send(1);
-            try ch.send(2);
-            try ch.send(3);
-            try ch.send(4); // This overwrites item 1
-            try ch.send(5); // This overwrites item 2
-
-            // asyncReceive should return Lagged immediately
-            var recv = ch.asyncReceive(consumer);
-            const result = try select(.{ .recv = &recv });
-            switch (result) {
-                .recv => |val| {
-                    try std.testing.expectError(error.Lagged, val);
-                },
-            }
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_lagged, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Send more items than buffer capacity without consuming
+    try channel.send(1);
+    try channel.send(2);
+    try channel.send(3);
+    try channel.send(4); // This overwrites item 1
+    try channel.send(5); // This overwrites item 2
+
+    // asyncReceive should return Lagged immediately
+    var recv = channel.asyncReceive(&consumer);
+    const result = try select(.{ .recv = &recv });
+    switch (result) {
+        .recv => |val| {
+            try std.testing.expectError(error.Lagged, val);
+        },
+    }
 }
 
 test "BroadcastChannel: select with multiple broadcast channels" {
@@ -1068,71 +1005,64 @@ test "BroadcastChannel: position counter overflow handling" {
 
     var buffer: [3]u32 = undefined;
     var channel = BroadcastChannel(u32).init(&buffer);
-
-    const TestFn = struct {
-        fn test_overflow(ch: *BroadcastChannel(u32), consumer: *BroadcastChannel(u32).Consumer) !void {
-            ch.subscribe(consumer);
-            defer ch.unsubscribe(consumer);
-
-            // Simulate near-overflow condition by setting positions close to usize max
-            // This tests that wrapping arithmetic works correctly
-            const near_max = std.math.maxInt(usize) - 5;
-
-            ch.impl.mutex.lockUncancelable();
-            ch.impl.write_pos = near_max;
-            consumer.read_pos = near_max;
-            ch.impl.mutex.unlock();
-
-            // Send items that will cause write_pos to wrap around
-            try ch.send(100);
-            try ch.send(101);
-            try ch.send(102);
-
-            // Verify we can receive correctly even after overflow
-            const val1 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(100, val1);
-
-            const val2 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(101, val2);
-
-            const val3 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(102, val3);
-
-            // At this point: write_pos has wrapped to (maxInt - 2),
-            // consumer.read_pos has wrapped to (maxInt - 2)
-            // Send more items - write_pos will continue wrapping
-            try ch.send(103);
-            try ch.send(104);
-            try ch.send(105);
-
-            // Receive them to verify wrapping arithmetic works
-            const val4 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(103, val4);
-
-            const val5 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(104, val5);
-
-            const val6 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(105, val6);
-
-            // Now test lag detection with wrapped counters
-            // Send more than buffer capacity without consuming
-            try ch.send(200);
-            try ch.send(201);
-            try ch.send(202);
-            try ch.send(203); // This overwrites oldest (200)
-
-            // Next receive should detect lag correctly even with wrapped positions
-            const err = ch.tryReceive(consumer);
-            try std.testing.expectError(error.Lagged, err);
-
-            // After lag, we should be at the oldest available message (201)
-            const val7 = try ch.tryReceive(consumer);
-            try std.testing.expectEqual(201, val7);
-        }
-    };
-
     var consumer = BroadcastChannel(u32).Consumer{};
-    var handle = try runtime.spawn(TestFn.test_overflow, .{ &channel, &consumer });
-    try handle.join();
+
+    channel.subscribe(&consumer);
+    defer channel.unsubscribe(&consumer);
+
+    // Simulate near-overflow condition by setting positions close to usize max
+    // This tests that wrapping arithmetic works correctly
+    const near_max = std.math.maxInt(usize) - 5;
+
+    channel.impl.mutex.lockUncancelable();
+    channel.impl.write_pos = near_max;
+    consumer.read_pos = near_max;
+    channel.impl.mutex.unlock();
+
+    // Send items that will cause write_pos to wrap around
+    try channel.send(100);
+    try channel.send(101);
+    try channel.send(102);
+
+    // Verify we can receive correctly even after overflow
+    const val1 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(100, val1);
+
+    const val2 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(101, val2);
+
+    const val3 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(102, val3);
+
+    // At this point: write_pos has wrapped to (maxInt - 2),
+    // consumer.read_pos has wrapped to (maxInt - 2)
+    // Send more items - write_pos will continue wrapping
+    try channel.send(103);
+    try channel.send(104);
+    try channel.send(105);
+
+    // Receive them to verify wrapping arithmetic works
+    const val4 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(103, val4);
+
+    const val5 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(104, val5);
+
+    const val6 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(105, val6);
+
+    // Now test lag detection with wrapped counters
+    // Send more than buffer capacity without consuming
+    try channel.send(200);
+    try channel.send(201);
+    try channel.send(202);
+    try channel.send(203); // This overwrites oldest (200)
+
+    // Next receive should detect lag correctly even with wrapped positions
+    const err = channel.tryReceive(&consumer);
+    try std.testing.expectError(error.Lagged, err);
+
+    // After lag, we should be at the oldest available message (201)
+    const val7 = try channel.tryReceive(&consumer);
+    try std.testing.expectEqual(201, val7);
 }


### PR DESCRIPTION
## Summary

- `Runtime.init()` converts the current thread to a task, so spawning just to immediately join is unnecessary overhead
- Inlined all single-task `spawn(fn)` + `join()` patterns to run directly on the main task
- Also cleaned up `@as(T, val)` casts in `expectEqual` calls that Zig no longer needs

## Files changed

`src/runtime.zig`, `src/io.zig`, `src/net.zig`, `src/autocancel.zig`, `src/group.zig`, `src/select.zig`, `src/signal.zig`, `src/sync/Barrier.zig`, `src/sync/Condition.zig`, `src/sync/Semaphore.zig`

Note: `src/sync/broadcast_channel.zig` and a few other sync files have the same pattern and will be handled in a follow-up PR.