### PR TITLE
simplify current task/executor tracking

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -31,6 +31,7 @@ const os = @import("os/root.zig");
 const common = @import("common.zig");
 const SimpleQueue = @import("utils/simple_queue.zig").SimpleQueue;
 const Runtime = @import("runtime.zig").Runtime;
+const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
 
 const Waiter = common.Waiter;
 const Cancelable = common.Cancelable;
@@ -56,10 +57,6 @@ pub const CompletionQueue = struct {
         };
     }
 
-    fn getLoop(self: *CompletionQueue) *ev.Loop {
-        return &self.waiter.mode.direct.task.?.getExecutor().loop;
-    }
-
     /// Get the Completion that owns a group node.
     inline fn completionFromGroup(node: *GroupNode) *Completion {
         return @fieldParentPtr("group", node);
@@ -74,7 +71,7 @@ pub const CompletionQueue = struct {
         self.pending.push(&c.group);
         self.mutex.unlock();
 
-        self.getLoop().add(c);
+        getCurrentExecutor().loop.add(c);
     }
 
     /// Reset the signal counter before checking the completed queue.
@@ -208,7 +205,7 @@ pub const CompletionQueue = struct {
         while (node) |n| {
             const next_node = n.next;
             const c = completionFromGroup(n);
-            self.getLoop().cancel(c);
+            if (c.loop) |loop| loop.cancel(c);
             node = next_node;
         }
     }

--- a/src/io.zig
+++ b/src/io.zig
@@ -15,6 +15,7 @@ const Alignment = std.mem.Alignment;
 const runtime_mod = @import("runtime.zig");
 const Runtime = runtime_mod.Runtime;
 const getCurrentTask = runtime_mod.getCurrentTask;
+const getCurrentExecutor = runtime_mod.getCurrentExecutor;
 const beginShield = runtime_mod.beginShield;
 const endShield = runtime_mod.endShield;
 const checkCancel = runtime_mod.checkCancel;
@@ -548,8 +549,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
     };
 
     // Get the event loop
-    const task = getCurrentTask();
-    const loop = &task.getExecutor().loop;
+    const loop = &getCurrentExecutor().loop;
 
     // Submit all pending operations
     var index = batch.submitted.head;
@@ -862,7 +862,7 @@ fn batchCancelImpl(_: ?*anyopaque, batch: *Io.Batch) void {
 
     // If there are pending operations, cancel them and wait
     if (batch.pending.head != .none) {
-        const loop = &getCurrentTask().getExecutor().loop;
+        const loop = &getCurrentExecutor().loop;
         batchCancelPending(batch, state, loop);
     }
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -611,7 +611,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
                 return error.Timeout;
             },
             error.Canceled => {
-                batchCancelPending(batch, state, loop);
+                batchCancelPending(batch, state);
                 return error.Canceled;
             },
         };
@@ -826,7 +826,7 @@ fn batchDrainReady(batch: *Io.Batch, state: *BatchState) void {
 }
 
 /// Cancel all pending batch operations and wait for them to complete
