### PR TITLE
dns: replace full-name cache key with prefix+hash

### DIFF
--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -6,23 +6,27 @@ const net = @import("../../net.zig");
 const Timestamp = @import("../../time.zig").Timestamp;
 
 pub const max_cached_addrs = 3;
-pub const max_cached_name_len = 31;
 const cache_capacity = 1024;
 const probe_limit = 8;
+pub const key_prefix_len = 23;
 
 pub const CacheKey = struct {
     len: u8,
-    buf: [max_cached_name_len]u8,
+    prefix: [key_prefix_len]u8,
+    hash: u64,
 
-    pub fn init(name: []const u8) ?CacheKey {
-        if (name.len > max_cached_name_len) return null;
-        var key: CacheKey = .{ .len = @intCast(name.len), .buf = undefined };
-        @memcpy(key.buf[0..name.len], name);
-        return key;
+    pub fn init(key: *CacheKey, name: []const u8, seed: u64) void {
+        const plen = @min(name.len, key_prefix_len);
+        key.len = @intCast(name.len);
+        key.hash = std.hash.Wyhash.hash(seed, name);
+        @memset(&key.prefix, 0);
+        @memcpy(key.prefix[0..plen], name[0..plen]);
     }
 
-    fn slice(self: *const CacheKey) []const u8 {
-        return self.buf[0..self.len];
+    pub fn eql(a: *const CacheKey, b: *const CacheKey) bool {
+        if (a.len != b.len or a.hash != b.hash) return false;
+        const plen = @min(a.len, key_prefix_len);
+        return std.mem.eql(u8, a.prefix[0..plen], b.prefix[0..plen]);
     }
 };
 
@@ -42,11 +46,7 @@ const CacheSlot = struct {
 };
 
 fn slotIndex(key: *const CacheKey) usize {
-    return @as(usize, @truncate(std.hash.Wyhash.hash(0, key.slice()))) & (cache_capacity - 1);
-}
-
-fn eqlKey(a: CacheKey, b: *const CacheKey) bool {
-    return a.len == b.len and std.mem.eql(u8, a.buf[0..a.len], b.buf[0..b.len]);
+    return @as(usize, @truncate(key.hash)) & (cache_capacity - 1);
 }
 
 pub const Cache = struct {
@@ -58,7 +58,7 @@ pub const Cache = struct {
         for (0..probe_limit) |probe| {
             const slot = &self.slots[(start + probe) & (cache_capacity - 1)];
             if (slot.key.len == 0) return null;
-            if (!eqlKey(slot.key, key)) continue;
+            if (!slot.key.eql(key)) continue;
             if (now.value < slot.entry.expiry.value) {
                 return slot.entry;
             }
@@ -75,7 +75,7 @@ pub const Cache = struct {
         for (0..probe_limit) |probe| {
             const idx = (start + probe) & (cache_capacity - 1);
             const slot = &self.slots[idx];
-            if (slot.key.len == 0 or eqlKey(slot.key, key)) {
+            if (slot.key.len == 0 or slot.key.eql(key)) {
                 target = idx;
                 break;
             }
@@ -94,7 +94,7 @@ pub const Cache = struct {
         for (0..probe_limit) |probe| {
             const slot = &self.slots[(start + probe) & (cache_capacity - 1)];
             if (slot.key.len == 0) break;
-            if (eqlKey(slot.key, key)) {
+            if (slot.key.eql(key)) {
                 slot.entry.expiry = .{ .value = 0 };
                 break;
             }
@@ -104,7 +104,8 @@ pub const Cache = struct {
 
 test "Cache: put and get" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "example.com", 0);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -118,7 +119,8 @@ test "Cache: put and get" {
 
 test "Cache: expired entry not returned" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "example.com", 0);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = 0 };
@@ -130,7 +132,8 @@ test "Cache: expired entry not returned" {
 
 test "Cache: expire invalidates entry" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "example.com", 0);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -144,7 +147,8 @@ test "Cache: expire invalidates entry" {
 
 test "Cache: update existing entry" {
     var cache: Cache = std.mem.zeroes(Cache);
-    const key = CacheKey.init("example.com").?;
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "example.com", 0);
 
     const now: Timestamp = .{ .value = 1 };
 
@@ -170,7 +174,8 @@ test "Cache: multiple independent entries" {
     const now: Timestamp = .{ .value = 1 };
 
     for (names, 0..) |name, i| {
-        const k = CacheKey.init(name).?;
+        var k: CacheKey = undefined;
+        CacheKey.init(&k, name, 0);
         var e: CacheEntry = std.mem.zeroes(CacheEntry);
         e.count = @intCast(i + 1);
         e.expiry = .{ .value = std.math.maxInt(u64) };
@@ -178,7 +183,8 @@ test "Cache: multiple independent entries" {
     }
 
     for (names, 0..) |name, i| {
-        const k = CacheKey.init(name).?;
+        var k: CacheKey = undefined;
+        CacheKey.init(&k, name, 0);
         const result = cache.get(&k, now);
         try std.testing.expect(result != null);
         try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);

--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -16,6 +16,7 @@ pub const CacheKey = struct {
     hash: u64,
 
     pub fn init(key: *CacheKey, name: []const u8, seed: u64) void {
+        std.debug.assert(name.len <= std.math.maxInt(u8));
         const plen = @min(name.len, key_prefix_len);
         key.len = @intCast(name.len);
         key.hash = std.hash.Wyhash.hash(seed, name);
@@ -189,4 +190,30 @@ test "Cache: multiple independent entries" {
         try std.testing.expect(result != null);
         try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);
     }
+}
+
+test "Cache: long names with shared prefix stay distinct" {
+    var cache: Cache = std.mem.zeroes(Cache);
+    const name1 = "abcdefghijklmnopqrstuvw-one.test";
+    const name2 = "abcdefghijklmnopqrstuvw-two.test";
+    comptime std.debug.assert(name1.len > key_prefix_len);
+
+    const now: Timestamp = .{ .value = 1 };
+
+    var k1: CacheKey = undefined;
+    CacheKey.init(&k1, name1, 0);
+    var e1: CacheEntry = std.mem.zeroes(CacheEntry);
+    e1.count = 1;
+    e1.expiry = .{ .value = std.math.maxInt(u64) };
+    cache.put(&k1, e1, now);
+
+    var k2: CacheKey = undefined;
+    CacheKey.init(&k2, name2, 0);
+    var e2: CacheEntry = std.mem.zeroes(CacheEntry);
+    e2.count = 2;
+    e2.expiry = .{ .value = std.math.maxInt(u64) };
+    cache.put(&k2, e2, now);
+
+    try std.testing.expectEqual(@as(u8, 1), cache.get(&k1, now).?.count);
+    try std.testing.expectEqual(@as(u8, 2), cache.get(&k2, now).?.count);
 }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -54,10 +54,6 @@ const Bucket = struct {
     waiters: SimpleQueue(WaiterNode) = .empty,
 };
 
-fn eqlCacheKey(a: CacheKey, b: CacheKey) bool {
-    return a.len == b.len and std.mem.eql(u8, a.buf[0..a.len], b.buf[0..b.len]);
-}
-
 pub const Resolver = struct {
     allocator: std.mem.Allocator,
     lock: RwLock,
@@ -73,6 +69,7 @@ pub const Resolver = struct {
     conf_reloading: std.atomic.Value(bool),
 
     cache: Cache,
+    hash_seed: u64,
     rotate_index: std.atomic.Value(u32) = .init(0),
 
     prng_mutex: Mutex,
@@ -84,6 +81,8 @@ pub const Resolver = struct {
         var hosts_mtime: i64 = 0;
         var conf_mtime: i64 = 0;
         const next_check_s: u32 = @as(u32, @truncate(Timestamp.now(.monotonic).toSeconds())) +% check_interval_secs;
+        var prng = std.Random.DefaultPrng.init(Timestamp.now(.realtime).value);
+        const hash_seed = prng.random().int(u64);
         return .{
             .allocator = allocator,
             .lock = .init,
@@ -96,15 +95,15 @@ pub const Resolver = struct {
             .conf_next_check = .init(next_check_s),
             .conf_reloading = .init(false),
             .cache = std.mem.zeroes(Cache),
+            .hash_seed = hash_seed,
             .prng_mutex = .init,
-            .prng = .init(Timestamp.now(.realtime).value),
+            .prng = prng,
             .dedup_buckets = [_]Bucket{.{}} ** num_dedup_buckets,
         };
     }
 
     fn getDedupBucket(self: *Resolver, key: *const CacheKey) *Bucket {
-        const hash: usize = @truncate(std.hash.Wyhash.hash(0, key.buf[0..key.len]));
-        return &self.dedup_buckets[hash & (num_dedup_buckets - 1)];
+        return &self.dedup_buckets[@as(usize, @truncate(key.hash)) & (num_dedup_buckets - 1)];
     }
 
     fn nextQueryId(self: *Resolver) u16 {
@@ -127,6 +126,9 @@ pub const Resolver = struct {
         self.maybeReloadHosts(now);
         self.maybeReloadResolvConf(now);
 
+        var key: CacheKey = undefined;
+        CacheKey.init(&key, options.name, self.hash_seed);
+
         // 1. Check /etc/hosts and DNS cache
         {
             try self.lock.lockShared();
@@ -147,34 +149,30 @@ pub const Resolver = struct {
                 if (i > 0) return i;
             }
 
-            if (CacheKey.init(options.name)) |key| {
-                if (self.cache.get(&key, now)) |entry| {
-                    var i: usize = 0;
-                    for (entry.addrs[0..entry.count]) |addr_in| {
-                        if (i >= storage.len) break;
-                        if (options.family) |f| {
-                            if (addr_in.getFamily() != f) continue;
-                        }
-                        var addr = addr_in;
-                        addr.setPort(options.port);
-                        storage[i] = .{ .address = addr };
-                        i += 1;
+            if (self.cache.get(&key, now)) |entry| {
+                var i: usize = 0;
+                for (entry.addrs[0..entry.count]) |addr_in| {
+                    if (i >= storage.len) break;
+                    if (options.family) |f| {
+                        if (addr_in.getFamily() != f) continue;
                     }
-                    if (i > 0) return i;
+                    var addr = addr_in;
+                    addr.setPort(options.port);
+                    storage[i] = .{ .address = addr };
+                    i += 1;
                 }
+                if (i > 0) return i;
             }
         }
 
-        // 2. Deduplicate concurrent identical DNS queries. Names that exceed the
-        //    CacheKey limit are too rare to bother deduplicating.
-        const key = CacheKey.init(options.name) orelse return self.lookupDns(storage, options);
+        // 2. Deduplicate concurrent identical DNS queries.
         const bucket = self.getDedupBucket(&key);
 
         try bucket.mutex.lock();
 
         var it = bucket.waiters.head;
         while (it) |n| : (it = n.next) {
-            if (n.is_active and n.family == options.family and eqlCacheKey(n.key, key)) {
+            if (n.is_active and n.family == options.family and n.key.eql(&key)) {
                 // An identical query is already in flight — join it.
                 var node: WaiterNode = .{
                     .key = key,
@@ -221,7 +219,7 @@ pub const Resolver = struct {
         bucket.mutex.lockUncancelable();
         var wit = bucket.waiters.head;
         while (wit) |n| : (wit = n.next) {
-            if (!n.is_active and !n.done and n.family == options.family and eqlCacheKey(n.key, key)) {
+            if (!n.is_active and !n.done and n.family == options.family and n.key.eql(&key)) {
                 if (result) |count| {
                     const jcount = @min(n.storage.len, count);
                     @memcpy(n.storage[0..jcount], buf[0..jcount]);
@@ -360,7 +358,8 @@ pub const Resolver = struct {
 
     fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
         if (options.family != null) return;
-        const key = CacheKey.init(options.name) orelse return;
+        var key: CacheKey = undefined;
+        CacheKey.init(&key, options.name, self.hash_seed);
 
         if (results.len == 0 or results.len > max_cached_addrs) {
             self.lock.lockUncancelable();


### PR DESCRIPTION
## Summary

- `CacheKey` is now `{ len: u8, prefix: [23]u8, hash: u64 }` — still 32 bytes, but now supports names of any length (previously capped at 31 bytes)
- Short names (≤23 bytes) match exactly on prefix+len; longer names are disambiguated by a seeded wyhash
- Hash seed is derived from the runtime PRNG at `Resolver.init` time, preventing deterministic collision attacks
- The stored hash is reused for slot indexing and dedup bucket selection — no redundant hash computations
- Consolidates the duplicate `eqlKey`/`eqlCacheKey` functions into a single `CacheKey.eql` method that checks integer fields first, then only the relevant prefix bytes
- `CacheKey.init` is now pointer-based to avoid copies

## Collision probability

For names longer than 23 bytes sharing the same prefix and length, collision requires a wyhash match: ~1/2⁶⁴ per pair. Practically impossible for accidental conflicts, and the random seed makes deliberate attacks infeasible.