### PR TITLE
runtime: periodic stack pool cleanup and higher default max_unused_stacks

### DIFF
--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -170,6 +170,39 @@ pub const StackPool = struct {
         }
     }
 
+    /// Evicts up to `limit` expired stacks from the pool.
+    /// Intended to be called periodically from a timer to reclaim idle stacks.
+    pub fn cleanup(self: *StackPool, now: Timestamp, limit: usize) void {
+        if (self.config.max_age.value == 0) return;
+
+        var to_free_head: ?*FreeNode = null;
+        var to_free_count: usize = 0;
+
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            while (self.head) |node| {
+                if (to_free_count >= limit) break;
+                const age = node.timestamp.durationTo(now);
+                if (age.value > self.config.max_age.value) {
+                    self.removeNode(node);
+                    node.next = to_free_head;
+                    to_free_head = node;
+                    to_free_count += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        while (to_free_head) |free_node| {
+            const next = free_node.next;
+            stack.stackFree(free_node.stack_info);
+            to_free_head = next;
+        }
+    }
+
     /// Removes a node from the doubly linked list and updates pool_size.
     fn removeNode(self: *StackPool, node: *FreeNode) void {
         if (node.prev) |prev| {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -63,7 +63,7 @@ pub const RuntimeOptions = struct {
     stack_pool: StackPoolConfig = .{
         .maximum_size = 8 * 1024 * 1024,
         .committed_size = 256 * 1024,
-        .max_unused_stacks = 16,
+        .max_unused_stacks = 1000,
         .max_age = .fromSeconds(60),
     },
     /// Number of executor threads to run (including main).
@@ -269,6 +269,9 @@ pub const Executor = struct {
     // When notified, it calls loop.stop() to exit the event loop.
     shutdown: ev.Async = ev.Async.init(),
 
+    // Periodic timer for evicting idle stacks from the shared stack pool.
+    stack_pool_eviction_timer: ev.Timer = ev.Timer.init(.{ .duration = .fromSeconds(60) }),
+
     // The task currently executing on this executor.
     // Updated before every context switch into a task and after every switch back.
     // Used by getCurrentTaskOrNull() instead of the TLS current_context chain.
@@ -328,6 +331,10 @@ pub const Executor = struct {
         self.shutdown.c.callback = shutdownCallback;
         self.loop.add(&self.shutdown.c);
 
+        // Register periodic stack pool eviction timer
+        self.stack_pool_eviction_timer.c.callback = stackPoolEvictionCallback;
+        self.loop.add(&self.stack_pool_eviction_timer.c);
+
         self.main_task.coro.setCurrent();
         Executor.current = self;
         self.current_task = &self.main_task;
@@ -344,6 +351,13 @@ pub const Executor = struct {
 
     fn shutdownCallback(loop: *ev.Loop, _: *ev.Completion) void {
         loop.stop();
+    }
+
+    fn stackPoolEvictionCallback(loop: *ev.Loop, c: *ev.Completion) void {
+        const timer = c.cast(ev.Timer);
+        const self: *Executor = @alignCast(@fieldParentPtr("stack_pool_eviction_timer", timer));
+        self.runtime.stack_pool.cleanup(loop.now(), 16);
+        loop.add(c);
     }
 
     pub const YieldCancelMode = enum { allow_cancel, no_cancel };


### PR DESCRIPTION
## Summary

- Raises default `max_unused_stacks` from 16 to 1000, so stacks are reused across tasks at typical concurrency levels instead of being freed and reallocated each time
- Adds `StackPool.cleanup(now, limit)` — evicts up to `limit` expired entries from the head of the pool (oldest-first, stops early on the first non-expired entry, frees outside the lock)
- Adds a 60s `ev.Timer` per `Executor` that calls `cleanup(loop.now(), 16)` and rearms itself, ensuring idle stacks are reclaimed even when task activity is low

The existing release-time eviction (up to 4 per `release()` call) remains unchanged as a fast path during active periods.

See https://github.com/lalinsky/zio/issues/415

## Test plan

- [ ] `./check.sh` passes
- [ ] `./check.sh --backend epoll` passes