### PR TITLE
std.Io: implement concurrent batch operations

### DIFF
--- a/src/ev/backends/common.zig
+++ b/src/ev/backends/common.zig
@@ -42,6 +42,7 @@ const DirRealPath = @import("../completion.zig").DirRealPath;
 const DirRealPathFile = @import("../completion.zig").DirRealPathFile;
 const FileRealPath = @import("../completion.zig").FileRealPath;
 const FileHardLink = @import("../completion.zig").FileHardLink;
+const DeviceIoControl = @import("../completion.zig").DeviceIoControl;
 const ProcessWait = @import("../completion.zig").ProcessWait;
 const net = @import("../../os/net.zig");
 const fs = @import("../../os/fs.zig");
@@ -815,4 +816,16 @@ pub fn processWaitWork(work: *Work) void {
     const internal: *@FieldType(ProcessWait, "internal") = @fieldParentPtr("work", work);
     const process_wait: *ProcessWait = @fieldParentPtr("internal", internal);
     handleProcessWait(&process_wait.c);
+}
+
+/// Work function for DeviceIoControl - performs blocking ioctl
+pub fn deviceIoControlWork(work: *Work) void {
+    const internal: *@FieldType(DeviceIoControl, "internal") = @fieldParentPtr("work", work);
+    const device_io_control: *DeviceIoControl = @fieldParentPtr("internal", internal);
+    handleDeviceIoControl(&device_io_control.c);
+}
+
+pub fn handleDeviceIoControl(c: *Completion) void {
+    const data = c.cast(DeviceIoControl);
+    c.setResult(.device_io_control, fs.ioctl(data.handle, data.code, data.arg));
 }

--- a/src/ev/backends/common.zig
+++ b/src/ev/backends/common.zig
@@ -827,5 +827,9 @@ pub fn deviceIoControlWork(work: *Work) void {
 
 pub fn handleDeviceIoControl(c: *Completion) void {
     const data = c.cast(DeviceIoControl);
-    c.setResult(.device_io_control, fs.ioctl(data.handle, data.code, data.arg));
+    if (builtin.os.tag == .windows) {
+        c.setResult(.device_io_control, fs.ioctl(data.handle, data.code, data.in, data.out));
+    } else {
+        c.setResult(.device_io_control, fs.ioctl(data.handle, data.code, data.arg));
+    }
 }

--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -455,7 +455,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
         },
 
         // File operations are handled by Loop via thread pool
-        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link => unreachable,
+        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control => unreachable,
         .mach_port => unreachable,
     }
 }

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -877,6 +877,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
             sqe.prep_waitid(linux.P.PID, data.handle, &data.internal.siginfo, linux.W.EXITED, 0);
             sqe.user_data = @intFromPtr(c);
         },
+        .device_io_control => unreachable, // Handled via thread pool
         .mach_port => unreachable,
     }
 }
@@ -1351,6 +1352,7 @@ fn storeResult(self: *Self, c: *Completion, res: i32) void {
                 });
             }
         },
+        .device_io_control => unreachable, // Handled via thread pool
         .mach_port => unreachable,
     }
 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -507,6 +507,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
         .dir_real_path_file,
         .file_real_path,
         .file_hard_link,
+        .device_io_control,
         => unreachable, // These are handled by thread pool (capabilities = false)
 
         .pipe_poll => {

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -372,7 +372,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
         },
 
         // File operations are handled by Loop via thread pool
-        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link => unreachable,
+        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control => unreachable,
     }
 }
 

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -418,8 +418,8 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
             state.markCompletedFromBackend(c);
         },
 
