### PR TITLE
io: implement dirCreateDirPath and dirCreateDirPathOpen

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -2695,19 +2695,20 @@ test "io: dir createDirPath creates nested directories" {
     const io = rt.io();
 
     const dir: Io.Dir = .cwd();
-    const nested_path = "test_io_createDirPath/a/b/c";
+    const sep = Io.Dir.path.sep_str;
+    const nested_path = "test_io_createDirPath" ++ sep ++ "a" ++ sep ++ "b" ++ sep ++ "c";
     const base_path = "test_io_createDirPath";
 
     // Clean up from previous failed runs.
-    dir.deleteDir(io, "test_io_createDirPath/a/b/c") catch {};
-    dir.deleteDir(io, "test_io_createDirPath/a/b") catch {};
-    dir.deleteDir(io, "test_io_createDirPath/a") catch {};
+    dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a" ++ sep ++ "b" ++ sep ++ "c") catch {};
+    dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a" ++ sep ++ "b") catch {};
+    dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a") catch {};
     dir.deleteDir(io, base_path) catch {};
 
     defer {
-        dir.deleteDir(io, "test_io_createDirPath/a/b/c") catch {};
-        dir.deleteDir(io, "test_io_createDirPath/a/b") catch {};
-        dir.deleteDir(io, "test_io_createDirPath/a") catch {};
+        dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a" ++ sep ++ "b" ++ sep ++ "c") catch {};
+        dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a" ++ sep ++ "b") catch {};
+        dir.deleteDir(io, "test_io_createDirPath" ++ sep ++ "a") catch {};
         dir.deleteDir(io, base_path) catch {};
     }
 
@@ -2730,17 +2731,18 @@ test "io: dir createDirPathOpen creates and opens" {
     const io = rt.io();
 
     const dir: Io.Dir = .cwd();
-    const nested_path = "test_io_createDirPathOpen/x/y";
+    const sep = Io.Dir.path.sep_str;
+    const nested_path = "test_io_createDirPathOpen" ++ sep ++ "x" ++ sep ++ "y";
     const base_path = "test_io_createDirPathOpen";
 
     // Clean up from previous failed runs.
-    dir.deleteDir(io, "test_io_createDirPathOpen/x/y") catch {};
-    dir.deleteDir(io, "test_io_createDirPathOpen/x") catch {};
+    dir.deleteDir(io, "test_io_createDirPathOpen" ++ sep ++ "x" ++ sep ++ "y") catch {};
+    dir.deleteDir(io, "test_io_createDirPathOpen" ++ sep ++ "x") catch {};
     dir.deleteDir(io, base_path) catch {};
 
     defer {
-        dir.deleteDir(io, "test_io_createDirPathOpen/x/y") catch {};
-        dir.deleteDir(io, "test_io_createDirPathOpen/x") catch {};
+        dir.deleteDir(io, "test_io_createDirPathOpen" ++ sep ++ "x" ++ sep ++ "y") catch {};
+        dir.deleteDir(io, "test_io_createDirPathOpen" ++ sep ++ "x") catch {};
         dir.deleteDir(io, base_path) catch {};
     }
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -464,12 +464,45 @@ fn resolveSetTimestamp(t: Io.File.SetTimestamp) ?i96 {
     };
 }
 
-fn dirCreateDirPathImpl(_: ?*anyopaque, _: Io.Dir, _: []const u8, _: Io.Dir.Permissions) Io.Dir.CreateDirPathError!Io.Dir.CreatePathStatus {
-    @panic("TODO: dirCreateDirPath");
+fn dirCreateDirPathImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, permissions: Io.Dir.Permissions) Io.Dir.CreateDirPathError!Io.Dir.CreatePathStatus {
+    var it = Io.Dir.path.componentIterator(sub_path);
+    var status: Io.Dir.CreatePathStatus = .existed;
+    var component = it.last() orelse return error.BadPathName;
+    while (true) {
+        var op = ev.DirCreateDir.init(stdIoHandleToZio(dir.handle), component.path, permissionsToZioMode(permissions));
+        waitForIo(&op.c) catch |err| return err;
+        if (op.getResult()) |_| {
+            status = .created;
+        } else |err| switch (err) {
+            error.PathAlreadyExists => {
+                const kind = try filePathKind(dir, component.path);
+                if (kind != .directory) return error.NotDir;
+            },
+            error.FileNotFound => {
+                component = it.previous() orelse return error.FileNotFound;
+                continue;
+            },
+            else => |e| return e,
+        }
+        component = it.next() orelse return status;
+    }
 }
 
-fn dirCreateDirPathOpenImpl(_: ?*anyopaque, _: Io.Dir, _: []const u8, _: Io.Dir.Permissions, _: Io.Dir.OpenOptions) Io.Dir.CreateDirPathOpenError!Io.Dir {
-    @panic("TODO: dirCreateDirPathOpen");
+fn filePathKind(dir: Io.Dir, sub_path: []const u8) Io.Dir.StatFileError!Io.File.Kind {
+    var op = ev.FileStat.init(stdIoHandleToZio(dir.handle), sub_path, .{ .follow_symlinks = false });
+    waitForIo(&op.c) catch |err| return err;
+    const info = op.getResult() catch |err| return statFileErrToStdErr(err);
+    return zioKindToStdIoKind(info.kind);
+}
+
+fn dirCreateDirPathOpenImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, permissions: Io.Dir.Permissions, options: Io.Dir.OpenOptions) Io.Dir.CreateDirPathOpenError!Io.Dir {
+    return dirOpenDirImpl(null, dir, sub_path, options) catch |err| switch (err) {
+        error.FileNotFound => {
+            _ = try dirCreateDirPathImpl(null, dir, sub_path, permissions);
+            return dirOpenDirImpl(null, dir, sub_path, options);
+        },
+        else => |e| return e,
+    };
 }
 
 fn dirOpenDirImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: Io.Dir.OpenOptions) Io.Dir.OpenError!Io.Dir {
@@ -2654,6 +2687,70 @@ test "io: dir create/delete" {
     try std.testing.expectError(error.PathAlreadyExists, dir.createDir(io, dir_path, .default_dir));
     try dir.deleteDir(io, dir_path);
     try std.testing.expectError(error.FileNotFound, dir.deleteDir(io, dir_path));
+}
+
+test "io: dir createDirPath creates nested directories" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const nested_path = "test_io_createDirPath/a/b/c";
+    const base_path = "test_io_createDirPath";
+
+    // Clean up from previous failed runs.
+    dir.deleteDir(io, "test_io_createDirPath/a/b/c") catch {};
+    dir.deleteDir(io, "test_io_createDirPath/a/b") catch {};
+    dir.deleteDir(io, "test_io_createDirPath/a") catch {};
+    dir.deleteDir(io, base_path) catch {};
+
+    defer {
+        dir.deleteDir(io, "test_io_createDirPath/a/b/c") catch {};
+        dir.deleteDir(io, "test_io_createDirPath/a/b") catch {};
+        dir.deleteDir(io, "test_io_createDirPath/a") catch {};
+        dir.deleteDir(io, base_path) catch {};
+    }
+
+    // Create nested path from scratch.
+    const status = try dir.createDirPathStatus(io, nested_path, .default_dir);
+    try std.testing.expectEqual(Io.Dir.CreatePathStatus.created, status);
+
+    // Verify it exists.
+    var sub = try dir.openDir(io, nested_path, .{});
+    sub.close(io);
+
+    // Creating again should return .existed.
+    const status2 = try dir.createDirPathStatus(io, nested_path, .default_dir);
+    try std.testing.expectEqual(Io.Dir.CreatePathStatus.existed, status2);
+}
+
+test "io: dir createDirPathOpen creates and opens" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const nested_path = "test_io_createDirPathOpen/x/y";
+    const base_path = "test_io_createDirPathOpen";
+
+    // Clean up from previous failed runs.
+    dir.deleteDir(io, "test_io_createDirPathOpen/x/y") catch {};
+    dir.deleteDir(io, "test_io_createDirPathOpen/x") catch {};
+    dir.deleteDir(io, base_path) catch {};
+
+    defer {
+        dir.deleteDir(io, "test_io_createDirPathOpen/x/y") catch {};
+        dir.deleteDir(io, "test_io_createDirPathOpen/x") catch {};
+        dir.deleteDir(io, base_path) catch {};
+    }
+
+    // Create and open nested path.
+    var sub = try dir.createDirPathOpen(io, nested_path, .{});
+    sub.close(io);
+
+    // Should be able to open it again.
+    var sub2 = try dir.openDir(io, nested_path, .{});
+    sub2.close(io);
 }
 
 test "io: dir iterate over files" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -470,7 +470,7 @@ fn dirCreateDirPathImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, permi
     var component = it.last() orelse return error.BadPathName;
     while (true) {
         var op = ev.DirCreateDir.init(stdIoHandleToZio(dir.handle), component.path, permissionsToZioMode(permissions));
-        waitForIo(&op.c) catch |err| return err;
+        try waitForIo(&op.c);
         if (op.getResult()) |_| {
             status = .created;
         } else |err| switch (err) {
@@ -490,7 +490,7 @@ fn dirCreateDirPathImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, permi
 
 fn filePathKind(dir: Io.Dir, sub_path: []const u8) Io.Dir.StatFileError!Io.File.Kind {
     var op = ev.FileStat.init(stdIoHandleToZio(dir.handle), sub_path, .{ .follow_symlinks = false });
-    waitForIo(&op.c) catch |err| return err;
+    try waitForIo(&op.c);
     const info = op.getResult() catch |err| return statFileErrToStdErr(err);
     return zioKindToStdIoKind(info.kind);
 }


### PR DESCRIPTION
## Summary
- Implement `dirCreateDirPath` to create nested directory paths
- Implement `dirCreateDirPathOpen` to create and open nested paths
- Mark `processExecutableOpen` and `progressParentFile` as unsupported

## Details
The implementation follows std.Io.Threaded's algorithm: iterate from the target path back to existing ancestors, then forward creating each component.

## Test plan
- Added tests for both `createDirPath` and `createDirPathOpen`
- Tests verify nested directory creation and idempotent behavior