### PR TITLE
Fix flaky RwLock test on macOS/aarch64/kqueue release

### DIFF
--- a/src/sync/RwLock.zig
+++ b/src/sync/RwLock.zig
@@ -38,6 +38,7 @@ const Group = @import("../group.zig").Group;
 const Cancelable = @import("../common.zig").Cancelable;
 const Mutex = @import("Mutex.zig");
 const Condition = @import("Condition.zig");
+const Stopwatch = @import("../time.zig").Stopwatch;
 
 const RwLock = @This();
 
@@ -262,8 +263,8 @@ test "RwLock last reader wakes writer when reader is queued first" {
     // should be woken and acquire the write lock; waking only the queued
     // reader would make it sleep again because writers_waiting > 0.
 
-    var spins: usize = 0;
-    while (!writer_acquired.load(.acquire) and spins < 1000) : (spins += 1) {
+    var stopwatch = Stopwatch.start();
+    while (!writer_acquired.load(.acquire) and stopwatch.read().toMilliseconds() < 500) {
         try yield();
     }
     const writer_woke_from_last_reader = writer_acquired.load(.acquire);


### PR DESCRIPTION
## Summary

- Replace the 1000-yield spin loop with a 500ms wall-clock timeout in the `RwLock last reader wakes writer when reader is queued first` test
- On macOS/aarch64 with kqueue in release mode, `yield()` can complete far faster than kqueue event delivery to the writer's executor thread, causing the test to exhaust 1000 yields before the writer had a chance to run
- The writer was being correctly woken by the broadcast in `unlockShared()` — it just needed more calendar time than the spin count allowed

## Test plan

- [ ] Verify the test no longer fails on macOS/aarch64/kqueue release builds
- [ ] Confirm the test still fails (and recovers) if `broadcast()` in `unlockShared()` is reverted to `signal()`, proving the detection logic still works