### PR TITLE
Fix thumb context switching asm for Cortex-M0 compatibility

### DIFF
--- a/src/coro/coroutines.zig
+++ b/src/coro/coroutines.zig
@@ -468,8 +468,11 @@ pub inline fn switchContext(
               .memory = true,
             }),
         .thumb => asm volatile (
-            // Calculate return address with Thumb bit (LSB=1) set via adr offset
-            \\ adr r2, 0f + 1
+            // Load resume address, then explicitly set Thumb bit (LSB=1).
+            // adr alone cannot target unaligned addresses on Thumb-1 (Cortex-M0),
+            // so we must compute the word-aligned address first, then OR in bit 0.
+            \\ adr r2, 0f
+            \\ adds r2, #1
             \\ mov r3, sp
             \\ str r3, [r0, #0]
             \\ str r7, [r0, #4]


### PR DESCRIPTION
`adr` with an unaligned target (e.g. `adr r2, 0f + 1`) is not supported on Thumb-1 (Cortex-M0/M0+), which only handles word-aligned offsets. This caused the Thumb context switch to fail on those cores.

The fix splits it into two instructions: `adr r2, 0f` to compute the word-aligned resume address, then `adds r2, #1` to set the Thumb bit (LSB=1). Both instructions are valid on all Thumb versions.