### PR TITLE
dns: split A and AAAA into separate cache entries

### DIFF
--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -8,24 +8,27 @@ const Timestamp = @import("../../time.zig").Timestamp;
 pub const max_cached_addrs = 3;
 const cache_capacity = 1024;
 const probe_limit = 8;
-pub const key_prefix_len = 23;
+pub const key_prefix_len = 22;
 
 pub const CacheKey = struct {
     len: u8,
+    // 0 = any (used for dedup keys), 1 = ipv4, 2 = ipv6
+    family: u8,
     prefix: [key_prefix_len]u8,
     hash: u64,
 
-    pub fn init(key: *CacheKey, name: []const u8, seed: u64) void {
+    pub fn init(key: *CacheKey, name: []const u8, seed: u64, family: ?net.IpAddress.Family) void {
         std.debug.assert(name.len <= std.math.maxInt(u8));
         const plen = @min(name.len, key_prefix_len);
         key.len = @intCast(name.len);
+        key.family = if (family) |f| @as(u8, @intFromEnum(f)) + 1 else 0;
         key.hash = std.hash.Wyhash.hash(seed, name);
         @memset(&key.prefix, 0);
         @memcpy(key.prefix[0..plen], name[0..plen]);
     }
 
     pub fn eql(a: *const CacheKey, b: *const CacheKey) bool {
-        if (a.len != b.len or a.hash != b.hash) return false;
+        if (a.len != b.len or a.family != b.family or a.hash != b.hash) return false;
         const plen = @min(a.len, key_prefix_len);
         return std.mem.eql(u8, a.prefix[0..plen], b.prefix[0..plen]);
     }
@@ -106,7 +109,7 @@ pub const Cache = struct {
 test "Cache: put and get" {
     var cache: Cache = std.mem.zeroes(Cache);
     var key: CacheKey = undefined;
-    CacheKey.init(&key, "example.com", 0);
+    CacheKey.init(&key, "example.com", 0, .ipv4);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -121,7 +124,7 @@ test "Cache: put and get" {
 test "Cache: expired entry not returned" {
     var cache: Cache = std.mem.zeroes(Cache);
     var key: CacheKey = undefined;
-    CacheKey.init(&key, "example.com", 0);
+    CacheKey.init(&key, "example.com", 0, .ipv4);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = 0 };
@@ -134,7 +137,7 @@ test "Cache: expired entry not returned" {
 test "Cache: expire invalidates entry" {
     var cache: Cache = std.mem.zeroes(Cache);
     var key: CacheKey = undefined;
-    CacheKey.init(&key, "example.com", 0);
+    CacheKey.init(&key, "example.com", 0, .ipv4);
     var entry: CacheEntry = std.mem.zeroes(CacheEntry);
     entry.count = 1;
     entry.expiry = .{ .value = std.math.maxInt(u64) };
@@ -149,7 +152,7 @@ test "Cache: expire invalidates entry" {
 test "Cache: update existing entry" {
     var cache: Cache = std.mem.zeroes(Cache);
     var key: CacheKey = undefined;
-    CacheKey.init(&key, "example.com", 0);
+    CacheKey.init(&key, "example.com", 0, .ipv4);
 
     const now: Timestamp = .{ .value = 1 };
 
@@ -176,7 +179,7 @@ test "Cache: multiple independent entries" {
 
     for (names, 0..) |name, i| {
         var k: CacheKey = undefined;
-        CacheKey.init(&k, name, 0);
+        CacheKey.init(&k, name, 0, .ipv4);
         var e: CacheEntry = std.mem.zeroes(CacheEntry);
         e.count = @intCast(i + 1);
         e.expiry = .{ .value = std.math.maxInt(u64) };
@@ -185,7 +188,7 @@ test "Cache: multiple independent entries" {
 
     for (names, 0..) |name, i| {
         var k: CacheKey = undefined;
-        CacheKey.init(&k, name, 0);
+        CacheKey.init(&k, name, 0, .ipv4);
         const result = cache.get(&k, now);
         try std.testing.expect(result != null);
         try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);
@@ -201,14 +204,14 @@ test "Cache: long names with shared prefix stay distinct" {
     const now: Timestamp = .{ .value = 1 };
 
     var k1: CacheKey = undefined;
-    CacheKey.init(&k1, name1, 0);
+    CacheKey.init(&k1, name1, 0, .ipv4);
     var e1: CacheEntry = std.mem.zeroes(CacheEntry);
     e1.count = 1;
     e1.expiry = .{ .value = std.math.maxInt(u64) };
     cache.put(&k1, e1, now);
 
     var k2: CacheKey = undefined;
-    CacheKey.init(&k2, name2, 0);
+    CacheKey.init(&k2, name2, 0, .ipv4);
     var e2: CacheEntry = std.mem.zeroes(CacheEntry);
     e2.count = 2;
     e2.expiry = .{ .value = std.math.maxInt(u64) };

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -349,7 +349,9 @@ pub const Resolver = struct {
         const r: QueryResult = blk: {
             // Rooted name: only try exactly as given.
             if (rooted) {
-                break :blk try queryOneType(self, storage, options, name, qtype, srvs, attempts, deadline);
+                const r = try queryOneType(self, storage, options, name, qtype, srvs, attempts, deadline);
+                if (r.count == 0) return error.UnknownHostName;
+                break :blk r;
             }
 
             var dot_count: usize = 0;

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -40,7 +40,6 @@ const WaiterNode = struct {
     prev: ?*WaiterNode = null,
     in_list: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_safety) false else {},
     key: CacheKey,
-    family: ?net.IpAddress.Family,
     is_active: bool,
     storage: []dns.LookupResult,
     count: usize = 0,
@@ -126,10 +125,7 @@ pub const Resolver = struct {
         self.maybeReloadHosts(now);
         self.maybeReloadResolvConf(now);
 
-        var key: CacheKey = undefined;
-        CacheKey.init(&key, options.name, self.hash_seed);
-
-        // 1. Check /etc/hosts and DNS cache
+        // 1. Check /etc/hosts
         {
             try self.lock.lockShared();
             defer self.lock.unlockShared();
@@ -148,23 +144,61 @@ pub const Resolver = struct {
                 }
                 if (i > 0) return i;
             }
+        }
 
-            var i: usize = 0;
-            const families: []const net.IpAddress.Family = if (options.family) |f| &.{f} else &.{ .ipv4, .ipv6 };
-            for (families) |fam| {
-                var fkey: CacheKey = undefined;
-                CacheKey.init(&fkey, options.name, familySeed(self.hash_seed, fam));
-                if (self.cache.get(&fkey, now)) |entry| {
-                    for (entry.addrs[0..entry.count]) |addr_in| {
-                        if (i >= storage.len) break;
-                        var addr = addr_in;
-                        addr.setPort(options.port);
-                        storage[i] = .{ .address = addr };
-                        i += 1;
-                    }
+        // 2. Query each requested family through its own cache/dedup/DNS path.
+        if (options.family) |fam| {
+            return self.lookupOneFamily(storage, options, fam);
+        }
+
+        var total: usize = 0;
+        var last_err: dns.LookupError = error.UnknownHostName;
+
+        if (self.lookupOneFamily(storage, options, .ipv4)) |n| {
+            total += n;
+        } else |err| switch (err) {
+            error.Canceled, error.RuntimeShutdown => return err,
+            else => last_err = err,
+        }
+
+        if (self.lookupOneFamily(storage[total..], options, .ipv6)) |n| {
+            total += n;
+        } else |err| switch (err) {
+            error.Canceled, error.RuntimeShutdown => return err,
+            else => {},
+        }
+
+        if (total == 0) return last_err;
+        return total;
+    }
+
+    fn lookupOneFamily(
+        self: *Resolver,
+        storage: []dns.LookupResult,
+        options: dns.LookupOptions,
+        family: net.IpAddress.Family,
+    ) dns.LookupError!usize {
+        var opts = options;
+        opts.family = family;
+
+        var key: CacheKey = undefined;
+        CacheKey.init(&key, options.name, self.hash_seed, family);
+
+        // 1. Check DNS cache.
+        {
+            try self.lock.lockShared();
+            defer self.lock.unlockShared();
+            if (self.cache.get(&key, Timestamp.now(.monotonic))) |entry| {
+                var i: usize = 0;
+                for (entry.addrs[0..entry.count]) |addr_in| {
+                    if (i >= storage.len) break;
+                    var addr = addr_in;
+                    addr.setPort(options.port);
+                    storage[i] = .{ .address = addr };
+                    i += 1;
                 }
+                if (i > 0) return i;
             }
-            if (i > 0) return i;
         }
 
         // 2. Deduplicate concurrent identical DNS queries.
@@ -174,11 +208,10 @@ pub const Resolver = struct {
 
         var it = bucket.waiters.head;
         while (it) |n| : (it = n.next) {
-            if (n.is_active and n.family == options.family and n.key.eql(&key)) {
+            if (n.is_active and n.key.eql(&key)) {
                 // An identical query is already in flight — join it.
                 var node: WaiterNode = .{
                     .key = key,
-                    .family = options.family,
                     .is_active = false,
                     .storage = storage,
                 };
@@ -206,7 +239,6 @@ pub const Resolver = struct {
         // No in-flight request for this name+family — become the active requester.
         var active_node: WaiterNode = .{
             .key = key,
-            .family = options.family,
             .is_active = true,
             .storage = storage,
         };
@@ -215,15 +247,20 @@ pub const Resolver = struct {
 
         var tmp: [16]dns.LookupResult = undefined;
         const buf: []dns.LookupResult = if (storage.len >= tmp.len) storage else tmp[0..];
-        const result = self.lookupDns(buf, options);
+        const result = self.lookupDns(buf, opts);
+
+        if (result) |r| {
+            const now = Timestamp.now(.monotonic);
+            self.cacheInsert(options.name, family, buf[0..r.count], r.ttl, now);
+        } else |_| {}
 
         // Notify all joiners, then remove the active node.
         bucket.mutex.lockUncancelable();
         var wit = bucket.waiters.head;
         while (wit) |n| : (wit = n.next) {
-            if (!n.is_active and !n.done and n.family == options.family and n.key.eql(&key)) {
-                if (result) |count| {
-                    const jcount = @min(n.storage.len, count);
+            if (!n.is_active and !n.done and n.key.eql(&key)) {
+                if (result) |r| {
+                    const jcount = @min(n.storage.len, r.count);
                     @memcpy(n.storage[0..jcount], buf[0..jcount]);
                     n.count = jcount;
                     n.err = null;
@@ -238,20 +275,20 @@ pub const Resolver = struct {
         _ = bucket.waiters.remove(&active_node);
         bucket.mutex.unlock();
 
-        const count = result catch return result;
+        const r = result catch |err| return err;
         if (buf.ptr != storage.ptr) {
-            const acount = @min(storage.len, count);
+            const acount = @min(storage.len, r.count);
             @memcpy(storage[0..acount], buf[0..acount]);
             return acount;
         }
-        return count;
+        return r.count;
     }
 
     fn lookupDns(
         self: *Resolver,
         storage: []dns.LookupResult,
         options: dns.LookupOptions,
-    ) dns.LookupError!usize {
+    ) dns.LookupError!QueryResult {
         // Snapshot conf fields while holding the shared lock so we don't hold
         // it across I/O operations.
         var servers: [max_nameservers]net.IpAddress = undefined;
@@ -300,14 +337,19 @@ pub const Resolver = struct {
         const srvs = servers[0..server_count];
         const name = options.name;
         const rooted = name.len > 0 and name[name.len - 1] == '.';
+        const qtype: message.QType = switch (options.family.?) {
+            .ipv4 => .a,
+            .ipv6 => .aaaa,
+        };
+        const deadline = (Timeout{ .duration = timeout }).toDeadline();
 
         var fqdn_buf: [256]u8 = undefined;
         var last_err: dns.LookupError = error.UnknownHostName;
 
-        const count: usize = blk: {
+        const r: QueryResult = blk: {
             // Rooted name: only try exactly as given.
             if (rooted) {
-                break :blk try queryOneName(self, storage, options, name, srvs, attempts, timeout);
+                break :blk try queryOneType(self, storage, options, name, qtype, srvs, attempts, deadline);
             }
 
             var dot_count: usize = 0;
@@ -319,8 +361,8 @@ pub const Resolver = struct {
             // Enough dots: try unsuffixed first (Go's nameList logic).
             if (has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
-                        if (n > 0) break :blk n;
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                        if (r.count > 0) break :blk r;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
                     }
@@ -331,8 +373,8 @@ pub const Resolver = struct {
             for (0..search_count) |i| {
                 const suffix = search_store[i][0..search_lens[i]];
                 if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
-                        if (n > 0) break :blk n;
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                        if (r.count > 0) break :blk r;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
                     }
@@ -342,8 +384,8 @@ pub const Resolver = struct {
             // Not enough dots: try unsuffixed last.
             if (!has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
-                        if (n > 0) break :blk n;
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                        if (r.count > 0) break :blk r;
                     } else |err| {
                         last_err = err;
                     }
@@ -353,12 +395,12 @@ pub const Resolver = struct {
             return last_err;
         };
 
-        return count;
+        return r;
     }
 
     fn cacheInsert(self: *Resolver, name: []const u8, family: net.IpAddress.Family, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
         var key: CacheKey = undefined;
-        CacheKey.init(&key, name, familySeed(self.hash_seed, family));
+        CacheKey.init(&key, name, self.hash_seed, family);
 
         if (results.len == 0 or results.len > max_cached_addrs) {
             self.lock.lockUncancelable();
@@ -456,58 +498,6 @@ fn makeFqdn(buf: *[256]u8, name: []const u8, suffix: ?[]const u8) ?[]u8 {
 }
 
 const QueryResult = struct { count: usize, ttl: u32 };
-
-fn familySeed(seed: u64, family: net.IpAddress.Family) u64 {
-    return seed ^ switch (family) {
-        .ipv4 => @as(u64, 1),
-        .ipv6 => @as(u64, 2),
-    };
-}
-
-/// Try a single FQDN against all servers, querying A and/or AAAA based on
-/// options.family. Fills storage and returns the total address count.
-/// Each RRset is cached immediately after its query returns, using its own timestamp.
-fn queryOneName(
-    resolver: *Resolver,
-    storage: []dns.LookupResult,
-    options: dns.LookupOptions,
-    fqdn: []const u8,
-    servers: []const net.IpAddress,
-    attempts: u8,
-    timeout: Duration,
-) dns.LookupError!usize {
-    const sock_timeout: Timeout = .{ .duration = timeout };
-    var filled: usize = 0;
-    var last_err: dns.LookupError = error.UnknownHostName;
-
-    const do_a = options.family == null or options.family == .ipv4;
-    const do_aaaa = options.family == null or options.family == .ipv6;
-
-    if (do_a and filled < storage.len) {
-        if (queryOneType(resolver, storage[filled..], options, fqdn, .a, servers, attempts, sock_timeout)) |r| {
-            const now = Timestamp.now(.monotonic);
-            resolver.cacheInsert(options.name, .ipv4, storage[filled..][0..r.count], r.ttl, now);
-            filled += r.count;
-        } else |err| switch (err) {
-            error.Canceled, error.RuntimeShutdown, error.NoThreadPool => return err,
-            else => last_err = err,
-        }
-    }
-
-    if (do_aaaa and filled < storage.len) {
-        if (queryOneType(resolver, storage[filled..], options, fqdn, .aaaa, servers, attempts, sock_timeout)) |r| {
-            const now = Timestamp.now(.monotonic);
-            resolver.cacheInsert(options.name, .ipv6, storage[filled..][0..r.count], r.ttl, now);
-            filled += r.count;
-        } else |err| switch (err) {
-            error.Canceled, error.RuntimeShutdown, error.NoThreadPool => return err,
-            else => last_err = err,
-        }
-    }
-
-    if (filled == 0) return last_err;
-    return filled;
-}
 
 /// Query all servers for one record type (A or AAAA), retrying up to `attempts`
 /// times. Returns count + TTL from the successful response, or an error if all

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -165,7 +165,7 @@ pub const Resolver = struct {
             total += n;
         } else |err| switch (err) {
             error.Canceled, error.RuntimeShutdown => return err,
-            else => {},
+            else => last_err = err,
         }
 
         if (total == 0) return last_err;
@@ -178,6 +178,7 @@ pub const Resolver = struct {
         options: dns.LookupOptions,
         family: net.IpAddress.Family,
     ) dns.LookupError!usize {
+        if (storage.len == 0) return 0;
         var opts = options;
         opts.family = family;
 
@@ -341,15 +342,13 @@ pub const Resolver = struct {
             .ipv4 => .a,
             .ipv6 => .aaaa,
         };
-        const deadline = (Timeout{ .duration = timeout }).toDeadline();
-
         var fqdn_buf: [256]u8 = undefined;
         var last_err: dns.LookupError = error.UnknownHostName;
 
         const r: QueryResult = blk: {
             // Rooted name: only try exactly as given.
             if (rooted) {
-                const r = try queryOneType(self, storage, options, name, qtype, srvs, attempts, deadline);
+                const r = try queryOneType(self, storage, options, name, qtype, srvs, attempts, .{ .duration = timeout });
                 if (r.count == 0) return error.UnknownHostName;
                 break :blk r;
             }
@@ -363,7 +362,7 @@ pub const Resolver = struct {
             // Enough dots: try unsuffixed first (Go's nameList logic).
             if (has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, .{ .duration = timeout })) |r| {
                         if (r.count > 0) break :blk r;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
@@ -375,7 +374,7 @@ pub const Resolver = struct {
             for (0..search_count) |i| {
                 const suffix = search_store[i][0..search_lens[i]];
                 if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
-                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, .{ .duration = timeout })) |r| {
                         if (r.count > 0) break :blk r;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
@@ -386,7 +385,7 @@ pub const Resolver = struct {
             // Not enough dots: try unsuffixed last.
             if (!has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, deadline)) |r| {
+                    if (queryOneType(self, storage, options, fqdn, qtype, srvs, attempts, .{ .duration = timeout })) |r| {
                         if (r.count > 0) break :blk r;
                     } else |err| {
                         last_err = err;

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -149,20 +149,22 @@ pub const Resolver = struct {
                 if (i > 0) return i;
             }
 
-            if (self.cache.get(&key, now)) |entry| {
-                var i: usize = 0;
-                for (entry.addrs[0..entry.count]) |addr_in| {
-                    if (i >= storage.len) break;
-                    if (options.family) |f| {
-                        if (addr_in.getFamily() != f) continue;
+            var i: usize = 0;
+            const families: []const net.IpAddress.Family = if (options.family) |f| &.{f} else &.{ .ipv4, .ipv6 };
+            for (families) |fam| {
+                var fkey: CacheKey = undefined;
+                CacheKey.init(&fkey, options.name, familySeed(self.hash_seed, fam));
+                if (self.cache.get(&fkey, now)) |entry| {
+                    for (entry.addrs[0..entry.count]) |addr_in| {
+                        if (i >= storage.len) break;
+                        var addr = addr_in;
+                        addr.setPort(options.port);
+                        storage[i] = .{ .address = addr };
+                        i += 1;
                     }
-                    var addr = addr_in;
-                    addr.setPort(options.port);
-                    storage[i] = .{ .address = addr };
-                    i += 1;
                 }
-                if (i > 0) return i;
             }
+            if (i > 0) return i;
         }
 
         // 2. Deduplicate concurrent identical DNS queries.
@@ -302,7 +304,7 @@ pub const Resolver = struct {
         var fqdn_buf: [256]u8 = undefined;
         var last_err: dns.LookupError = error.UnknownHostName;
 
-        const r: QueryResult = blk: {
+        const count: usize = blk: {
             // Rooted name: only try exactly as given.
             if (rooted) {
                 break :blk try queryOneName(self, storage, options, name, srvs, attempts, timeout);
@@ -317,8 +319,8 @@ pub const Resolver = struct {
             // Enough dots: try unsuffixed first (Go's nameList logic).
             if (has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                        if (r.count > 0) break :blk r;
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
+                        if (n > 0) break :blk n;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
                     }
@@ -329,8 +331,8 @@ pub const Resolver = struct {
             for (0..search_count) |i| {
                 const suffix = search_store[i][0..search_lens[i]];
                 if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                        if (r.count > 0) break :blk r;
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
+                        if (n > 0) break :blk n;
                     } else |err| {
                         if (err != error.UnknownHostName) return err;
                     }
@@ -340,8 +342,8 @@ pub const Resolver = struct {
             // Not enough dots: try unsuffixed last.
             if (!has_enough_dots) {
                 if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |r| {
-                        if (r.count > 0) break :blk r;
+                    if (queryOneName(self, storage, options, fqdn, srvs, attempts, timeout)) |n| {
+                        if (n > 0) break :blk n;
                     } else |err| {
                         last_err = err;
                     }
@@ -351,15 +353,12 @@ pub const Resolver = struct {
             return last_err;
         };
 
-        const now = Timestamp.now(.monotonic);
-        self.cacheInsert(options, storage[0..r.count], r.ttl, now);
-        return r.count;
+        return count;
     }
 
-    fn cacheInsert(self: *Resolver, options: dns.LookupOptions, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
-        if (options.family != null) return;
+    fn cacheInsert(self: *Resolver, name: []const u8, family: net.IpAddress.Family, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
         var key: CacheKey = undefined;
-        CacheKey.init(&key, options.name, self.hash_seed);
+        CacheKey.init(&key, name, familySeed(self.hash_seed, family));
 
         if (results.len == 0 or results.len > max_cached_addrs) {
             self.lock.lockUncancelable();
@@ -458,8 +457,16 @@ fn makeFqdn(buf: *[256]u8, name: []const u8, suffix: ?[]const u8) ?[]u8 {
 
 const QueryResult = struct { count: usize, ttl: u32 };
 
+fn familySeed(seed: u64, family: net.IpAddress.Family) u64 {
+    return seed ^ switch (family) {
+        .ipv4 => @as(u64, 1),
+        .ipv6 => @as(u64, 2),
+    };
+}
+
 /// Try a single FQDN against all servers, querying A and/or AAAA based on
-/// options.family. Fills storage and returns count + minimum TTL.
+/// options.family. Fills storage and returns the total address count.
+/// Each RRset is cached immediately after its query returns, using its own timestamp.
 fn queryOneName(
     resolver: *Resolver,
     storage: []dns.LookupResult,
@@ -468,10 +475,9 @@ fn queryOneName(
     servers: []const net.IpAddress,
     attempts: u8,
     timeout: Duration,
-) dns.LookupError!QueryResult {
+) dns.LookupError!usize {
     const sock_timeout: Timeout = .{ .duration = timeout };
     var filled: usize = 0;
-    var min_ttl: u32 = std.math.maxInt(u32);
     var last_err: dns.LookupError = error.UnknownHostName;
 
     const do_a = options.family == null or options.family == .ipv4;
@@ -479,8 +485,9 @@ fn queryOneName(
 
     if (do_a and filled < storage.len) {
         if (queryOneType(resolver, storage[filled..], options, fqdn, .a, servers, attempts, sock_timeout)) |r| {
+            const now = Timestamp.now(.monotonic);
+            resolver.cacheInsert(options.name, .ipv4, storage[filled..][0..r.count], r.ttl, now);
             filled += r.count;
-            min_ttl = @min(min_ttl, r.ttl);
         } else |err| switch (err) {
             error.Canceled, error.RuntimeShutdown, error.NoThreadPool => return err,
             else => last_err = err,
@@ -489,8 +496,9 @@ fn queryOneName(
 
     if (do_aaaa and filled < storage.len) {
         if (queryOneType(resolver, storage[filled..], options, fqdn, .aaaa, servers, attempts, sock_timeout)) |r| {
+            const now = Timestamp.now(.monotonic);
+            resolver.cacheInsert(options.name, .ipv6, storage[filled..][0..r.count], r.ttl, now);
             filled += r.count;
-            min_ttl = @min(min_ttl, r.ttl);
         } else |err| switch (err) {
             error.Canceled, error.RuntimeShutdown, error.NoThreadPool => return err,
             else => last_err = err,
@@ -498,7 +506,7 @@ fn queryOneName(
     }
 
     if (filled == 0) return last_err;
-    return .{ .count = filled, .ttl = if (min_ttl == std.math.maxInt(u32)) 0 else min_ttl };
+    return filled;
 }
 
 /// Query all servers for one record type (A or AAAA), retrying up to `attempts`


### PR DESCRIPTION
## Summary

- Cache A and AAAA records under distinct slots (family-specific seed XOR in `familySeed`) so each RRset has its own expiry
- Capture `now` immediately after each `queryOneType` call, before the other family's query starts — a slow AAAA response no longer extends the A entry's lifetime past its actual TTL
- Remove the early-out that skipped caching for family-specific lookups — IPv4-only and IPv6-only queries are now cached too

Closes #418

## Test plan

- [ ] `./check.sh` passes (DNS tests all green)
- [ ] Manual: verify IPv4-only lookup (`family = .ipv4`) hits cache on second call
- [ ] Manual: verify A and AAAA entries expire independently