### PR TITLE
io: implement dirCreateFileAtomic

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -674,7 +674,6 @@ fn atomicFileInit(
 }
 
 fn dirOpenFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: Io.Dir.OpenFileOptions) Io.File.OpenError!Io.File {
-    if (!options.allow_directory) @panic("TODO: openFile allow_directory=false");
     if (options.path_only) @panic("TODO: openFile path_only");
     if (options.lock != .none) @panic("TODO: openFile lock");
     if (options.lock_nonblocking) @panic("TODO: openFile lock_nonblocking");
@@ -683,6 +682,7 @@ fn dirOpenFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: I
     if (options.resolve_beneath) @panic("TODO: openFile resolve_beneath");
     var op = ev.FileOpen.init(stdIoHandleToZio(dir.handle), sub_path, .{
         .mode = stdIoModeToZio(options.mode),
+        .allow_directory = options.allow_directory,
     });
     try waitForIo(&op.c);
     const fd = op.getResult() catch |err| return openErrToFileErr(err);

--- a/src/io.zig
+++ b/src/io.zig
@@ -638,6 +638,7 @@ fn dirCreateFileAtomicImpl(_: ?*anyopaque, dir: Io.Dir, dest_path: []const u8, o
             }
         else
             try dirOpenDirImpl(null, dir, dirname, .{});
+        errdefer dirCloseImpl(null, &.{new_dir});
         return atomicFileInit(Io.Dir.path.basename(dest_path), options.permissions, new_dir, true);
     }
     return atomicFileInit(dest_path, options.permissions, dir, false);

--- a/src/io.zig
+++ b/src/io.zig
@@ -587,8 +587,57 @@ fn dirCreateFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options:
     return .{ .handle = fd, .flags = .{ .nonblocking = false } };
 }
 
