### PR TITLE
runtime: add initStatic for embedded/stack-allocated Runtime

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -725,7 +725,7 @@ pub const Runtime = struct {
         const self = try allocator.create(Runtime);
         errdefer allocator.destroy(self);
 
-        try self.initCustom(allocator, options);
+        try self.initStatic(allocator, options);
         self.own_self = true;
         return self;
     }
@@ -773,7 +773,6 @@ pub const Runtime = struct {
             }
             self.executors.appendAssumeCapacity(&worker.executor);
         }
-
     }
 
     /// Stop worker executors and join threads. Used by deinit() and init() error path.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -712,6 +712,7 @@ pub const Runtime = struct {
     workers: std.ArrayList(Worker) = .empty,
     task_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0), // Active task counter
     shutting_down: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    own_self: bool = false,
 
     const Worker = struct {
         thread: std.Thread = undefined,
@@ -724,6 +725,12 @@ pub const Runtime = struct {
         const self = try allocator.create(Runtime);
         errdefer allocator.destroy(self);
 
+        try self.initCustom(allocator, options);
+        self.own_self = true;
+        return self;
+    }
+
+    pub fn initStatic(self: *Runtime, allocator: Allocator, options: RuntimeOptions) !void {
         const num_executors = options.executors.resolve();
 
         self.* = .{
@@ -767,7 +774,6 @@ pub const Runtime = struct {
             self.executors.appendAssumeCapacity(&worker.executor);
         }
 
-        return self;
     }
 
     /// Stop worker executors and join threads. Used by deinit() and init() error path.
@@ -819,7 +825,9 @@ pub const Runtime = struct {
         self.task_pool.deinit();
 
         // Free the Runtime allocation
-        allocator.destroy(self);
+        if (self.own_self) {
+            allocator.destroy(self);
+        }
     }
 
     // High-level public API


### PR DESCRIPTION
## Summary

- Adds `initStatic(self: *Runtime, allocator, options)` for initializing a caller-provided `Runtime` (stack-allocated or embedded in another struct)
- Adds `own_self: bool` field so `deinit()` knows whether to free the `Runtime` itself
- Existing `init()` now delegates to `initStatic` and sets `own_self = true`, keeping the heap-allocated path unchanged

## Test plan

- [ ] Existing tests pass
- [ ] Verify a stack-allocated `Runtime` can be initialized via `initStatic` and deinitialized without double-free