-        // File operations and process_wait are handled by Loop via thread pool
-        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .process_wait => unreachable,
+        // File operations, process_wait and device_io_control are handled by Loop via thread pool
+        .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_size, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .file_stat, .dir_open, .dir_close, .dir_read, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control, .process_wait => unreachable,
         .mach_port => unreachable,
     }
 }

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -583,5 +583,9 @@ fn handleWork(c: *Completion) void {
 /// Helper to handle device I/O control (ioctl) operation
 fn handleDeviceIoControl(c: *Completion) void {
     const data = c.cast(DeviceIoControl);
-    c.setResult(.device_io_control, os.fs.ioctl(data.handle, data.code, data.arg));
+    if (builtin.os.tag == .windows) {
+        c.setResult(.device_io_control, os.fs.ioctl(data.handle, data.code, data.in, data.out));
+    } else {
+        c.setResult(.device_io_control, os.fs.ioctl(data.handle, data.code, data.arg));
+    }
 }

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -30,6 +30,7 @@ const PipePoll = @import("completion.zig").PipePoll;
 const Timer = @import("completion.zig").Timer;
 const Work = @import("completion.zig").Work;
 const ProcessWait = @import("completion.zig").ProcessWait;
+const DeviceIoControl = @import("completion.zig").DeviceIoControl;
 const common = @import("backends/common.zig");
 const os = @import("../os/root.zig");
 const time = @import("../time.zig");
@@ -111,6 +112,9 @@ pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
 
         // Process wait - blocking wait
         .process_wait => common.handleProcessWait(c),
+
+        // Device I/O control - blocking ioctl
+        .device_io_control => handleDeviceIoControl(c),
 
         // Async operations require the event loop
         .async,
@@ -574,4 +578,10 @@ fn handleWork(c: *Completion) void {
     data.func(data);
     data.state.store(.completed, .monotonic);
     c.setResult(.work, {});
+}
+
+/// Helper to handle device I/O control (ioctl) operation
+fn handleDeviceIoControl(c: *Completion) void {
+    const data = c.cast(DeviceIoControl);
+    c.setResult(.device_io_control, os.fs.ioctl(data.handle, data.code, data.arg));
 }

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -48,6 +48,7 @@ pub const BackendCapabilities = struct {
     dir_real_path_file: bool = false,
     file_real_path: bool = false,
     file_hard_link: bool = false,
+    device_io_control: bool = false,
     process_wait: bool = false,
     /// When true, completions submitted to one loop in a group may be completed
     /// on another loop's thread. Timer operations are protected by a mutex.
@@ -117,6 +118,7 @@ pub const Op = enum {
     pipe_read,
     pipe_write,
     pipe_close,
+    device_io_control,
     mach_port,
     process_wait,
 
@@ -181,6 +183,7 @@ pub const Op = enum {
             .pipe_read => PipeRead,
             .pipe_write => PipeWrite,
             .pipe_close => PipeClose,
+            .device_io_control => DeviceIoControl,
             .mach_port => MachPort,
             .process_wait => ProcessWait,
         };
@@ -247,6 +250,7 @@ pub const Op = enum {
             PipeRead => .pipe_read,
             PipeWrite => .pipe_write,
             PipeClose => .pipe_close,
+            DeviceIoControl => .device_io_control,
             MachPort => .mach_port,
             ProcessWait => .process_wait,
             else => @compileError("unknown completion type"),
@@ -1942,6 +1946,30 @@ pub const PipeClose = struct {
 
     pub fn getResult(self: *const PipeClose) Error!void {
         return self.c.getResult(.pipe_close);
+    }
+};
+
+pub const DeviceIoControl = struct {
+    c: Completion,
+    result_private_do_not_touch: i32 = undefined,
+    internal: struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined } = .{},
+    handle: fs.fd_t,
+    code: u32,
+    arg: ?*anyopaque,
+
+    pub const Error = Cancelable;
+
+    pub fn init(handle: fs.fd_t, code: u32, arg: ?*anyopaque) DeviceIoControl {
+        return .{
+            .c = .init(.device_io_control),
+            .handle = handle,
+            .code = code,
+            .arg = arg,
+        };
+    }
+
+    pub fn getResult(self: *const DeviceIoControl) Error!i32 {
+        return self.c.getResult(.device_io_control);
     }
 };
 

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -1949,7 +1949,32 @@ pub const PipeClose = struct {
     }
 };
 
-pub const DeviceIoControl = struct {
+pub const DeviceIoControl = if (builtin.os.tag == .windows) struct {
+    c: Completion,
+    result_private_do_not_touch: std.os.windows.IO_STATUS_BLOCK = undefined,
+    internal: struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined } = .{},
+    handle: fs.fd_t,
+    code: std.os.windows.CTL_CODE,
+    in: []const u8,
+    out: []u8,
+
+    pub const Result = std.os.windows.IO_STATUS_BLOCK;
+    pub const Error = Cancelable;
+
+    pub fn init(handle: fs.fd_t, code: std.os.windows.CTL_CODE, in: []const u8, out: []u8) DeviceIoControl {
+        return .{
+            .c = .init(.device_io_control),
+            .handle = handle,
+            .code = code,
+            .in = in,
+            .out = out,
+        };
+    }
+
+    pub fn getResult(self: *const DeviceIoControl) Error!Result {
+        return self.c.getResult(.device_io_control);
+    }
+} else struct {
     c: Completion,
     result_private_do_not_touch: i32 = undefined,
     internal: struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined } = .{},
@@ -1957,6 +1982,7 @@ pub const DeviceIoControl = struct {
     code: u32,
     arg: ?*anyopaque,
 
+    pub const Result = i32;
     pub const Error = Cancelable;
 
     pub fn init(handle: fs.fd_t, code: u32, arg: ?*anyopaque) DeviceIoControl {
@@ -1968,7 +1994,7 @@ pub const DeviceIoControl = struct {
         };
     }
 
-    pub fn getResult(self: *const DeviceIoControl) Error!i32 {
+    pub fn getResult(self: *const DeviceIoControl) Error!Result {
         return self.c.getResult(.device_io_control);
     }
 };

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -716,7 +716,7 @@ pub const Loop = struct {
         self.state.active += 1;
 
         switch (completion.op) {
-            inline .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .file_size, .file_stat, .dir_open, .dir_close, .dir_read, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .process_wait => |op| {
+            inline .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .file_size, .file_stat, .dir_open, .dir_close, .dir_read, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control, .process_wait => |op| {
                 if (@field(Backend.capabilities, @tagName(op))) {
                     unreachable;
                 }
@@ -757,6 +757,7 @@ pub const Loop = struct {
                     .dir_real_path_file => common.dirRealPathFileWork,
                     .file_real_path => common.fileRealPathWork,
                     .file_hard_link => common.fileHardLinkWork,
+                    .device_io_control => common.deviceIoControlWork,
                     .process_wait => common.processWaitWork,
                     else => unreachable,
                 };

--- a/src/ev/root.zig
+++ b/src/ev/root.zig
@@ -85,6 +85,7 @@ pub const PipeCreate = completion.PipeCreate;
 pub const PipeRead = completion.PipeRead;
 pub const PipeWrite = completion.PipeWrite;
 pub const PipeClose = completion.PipeClose;
+pub const DeviceIoControl = completion.DeviceIoControl;
 pub const MachPort = completion.MachPort;
 pub const ProcessWait = completion.ProcessWait;
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -454,18 +454,20 @@ const BatchCompletionData = union(Io.Operation.Tag) {
 };
 
 /// State for concurrent batch operations, stored in batch.userdata.
+/// Pool is only accessed from await thread (no mutex needed).
+/// Callback signals completion via ready flag in pending.userdata and futex wake.
 const BatchState = struct {
     pool: MemoryPool(BatchCompletionData),
     allocator: std.mem.Allocator,
     batch: *Io.Batch,
-    in_flight: std.atomic.Value(u32),
+    ready_count: std.atomic.Value(u32),
 
     fn init(allocator: std.mem.Allocator, batch: *Io.Batch) BatchState {
         return .{
             .pool = MemoryPool(BatchCompletionData).init(allocator),
             .allocator = allocator,
             .batch = batch,
-            .in_flight = std.atomic.Value(u32).init(0),
+            .ready_count = std.atomic.Value(u32).init(0),
         };
     }
 
@@ -522,13 +524,13 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
 
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
 
-    // Initialize batch state on first use
+    // Get or create batch state (stored in batch.userdata)
     const state: *BatchState = if (batch.userdata) |ptr|
         @ptrCast(@alignCast(ptr))
     else blk: {
         const s = rt.allocator.create(BatchState) catch return error.ConcurrencyUnavailable;
         s.* = BatchState.init(rt.allocator, batch);
-        batch.userdata = @ptrCast(s);
+        batch.userdata = s;
         break :blk s;
     };
 
@@ -549,18 +551,21 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         // Initialize the ev operation based on operation type
         const completion = initBatchOperation(data, submission.operation);
 
-        // Set up callback
+        // Set up callback - store state pointer in completion userdata
         completion.userdata = state;
         completion.callback = batchCompletionCallback;
         completion.group.userdata = index.toIndex(); // Store batch index
 
-        // Move from submitted to pending, store data pointer in userdata
+        // Move from submitted to pending
+        // userdata layout:
+        //   [0]: data pointer (BatchCompletionData*) with low bit as ready flag
+        //   [1..]: result (Io.Operation.Result)
         storage.* = .{ .pending = .{
             .node = .{ .prev = batch.pending.tail, .next = .none },
             .tag = submission.operation,
             .userdata = undefined,
         } };
-        @as(*usize, @ptrCast(&storage.pending.userdata[0])).* = @intFromPtr(data);
+        @as(*usize, @ptrCast(&storage.pending.userdata[0])).* = @intFromPtr(data); // low bit 0 = not ready
 
         if (batch.pending.tail != .none) {
             batch.storage[batch.pending.tail.toIndex()].pending.node.next = index;
@@ -570,24 +575,35 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         batch.pending.tail = index;
 
         // Submit to loop
-        _ = state.in_flight.fetchAdd(1, .release);
         loop.add(completion);
 
         index = next_index;
     }
     batch.submitted = .{ .head = .none, .tail = .none };
 
-    // Wait for at least one completion
-    const in_flight_after_submit = state.in_flight.load(.acquire);
-    if (in_flight_after_submit == 0) return; // All already completed
+    // Wait loop: drain ready items, check for completions, wait if needed
+    while (true) {
+        batchDrainReady(batch, state);
 
-    Futex.timedWait(&state.in_flight.raw, in_flight_after_submit, .fromStd(timeout)) catch |err| switch (err) {
-        error.Timeout => return error.Timeout,
-        error.Canceled => {
-            batchCancelPending(batch, &task.getExecutor().loop);
-            return error.Canceled;
-        },
-    };
+        // Return if we have completions or nothing pending
+        if (batch.completed.head != .none or batch.pending.head == .none) return;
+
+        // Wait for ready_count to become non-zero
+        Futex.timedWait(&state.ready_count.raw, 0, .fromStd(timeout)) catch |err| switch (err) {
+            error.Timeout => {
+                // Drain one more time before returning timeout
+                batchDrainReady(batch, state);
+                if (batch.completed.head != .none) return;
+                return error.Timeout;
+            },
+            error.Canceled => {
+                batchCancelPending(batch, state, loop);
+                return error.Canceled;
+            },
+        };
+        // Reset count after waking
+        _ = state.ready_count.swap(0, .acquire);
+    }
 }
 
 /// Initialize a BatchCompletionData from an Io.Operation
@@ -665,47 +681,31 @@ fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.C
     }
 }
 
-/// Callback when a batch operation completes
+/// Callback when a batch operation completes.
+/// Stores result in userdata, sets ready flag (low bit of data pointer), signals waiter via futex.
 fn batchCompletionCallback(_: *ev.Loop, completion: *ev.Completion) void {
     const state: *BatchState = @ptrCast(@alignCast(completion.userdata.?));
     const batch = state.batch;
-    const batch_index: Io.Operation.OptionalIndex = @enumFromInt(@as(u32, @intCast(completion.group.userdata)));
+    const batch_index: u32 = @intCast(completion.group.userdata);
 
-    // Get the pending storage and data pointer
-    const storage = &batch.storage[batch_index.toIndex()];
-    const data: *BatchCompletionData = @ptrFromInt(@as(*const usize, @ptrCast(&storage.pending.userdata[0])).*);
+    // Get the pending storage and userdata
+    const storage = &batch.storage[batch_index];
+    const userdata = &storage.pending.userdata;
 
-    // Extract result from ev operation
+    // Get completion data and extract result
+    const data_ptr = @as(*const usize, @ptrCast(&userdata[0])).*;
+    const data: *BatchCompletionData = @ptrFromInt(data_ptr);
     const result = extractBatchResult(data, storage.pending.tag);
 
-    // Remove from pending list
-    const pending = storage.pending;
-    if (pending.node.prev != .none) {
-        batch.storage[pending.node.prev.toIndex()].pending.node.next = pending.node.next;
-    } else {
-        batch.pending.head = pending.node.next;
-    }
-    if (pending.node.next != .none) {
-        batch.storage[pending.node.next.toIndex()].pending.node.prev = pending.node.prev;
-    } else {
-        batch.pending.tail = pending.node.prev;
-    }
+    // Store result in userdata[1..] (after data pointer)
+    @as(*Io.Operation.Result, @ptrCast(@alignCast(&userdata[1]))).* = result;
 
-    // Add to completed list
-    storage.* = .{ .completion = .{ .node = .{ .next = .none }, .result = result } };
-    if (batch.completed.tail != .none) {
-        batch.storage[batch.completed.tail.toIndex()].completion.node.next = batch_index;
-    } else {
-        batch.completed.head = batch_index;
-    }
-    batch.completed.tail = batch_index;
-
-    // Free the completion data
-    state.pool.destroy(data);
+    // Set ready flag by setting low bit of data pointer (release to ensure result is visible)
+    @atomicStore(usize, @as(*usize, @ptrCast(&userdata[0])), data_ptr | 1, .release);
 
     // Signal waiter
-    _ = state.in_flight.fetchSub(1, .release);
-    Futex.wake(&state.in_flight.raw, 1);
+    _ = state.ready_count.fetchAdd(1, .release);
+    Futex.wake(&state.ready_count.raw, 1);
 }
 
 /// Extract result from completed BatchCompletionData
@@ -741,38 +741,100 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
     };
 }
 
-/// Cancel all pending batch operations
-fn batchCancelPending(batch: *Io.Batch, loop: *ev.Loop) void {
+/// Drain ready items: scan pending list, move ready items to completed.
+/// Called only from the await thread, so no lock needed for list manipulation.
+fn batchDrainReady(batch: *Io.Batch, state: *BatchState) void {
     var index = batch.pending.head;
     while (index != .none) {
         const storage = &batch.storage[index.toIndex()];
-        const data: *BatchCompletionData = @ptrFromInt(@as(*const usize, @ptrCast(&storage.pending.userdata[0])).*);
-        const completion = data.getCompletion();
-        loop.cancel(completion);
+        const userdata = &storage.pending.userdata;
+        const next_index = storage.pending.node.next;
+
+        // Check ready flag (low bit of data pointer, acquire to see result)
+        const data_ptr = @atomicLoad(usize, @as(*usize, @ptrCast(&userdata[0])), .acquire);
+        if (data_ptr & 1 == 0) {
+            index = next_index;
+            continue;
+        }
+
+        // Get data pointer (mask off ready bit) and free it
+        const data: *BatchCompletionData = @ptrFromInt(data_ptr & ~@as(usize, 1));
+        state.pool.destroy(data);
+
+        // Get result from userdata[1..]
+        const result = @as(*const Io.Operation.Result, @ptrCast(@alignCast(&userdata[1]))).*;
+
+        // Remove from pending list
+        const pending = &storage.pending;
+        if (pending.node.prev != .none) {
+            batch.storage[pending.node.prev.toIndex()].pending.node.next = pending.node.next;
+        } else {
+            batch.pending.head = pending.node.next;
+        }
+        if (pending.node.next != .none) {
+            batch.storage[pending.node.next.toIndex()].pending.node.prev = pending.node.prev;
+        } else {
+            batch.pending.tail = pending.node.prev;
+        }
+
+        // Add to completed list
+        storage.* = .{ .completion = .{ .node = .{ .next = .none }, .result = result } };
+        if (batch.completed.tail != .none) {
+            batch.storage[batch.completed.tail.toIndex()].completion.node.next = index;
+        } else {
+            batch.completed.head = index;
+        }
+        batch.completed.tail = index;
+
+        index = next_index;
+    }
+}
+
+/// Cancel all pending batch operations and wait for them to complete
+fn batchCancelPending(batch: *Io.Batch, state: *BatchState, loop: *ev.Loop) void {
+    // First drain any ready items
+    batchDrainReady(batch, state);
+
+    // Cancel all pending operations (only those not yet ready)
+    var index = batch.pending.head;
+    while (index != .none) {
+        const storage = &batch.storage[index.toIndex()];
+        const userdata = &storage.pending.userdata;
+        // Only cancel if not already ready (check low bit)
+        const data_ptr = @atomicLoad(usize, @as(*usize, @ptrCast(&userdata[0])), .acquire);
+        if (data_ptr & 1 == 0) {
+            const data: *BatchCompletionData = @ptrFromInt(data_ptr);
+            const completion = data.getCompletion();
+            loop.cancel(completion);
+        }
         index = storage.pending.node.next;
     }
-    // Wait for all cancellations to complete - they'll move to completed list via callback
-    // The waiter will be signaled for each
+
+    // Wait for all cancellations to complete
+    while (batch.pending.head != .none) {
+        Futex.waitUncancelable(&state.ready_count.raw, 0);
+        _ = state.ready_count.swap(0, .acquire);
+        batchDrainReady(batch, state);
+    }
 }
 
 fn batchCancelImpl(_: ?*anyopaque, batch: *Io.Batch) void {
-    // Clean up batch state if it exists
-    if (batch.userdata) |ptr| {
-        const state: *BatchState = @ptrCast(@alignCast(ptr));
+    // Get state if it exists
+    const state: *BatchState = @ptrCast(@alignCast(batch.userdata orelse return));
 
-        // If there are pending operations, we need to cancel them
-        if (batch.pending.head != .none) {
-            const loop = &getCurrentTask().getExecutor().loop;
-            batchCancelPending(batch, loop);
-            // TODO: wait for cancellations to complete
-        }
+    // Drain any ready items first
+    batchDrainReady(batch, state);
 
-        state.deinit();
-        const allocator = state.allocator;
-        allocator.destroy(state);
-        batch.userdata = null;
+    // If there are pending operations, cancel them and wait
+    if (batch.pending.head != .none) {
+        const loop = &getCurrentTask().getExecutor().loop;
+        batchCancelPending(batch, state, loop);
     }
 
+    state.deinit();
+    const allocator = state.allocator;
+    allocator.destroy(state);
+    batch.userdata = null;
     batch.pending = .{ .head = .none, .tail = .none };
 }
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -41,6 +41,7 @@ const process_impl = @import("process.zig");
 const zio_net = @import("net.zig");
 const zio_dns = @import("dns/root.zig");
 const fillBuf = @import("utils/writer.zig").fillBuf;
+const MemoryPool = @import("utils/memory_pool.zig").MemoryPool;
 
 /// Must match `net.Stream.max_iovecs_len` in std.Io. Used as the cap on
 /// scatter/gather vector counts for netRead/netWrite so we never promise
@@ -422,6 +423,56 @@ fn fileWriteStreamingImpl(
     return try op.getResult();
 }
 
+/// Data for a single concurrent batch operation.
+/// Tagged union matching Io.Operation, holding the ev completion struct and any auxiliary data.
+const BatchCompletionData = union(Io.Operation.Tag) {
+    file_read_streaming: struct {
+        op: ev.FileReadStreaming,
+        iovecs: [max_iovecs_len]os_fs.iovec,
+    },
+    file_write_streaming: struct {
+        op: ev.FileWriteStreaming,
+        iovecs: [max_iovecs_len]os_fs.iovec_const,
+    },
+    device_io_control: struct {
+        op: ev.DeviceIoControl,
+    },
+    net_receive: struct {
+        op: ev.NetRecvMsg,
+        iov: os_net.iovec,
+        addr_storage: zio_net.Address,
+        addr_len: os_net.socklen_t,
+        message_buffer: *Io.net.IncomingMessage,
+        data_buffer: []u8,
+    },
+
+    fn getCompletion(self: *BatchCompletionData) *ev.Completion {
+        return switch (self.*) {
+            .file_read_streaming => |*d| &d.op.c,
+            .file_write_streaming => |*d| &d.op.c,
+            .device_io_control => |*d| &d.op.c,
+            .net_receive => |*d| &d.op.c,
+        };
+    }
+};
+
+/// State for concurrent batch operations, stored in batch.userdata.
+const BatchState = struct {
+    pool: MemoryPool(BatchCompletionData),
+    allocator: std.mem.Allocator,
+
+    fn init(allocator: std.mem.Allocator) BatchState {
+        return .{
+            .pool = MemoryPool(BatchCompletionData).init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    fn deinit(self: *BatchState) void {
+        self.pool.deinit();
+    }
+};
+
 // TODO: implement true concurrent batch operations
 fn batchAwaitAsyncImpl(userdata: ?*anyopaque, batch: *Io.Batch) Io.Cancelable!void {
     var tail_index = batch.completed.tail;
@@ -445,7 +496,7 @@ fn batchAwaitAsyncImpl(userdata: ?*anyopaque, batch: *Io.Batch) Io.Cancelable!vo
     batch.submitted = .{ .head = .none, .tail = .none };
 }
 
-fn batchAwaitConcurrentImpl(_: ?*anyopaque, batch: *Io.Batch, timeout: Io.Timeout) Io.Batch.AwaitConcurrentError!void {
+fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io.Timeout) Io.Batch.AwaitConcurrentError!void {
     // Specialized path: exactly one submitted operation, none in flight.
     const only = batch.submitted.head;
     if (only != .none and only == batch.submitted.tail and batch.pending.head == .none) {
@@ -465,13 +516,303 @@ fn batchAwaitConcurrentImpl(_: ?*anyopaque, batch: *Io.Batch, timeout: Io.Timeou
         return;
     }
 
-    // TODO: implement true concurrent batch operations
-    return error.ConcurrencyUnavailable;
+    // Nothing to do if no submissions
+    if (batch.submitted.head == .none) return;
+
+    const rt: *Runtime = @ptrCast(@alignCast(userdata));
+
+    // Initialize batch state on first use
+    const state: *BatchState = if (batch.userdata) |ptr|
+        @ptrCast(@alignCast(ptr))
+    else blk: {
+        const s = rt.allocator.create(BatchState) catch return error.ConcurrencyUnavailable;
+        s.* = BatchState.init(rt.allocator);
+        batch.userdata = @ptrCast(s);
+        break :blk s;
+    };
+
+    // Context for completion callbacks - lives on stack for this await call
+    var await_ctx = BatchAwaitContext{
+        .batch = batch,
+        .state = state,
+        .waiter = Waiter.init(),
+    };
+
+    // Get the event loop
+    const task = runtime_mod.getCurrentTaskOrNull() orelse return error.ConcurrencyUnavailable;
+    const loop = &task.getExecutor().loop;
+
+    // Submit all pending operations
+    var index = batch.submitted.head;
+    while (index != .none) {
+        const storage = &batch.storage[index.toIndex()];
+        const submission = storage.submission;
+        const next_index = submission.node.next;
+
+        // Allocate completion data from pool
+        const data = state.pool.create() catch return error.ConcurrencyUnavailable;
+
+        // Initialize the ev operation based on operation type
+        const completion = initBatchOperation(data, submission.operation);
+
+        // Set up callback
+        completion.userdata = &await_ctx;
+        completion.callback = batchCompletionCallback;
+        completion.group.userdata = index.toIndex(); // Store batch index
+
+        // Move from submitted to pending, store data pointer in userdata
+        storage.* = .{ .pending = .{
+            .node = .{ .prev = batch.pending.tail, .next = .none },
+            .tag = submission.operation,
+            .userdata = undefined,
+        } };
+        @as(*usize, @ptrCast(&storage.pending.userdata[0])).* = @intFromPtr(data);
+
+        if (batch.pending.tail != .none) {
+            batch.storage[batch.pending.tail.toIndex()].pending.node.next = index;
+        } else {
+            batch.pending.head = index;
+        }
+        batch.pending.tail = index;
+
+        // Submit to loop
+        loop.add(completion);
+
+        index = next_index;
+    }
+    batch.submitted = .{ .head = .none, .tail = .none };
+
+    // Set up timeout if specified
+    var timer: ev.Timer = undefined;
+    const zio_timeout = time.Timeout.fromStd(timeout);
+    if (zio_timeout != .none) {
+        timer = ev.Timer.init(zio_timeout);
+        timer.c.userdata = &await_ctx;
+        timer.c.callback = batchTimeoutCallback;
+        loop.add(&timer.c);
+    }
+
+    // Wait for at least one completion
+    await_ctx.waiter.wait(1, .allow_cancel) catch |err| {
+        // On cancel, cancel all pending operations
+        batchCancelPending(batch, loop);
+        if (zio_timeout != .none) {
+            loop.cancel(&timer.c);
+        }
+        return err;
+    };
+
+    // Cancel timer if it didn't fire
+    if (zio_timeout != .none and !await_ctx.timed_out) {
+        loop.cancel(&timer.c);
+    }
+
+    // Check if we timed out with no completions
+    if (await_ctx.timed_out and batch.completed.head == .none) {
+        return error.Timeout;
+    }
+}
+
+/// Context passed to batch completion callbacks
+const BatchAwaitContext = struct {
+    batch: *Io.Batch,
+    state: *BatchState,
+    waiter: Waiter,
+    timed_out: bool = false,
+};
+
+/// Initialize a BatchCompletionData from an Io.Operation
+fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.Completion {
+    switch (operation) {
+        .file_read_streaming => |*o| {
+            data.* = .{ .file_read_streaming = .{
+                .op = undefined,
+                .iovecs = undefined,
+            } };
+            var count: usize = 0;
+            for (o.data) |buf| {
+                if (count == max_iovecs_len) break;
+                if (buf.len != 0) {
+                    data.file_read_streaming.iovecs[count] = os_net.iovecFromSlice(buf);
+                    count += 1;
+                }
+            }
+            data.file_read_streaming.op = ev.FileReadStreaming.init(
+                stdIoHandleToZio(o.file.handle),
+                .{ .iovecs = data.file_read_streaming.iovecs[0..count] },
+            );
+            return &data.file_read_streaming.op.c;
+        },
+        .file_write_streaming => |*o| {
+            data.* = .{ .file_write_streaming = .{
+                .op = undefined,
+                .iovecs = undefined,
+            } };
+            var slices: [max_iovecs_len][]const u8 = undefined;
+            var splat_buf: [64]u8 = undefined;
+            const n = fillBuf(&slices, o.header, o.data, o.splat, &splat_buf);
+            const wbuf = ev.WriteBuf.fromSlices(slices[0..n], &data.file_write_streaming.iovecs);
+            data.file_write_streaming.op = ev.FileWriteStreaming.init(
+                stdIoHandleToZio(o.file.handle),
+                wbuf,
+            );
+            return &data.file_write_streaming.op.c;
+        },
+        .device_io_control => |*o| {
+            data.* = .{ .device_io_control = .{
+                .op = ev.DeviceIoControl.init(
+                    stdIoHandleToZio(o.file.handle),
+                    o.code,
+                    o.arg,
+                ),
+            } };
+            return &data.device_io_control.op.c;
+        },
+        .net_receive => |*o| {
+            const zio_flags: os_net.RecvFlags = .{
+                .peek = o.flags.peek,
+                .oob = o.flags.oob,
+                .trunc = o.flags.trunc,
+            };
+            const has_control = o.message_buffer[0].control.len != 0;
+            data.* = .{ .net_receive = .{
+                .op = undefined,
+                .iov = os_net.iovecFromSlice(o.data_buffer),
+                .addr_storage = undefined,
+                .addr_len = @sizeOf(zio_net.Address),
+                .message_buffer = &o.message_buffer[0],
+                .data_buffer = o.data_buffer,
+            } };
+            data.net_receive.op = ev.NetRecvMsg.init(
+                stdIoHandleToZio(o.socket_handle),
+                .{ .iovecs = (&data.net_receive.iov)[0..1] },
+                zio_flags,
+                &data.net_receive.addr_storage.any,
+                &data.net_receive.addr_len,
+                if (has_control) o.message_buffer[0].control else null,
+            );
+            return &data.net_receive.op.c;
+        },
+    }
+}
+
+/// Callback when a batch operation completes
+fn batchCompletionCallback(_: *ev.Loop, completion: *ev.Completion) void {
+    const ctx: *BatchAwaitContext = @ptrCast(@alignCast(completion.userdata.?));
+    const batch = ctx.batch;
+    const state = ctx.state;
+    const batch_index: Io.Operation.OptionalIndex = @enumFromInt(@as(u32, @intCast(completion.group.userdata)));
+
+    // Get the pending storage and data pointer
+    const storage = &batch.storage[batch_index.toIndex()];
+    const data: *BatchCompletionData = @ptrFromInt(@as(*const usize, @ptrCast(&storage.pending.userdata[0])).*);
+
+    // Extract result from ev operation
+    const result = extractBatchResult(data, storage.pending.tag);
+
+    // Remove from pending list
+    const pending = storage.pending;
+    if (pending.node.prev != .none) {
+        batch.storage[pending.node.prev.toIndex()].pending.node.next = pending.node.next;
+    } else {
+        batch.pending.head = pending.node.next;
+    }
+    if (pending.node.next != .none) {
+        batch.storage[pending.node.next.toIndex()].pending.node.prev = pending.node.prev;
+    } else {
+        batch.pending.tail = pending.node.prev;
+    }
+
+    // Add to completed list
+    storage.* = .{ .completion = .{ .node = .{ .next = .none }, .result = result } };
+    if (batch.completed.tail != .none) {
+        batch.storage[batch.completed.tail.toIndex()].completion.node.next = batch_index;
+    } else {
+        batch.completed.head = batch_index;
+    }
+    batch.completed.tail = batch_index;
+
+    // Free the completion data
+    state.pool.destroy(data);
+
+    // Signal waiter
+    ctx.waiter.signal();
+}
+
+/// Extract result from completed BatchCompletionData
+fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Operation.Result {
+    return switch (tag) {
+        .file_read_streaming => .{ .file_read_streaming = blk: {
+            const n = data.file_read_streaming.op.getResult() catch |err| switch (err) {
+                error.BrokenPipe, error.Canceled => break :blk error.Unexpected,
+                else => |e| break :blk e,
+            };
+            break :blk if (n == 0) error.EndOfStream else n;
+        } },
+        .file_write_streaming => .{ .file_write_streaming = blk: {
+            break :blk data.file_write_streaming.op.getResult() catch |err| switch (err) {
+                error.Canceled => error.Unexpected,
+                else => |e| e,
+            };
+        } },
+        .device_io_control => .{ .device_io_control = data.device_io_control.op.getResult() catch 0 },
+        .net_receive => .{
+            .net_receive = blk: {
+                const result = data.net_receive.op.getResult() catch |err| break :blk .{ recvMsgErrToReceiveErr(err), 0 };
+                // Populate the message buffer with received data
+                data.net_receive.message_buffer.* = .{
+                    .from = zioIpToStdIo(data.net_receive.addr_storage.ip),
+                    .data = data.net_receive.data_buffer[0..result.len],
+                    .control = data.net_receive.message_buffer.control,
+                    .flags = decodeIncomingFlags(result.flags),
+                };
+                break :blk .{ null, 1 };
+            },
+        },
+    };
+}
+
+/// Timeout callback for batch await
+fn batchTimeoutCallback(_: *ev.Loop, completion: *ev.Completion) void {
+    const ctx: *BatchAwaitContext = @ptrCast(@alignCast(completion.userdata.?));
+    ctx.timed_out = true;
+    ctx.waiter.signal();
+}
+
+/// Cancel all pending batch operations
+fn batchCancelPending(batch: *Io.Batch, loop: *ev.Loop) void {
+    var index = batch.pending.head;
+    while (index != .none) {
+        const storage = &batch.storage[index.toIndex()];
+        const data: *BatchCompletionData = @ptrFromInt(@as(*const usize, @ptrCast(&storage.pending.userdata[0])).*);
+        const completion = data.getCompletion();
+        loop.cancel(completion);
+        index = storage.pending.node.next;
+    }
+    // Wait for all cancellations to complete - they'll move to completed list via callback
+    // The waiter will be signaled for each
 }
 
 fn batchCancelImpl(_: ?*anyopaque, batch: *Io.Batch) void {
-    // TODO: implement proper cancellation for pending operations
-    // For now, just ensure pending list is empty (nothing is actually pending in our linear impl)
+    // Clean up batch state if it exists
+    if (batch.userdata) |ptr| {
+        const state: *BatchState = @ptrCast(@alignCast(ptr));
+
+        // If there are pending operations, we need to cancel them
+        if (batch.pending.head != .none) {
+            if (runtime_mod.getCurrentTaskOrNull()) |task| {
+                const loop = &task.getExecutor().loop;
+                batchCancelPending(batch, loop);
+                // TODO: wait for cancellations to complete
+            }
+        }
+
+        state.deinit();
+        const allocator = state.allocator;
+        allocator.destroy(state);
+        batch.userdata = null;
+    }
+
     batch.pending = .{ .head = .none, .tail = .none };
 }
 
@@ -3193,7 +3534,7 @@ test "io: batch awaitAsync executes operations linearly" {
     try std.testing.expectEqualStrings(data, read_buf[0..n]);
 }
 
-test "io: batch awaitConcurrent returns ConcurrencyUnavailable" {
+test "io: batch awaitConcurrent with empty batch returns immediately" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
     const io = rt.io();
@@ -3201,8 +3542,8 @@ test "io: batch awaitConcurrent returns ConcurrencyUnavailable" {
     var storage: [1]Io.Operation.Storage = undefined;
     var batch = Io.Batch.init(&storage);
 
-    const err = batch.awaitConcurrent(io, .{ .none = {} });
-    try std.testing.expectError(error.ConcurrencyUnavailable, err);
+    // Empty batch should return immediately without error
+    try batch.awaitConcurrent(io, .{ .none = {} });
 }
 
 test "io: createFileAtomic link" {
@@ -3281,4 +3622,77 @@ test "io: createFileAtomic with make_path" {
     const content = try dir.readFileAlloc(io, dest_path, std.testing.allocator, .unlimited);
     defer std.testing.allocator.free(content);
     try std.testing.expectEqualStrings("nested atomic", content);
+}
+
+test "io: batch awaitConcurrent with two net_receive operations" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    // Create two UDP sockets
+    var sock1 = try Io.net.IpAddress.bind(&.{ .ip4 = .loopback(0) }, io, .{ .mode = .dgram });
+    defer sock1.close(io);
+    var sock2 = try Io.net.IpAddress.bind(&.{ .ip4 = .loopback(0) }, io, .{ .mode = .dgram });
+    defer sock2.close(io);
+
+    // Create a sender socket
+    var sender = try Io.net.IpAddress.bind(&.{ .ip4 = .loopback(0) }, io, .{ .mode = .dgram });
+    defer sender.close(io);
+
+    // Send data to both sockets
+    try sender.send(io, &sock1.address, "hello1");
+    try sender.send(io, &sock2.address, "hello2");
+
+    // Set up batch with receive operations for both sockets
+    var storage: [2]Io.Operation.Storage = undefined;
+    var batch: Io.Batch = .init(&storage);
+
+    var msg1: Io.net.IncomingMessage = .init;
+    var buf1: [16]u8 = undefined;
+    _ = batch.add(.{ .net_receive = .{
+        .socket_handle = sock1.handle,
+        .message_buffer = (&msg1)[0..1],
+        .data_buffer = &buf1,
+        .flags = .{},
+    } });
+
+    var msg2: Io.net.IncomingMessage = .init;
+    var buf2: [16]u8 = undefined;
+    _ = batch.add(.{ .net_receive = .{
+        .socket_handle = sock2.handle,
+        .message_buffer = (&msg2)[0..1],
+        .data_buffer = &buf2,
+        .flags = .{},
+    } });
+
+    // Wait for at least one completion
+    try batch.awaitConcurrent(io, .{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
+
+    // Get first completion
+    const completion1 = batch.next();
+    try std.testing.expect(completion1 != null);
+    const err1, const n1 = completion1.?.result.net_receive;
+    try std.testing.expectEqual(null, err1);
+    try std.testing.expectEqual(1, n1);
+
+    // Wait for second completion
+    try batch.awaitConcurrent(io, .{ .duration = .{ .raw = .fromSeconds(1), .clock = .awake } });
+
+    // Get second completion
+    const completion2 = batch.next();
+    try std.testing.expect(completion2 != null);
+    const err2, const n2 = completion2.?.result.net_receive;
+    try std.testing.expectEqual(null, err2);
+    try std.testing.expectEqual(1, n2);
+
+    // Verify both messages received (order may vary)
+    const received1 = msg1.data;
+    const received2 = msg2.data;
+    try std.testing.expect(
+        (std.mem.eql(u8, received1, "hello1") and std.mem.eql(u8, received2, "hello2")) or
+            (std.mem.eql(u8, received1, "hello2") and std.mem.eql(u8, received2, "hello1")),
+    );
+
+    // Clean up
+    batch.cancel(io);
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -476,7 +476,6 @@ const BatchState = struct {
     }
 };
 
-// TODO: implement true concurrent batch operations
 fn batchAwaitAsyncImpl(userdata: ?*anyopaque, batch: *Io.Batch) Io.Cancelable!void {
     var tail_index = batch.completed.tail;
     defer batch.completed.tail = tail_index;
@@ -3717,4 +3716,29 @@ test "io: batch awaitConcurrent with two net_receive operations" {
 
     // Clean up
     batch.cancel(io);
+}
+
+test "io: batch awaitConcurrent times out when no data arrives" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    var receiver = try Io.net.IpAddress.bind(&.{ .ip4 = .loopback(0) }, io, .{ .mode = .dgram });
+    defer receiver.close(io);
+
+    var storage: [1]Io.Operation.Storage = undefined;
+    var batch: Io.Batch = .init(&storage);
+    defer batch.cancel(io);
+
+    var msg: Io.net.IncomingMessage = .init;
+    var buf: [16]u8 = undefined;
+    _ = batch.add(.{ .net_receive = .{
+        .socket_handle = receiver.handle,
+        .message_buffer = (&msg)[0..1],
+        .data_buffer = &buf,
+        .flags = .{},
+    } });
+
+    // Should timeout since no data arrives
+    try std.testing.expectError(error.Timeout, batch.awaitConcurrent(io, .{ .duration = .{ .raw = .fromMilliseconds(50), .clock = .awake } }));
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -457,11 +457,15 @@ const BatchCompletionData = union(Io.Operation.Tag) {
 const BatchState = struct {
     pool: MemoryPool(BatchCompletionData),
     allocator: std.mem.Allocator,
+    batch: *Io.Batch,
+    in_flight: std.atomic.Value(u32),
 
-    fn init(allocator: std.mem.Allocator) BatchState {
+    fn init(allocator: std.mem.Allocator, batch: *Io.Batch) BatchState {
         return .{
             .pool = MemoryPool(BatchCompletionData).init(allocator),
             .allocator = allocator,
+            .batch = batch,
+            .in_flight = std.atomic.Value(u32).init(0),
         };
     }
 
@@ -513,8 +517,8 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         return;
     }
 
-    // Nothing to do if no submissions
-    if (batch.submitted.head == .none) return;
+    // Nothing to do if no submissions and nothing pending
+    if (batch.submitted.head == .none and batch.pending.head == .none) return;
 
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
 
@@ -523,16 +527,9 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         @ptrCast(@alignCast(ptr))
     else blk: {
         const s = rt.allocator.create(BatchState) catch return error.ConcurrencyUnavailable;
-        s.* = BatchState.init(rt.allocator);
+        s.* = BatchState.init(rt.allocator, batch);
         batch.userdata = @ptrCast(s);
         break :blk s;
-    };
-
-    // Context for completion callbacks - lives on stack for this await call
-    var await_ctx = BatchAwaitContext{
-        .batch = batch,
-        .state = state,
-        .waiter = Waiter.init(),
     };
 
     // Get the event loop
@@ -553,7 +550,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         const completion = initBatchOperation(data, submission.operation);
 
         // Set up callback
-        completion.userdata = &await_ctx;
+        completion.userdata = state;
         completion.callback = batchCompletionCallback;
         completion.group.userdata = index.toIndex(); // Store batch index
 
@@ -573,30 +570,25 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         batch.pending.tail = index;
 
         // Submit to loop
+        _ = state.in_flight.fetchAdd(1, .release);
         loop.add(completion);
 
         index = next_index;
     }
     batch.submitted = .{ .head = .none, .tail = .none };
 
-    // Wait for at least one completion (or timeout)
-    await_ctx.waiter.timedWait(1, .fromStd(timeout), .allow_cancel) catch |err| {
-        batchCancelPending(batch, &task.getExecutor().loop);
-        return err;
+    // Wait for at least one completion
+    const in_flight_after_submit = state.in_flight.load(.acquire);
+    if (in_flight_after_submit == 0) return; // All already completed
+
+    Futex.timedWait(&state.in_flight.raw, in_flight_after_submit, .fromStd(timeout)) catch |err| switch (err) {
+        error.Timeout => return error.Timeout,
+        error.Canceled => {
+            batchCancelPending(batch, &task.getExecutor().loop);
+            return error.Canceled;
+        },
     };
-
-    // Check if we timed out with no completions
-    if (batch.completed.head == .none) {
-        return error.Timeout;
-    }
 }
-
-/// Context passed to batch completion callbacks
-const BatchAwaitContext = struct {
-    batch: *Io.Batch,
-    state: *BatchState,
-    waiter: Waiter,
-};
 
 /// Initialize a BatchCompletionData from an Io.Operation
 fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.Completion {
@@ -675,9 +667,8 @@ fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.C
 
 /// Callback when a batch operation completes
 fn batchCompletionCallback(_: *ev.Loop, completion: *ev.Completion) void {
-    const ctx: *BatchAwaitContext = @ptrCast(@alignCast(completion.userdata.?));
-    const batch = ctx.batch;
-    const state = ctx.state;
+    const state: *BatchState = @ptrCast(@alignCast(completion.userdata.?));
+    const batch = state.batch;
     const batch_index: Io.Operation.OptionalIndex = @enumFromInt(@as(u32, @intCast(completion.group.userdata)));
 
     // Get the pending storage and data pointer
@@ -713,7 +704,8 @@ fn batchCompletionCallback(_: *ev.Loop, completion: *ev.Completion) void {
     state.pool.destroy(data);
 
     // Signal waiter
-    ctx.waiter.signal();
+    _ = state.in_flight.fetchSub(1, .release);
+    Futex.wake(&state.in_flight.raw, 1);
 }
 
 /// Extract result from completed BatchCompletionData

--- a/src/io.zig
+++ b/src/io.zig
@@ -553,6 +553,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
 
     // Submit all pending operations
     var index = batch.submitted.head;
+    errdefer batch.submitted.head = index;
     while (index != .none) {
         const storage = &batch.storage[index.toIndex()];
         const submission = storage.submission;

--- a/src/io.zig
+++ b/src/io.zig
@@ -767,7 +767,7 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
                 data.net_receive.message_buffer.* = .{
                     .from = zioIpToStdIo(data.net_receive.addr_storage.ip),
                     .data = data.net_receive.data_buffer[0..result.len],
-                    .control = data.net_receive.message_buffer.control,
+                    .control = data.net_receive.message_buffer.control[0..result.controllen],
                     .flags = decodeIncomingFlags(result.flags),
                 };
                 break :blk .{ null, 1 };

--- a/src/io.zig
+++ b/src/io.zig
@@ -354,7 +354,14 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
             };
             break :result n;
         } },
-        .device_io_control => |*o| return .{ .device_io_control = common.blockInPlace(deviceIoControlBlocking, .{o}) },
+        .device_io_control => |*o| return .{ .device_io_control = result: {
+            var op = ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.arg);
+            timedWaitForIo(&op.c, timeout) catch |err| switch (err) {
+                error.Canceled => |e| return e,
+                error.Timeout => |e| return e,
+            };
+            break :result try op.getResult();
+        } },
         .net_receive => |*o| return .{ .net_receive = result: {
             netReceiveImpl(o.socket_handle, &o.message_buffer[0], o.data_buffer, o.flags, timeout) catch |err| switch (err) {
                 error.Canceled => |e| return e,
@@ -364,11 +371,6 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
             break :result .{ null, 1 };
         } },
     }
-}
-
-fn deviceIoControlBlocking(o: *const Io.Operation.DeviceIoControl) Io.Operation.DeviceIoControl.Result {
-    if (builtin.os.tag == .windows) @panic("device_io_control: not supported on Windows");
-    return os_fs.ioctl(stdIoHandleToZio(o.file.handle), o.code, o.arg);
 }
 
 /// Read from `file` at its current position into `data`, advancing the

--- a/src/io.zig
+++ b/src/io.zig
@@ -616,7 +616,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
             },
         };
         // Reset count after waking
-        _ = state.ready_count.swap(0, .acquire);
+        _ = state.ready_count.swap(0, .acq_rel);
     }
 }
 
@@ -848,7 +848,7 @@ fn batchCancelPending(batch: *Io.Batch, state: *BatchState, loop: *ev.Loop) void
     // Wait for all cancellations to complete
     while (batch.pending.head != .none) {
         Futex.waitUncancelable(&state.ready_count.raw, 0);
-        _ = state.ready_count.swap(0, .acquire);
+        _ = state.ready_count.swap(0, .acq_rel);
         batchDrainReady(batch, state);
     }
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -433,6 +433,7 @@ const BatchCompletionData = union(Io.Operation.Tag) {
     file_write_streaming: struct {
         op: ev.FileWriteStreaming,
         iovecs: [max_iovecs_len]os_fs.iovec_const,
+        splat_buf: [8]u8,
     },
     device_io_control: if (builtin.os.tag == .windows) struct {
         op: ev.DeviceIoControl,
@@ -644,10 +645,10 @@ fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.C
             data.* = .{ .file_write_streaming = .{
                 .op = undefined,
                 .iovecs = undefined,
+                .splat_buf = undefined,
             } };
             var slices: [max_iovecs_len][]const u8 = undefined;
-            var splat_buf: [64]u8 = undefined;
-            const n = fillBuf(&slices, o.header, o.data, o.splat, &splat_buf);
+            const n = fillBuf(&slices, o.header, o.data, o.splat, &data.file_write_streaming.splat_buf);
             const wbuf = ev.WriteBuf.fromSlices(slices[0..n], &data.file_write_streaming.iovecs);
             data.file_write_streaming.op = ev.FileWriteStreaming.init(
                 stdIoHandleToZio(o.file.handle),

--- a/src/io.zig
+++ b/src/io.zig
@@ -357,10 +357,7 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
         } },
         .device_io_control => |*o| return .{ .device_io_control = result: {
             var op = ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.arg);
-            timedWaitForIo(&op.c, timeout) catch |err| switch (err) {
-                error.Canceled => |e| return e,
-                error.Timeout => |e| return e,
-            };
+            try timedWaitForIo(&op.c, timeout);
             break :result try op.getResult();
         } },
         .net_receive => |*o| return .{ .net_receive = result: {
@@ -539,7 +536,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
     };
 
     // Get the event loop
-    const task = runtime_mod.getCurrentTaskOrNull() orelse return error.ConcurrencyUnavailable;
+    const task = getCurrentTask();
     const loop = &task.getExecutor().loop;
 
     // Submit all pending operations
@@ -582,33 +579,14 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
     }
     batch.submitted = .{ .head = .none, .tail = .none };
 
-    // Set up timeout if specified
-    var timer: ev.Timer = undefined;
-    const zio_timeout = time.Timeout.fromStd(timeout);
-    if (zio_timeout != .none) {
-        timer = ev.Timer.init(zio_timeout);
-        timer.c.userdata = &await_ctx;
-        timer.c.callback = batchTimeoutCallback;
-        loop.add(&timer.c);
-    }
-
-    // Wait for at least one completion
-    await_ctx.waiter.wait(1, .allow_cancel) catch |err| {
-        // On cancel, cancel all pending operations
-        batchCancelPending(batch, loop);
-        if (zio_timeout != .none) {
-            loop.cancel(&timer.c);
-        }
+    // Wait for at least one completion (or timeout)
+    await_ctx.waiter.timedWait(1, .fromStd(timeout), .allow_cancel) catch |err| {
+        batchCancelPending(batch, &task.getExecutor().loop);
         return err;
     };
 
-    // Cancel timer if it didn't fire
-    if (zio_timeout != .none and !await_ctx.timed_out) {
-        loop.cancel(&timer.c);
-    }
-
     // Check if we timed out with no completions
-    if (await_ctx.timed_out and batch.completed.head == .none) {
+    if (batch.completed.head == .none) {
         return error.Timeout;
     }
 }
@@ -618,7 +596,6 @@ const BatchAwaitContext = struct {
     batch: *Io.Batch,
     state: *BatchState,
     waiter: Waiter,
-    timed_out: bool = false,
 };
 
 /// Initialize a BatchCompletionData from an Io.Operation
@@ -772,13 +749,6 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
     };
 }
 
-/// Timeout callback for batch await
-fn batchTimeoutCallback(_: *ev.Loop, completion: *ev.Completion) void {
-    const ctx: *BatchAwaitContext = @ptrCast(@alignCast(completion.userdata.?));
-    ctx.timed_out = true;
-    ctx.waiter.signal();
-}
-
 /// Cancel all pending batch operations
 fn batchCancelPending(batch: *Io.Batch, loop: *ev.Loop) void {
     var index = batch.pending.head;
@@ -800,11 +770,9 @@ fn batchCancelImpl(_: ?*anyopaque, batch: *Io.Batch) void {
 
         // If there are pending operations, we need to cancel them
         if (batch.pending.head != .none) {
-            if (runtime_mod.getCurrentTaskOrNull()) |task| {
-                const loop = &task.getExecutor().loop;
-                batchCancelPending(batch, loop);
-                // TODO: wait for cancellations to complete
-            }
+            const loop = &getCurrentTask().getExecutor().loop;
+            batchCancelPending(batch, loop);
+            // TODO: wait for cancellations to complete
         }
 
         state.deinit();

--- a/src/io.zig
+++ b/src/io.zig
@@ -459,6 +459,13 @@ const BatchCompletionData = union(Io.Operation.Tag) {
     }
 };
 
+comptime {
+    const Userdata = Io.Operation.Storage.Pending.Userdata;
+    const Result = Io.Operation.Result;
+    std.debug.assert(@sizeOf(Result) <= @sizeOf(Userdata) - @sizeOf(usize));
+    std.debug.assert(@alignOf(Result) <= @alignOf(usize));
+}
+
 /// State for concurrent batch operations, stored in batch.userdata.
 /// Pool is only accessed from await thread (no mutex needed).
 /// Callback signals completion via ready flag in pending.userdata and futex wake.

--- a/src/io.zig
+++ b/src/io.zig
@@ -356,7 +356,10 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
             break :result n;
         } },
         .device_io_control => |*o| return .{ .device_io_control = result: {
-            var op = ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.arg);
+            var op = if (builtin.os.tag == .windows)
+                ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.in, o.out)
+            else
+                ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.arg);
             try timedWaitForIo(&op.c, timeout);
             break :result try op.getResult();
         } },
@@ -431,7 +434,10 @@ const BatchCompletionData = union(Io.Operation.Tag) {
         op: ev.FileWriteStreaming,
         iovecs: [max_iovecs_len]os_fs.iovec_const,
     },
-    device_io_control: struct {
+    device_io_control: if (builtin.os.tag == .windows) struct {
+        op: ev.DeviceIoControl,
+        out: []u8,
+    } else struct {
         op: ev.DeviceIoControl,
     },
     net_receive: struct {
@@ -643,13 +649,25 @@ fn initBatchOperation(data: *BatchCompletionData, operation: Io.Operation) *ev.C
             return &data.file_write_streaming.op.c;
         },
         .device_io_control => |*o| {
-            data.* = .{ .device_io_control = .{
-                .op = ev.DeviceIoControl.init(
-                    stdIoHandleToZio(o.file.handle),
-                    o.code,
-                    o.arg,
-                ),
-            } };
+            if (builtin.os.tag == .windows) {
+                data.* = .{ .device_io_control = .{
+                    .op = ev.DeviceIoControl.init(
+                        stdIoHandleToZio(o.file.handle),
+                        o.code,
+                        o.in,
+                        o.out,
+                    ),
+                    .out = o.out,
+                } };
+            } else {
+                data.* = .{ .device_io_control = .{
+                    .op = ev.DeviceIoControl.init(
+                        stdIoHandleToZio(o.file.handle),
+                        o.code,
+                        o.arg,
+                    ),
+                } };
+            }
             return &data.device_io_control.op.c;
         },
         .net_receive => |*o| {
@@ -723,7 +741,16 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
                 else => |e| e,
             };
         } },
-        .device_io_control => .{ .device_io_control = data.device_io_control.op.getResult() catch 0 },
+        .device_io_control => .{ .device_io_control = blk: {
+            if (builtin.os.tag == .windows) {
+                break :blk data.device_io_control.op.getResult() catch .{
+                    .u = .{ .Status = .CANCELLED },
+                    .Information = 0,
+                };
+            } else {
+                break :blk data.device_io_control.op.getResult() catch 0;
+            }
+        } },
         .net_receive => .{
             .net_receive = blk: {
                 const result = data.net_receive.op.getResult() catch |err| break :blk .{ recvMsgErrToReceiveErr(err), 0 };

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -2620,7 +2620,9 @@ fn dirRealPathFileWindows(allocator: std.mem.Allocator, dir: fd_t, path: []const
 /// Call ioctl(2) on `fd`, retrying on EINTR. Returns the raw ioctl return
 /// value on success, or a negative errno value on failure, matching the
 /// `std.Io.Operation.DeviceIoControl.Result` contract.
-pub fn ioctl(fd: fd_t, code: u32, arg: ?*anyopaque) i32 {
+pub const ioctl = if (builtin.os.tag == .windows) ioctlWindows else ioctlPosix;
+
+fn ioctlPosix(fd: fd_t, code: u32, arg: ?*anyopaque) i32 {
     while (true) {
         const rc = posix.system.ioctl(fd, @bitCast(code), @intFromPtr(arg));
         switch (posix.errno(rc)) {
@@ -2632,4 +2634,25 @@ pub fn ioctl(fd: fd_t, code: u32, arg: ?*anyopaque) i32 {
             else => |err| return -@as(i32, @intFromEnum(err)),
         }
     }
+}
+
+fn ioctlWindows(handle: fd_t, code: std.os.windows.CTL_CODE, in: []const u8, out: []u8) std.os.windows.IO_STATUS_BLOCK {
+    var io_status: std.os.windows.IO_STATUS_BLOCK = undefined;
+    const status = std.os.windows.ntdll.NtDeviceIoControlFile(
+        handle,
+        null,
+        null,
+        null,
+        &io_status,
+        @bitCast(code),
+        in.ptr,
+        @intCast(in.len),
+        out.ptr,
+        @intCast(out.len),
+    );
+    if (status != .SUCCESS) {
+        io_status.u = .{ .Status = status };
+        io_status.Information = 0;
+    }
+    return io_status;
 }

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -30,6 +30,8 @@ const builtin = @import("builtin");
 
 const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
+const beginShield = @import("../runtime.zig").beginShield;
+const endShield = @import("../runtime.zig").endShield;
 const Cancelable = @import("../common.zig").Cancelable;
 const Timeoutable = @import("../common.zig").Timeoutable;
 const Waiter = @import("../common.zig").Waiter;
@@ -104,6 +106,14 @@ pub fn wait(ptr: *const u32, expect: u32) Cancelable!void {
         }
         return err;
     };
+}
+
+/// Like `wait`, but ignores cancellation requests.
+/// Useful in cleanup paths where we must wait for completion regardless of cancellation.
+pub fn waitUncancelable(ptr: *const u32, expect: u32) void {
+    beginShield();
+    defer endShield();
+    wait(ptr, expect) catch unreachable;
 }
 
 /// Stack-allocated waiter for futex operations.


### PR DESCRIPTION
## Summary
- Add `ev.DeviceIoControl` operation to make ioctl consistent with other ev operations
- Implement true concurrent batch operations via `awaitConcurrent`

## Details

Operations are now submitted to the event loop in parallel and completion callbacks move them to the completed list as they finish.

Key components:
- `BatchCompletionData`: tagged union holding ev operation + auxiliary data (iovecs, address storage, etc.)
- `BatchState`: memory pool for completion data, stored in `batch.userdata`
- Callbacks signal a waiter when operations complete
- Timeout support via `ev.Timer` racing with operations

The single-operation fast path is preserved - it calls `operateInner` directly without allocating from the pool.

## Test plan
- [x] `io: batch awaitConcurrent with empty batch returns immediately`
- [x] `io: batch awaitConcurrent with two net_receive operations`
- [x] All existing io tests pass

