### PR TITLE
dns: extend CacheKey to handle names longer than 31 characters

### DIFF
--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -6,28 +6,28 @@ const net = @import("../../net.zig");
 const Timestamp = @import("../../time.zig").Timestamp;
 
 pub const max_cached_addrs = 3;
-pub const max_cached_name_len = 31;
 const cache_capacity = 1024;
 const probe_limit = 8;
 
 pub const CacheKey = struct {
+    hash: u64,
     len: u8,
-    buf: [max_cached_name_len]u8,
+    buf: [48 - @sizeOf(u64) - @sizeOf(u8)]u8,
 
-    pub fn init(name: []const u8) ?CacheKey {
-        if (name.len > max_cached_name_len) return null;
-        var key: CacheKey = .{ .len = @intCast(name.len), .buf = undefined };
-        @memcpy(key.buf[0..name.len], name);
+    pub fn init(name: []const u8) CacheKey {
+        var key: CacheKey = .{
+            .len = @intCast(name.len),
+            .hash = std.hash.Wyhash.hash(0, name),
+            .buf = @splat(0),
+        };
+        const n = @min(name.len, key.buf.len);
+        @memcpy(key.buf[0..n], name[0..n]);
         return key;
-    }
-
-    fn slice(self: *const CacheKey) []const u8 {
-        return self.buf[0..self.len];
     }
 };
 
 comptime {
-    if (@sizeOf(CacheKey) != 32) @compileError("CacheKey must be exactly 32 bytes");
+    if (@sizeOf(CacheKey) != 48) @compileError("CacheKey must be exactly 48 bytes");
 }
 
 pub const CacheEntry = struct {
@@ -42,11 +42,11 @@ const CacheSlot = struct {
 };
 
 fn slotIndex(key: *const CacheKey) usize {
-    return @as(usize, @truncate(std.hash.Wyhash.hash(0, key.slice()))) & (cache_capacity - 1);
+    return @as(usize, @truncate(key.hash)) & (cache_capacity - 1);
 }
 
 fn eqlKey(a: CacheKey, b: *const CacheKey) bool {
-    return a.len == b.len and std.mem.eql(u8, a.buf[0..a.len], b.buf[0..b.len]);
+    return a.len == b.len and a.hash == b.hash and std.mem.eql(u8, &a.buf, &b.buf);
 }
 
 pub const Cache = struct {
@@ -105,7 +105,7 @@ pub const Cache = struct {
 
 test "Cache: put and get" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    const key = CacheKey.init("example.com");
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -118,7 +118,7 @@ test "Cache: put and get" {
 
 test "Cache: expired entry not returned" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    const key = CacheKey.init("example.com");
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = 0 };
@@ -129,7 +129,7 @@ test "Cache: expired entry not returned" {
 
 test "Cache: expire invalidates entry" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    const key = CacheKey.init("example.com");
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -142,7 +142,7 @@ test "Cache: expire invalidates entry" {
 
 test "Cache: update existing entry" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    const key = CacheKey.init("example.com");
 
     var e1: CacheEntry = std.mem.zeroes(CacheEntry);
     e1.count = 1;
@@ -164,7 +164,7 @@ test "Cache: multiple independent entries" {
     const names = [_][]const u8{ "a.test", "b.test", "c.test", "d.test" };
 
     for (names, 0..) |name, i| {
-        const k = CacheKey.init(name).?;
+        const k = CacheKey.init(name);
         var e: CacheEntry = std.mem.zeroes(CacheEntry);
         e.count = @intCast(i + 1);
         e.expiry = .{ .value = std.math.maxInt(u64) };
@@ -172,7 +172,7 @@ test "Cache: multiple independent entries" {
     }
 
     for (names, 0..) |name, i| {
-        const k = CacheKey.init(name).?;
+        const k = CacheKey.init(name);
         const result = cache.get(&k);
         try std.testing.expect(result != null);
         try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -149,27 +149,25 @@ pub const Resolver = struct {
                 if (i > 0) return i;
             }
 
-            if (CacheKey.init(options.name)) |key| {
-                if (self.cache.get(&key)) |entry| {
-                    var i: usize = 0;
-                    for (entry.addrs[0..entry.count]) |addr_in| {
-                        if (i >= storage.len) break;
-                        if (options.family) |f| {
-                            if (addr_in.getFamily() != f) continue;
-                        }
-                        var addr = addr_in;
-                        addr.setPort(options.port);
-                        storage[i] = .{ .address = addr };
-                        i += 1;
+            const cache_key = CacheKey.init(options.name);
+            if (self.cache.get(&cache_key)) |entry| {
+                var i: usize = 0;
+                for (entry.addrs[0..entry.count]) |addr_in| {
+                    if (i >= storage.len) break;
+                    if (options.family) |f| {
+                        if (addr_in.getFamily() != f) continue;
                     }
-                    if (i > 0) return i;
+                    var addr = addr_in;
+                    addr.setPort(options.port);
+                    storage[i] = .{ .address = addr };
+                    i += 1;
                 }
+                if (i > 0) return i;
             }
         }
 
-        // 2. Deduplicate concurrent identical DNS queries. Names that exceed the
-        //    CacheKey limit are too rare to bother deduplicating.
-        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options);
+        // 2. Deduplicate concurrent identical DNS queries.
+        const key = CacheKey.init(options.name);
         const bucket = self.getDedupBucket(&key);
 
         try bucket.mutex.lock();
@@ -359,7 +357,7 @@ pub const Resolver = struct {
 
     fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32) void {
         if (options.family != null) return;
-        const key = CacheKey.init(options.name) orelse return;
+        const key = CacheKey.init(options.name);
 
         if (results.len == 0 or results.len > max_cached_addrs) {
             self.lock.lockUncancelable();

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -57,8 +57,8 @@ const Bucket = struct {
     waiters: SimpleQueue(WaiterNode) = .empty,
 };
 
-fn eqlCacheKey(a: CacheKey, b: CacheKey) bool {
-    return a.len == b.len and std.mem.eql(u8, a.buf[0..a.len], b.buf[0..b.len]);
+fn eqlCacheKey(a: *const CacheKey, b: *const CacheKey) bool {
+    return a.len == b.len and a.hash == b.hash and std.mem.eql(u8, &a.buf, &b.buf);
 }
 
 pub const Resolver = struct {
@@ -174,7 +174,7 @@ pub const Resolver = struct {
 
         var it = bucket.waiters.head;
         while (it) |n| : (it = n.next) {
-            if (n.is_active and n.family == options.family and eqlCacheKey(n.key, key)) {
+            if (n.is_active and n.family == options.family and eqlCacheKey(&n.key, &key)) {
                 // An identical query is already in flight — join it.
                 var node: WaiterNode = .{
                     .key = key,
@@ -219,7 +219,7 @@ pub const Resolver = struct {
         bucket.mutex.lockUncancelable();
         var wit = bucket.waiters.head;
         while (wit) |n| : (wit = n.next) {
-            if (!n.is_active and n.family == options.family and eqlCacheKey(n.key, key)) {
+            if (!n.is_active and n.family == options.family and eqlCacheKey(&n.key, &key)) {
                 if (result) |count| {
                     const jcount = @min(n.storage.len, count);
                     @memcpy(n.storage[0..jcount], storage[0..jcount]);

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -19,6 +19,8 @@ fn nowS() u32 {
 }
 const RwLock = @import("../../sync/RwLock.zig");
 const Mutex = @import("../../sync/Mutex.zig");
+const Condition = @import("../../sync/Condition.zig");
+const SimpleQueue = @import("../../utils/simple_queue.zig").SimpleQueue;
 
 const check_interval_secs: u32 = 5;
 
@@ -33,6 +35,31 @@ const Cache = @import("cache.zig").Cache;
 const CacheKey = @import("cache.zig").CacheKey;
 const CacheEntry = @import("cache.zig").CacheEntry;
 const max_cached_addrs = @import("cache.zig").max_cached_addrs;
+
+const num_dedup_buckets = 64;
+
+const WaiterNode = struct {
+    next: ?*WaiterNode = null,
+    prev: ?*WaiterNode = null,
+    in_list: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_safety) false else {},
+    key: CacheKey,
+    family: ?net.IpAddress.Family,
+    is_active: bool,
+    storage: []dns.LookupResult,
+    count: usize = 0,
+    err: ?dns.LookupError = null,
+    done: bool = false,
+    cond: Condition = .init,
+};
+
+const Bucket = struct {
+    mutex: Mutex = .init,
+    waiters: SimpleQueue(WaiterNode) = .empty,
+};
+
+fn eqlCacheKey(a: CacheKey, b: CacheKey) bool {
+    return a.len == b.len and std.mem.eql(u8, a.buf[0..a.len], b.buf[0..b.len]);
+}
 
 pub const Resolver = struct {
     allocator: std.mem.Allocator,
@@ -54,6 +81,8 @@ pub const Resolver = struct {
     prng_mutex: Mutex,
     prng: std.Random.DefaultPrng,
 
+    dedup_buckets: [num_dedup_buckets]Bucket,
+
     pub fn init(allocator: std.mem.Allocator) Resolver {
         var hosts_mtime: i64 = 0;
         var conf_mtime: i64 = 0;
@@ -72,7 +101,13 @@ pub const Resolver = struct {
             .cache = std.mem.zeroes(Cache),
             .prng_mutex = .init,
             .prng = .init(Timestamp.now(.realtime).value),
+            .dedup_buckets = [_]Bucket{.{}} ** num_dedup_buckets,
         };
+    }
+
+    fn getDedupBucket(self: *Resolver, key: *const CacheKey) *Bucket {
+        const hash = std.hash.Wyhash.hash(0, key.buf[0..key.len]);
+        return &self.dedup_buckets[hash & (num_dedup_buckets - 1)];
     }
 
     fn nextQueryId(self: *Resolver) u16 {
@@ -132,8 +167,87 @@ pub const Resolver = struct {
             }
         }
 
-        // 2. DNS query — snapshot conf fields while holding the shared lock so
-        //    we don't hold it across I/O operations.
+        // 2. Deduplicate concurrent identical DNS queries. Names that exceed the
+        //    CacheKey limit are too rare to bother deduplicating.
+        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options);
+        const bucket = self.getDedupBucket(&key);
+
+        try bucket.mutex.lock();
+
+        var it = bucket.waiters.head;
+        while (it) |n| : (it = n.next) {
+            if (n.is_active and n.family == options.family and eqlCacheKey(n.key, key)) {
+                // An identical query is already in flight — join it.
+                var node: WaiterNode = .{
+                    .key = key,
+                    .family = options.family,
+                    .is_active = false,
+                    .storage = storage,
+                };
+                bucket.waiters.push(&node);
+
+                while (!node.done) {
+                    node.cond.wait(&bucket.mutex) catch |err| {
+                        if (!node.done) {
+                            _ = bucket.waiters.remove(&node);
+                            bucket.mutex.unlock();
+                            return err;
+                        }
+                        break;
+                    };
+                }
+                _ = bucket.waiters.remove(&node);
+                bucket.mutex.unlock();
+
+                if (node.err) |err| return err;
+                for (node.storage[0..node.count]) |*r| r.address.setPort(options.port);
+                return node.count;
+            }
+        }
+
+        // No in-flight request for this name+family — become the active requester.
+        var active_node: WaiterNode = .{
+            .key = key,
+            .family = options.family,
+            .is_active = true,
+            .storage = storage,
+        };
+        bucket.waiters.push(&active_node);
+        bucket.mutex.unlock();
+
+        const result = self.lookupDns(storage, options);
+
+        // Notify all joiners, then remove the active node.
+        bucket.mutex.lockUncancelable();
+        var wit = bucket.waiters.head;
+        while (wit) |n| : (wit = n.next) {
+            if (!n.is_active and n.family == options.family and eqlCacheKey(n.key, key)) {
+                if (result) |count| {
+                    const jcount = @min(n.storage.len, count);
+                    @memcpy(n.storage[0..jcount], storage[0..jcount]);
+                    n.count = jcount;
+                    n.err = null;
+                } else |err| {
+                    n.count = 0;
+                    n.err = err;
+                }
+                n.done = true;
+                n.cond.signal();
+            }
+        }
+        _ = bucket.waiters.remove(&active_node);
+        bucket.mutex.unlock();
+
+        return result;
+    }
+
+    fn lookupDns(
+        self: *Resolver,
+        storage: []dns.LookupResult,
+        options: dns.LookupOptions,
+    ) dns.LookupError!usize {
+        // Snapshot conf fields while holding the shared lock so we don't hold
+        // it across I/O operations.
         var servers: [max_nameservers]net.IpAddress = undefined;
         var server_count: usize = 0;
         var ndots: u8 = undefined;


### PR DESCRIPTION
The previous `CacheKey` silently skipped caching and deduplication for
hostnames longer than 31 characters. Long names (AWS endpoints, generated
subdomains) are common in practice and benefit from both.

## New layout (48 bytes)

```
hash: u64    — Wyhash of the full name, used for slot index and equality
len:  u8     — full name length, panics on overflow (DNS max is 253)
buf:  [39]u8 — first 39 bytes of the name, zero-padded
```

Collision requires matching `len`, `hash`, and the first 39 chars
simultaneously — negligible in practice (~1/2^64 per pair).

`CacheKey.init` now always returns `CacheKey` (non-optional), removing
the length guard from all callers.