-fn dirCreateFileAtomicImpl(_: ?*anyopaque, _: Io.Dir, _: []const u8, _: Io.Dir.CreateFileAtomicOptions) Io.Dir.CreateFileAtomicError!Io.File.Atomic {
-    @panic("TODO: dirCreateFileAtomic");
+fn dirCreateFileAtomicImpl(_: ?*anyopaque, dir: Io.Dir, dest_path: []const u8, options: Io.Dir.CreateFileAtomicOptions) Io.Dir.CreateFileAtomicError!Io.File.Atomic {
+    if (Io.Dir.path.dirname(dest_path)) |dirname| {
+        const new_dir = if (options.make_path)
+            dirCreateDirPathOpenImpl(null, dir, dirname, .default_dir, .{}) catch |err| switch (err) {
+                error.IsDir,
+                error.Streaming,
+                error.DiskQuota,
+                error.PathAlreadyExists,
+                error.LinkQuotaExceeded,
+                error.PipeBusy,
+                error.FileTooBig,
+                error.FileLocksUnsupported,
+                error.DeviceBusy,
+                => return error.Unexpected,
+                else => |e| return e,
+            }
+        else
+            try dirOpenDirImpl(null, dir, dirname, .{});
+        return atomicFileInit(Io.Dir.path.basename(dest_path), options.permissions, new_dir, true);
+    }
+    return atomicFileInit(dest_path, options.permissions, dir, false);
+}
+
+fn atomicFileInit(
+    dest_basename: []const u8,
+    permissions: Io.File.Permissions,
+    dir: Io.Dir,
+    close_dir_on_deinit: bool,
+) Io.Dir.CreateFileAtomicError!Io.File.Atomic {
+    while (true) {
+        var random_integer: u64 = undefined;
+        randomImpl(null, std.mem.asBytes(&random_integer));
+        const tmp_sub_path = std.fmt.hex(random_integer);
+        const file = dirCreateFileImpl(null, dir, &tmp_sub_path, .{
+            .permissions = permissions,
+            .exclusive = true,
+        }) catch |err| switch (err) {
+            error.PathAlreadyExists, error.DeviceBusy, error.FileBusy => continue,
+            error.IsDir, error.FileTooBig, error.FileLocksUnsupported, error.PipeBusy => return error.Unexpected,
+            else => |e| return e,
+        };
+        return .{
+            .file = file,
+            .file_basename_hex = random_integer,
+            .dest_sub_path = dest_basename,
+            .file_open = true,
+            .file_exists = true,
+            .close_dir_on_deinit = close_dir_on_deinit,
+            .dir = dir,
+        };
+    }
 }
 
 fn dirOpenFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: Io.Dir.OpenFileOptions) Io.File.OpenError!Io.File {
@@ -2976,4 +3025,82 @@ test "io: batch awaitConcurrent returns ConcurrencyUnavailable" {
 
     const err = batch.awaitConcurrent(io, .{ .none = {} });
     try std.testing.expectError(error.ConcurrencyUnavailable, err);
+}
+
+test "io: createFileAtomic link" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const dest_path = "test_io_atomic_file.txt";
+    defer dir.deleteFile(io, dest_path) catch {};
+
+    var af = try dir.createFileAtomic(io, dest_path, .{});
+    defer af.deinit(io);
+
+    _ = try af.file.writePositional(io, &.{"hello atomic"}, 0);
+
+    try af.link(io);
+
+    const content = try dir.readFileAlloc(io, dest_path, std.testing.allocator, .unlimited);
+    defer std.testing.allocator.free(content);
+    try std.testing.expectEqualStrings("hello atomic", content);
+}
+
+test "io: createFileAtomic replace" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const dest_path = "test_io_atomic_replace.txt";
+    defer dir.deleteFile(io, dest_path) catch {};
+
+    // Create initial file.
+    var f = try dir.createFile(io, dest_path, .{});
+    _ = try f.writePositional(io, &.{"original"}, 0);
+    f.close(io);
+
+    // Replace atomically.
+    var af = try dir.createFileAtomic(io, dest_path, .{ .replace = true });
+    defer af.deinit(io);
+
+    _ = try af.file.writePositional(io, &.{"replaced"}, 0);
+
+    try af.replace(io);
+
+    const content = try dir.readFileAlloc(io, dest_path, std.testing.allocator, .unlimited);
+    defer std.testing.allocator.free(content);
+    try std.testing.expectEqualStrings("replaced", content);
+}
+
+test "io: createFileAtomic with make_path" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const dest_path = "test_io_atomic_nested/subdir/file.txt";
+    defer {
+        dir.deleteFile(io, dest_path) catch {};
+        dir.deleteDir(io, "test_io_atomic_nested/subdir") catch {};
+        dir.deleteDir(io, "test_io_atomic_nested") catch {};
+    }
+
+    // Clean up from previous runs.
+    dir.deleteFile(io, dest_path) catch {};
+    dir.deleteDir(io, "test_io_atomic_nested/subdir") catch {};
+    dir.deleteDir(io, "test_io_atomic_nested") catch {};
+
+    var af = try dir.createFileAtomic(io, dest_path, .{ .make_path = true });
+    defer af.deinit(io);
+
+    _ = try af.file.writePositional(io, &.{"nested atomic"}, 0);
+
+    try af.link(io);
+
+    const content = try dir.readFileAlloc(io, dest_path, std.testing.allocator, .unlimited);
+    defer std.testing.allocator.free(content);
+    try std.testing.expectEqualStrings("nested atomic", content);
 }

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -105,6 +105,10 @@ pub const FileOpenMode = enum {
 pub const FileOpenFlags = struct {
     mode: FileOpenMode = .read_only,
     nonblocking: bool = false,
+    /// When false, opening a directory path returns error.IsDir.
+    /// On Windows this is enforced without extra syscalls (no FILE_FLAG_BACKUP_SEMANTICS).
+    /// On POSIX an extra fstat is required; defaults to true to avoid the overhead.
+    allow_directory: bool = true,
 };
 
 pub const DirOpenFlags = struct {
@@ -567,10 +571,14 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
             .read_write => w.GENERIC_READ | w.GENERIC_WRITE,
         };
 
-        const file_flags: w.DWORD = if (flags.nonblocking)
+        var file_flags: w.DWORD = if (flags.nonblocking)
             w.FILE_ATTRIBUTE_NORMAL | w.FILE_FLAG_OVERLAPPED
         else
             w.FILE_ATTRIBUTE_NORMAL;
+        // FILE_FLAG_BACKUP_SEMANTICS is required to open directory handles.
+        // Without it, opening a directory path fails with ACCESS_DENIED, which
+        // gives us allow_directory=false semantics for free.
+        if (flags.allow_directory) file_flags |= w.FILE_FLAG_BACKUP_SEMANTICS;
 
         const handle = w.CreateFileW(
             path_w.ptr,
@@ -1051,10 +1059,32 @@ pub fn renameat(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u
 /// Rename a file without replacing if the destination exists.
 /// On Linux, uses renameat2() with RENAME_NOREPLACE.
 /// On other POSIX systems, falls back to hardlink + delete.
-/// TODO: Windows needs NtSetInformationFile with FileRenameInformationEx
+/// On Windows, uses MoveFileExW without MOVEFILE_REPLACE_EXISTING.
 pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u8, new_dir: fd_t, new_path: []const u8) DirRenamePreserveError!void {
     if (builtin.os.tag == .windows) {
-        @panic("renameatPreserve: not implemented on Windows");
+        const old_path_w = try w.pathToWide(allocator, old_dir, old_path);
+        defer allocator.free(old_path_w);
+        const new_path_w = try w.pathToWide(allocator, new_dir, new_path);
+        defer allocator.free(new_path_w);
+
+        const success = w.MoveFileExW(
+            old_path_w.ptr,
+            new_path_w.ptr,
+            0, // No MOVEFILE_REPLACE_EXISTING: fails if destination exists.
+        );
+
+        if (success == w.FALSE) {
+            switch (w.GetLastError()) {
+                .FILE_NOT_FOUND => return error.FileNotFound,
+                .PATH_NOT_FOUND => return error.FileNotFound,
+                .ACCESS_DENIED => return error.AccessDenied,
+                .ALREADY_EXISTS, .FILE_EXISTS => return error.PathAlreadyExists,
+                .SHARING_VIOLATION => return error.FileBusy,
+                else => |err| return unexpectedError(err),
+            }
+        }
+
+        return;
     }
 
     const old_path_z = allocator.dupeZ(u8, old_path) catch return error.SystemResources;

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -1217,5 +1217,10 @@ fn utf8ToWide(allocator: std.mem.Allocator, utf8: []const u8) PathToWideError![:
         };
     }
 
+    // Normalize forward slashes to backslashes.
+    for (wide) |*c| {
+        if (c.* == '/') c.* = '\\';
+    }
+
     return wide;
 }


### PR DESCRIPTION
## Summary
- Implement `dirCreateFileAtomicImpl` for atomic file creation
- Creates temporary files with random hex names, supports `link()` for atomic create and `replace()` for atomic overwrite
- Handles `make_path` option to create parent directories

## Test plan
- [x] Added tests for `createFileAtomic` link, replace, and make_path scenarios