### PR TITLE
dns: enable custom resolver by default on io_uring

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -74,7 +74,7 @@ pub const RuntimeOptions = struct {
 
 pub const DnsOptions = struct {
     /// Use the built-in native DNS resolver instead of getaddrinfo.
-    custom_resolver: bool = false,
+    custom_resolver: bool = ev.backend == .io_uring,
 };
 
 const Awaitable = @import("awaitable.zig").Awaitable;


### PR DESCRIPTION
The built-in DNS resolver integrates better with io_uring's async I/O model. Default `custom_resolver` to `true` when the io_uring backend is selected, and `false` everywhere else.