-fn batchCancelPending(batch: *Io.Batch, state: *BatchState, loop: *ev.Loop) void {
+fn batchCancelPending(batch: *Io.Batch, state: *BatchState) void {
     // First drain any ready items
     batchDrainReady(batch, state);
 
@@ -840,7 +840,7 @@ fn batchCancelPending(batch: *Io.Batch, state: *BatchState, loop: *ev.Loop) void
         if (data_ptr & 1 == 0) {
             const data: *BatchCompletionData = @ptrFromInt(data_ptr);
             const completion = data.getCompletion();
-            loop.cancel(completion);
+            if (completion.loop) |l| l.cancel(completion);
         }
         index = storage.pending.node.next;
     }
@@ -862,8 +862,7 @@ fn batchCancelImpl(_: ?*anyopaque, batch: *Io.Batch) void {
 
     // If there are pending operations, cancel them and wait
     if (batch.pending.head != .none) {
-        const loop = &getCurrentExecutor().loop;
-        batchCancelPending(batch, state, loop);
+        batchCancelPending(batch, state);
     }
 
     state.deinit();

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -260,6 +260,11 @@ pub const Executor = struct {
     // When notified, it calls loop.stop() to exit the event loop.
     shutdown: ev.Async = ev.Async.init(),
 
+    // The task currently executing on this executor.
+    // Updated before every context switch into a task and after every switch back.
+    // Used by getCurrentTaskOrNull() instead of the TLS current_context chain.
+    current_task: *AnyTask,
+
     // Executor dedicated to this thread. Written once on init, never updated.
     pub threadlocal var current: ?*Executor = null;
 
@@ -277,6 +282,7 @@ pub const Executor = struct {
         self.* = .{
             .id = id,
             .loop = undefined,
+            .current_task = undefined,
             .runtime = runtime,
             .shutdown = ev.Async.init(),
         };
@@ -315,6 +321,7 @@ pub const Executor = struct {
 
         self.main_task.coro.setCurrent();
         Executor.current = self;
+        self.current_task = &self.main_task;
     }
 
     pub fn deinit(self: *Executor) void {
@@ -364,7 +371,9 @@ pub const Executor = struct {
                 // Both the store and the subsequent load in fromCoroutine() happen on
                 // the same executor thread, so no cross-thread ordering is needed.
                 next_task.coro.parent_context_ptr = &self.main_task.coro.context;
+                self.current_task = next_task;
                 next_task.coro.step();
+                self.current_task = &self.main_task;
                 self.processCleanup();
             }
 
@@ -498,14 +507,14 @@ pub const Executor = struct {
         // main_task is never queued - it just checks state in run().
         if (task.coro.parent_context_ptr == &task.coro.context) {
             const home_executor: *Executor = @alignCast(@fieldParentPtr("main_task", task));
-            if (getCurrentExecutorOrNull() != home_executor) {
+            if (Executor.current != home_executor) {
                 home_executor.loop.wake();
             }
             return;
         }
 
         // Normal scheduling
-        if (getCurrentExecutorOrNull()) |current_exec| {
+        if (Executor.current) |current_exec| {
             // TODO: for now, we are forcing .new tasks to be remotely scheduled
             //       to distribute them across executors, until we have work stealing
             //       for re-balancing them
@@ -601,8 +610,10 @@ pub const Executor = struct {
             // Both the store and the subsequent load in fromCoroutine() happen on
             // the same executor thread, so no cross-thread ordering is needed.
             next_task.coro.parent_context_ptr = &self.main_task.coro.context;
+            self.current_task = next_task;
             coro.yieldTo(&next_task.coro);
         } else {
+            self.current_task = &self.main_task;
             coro.yield();
         }
     }
@@ -611,12 +622,7 @@ pub const Executor = struct {
 /// Get the current thread's executor.
 /// Panics if called from a thread without an active executor context.
 pub fn getCurrentExecutor() *Executor {
-    return getCurrentExecutorOrNull() orelse @panic("no current executor");
-}
-
-pub fn getCurrentExecutorOrNull() ?*Executor {
-    const task = getCurrentTaskOrNull() orelse return null;
-    return task.getExecutor();
+    return Executor.current orelse @panic("no current executor");
 }
 
 /// Get the currently executing task.
@@ -627,8 +633,8 @@ pub fn getCurrentTask() *AnyTask {
 
 /// Get the currently executing task, or null if not in task context.
 pub fn getCurrentTaskOrNull() ?*AnyTask {
-    const coro = Coroutine.getCurrent() orelse return null;
-    return AnyTask.fromCoroutine(coro);
+    const exec = Executor.current orelse return null;
+    return exec.current_task;
 }
 
 /// Cooperatively yield control to allow other tasks to run.

--- a/src/task.zig
+++ b/src/task.zig
@@ -7,11 +7,11 @@ const ev = @import("ev/root.zig");
 
 const Runtime = @import("runtime.zig").Runtime;
 const Executor = @import("runtime.zig").Executor;
-const getCurrentExecutorOrNull = @import("runtime.zig").getCurrentExecutorOrNull;
 const Awaitable = @import("awaitable.zig").Awaitable;
 const Coroutine = @import("coro/coroutines.zig").Coroutine;
 const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const Cancelable = @import("common.zig").Cancelable;
+const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
 const Group = @import("group.zig").Group;
 const registerGroupTask = @import("group.zig").registerGroupTask;
 const unregisterGroupTask = @import("group.zig").unregisterGroupTask;
@@ -250,7 +250,7 @@ pub const AnyTask = struct {
     /// - `.reschedule`: Reschedule immediately (cooperative yielding).
     ///   The task state remains `.ready`.
     pub fn yield(self: *AnyTask, comptime mode: YieldMode, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
-        var executor = self.getExecutor();
+        var executor = getCurrentExecutor();
 
         // Check and consume cancellation flag before yielding (unless no_cancel).
         // On cancel: restore clean .ready state (clearing any awaken bit) before returning.
@@ -277,7 +277,7 @@ pub const AnyTask = struct {
 
             // --- Resumed: landing site (b) ---
             // We could be on a different executor now due to task migration
-            executor = self.getExecutor();
+            executor = getCurrentExecutor();
             executor.processCleanup();
         }
 
@@ -455,14 +455,15 @@ pub const AnyTask = struct {
         const self = fromCoroutine(coro);
 
         // Landing site (a): handle cleanup for the task that yielded to us
-        var executor = self.getExecutor();
+        var executor = getCurrentExecutor();
+        executor.current_task = self;
         executor.processCleanup();
 
         // Run the task's function
         self.closure.call(AnyTask, self);
 
         // Re-fetch executor — task may have migrated during execution
-        executor = self.getExecutor();
+        executor = getCurrentExecutor();
         executor.pending_cleanup = .{ .finish = self };
         executor.switchOut(&self.coro);
         unreachable;
@@ -532,7 +533,7 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
 
     Executor.scheduleTask(task);
 
-    if (getCurrentExecutorOrNull()) |current_executor| {
+    if (Executor.current) |current_executor| {
         if (current_executor.runtime == task.runtime) {
             current_executor.maybeYield(.reschedule, .no_cancel);
         }


### PR DESCRIPTION
Replace the coroutine TLS chain lookup with an explicit `current_task` field on `Executor`, updated at every context switch boundary.

- `Executor` gains `current_task: *AnyTask`, set before `coro.step`/`yieldTo` and reset to `&main_task` after
- `getCurrentExecutor()` returns `Executor.current` directly instead of going through `getCurrentTaskOrNull()` → `getExecutor()`
- `getCurrentTaskOrNull()` returns `Executor.current.current_task`
- `getCurrentExecutorOrNull()` removed; callers use `Executor.current`
- `yield()` and `startFn()` use `getCurrentExecutor()` instead of `self.getExecutor()` (avoids parent_context_ptr walk)
- `completion_queue`: `submit()` uses `getCurrentExecutor().loop`; `cancelAll()` uses `c.loop` (migration-safe); removed `getLoop()` wrapper