### PR TITLE
dns: refactor lookup API from iterator to buffer-fill model

### DIFF
--- a/examples/ntp_client.zig
+++ b/examples/ntp_client.zig
@@ -4,10 +4,10 @@ const zio = @import("zio");
 // --8<-- [start:lookup]
 fn lookupHost(hostname: []const u8, port: u16) !zio.net.Address {
     const host = try zio.net.HostName.init(hostname);
-    var iter = try host.lookup(.{ .port = port });
-    defer iter.deinit();
+    var results: [32]zio.net.HostName.LookupResult = undefined;
+    const count = try host.lookup(&results, .{ .port = port });
 
-    while (iter.next()) |result| {
+    for (results[0..count]) |result| {
         switch (result) {
             .address => |ip_addr| return .{ .ip = ip_addr },
             else => continue,

--- a/src/dns/darwin.zig
+++ b/src/dns/darwin.zig
@@ -11,8 +11,7 @@ const darwin = @import("../os/darwin.zig");
 const common = @import("../common.zig");
 const ev = @import("../ev/root.zig");
 const dns = @import("root.zig");
-
-pub const Result = @import("posix.zig").Result;
+const fillResultsFromAddrinfo = @import("posix.zig").fillResultsFromAddrinfo;
 
 const LookupContext = struct {
     result: ?*os_net.addrinfo = null,
@@ -31,7 +30,10 @@ const MachMsgRcv = extern struct {
     _trailer: [32]u8,
 };
 
-pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
+pub fn lookup(
+    storage: []dns.LookupResult,
+    options: dns.LookupOptions,
+) dns.LookupError!usize {
     var buf: [512]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&buf);
     const allocator = fba.allocator();
@@ -46,7 +48,7 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
     } else os_net.AF.UNSPEC;
     hints.socktype = os_net.SOCK.STREAM;
     hints.protocol = os_net.IPPROTO.TCP;
-    if (options.canonical_name) {
+    if (options.canonical_name_buffer != null) {
         hints.flags.CANONNAME = true;
     }
 
@@ -88,10 +90,10 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
         0,
         @sizeOf(MachMsgRcv),
         machport,
-        .NONE, // MACH_MSG_TIMEOUT_NONE
+        .NONE,
         darwin.MACH_PORT_NULL,
     );
-    if (status != 0) { // KERN_SUCCESS = 0
+    if (status != 0) {
         return error.Unexpected;
     }
 
@@ -107,11 +109,9 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
         return eaiToLookupError(ctx.status);
     }
 
-    return .{
-        .head = ctx.result,
-        .current = ctx.result,
-        .return_canonical_name = options.canonical_name,
-    };
+    defer if (ctx.result) |r| os_net.freeaddrinfo(r);
+
+    return fillResultsFromAddrinfo(storage, options, ctx.result);
 }
 
 fn eaiToLookupError(status: i32) dns.LookupError {

--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -8,17 +8,20 @@ const blockInPlace = common.blockInPlace;
 const dns = @import("root.zig");
 
 /// Fills `storage` with canonical name (if requested) and addresses from
-/// a `getaddrinfo` linked list. Returns the number of entries written.
+/// a `getaddrinfo` linked list. Returns the number of entries written, or
+/// `error.TooManyAddresses` if the resolver returned more addresses than
+/// `storage` can hold (the buffer is fully populated in that case).
 pub fn fillResultsFromAddrinfo(
     storage: []dns.LookupResult,
     options: dns.LookupOptions,
     head: ?*os_net.addrinfo,
-) usize {
+) dns.LookupError!usize {
     var i: usize = 0;
 
     if (options.canonical_name_buffer) |cname_buf| {
         if (head) |h| {
             if (h.canonname) |name_ptr| {
+                if (i >= storage.len) return i;
                 const name_slice = std.mem.sliceTo(name_ptr, 0);
                 @memcpy(cname_buf[0..name_slice.len], name_slice);
                 cname_buf[name_slice.len] = 0;
@@ -30,9 +33,9 @@ pub fn fillResultsFromAddrinfo(
 
     var current: ?*os_net.addrinfo = head;
     while (current) |info| : (current = @ptrCast(info.next)) {
-        if (i >= storage.len) break;
         const addr = info.addr orelse continue;
         if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
+        if (i >= storage.len) return error.TooManyAddresses;
         storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.addrlen)) };
         i += 1;
     }

--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -7,46 +7,50 @@ const common = @import("../common.zig");
 const blockInPlace = common.blockInPlace;
 const dns = @import("root.zig");
 
-pub const Result = struct {
+/// Fills `storage` with canonical name (if requested) and addresses from
+/// a `getaddrinfo` linked list. Returns the number of entries written.
+pub fn fillResultsFromAddrinfo(
+    storage: []dns.LookupResult,
+    options: dns.LookupOptions,
     head: ?*os_net.addrinfo,
-    current: ?*os_net.addrinfo,
-    return_canonical_name: bool,
+) usize {
+    var i: usize = 0;
 
-    pub fn deinit(self: *Result) void {
-        if (self.head) |head| {
-            os_net.freeaddrinfo(head);
-        }
-    }
-
-    pub fn next(self: *Result) ?dns.LookupResult {
-        if (self.return_canonical_name) {
-            self.return_canonical_name = false;
-            if (self.head) |head| {
-                if (head.canonname) |name| {
-                    return .{ .canonical_name = .{ .bytes = std.mem.sliceTo(name, 0) } };
-                }
+    if (options.canonical_name_buffer) |cname_buf| {
+        if (head) |h| {
+            if (h.canonname) |name_ptr| {
+                const name_slice = std.mem.sliceTo(name_ptr, 0);
+                @memcpy(cname_buf[0..name_slice.len], name_slice);
+                cname_buf[name_slice.len] = 0;
+                storage[i] = .{ .canonical_name = .{ .bytes = cname_buf[0..name_slice.len] } };
+                i += 1;
             }
         }
-
-        while (self.current) |info| {
-            self.current = @ptrCast(info.next);
-            const addr = info.addr orelse continue;
-            if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
-            return .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.addrlen)) };
-        }
-        return null;
     }
-};
+
+    var current: ?*os_net.addrinfo = head;
+    while (current) |info| : (current = @ptrCast(info.next)) {
+        if (i >= storage.len) break;
+        const addr = info.addr orelse continue;
+        if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
+        storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.addrlen)) };
+        i += 1;
+    }
+
+    return i;
+}
 
 /// Resolves a hostname to addresses. Dispatches to the thread pool and
 /// suspends the current task until the blocking getaddrinfo call completes.
-pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
+/// Returns the number of entries written to `storage`.
+pub fn lookup(
+    storage: []dns.LookupResult,
+    options: dns.LookupOptions,
+) dns.LookupError!usize {
     const head = try blockInPlace(lookupBlocking, .{options});
-    return .{
-        .head = head,
-        .current = head,
-        .return_canonical_name = options.canonical_name,
-    };
+    defer if (head) |h| os_net.freeaddrinfo(h);
+
+    return fillResultsFromAddrinfo(storage, options, head);
 }
 
 fn lookupBlocking(options: dns.LookupOptions) dns.LookupError!?*os_net.addrinfo {
@@ -64,7 +68,7 @@ fn lookupBlocking(options: dns.LookupOptions) dns.LookupError!?*os_net.addrinfo 
     } else os_net.AF.UNSPEC;
     hints.socktype = os_net.SOCK.STREAM;
     hints.protocol = os_net.IPPROTO.TCP;
-    if (options.canonical_name) {
+    if (options.canonical_name_buffer != null) {
         hints.flags.CANONNAME = true;
     }
 

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -12,7 +12,7 @@ pub const LookupOptions = struct {
     name: []const u8,
     port: u16,
     family: ?IpAddress.Family = null,
-    canonical_name: bool = false,
+    canonical_name_buffer: ?*[HostName.max_len]u8 = null,
 };
 
 pub const LookupResult = union(enum) {
@@ -46,5 +46,4 @@ else if (builtin.os.tag.isDarwin() and backend.backend == .kqueue)
 else
     @import("posix.zig");
 
-pub const Result = impl.Result;
 pub const lookup = impl.lookup;

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -35,6 +35,7 @@ pub const LookupError = error{
     RuntimeShutdown,
     Closed,
     NoThreadPool,
+    TooManyAddresses,
 };
 
 const backend = @import("../ev/backend.zig");

--- a/src/dns/windows.zig
+++ b/src/dns/windows.zig
@@ -28,42 +28,10 @@ fn completionCallback(dwError: u32, _: u32, lpOverlapped: ?*windows.OVERLAPPED) 
     ctx.waiter.signal();
 }
 
-pub const Result = struct {
-    head: ?*ADDRINFOEXW,
-    current: ?*ADDRINFOEXW,
-    return_canonical_name: bool,
-    canonical_name_buf: [dns.HostName.max_len]u8,
-
-    pub fn deinit(self: *Result) void {
-        if (self.head) |head| {
-            windows.FreeAddrInfoExW(head);
-        }
-    }
-
-    pub fn next(self: *Result) ?dns.LookupResult {
-        if (self.return_canonical_name) {
-            self.return_canonical_name = false;
-            if (self.head) |head| {
-                if (head.ai_canonname) |name| {
-                    const len = std.unicode.utf16LeToUtf8(&self.canonical_name_buf, std.mem.sliceTo(name, 0)) catch 0;
-                    if (len > 0) {
-                        return .{ .canonical_name = .{ .bytes = self.canonical_name_buf[0..len] } };
-                    }
-                }
-            }
-        }
-
-        while (self.current) |info| {
-            self.current = info.ai_next;
-            const addr = info.ai_addr orelse continue;
-            if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
-            return .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.ai_addrlen)) };
-        }
-        return null;
-    }
-};
-
-pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
+pub fn lookup(
+    storage: []dns.LookupResult,
+    options: dns.LookupOptions,
+) dns.LookupError!usize {
     os_net.ensureWSAInitialized();
 
     // Convert name to null-terminated UTF-16
@@ -85,7 +53,7 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
     } else @as(i32, os_net.AF.UNSPEC);
     hints.ai_socktype = os_net.SOCK.STREAM;
     hints.ai_protocol = os_net.IPPROTO.TCP;
-    if (options.canonical_name) {
+    if (options.canonical_name_buffer != null) {
         hints.ai_flags = @bitCast(windows.AI{ .CANONNAME = true });
     }
 
@@ -111,12 +79,7 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
     );
 
     if (rc == 0) {
-        return .{
-            .head = result,
-            .current = result,
-            .return_canonical_name = options.canonical_name,
-            .canonical_name_buf = undefined,
-        };
+        return fillBuffers(storage, options, result);
     }
 
     if (rc != windows.WSA_IO_PENDING) {
@@ -138,12 +101,41 @@ pub fn lookup(options: dns.LookupOptions) dns.LookupError!Result {
         return winsockToLookupError(@intCast(ctx.err));
     }
 
-    return .{
-        .head = result,
-        .current = result,
-        .return_canonical_name = options.canonical_name,
-        .canonical_name_buf = undefined,
-    };
+    return fillBuffers(storage, options, result);
+}
+
+fn fillBuffers(
+    storage: []dns.LookupResult,
+    options: dns.LookupOptions,
+    head: ?*ADDRINFOEXW,
+) dns.LookupError!usize {
+    defer if (head) |h| windows.FreeAddrInfoExW(h);
+
+    var i: usize = 0;
+
+    if (options.canonical_name_buffer) |cname_buf| {
+        if (head) |h| {
+            if (h.ai_canonname) |name_ptr| {
+                const name_slice = std.mem.sliceTo(name_ptr, 0);
+                const len = std.unicode.utf16LeToUtf8(cname_buf, name_slice) catch return error.UnknownHostName;
+                cname_buf[len] = 0;
+                storage[i] = .{ .canonical_name = .{ .bytes = cname_buf[0..len] } };
+                i += 1;
+            }
+        }
+    }
+
+    var current: ?*ADDRINFOEXW = head;
+    while (current) |info| : (current = info.ai_next) {
+        if (i >= storage.len) break;
+        const addr = info.ai_addr orelse continue;
+        const family = @as(os_net.sa_family_t, @intCast(addr.family));
+        if (family != os_net.AF.INET and family != os_net.AF.INET6) continue;
+        storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.ai_addrlen)) };
+        i += 1;
+    }
+
+    return i;
 }
 
 fn winsockToLookupError(err: i32) dns.LookupError {

--- a/src/dns/windows.zig
+++ b/src/dns/windows.zig
@@ -116,6 +116,7 @@ fn fillBuffers(
     if (options.canonical_name_buffer) |cname_buf| {
         if (head) |h| {
             if (h.ai_canonname) |name_ptr| {
+                if (i >= storage.len) return i;
                 const name_slice = std.mem.sliceTo(name_ptr, 0);
                 const len = std.unicode.utf16LeToUtf8(cname_buf, name_slice) catch return error.UnknownHostName;
                 cname_buf[len] = 0;
@@ -127,10 +128,9 @@ fn fillBuffers(
 
     var current: ?*ADDRINFOEXW = head;
     while (current) |info| : (current = info.ai_next) {
-        if (i >= storage.len) break;
         const addr = info.ai_addr orelse continue;
-        const family = @as(os_net.sa_family_t, @intCast(addr.family));
-        if (family != os_net.AF.INET and family != os_net.AF.INET6) continue;
+        if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
+        if (i >= storage.len) return error.TooManyAddresses;
         storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.ai_addrlen)) };
         i += 1;
     }

--- a/src/io.zig
+++ b/src/io.zig
@@ -2327,30 +2327,27 @@ fn netLookupImpl(
     const io = fromRuntime(rt);
     defer resolved.close(io);
 
-    var result = zio_dns.lookup(.{
+    var storage: [32]zio_dns.LookupResult = undefined;
+    const count = zio_dns.lookup(&storage, .{
         .name = host_name.bytes,
         .port = options.port,
         .family = if (options.family) |f| switch (f) {
             .ip4 => .ipv4,
             .ip6 => .ipv6,
         } else null,
-        .canonical_name = options.canonical_name_buffer != null,
+        .canonical_name_buffer = options.canonical_name_buffer,
     }) catch |err| return dnsLookupErrToStdErr(err);
-    defer result.deinit();
 
-    while (result.next()) |entry| switch (entry) {
+    for (storage[0..count]) |entry| switch (entry) {
         .address => |addr| {
             resolved.putOne(io, .{ .address = zioIpToStdIo(addr) }) catch |err| switch (err) {
                 error.Canceled => |e| return e,
-                error.Closed => unreachable, // caller must not close `resolved` until we return
+                error.Closed => unreachable,
             };
         },
         .canonical_name => |name| {
             if (name.bytes.len > Io.net.HostName.max_len) return error.InvalidDnsCnameRecord;
-            const buf = options.canonical_name_buffer.?;
-            const dest = buf[0..name.bytes.len];
-            @memcpy(dest, name.bytes);
-            resolved.putOne(io, .{ .canonical_name = .{ .bytes = dest } }) catch |err| switch (err) {
+            resolved.putOne(io, .{ .canonical_name = .{ .bytes = name.bytes } }) catch |err| switch (err) {
                 error.Canceled => |e| return e,
                 error.Closed => unreachable,
             };
@@ -2829,7 +2826,7 @@ test "io: netLookup resolves numeric IPv4" {
     const io = rt.io();
 
     const host: Io.net.HostName = try .init("127.0.0.1");
-    var buf: [16]Io.net.HostName.LookupResult = undefined;
+    var buf: [32]Io.net.HostName.LookupResult = undefined;
     var queue: Io.Queue(Io.net.HostName.LookupResult) = .init(&buf);
     try Io.net.HostName.lookup(host, io, &queue, .{ .port = 8080 });
 
@@ -2855,7 +2852,7 @@ test "io: netLookup returns canonical name when buffer provided" {
     // Use "localhost" rather than a numeric IP: macOS getaddrinfo skips
     // AI_CANONNAME for numeric inputs.
     const host: Io.net.HostName = try .init("localhost");
-    var buf: [16]Io.net.HostName.LookupResult = undefined;
+    var buf: [32]Io.net.HostName.LookupResult = undefined;
     var queue: Io.Queue(Io.net.HostName.LookupResult) = .init(&buf);
     var canon_buf: [Io.net.HostName.max_len]u8 = undefined;
     try Io.net.HostName.lookup(host, io, &queue, .{

--- a/src/io.zig
+++ b/src/io.zig
@@ -2336,7 +2336,10 @@ fn netLookupImpl(
             .ip6 => .ipv6,
         } else null,
         .canonical_name_buffer = options.canonical_name_buffer,
-    }) catch |err| return dnsLookupErrToStdErr(err);
+    }) catch |err| switch (err) {
+        error.TooManyAddresses => storage.len,
+        else => return dnsLookupErrToStdErr(err),
+    };
 
     for (storage[0..count]) |entry| switch (entry) {
         .address => |addr| {
@@ -2364,6 +2367,7 @@ fn dnsLookupErrToStdErr(err: zio_dns.LookupError) Io.net.HostName.LookupError {
         error.ProcessFdQuotaExceeded => error.ProcessFdQuotaExceeded,
         error.SystemResources, error.OutOfMemory => error.SystemResources,
         error.Canceled => error.Canceled,
+        error.TooManyAddresses => unreachable, // handled before calling this function
         error.Unexpected, error.ServiceUnavailable, error.NoThreadPool, error.RuntimeShutdown => error.Unexpected,
         error.Closed => unreachable,
     };

--- a/src/net.zig
+++ b/src/net.zig
@@ -160,7 +160,10 @@ pub const HostName = struct {
     /// Resolves the hostname and connects to the first successful address.
     pub fn connect(self: HostName, port: u16, options: IpAddress.ConnectOptions) !Stream {
         var storage: [32]LookupResult = undefined;
-        const count = try self.lookup(&storage, .{ .port = port });
+        const count = self.lookup(&storage, .{ .port = port }) catch |err| switch (err) {
+            error.TooManyAddresses => storage.len,
+            else => return err,
+        };
 
         var last_err: ?anyerror = null;
         for (storage[0..count]) |entry| {

--- a/src/net.zig
+++ b/src/net.zig
@@ -134,34 +134,36 @@ pub const HostName = struct {
         port: u16,
         /// Filter by address family. `null` means either.
         family: ?IpAddress.Family = null,
-        /// Request canonical name from DNS.
-        canonical_name: bool = false,
+        /// If non-null, the canonical name will be copied into this buffer.
+        canonical_name_buffer: ?*[max_len]u8 = null,
     };
 
     pub const LookupResult = dns.LookupResult;
     pub const LookupError = dns.LookupError;
 
     /// Resolves the hostname to IP addresses.
-    /// Returns an iterator over the results. Call `deinit()` when done.
+    /// Fills `storage` with up to `storage.len` results.
+    /// Returns the number of entries written.
     pub fn lookup(
         self: HostName,
+        storage: []LookupResult,
         options: LookupOptions,
-    ) LookupError!dns.Result {
-        return dns.lookup(.{
+    ) LookupError!usize {
+        return dns.lookup(storage, .{
             .name = self.bytes,
             .port = options.port,
             .family = options.family,
-            .canonical_name = options.canonical_name,
+            .canonical_name_buffer = options.canonical_name_buffer,
         });
     }
 
     /// Resolves the hostname and connects to the first successful address.
     pub fn connect(self: HostName, port: u16, options: IpAddress.ConnectOptions) !Stream {
-        var iter = try self.lookup(.{ .port = port });
-        defer iter.deinit();
+        var storage: [32]LookupResult = undefined;
+        const count = try self.lookup(&storage, .{ .port = port });
 
         var last_err: ?anyerror = null;
-        while (iter.next()) |entry| {
+        for (storage[0..count]) |entry| {
             switch (entry) {
                 .address => |addr| {
                     return addr.connect(.{ .timeout = options.timeout }) catch |err| {
@@ -1296,20 +1298,18 @@ test "HostName: lookup" {
     defer rt.deinit();
 
     const host = try HostName.init("localhost");
-    var iter = try host.lookup(.{ .port = 80 });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
 
-    var has_address = false;
-    while (iter.next()) |entry| {
+    try std.testing.expect(count > 0);
+    for (storage[0..count]) |entry| {
         switch (entry) {
             .address => |addr| {
                 try std.testing.expectEqual(80, addr.getPort());
-                has_address = true;
             },
             .canonical_name => unreachable,
         }
     }
-    try std.testing.expect(has_address);
 }
 
 test "HostName: lookup with family filter" {
@@ -1317,10 +1317,10 @@ test "HostName: lookup with family filter" {
     defer rt.deinit();
 
     const host = try HostName.init("localhost");
-    var iter = try host.lookup(.{ .port = 80, .family = .ipv4 });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .family = .ipv4 });
 
-    while (iter.next()) |entry| {
+    for (storage[0..count]) |entry| {
         switch (entry) {
             .address => |addr| {
                 try std.testing.expectEqual(IpAddress.Family.ipv4, addr.getFamily());
@@ -1335,12 +1335,13 @@ test "HostName: lookup with canonical name" {
     defer rt.deinit();
 
     const host = try HostName.init("localhost");
-    var iter = try host.lookup(.{ .port = 80, .canonical_name = true });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    var cname_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
 
     var has_canonical_name = false;
     var has_address = false;
-    while (iter.next()) |entry| {
+    for (storage[0..count]) |entry| {
         switch (entry) {
             .address => {
                 has_address = true;
@@ -1402,13 +1403,9 @@ test "HostName: lookup localhost" {
     defer rt.deinit();
 
     const host = try HostName.init("localhost");
-    var iter = try host.lookup(.{ .port = 80 });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
 
-    var count: usize = 0;
-    while (iter.next()) |_| {
-        count += 1;
-    }
     try std.testing.expect(count > 0);
 }
 
@@ -1417,22 +1414,12 @@ test "HostName: lookup numeric IP" {
     defer rt.deinit();
 
     const host = try HostName.init("127.0.0.1");
-    var iter = try host.lookup(.{ .port = 8080 });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 8080 });
 
-    var count: usize = 0;
-    var first_addr: ?IpAddress = null;
-    while (iter.next()) |entry| {
-        switch (entry) {
-            .address => |addr| {
-                if (first_addr == null) first_addr = addr;
-                count += 1;
-            },
-            .canonical_name => unreachable,
-        }
-    }
     try std.testing.expectEqual(1, count);
-    try std.testing.expectEqual(8080, first_addr.?.getPort());
+    try std.testing.expect(storage[0] == .address);
+    try std.testing.expectEqual(8080, storage[0].address.getPort());
 }
 
 test "HostName: lookup google.com" {
@@ -1440,20 +1427,18 @@ test "HostName: lookup google.com" {
     defer rt.deinit();
 
     const host = try HostName.init("google.com");
-    var iter = try host.lookup(.{ .port = 443 });
-    defer iter.deinit();
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 443 });
 
-    var count: usize = 0;
-    while (iter.next()) |entry| {
+    try std.testing.expect(count > 0);
+    for (storage[0..count]) |entry| {
         switch (entry) {
             .address => |addr| {
                 try std.testing.expectEqual(443, addr.getPort());
-                count += 1;
             },
             .canonical_name => unreachable,
         }
     }
-    try std.testing.expect(count > 0);
 }
 
 test "tcpConnectToAddress: basic" {


### PR DESCRIPTION
## Summary

Replaces the DNS lookup iterator pattern (`Result` with `next()`/`deinit()`) with a caller-provided buffer model: `lookup()` now takes `storage: []LookupResult` and returns the count of entries written.

## Changes

- **`src/dns/root.zig`** — `LookupOptions.canonical_name: bool` → `canonical_name_buffer: ?*[max_len]u8`. Removes the platform-specific `Result` type. `lookup()` signature changed to `(storage, options) !usize`.
- **`src/dns/posix.zig`** — Extracts `fillResultsFromAddrinfo()` shared with darwin. Frees the addrinfo chain immediately via `defer`.
- **`src/dns/darwin.zig`** — Reuses `fillResultsFromAddrinfo` from posix. Same immediate-free pattern.
- **`src/dns/windows.zig`** — Local `fillBuffers()` with UTF-16→UTF-8 canonical name conversion. `FreeAddrInfoExW` called via `defer`.
- **`src/net.zig`** — `HostName.lookup()` adopts the buffer model. `connect()` and all tests updated.
- **`src/io.zig`** — `netLookupImpl` adapted; no longer needs manual `@memcpy` since canonical name is already in the caller's buffer.
- **`examples/ntp_client.zig`** — Updated to new API.
- **Buffer size** — All result arrays use `[32]` to handle any reasonable DNS response.

## Motivation

- No `deinit()` to forget — resources freed immediately
- Clear lifetime semantics — buffer owned by caller
- Simpler API — no opaque iterator state