### PR TITLE
dns: capture now once per lookup instead of calling clock_gettime repeatedly

### DIFF
--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -53,13 +53,13 @@ pub const Cache = struct {
     slots: [cache_capacity]CacheSlot,
 
     // Returns the cached entry for key if present and not expired.
-    pub fn get(self: *const Cache, key: *const CacheKey) ?CacheEntry {
+    pub fn get(self: *const Cache, key: *const CacheKey, now: Timestamp) ?CacheEntry {
         const start = slotIndex(key);
         for (0..probe_limit) |probe| {
             const slot = &self.slots[(start + probe) & (cache_capacity - 1)];
             if (slot.key.len == 0) return null;
             if (!eqlKey(slot.key, key)) continue;
-            if (Timestamp.now(.monotonic).value < slot.entry.expiry.value) {
+            if (now.value < slot.entry.expiry.value) {
                 return slot.entry;
             }
             return null;
@@ -69,9 +69,8 @@ pub const Cache = struct {
 
     // Stores or updates an entry. Prefers an empty or exact-match slot, then the
     // first expired slot found in the probe window, then the primary slot.
-    pub fn put(self: *Cache, key: *const CacheKey, entry: CacheEntry) void {
+    pub fn put(self: *Cache, key: *const CacheKey, entry: CacheEntry, now: Timestamp) void {
         const start = slotIndex(key);
-        const now = Timestamp.now(.monotonic);
         var target: usize = cache_capacity; // sentinel: no preferred slot yet
         for (0..probe_limit) |probe| {
             const idx = (start + probe) & (cache_capacity - 1);
@@ -110,8 +109,9 @@ test "Cache: put and get" {
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
 
-    cache.put(&key, entry);
-    const result = cache.get(&key);
+    const now: Timestamp = .{ .value = 1 };
+    cache.put(&key, entry, now);
+    const result = cache.get(&key, now);
     try std.testing.expect(result != null);
     try std.testing.expectEqual(@as(u8, 1), result.?.count);
 }
@@ -123,8 +123,9 @@ test "Cache: expired entry not returned" {
     entry.count = 1;
     entry.expiry = .{ .value = 0 };
 
-    cache.put(&key, entry);
-    try std.testing.expect(cache.get(&key) == null);
+    const now: Timestamp = .{ .value = 1 };
+    cache.put(&key, entry, now);
+    try std.testing.expect(cache.get(&key, now) == null);
 }
 
 test "Cache: expire invalidates entry" {
@@ -134,27 +135,30 @@ test "Cache: expire invalidates entry" {
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
 
-    cache.put(&key, entry);
-    try std.testing.expect(cache.get(&key) != null);
+    const now: Timestamp = .{ .value = 1 };
+    cache.put(&key, entry, now);
+    try std.testing.expect(cache.get(&key, now) != null);
     cache.expire(&key);
-    try std.testing.expect(cache.get(&key) == null);
+    try std.testing.expect(cache.get(&key, now) == null);
 }
 
 test "Cache: update existing entry" {
     var cache: Cache = std.mem.zeroes(Cache);
     const key = CacheKey.init("example.com").?;
 
+    const now: Timestamp = .{ .value = 1 };
+
     var e1: CacheEntry = std.mem.zeroes(CacheEntry);
     e1.count = 1;
     e1.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&key, e1);
+    cache.put(&key, e1, now);
 
     var e2: CacheEntry = std.mem.zeroes(CacheEntry);
     e2.count = 2;
     e2.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&key, e2);
+    cache.put(&key, e2, now);
 
-    const result = cache.get(&key);
+    const result = cache.get(&key, now);
     try std.testing.expect(result != null);
     try std.testing.expectEqual(@as(u8, 2), result.?.count);
 }
@@ -163,17 +167,19 @@ test "Cache: multiple independent entries" {
     var cache: Cache = std.mem.zeroes(Cache);
     const names = [_][]const u8{ "a.test", "b.test", "c.test", "d.test" };
 
+    const now: Timestamp = .{ .value = 1 };
+
     for (names, 0..) |name, i| {
         const k = CacheKey.init(name).?;
         var e: CacheEntry = std.mem.zeroes(CacheEntry);
         e.count = @intCast(i + 1);
         e.expiry = .{ .value = std.math.maxInt(u64) };
-        cache.put(&k, e);
+        cache.put(&k, e, now);
     }
 
     for (names, 0..) |name, i| {
         const k = CacheKey.init(name).?;
-        const result = cache.get(&k);
+        const result = cache.get(&k, now);
         try std.testing.expect(result != null);
         try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);
     }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -167,7 +167,7 @@ pub const Resolver = struct {
 
         // 2. Deduplicate concurrent identical DNS queries. Names that exceed the
         //    CacheKey limit are too rare to bother deduplicating.
-        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options, now);
+        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options);
         const bucket = self.getDedupBucket(&key);
 
         try bucket.mutex.lock();
@@ -215,7 +215,7 @@ pub const Resolver = struct {
 
         var tmp: [16]dns.LookupResult = undefined;
         const buf: []dns.LookupResult = if (storage.len >= tmp.len) storage else tmp[0..];
-        const result = self.lookupDns(buf, options, now);
+        const result = self.lookupDns(buf, options);
 
         // Notify all joiners, then remove the active node.
         bucket.mutex.lockUncancelable();
@@ -251,7 +251,6 @@ pub const Resolver = struct {
         self: *Resolver,
         storage: []dns.LookupResult,
         options: dns.LookupOptions,
-        now: Timestamp,
     ) dns.LookupError!usize {
         // Snapshot conf fields while holding the shared lock so we don't hold
         // it across I/O operations.
@@ -305,63 +304,58 @@ pub const Resolver = struct {
         var fqdn_buf: [256]u8 = undefined;
         var last_err: dns.LookupError = error.UnknownHostName;
 
-        // Rooted name: only try exactly as given.
-        if (rooted) {
-            const r = try queryOneName(self, storage, options, name, srvs, attempts, timeout);
-            self.cacheInsert(options, storage[0..r.count], r.ttl, now);
-            return r.count;
-        }
+        const r: QueryResult = blk: {
+            // Rooted name: only try exactly as given.
+            if (rooted) {
+                break :blk try queryOneName(self, storage, options, name, srvs, attempts, timeout);
+            }
 
-        var dot_count: usize = 0;
-        for (name) |c| {
-            if (c == '.') dot_count += 1;
-        }
-        const has_enough_dots = dot_count >= ndots;
+            var dot_count: usize = 0;
+            for (name) |c| {
+                if (c == '.') dot_count += 1;
+            }
+            const has_enough_dots = dot_count >= ndots;
 
-        // Enough dots: try unsuffixed first (Go's nameList logic).
-        if (has_enough_dots) {
-            if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                    if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
-                        return r.count;
+            // Enough dots: try unsuffixed first (Go's nameList logic).
+            if (has_enough_dots) {
+                if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
+                        if (r.count > 0) break :blk r;
+                    } else |err| {
+                        if (err != error.UnknownHostName) return err;
                     }
-                } else |err| {
-                    if (err != error.UnknownHostName) return err;
                 }
             }
-        }
 
-        // Try with each search domain.
-        for (0..search_count) |i| {
-            const suffix = search_store[i][0..search_lens[i]];
-            if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
-                if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                    if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
-                        return r.count;
+            // Try with each search domain.
+            for (0..search_count) |i| {
+                const suffix = search_store[i][0..search_lens[i]];
+                if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
+                        if (r.count > 0) break :blk r;
+                    } else |err| {
+                        if (err != error.UnknownHostName) return err;
                     }
-                } else |err| {
-                    if (err != error.UnknownHostName) return err;
                 }
             }
-        }
 
-        // Not enough dots: try unsuffixed last.
-        if (!has_enough_dots) {
-            if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                    if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
-                        return r.count;
+            // Not enough dots: try unsuffixed last.
+            if (!has_enough_dots) {
+                if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
+                        if (r.count > 0) break :blk r;
+                    } else |err| {
+                        last_err = err;
                     }
-                } else |err| {
-                    last_err = err;
                 }
             }
-        }
 
-        return last_err;
+            return last_err;
+        };
+
+        const now = Timestamp.now(.monotonic);
+        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
+        return r.count;
     }
 
     fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -14,9 +14,6 @@ const Timestamp = @import("../../time.zig").Timestamp;
 const Duration = @import("../../time.zig").Duration;
 const Timeout = @import("../../time.zig").Timeout;
 
-fn nowS() u32 {
-    return @truncate(Timestamp.now(.monotonic).toSeconds());
-}
 const RwLock = @import("../../sync/RwLock.zig");
 const Mutex = @import("../../sync/Mutex.zig");
 const Condition = @import("../../sync/Condition.zig");
@@ -86,7 +83,7 @@ pub const Resolver = struct {
     pub fn init(allocator: std.mem.Allocator) Resolver {
         var hosts_mtime: i64 = 0;
         var conf_mtime: i64 = 0;
-        const next_check_s = nowS() +% check_interval_secs;
+        const next_check_s: u32 = @as(u32, @truncate(Timestamp.now(.monotonic).toSeconds())) +% check_interval_secs;
         return .{
             .allocator = allocator,
             .lock = .init,
@@ -126,8 +123,9 @@ pub const Resolver = struct {
         storage: []dns.LookupResult,
         options: dns.LookupOptions,
     ) dns.ResolverError!usize {
-        self.maybeReloadHosts();
-        self.maybeReloadResolvConf();
+        const now = Timestamp.now(.monotonic);
+        self.maybeReloadHosts(now);
+        self.maybeReloadResolvConf(now);
 
         // 1. Check /etc/hosts and DNS cache
         {
@@ -150,7 +148,7 @@ pub const Resolver = struct {
             }
 
             if (CacheKey.init(options.name)) |key| {
-                if (self.cache.get(&key)) |entry| {
+                if (self.cache.get(&key, now)) |entry| {
                     var i: usize = 0;
                     for (entry.addrs[0..entry.count]) |addr_in| {
                         if (i >= storage.len) break;
@@ -169,7 +167,7 @@ pub const Resolver = struct {
 
         // 2. Deduplicate concurrent identical DNS queries. Names that exceed the
         //    CacheKey limit are too rare to bother deduplicating.
-        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options);
+        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options, now);
         const bucket = self.getDedupBucket(&key);
 
         try bucket.mutex.lock();
@@ -217,7 +215,7 @@ pub const Resolver = struct {
 
         var tmp: [16]dns.LookupResult = undefined;
         const buf: []dns.LookupResult = if (storage.len >= tmp.len) storage else tmp[0..];
-        const result = self.lookupDns(buf, options);
+        const result = self.lookupDns(buf, options, now);
 
         // Notify all joiners, then remove the active node.
         bucket.mutex.lockUncancelable();
@@ -253,6 +251,7 @@ pub const Resolver = struct {
         self: *Resolver,
         storage: []dns.LookupResult,
         options: dns.LookupOptions,
+        now: Timestamp,
     ) dns.LookupError!usize {
         // Snapshot conf fields while holding the shared lock so we don't hold
         // it across I/O operations.
@@ -309,7 +308,7 @@ pub const Resolver = struct {
         // Rooted name: only try exactly as given.
         if (rooted) {
             const r = try queryOneName(self, storage, options, name, srvs, attempts, timeout);
-            self.cacheInsert(options, storage[0..r.count], r.ttl);
+            self.cacheInsert(options, storage[0..r.count], r.ttl, now);
             return r.count;
         }
 
@@ -324,7 +323,7 @@ pub const Resolver = struct {
             if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
                 if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
                     if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl);
+                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
                         return r.count;
                     }
                 } else |err| {
@@ -339,7 +338,7 @@ pub const Resolver = struct {
             if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
                 if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
                     if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl);
+                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
                         return r.count;
                     }
                 } else |err| {
@@ -353,7 +352,7 @@ pub const Resolver = struct {
             if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
                 if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
                     if (r.count > 0) {
-                        self.cacheInsert(options, storage[0..r.count], r.ttl);
+                        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
                         return r.count;
                     }
                 } else |err| {
@@ -365,7 +364,7 @@ pub const Resolver = struct {
         return last_err;
     }
 
-    fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32) void {
+    fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
         if (options.family != null) return;
         const key = CacheKey.init(options.name) orelse return;
 
@@ -380,7 +379,7 @@ pub const Resolver = struct {
         var entry: CacheEntry = .{
             .addrs = undefined,
             .count = @intCast(results.len),
-            .expiry = Timestamp.now(.monotonic).addDuration(.fromSeconds(ttl_secs)),
+            .expiry = now.addDuration(.fromSeconds(ttl_secs)),
         };
         for (results, 0..) |r, i| {
             entry.addrs[i] = r.address;
@@ -389,11 +388,11 @@ pub const Resolver = struct {
 
         self.lock.lockUncancelable();
         defer self.lock.unlock();
-        self.cache.put(&key, entry);
+        self.cache.put(&key, entry, now);
     }
 
-    fn maybeReloadHosts(self: *Resolver) void {
-        const now_s = nowS();
+    fn maybeReloadHosts(self: *Resolver, now: Timestamp) void {
+        const now_s: u32 = @truncate(now.toSeconds());
         if (now_s < self.hosts_next_check.load(.monotonic)) return;
 
         if (self.hosts_reloading.cmpxchgStrong(false, true, .acquire, .monotonic) != null) return;
@@ -417,8 +416,8 @@ pub const Resolver = struct {
         old.deinit();
     }
 
-    fn maybeReloadResolvConf(self: *Resolver) void {
-        const now_s = nowS();
+    fn maybeReloadResolvConf(self: *Resolver, now: Timestamp) void {
+        const now_s: u32 = @truncate(now.toSeconds());
         if (now_s < self.conf_next_check.load(.monotonic)) return;
 
         if (self.conf_reloading.cmpxchgStrong(false, true, .acquire, .monotonic) != null) return;


### PR DESCRIPTION
Related to https://github.com/lalinsky/zio/issues/415

## Summary

- `clock_gettime` was called up to 4 times per DNS lookup: once each in `maybeReloadHosts`, `maybeReloadResolvConf`, `cache.get`, and `cacheInsert`
- Now captured once at the start of `lookup()` and passed as a `Timestamp` parameter to `maybeReloadHosts`, `maybeReloadResolvConf`, and `cache.get`
- On cache miss, `now` is recaptured after the query returns so cache expiry is based on response time, not lookup-start time
- Cache hit path: 3 calls → 1. Cache miss path: 4 calls → 2.

## Test plan

- [ ] `./check.sh` passes (453/457, the 4 pre-existing failures are unrelated to DNS)