### PR TITLE
Fix deadlock in RwLock.unlockShared by using broadcast

### DIFF
--- a/src/sync/RwLock.zig
+++ b/src/sync/RwLock.zig
@@ -174,7 +174,7 @@ pub fn unlockShared(self: *RwLock) void {
     self.mutex.lockUncancelable();
     self.permits += 1;
     self.mutex.unlock();
-    self.cond.signal();
+    self.cond.broadcast();
 }
 
 test "RwLock basic write lock/unlock" {


### PR DESCRIPTION
## Summary

\`unlockShared\` used \`cond.signal()\`, which wakes a single FIFO-ordered waiter. Because \`Condition\` doesn't know what predicate each waiter is waiting on, the woken waiter may be unable to proceed and just goes back to sleep — consuming the signal. Any other waiter ahead in the queue is then stuck with no further wakeups.

### Deadlock scenario

\`\`\`
State: R1, R2 hold the lock (permits = max-2)
       W3 waits   (writers_waiting = 1, queue = [W3])
       R4 arrives, sees writers_waiting > 0, waits (queue = [W3, R4])

R1.unlockShared:  permits = max-1, signal() pops W3
  W3 wakes, sees permits < max, cond.wait again -> queue = [R4, W3]

R2.unlockShared:  permits = max, signal() pops R4
  R4 wakes, sees writers_waiting > 0, cond.wait again -> queue = [W3, R4]

No more unlocks coming. W3 and R4 are stuck.
\`\`\`

Switching to \`broadcast()\` makes all waiters re-check the predicate. Wrong-class waiters return to sleep, but at least one waiter is guaranteed to proceed.

A structural fix (dedicated kind-tagged waiter queue with direct hand-off, similar to parking_lot) would eliminate the wake-storm and predicate loop entirely, but is left for the future.

## Test plan
- [x] \`RwLock concurrent readers and writers\` test passes (was hanging before)