### PR TITLE
When resolv.conf is missing, fallback to default

### DIFF
--- a/src/dns/resolver/resolvconf.zig
+++ b/src/dns/resolver/resolvconf.zig
@@ -25,6 +25,20 @@ pub const ResolvConf = struct {
         self.* = undefined;
     }
 
+    pub fn default(parent_allocator: std.mem.Allocator) !ResolvConf {
+        var conf: ResolvConf = .{
+            .arena = .init(parent_allocator),
+            .servers = &.{},
+            .search = &.{},
+        };
+        const allocator = conf.arena.allocator();
+        conf.servers = try allocator.dupe(net.IpAddress, &.{
+            try net.IpAddress.parseIp4("127.0.0.1", 53),
+            try net.IpAddress.parseIp6("::1", 53),
+        });
+        return conf;
+    }
+
     /// Parse resolv.conf from a reader. All returned memory is owned by
     /// the struct and freed by `deinit()`.
     pub fn parse(parent_allocator: std.mem.Allocator, reader: *std.Io.Reader) !ResolvConf {

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -304,8 +304,14 @@ pub const Resolver = struct {
 
         self.conf_next_check.store(now_s +% check_interval_secs, .monotonic);
 
-        const info = fs.stat("/etc/resolv.conf") catch return;
-        if (info.mtime == self.conf_mtime) return;
+        const mtime = check_mtime: {
+            const info = fs.stat("/etc/resolv.conf") catch |err| switch (err) {
+                error.FileNotFound => break :check_mtime 0,
+                else => return,
+            };
+            break :check_mtime info.mtime;
+        };
+        if (mtime == self.conf_mtime) return;
 
         var new_mtime: i64 = 0;
         var new_conf = loadResolvConf(self.allocator, &new_mtime);
@@ -545,6 +551,14 @@ fn loadHosts(allocator: std.mem.Allocator, mtime_out: *i64) Hosts {
 
 fn loadResolvConf(allocator: std.mem.Allocator, mtime_out: *i64) ResolvConf {
     const file = fs.openFile("/etc/resolv.conf") catch |err| {
+        if (err == error.FileNotFound) {
+            const conf = ResolvConf.default(allocator) catch |err2| {
+                log.warn("dns: failed to init default ResolvConf: {}", .{err2});
+                return .{ .arena = .init(allocator), .servers = &.{}, .search = &.{}, .parse_error = true };
+            };
+            mtime_out.* = 0;
+            return conf;
+        }
         log.warn("dns: failed to open /etc/resolv.conf: {}", .{err});
         return .{ .arena = .init(allocator), .servers = &.{}, .search = &.{}, .parse_error = true };
     };


### PR DESCRIPTION
When resolv.conf is missing, resolver should use default 127.0.0.1:53