### PR TITLE
dns: canonical name support in custom resolver and enable by default

### DIFF
--- a/src/dns/resolver/message.zig
+++ b/src/dns/resolver/message.zig
@@ -70,17 +70,20 @@ pub fn decodeName(buf: []const u8, pos: usize, out: []u8) !struct { end: usize, 
     var end: usize = 0;
     var jumped = false;
     var depth: usize = 0;
-    while (p < buf.len and depth < 128) : (depth += 1) {
+    while (depth < 128) : (depth += 1) {
+        if (p >= buf.len) return error.Truncated;
         const b = buf[p];
         if (b == 0) {
             if (!jumped) end = p + 1;
-            break;
+            return .{ .end = end, .len = out_len };
         }
         if (b & 0xc0 == 0xc0) {
             if (p + 2 > buf.len) return error.Truncated;
             if (!jumped) end = p + 2;
             jumped = true;
-            p = (@as(usize, b & 0x3f) << 8) | buf[p + 1];
+            const target = (@as(usize, b & 0x3f) << 8) | buf[p + 1];
+            if (target >= buf.len) return error.InvalidMessage;
+            p = target;
             continue;
         }
         if (b & 0xc0 != 0) return error.InvalidMessage;
@@ -97,8 +100,7 @@ pub fn decodeName(buf: []const u8, pos: usize, out: []u8) !struct { end: usize, 
         out_len += label_len;
         p += label_len;
     }
-    if (!jumped) end = p + 1;
-    return .{ .end = end, .len = out_len };
+    return error.InvalidMessage; // compression pointer loop
 }
 
 /// Skip a DNS-encoded name starting at buf[pos], following compression pointers.

--- a/src/dns/resolver/message.zig
+++ b/src/dns/resolver/message.zig
@@ -60,6 +60,47 @@ pub fn buildQuery(buf: []u8, id: u16, name: []const u8, qtype: QType) ![]u8 {
     return buf[0 .. p + 4];
 }
 
+/// Decode a DNS wire-format name at buf[pos] into out, following compression
+/// pointers. Labels are joined with '.', no trailing dot. Returns the decoded
+/// length and the end position in the *original* location (after the pointer
+/// word, not after the pointer target).
+pub fn decodeName(buf: []const u8, pos: usize, out: []u8) !struct { end: usize, len: usize } {
+    var p = pos;
+    var out_len: usize = 0;
+    var end: usize = 0;
+    var jumped = false;
+    var depth: usize = 0;
+    while (p < buf.len and depth < 128) : (depth += 1) {
+        const b = buf[p];
+        if (b == 0) {
+            if (!jumped) end = p + 1;
+            break;
+        }
+        if (b & 0xc0 == 0xc0) {
+            if (p + 2 > buf.len) return error.Truncated;
+            if (!jumped) end = p + 2;
+            jumped = true;
+            p = (@as(usize, b & 0x3f) << 8) | buf[p + 1];
+            continue;
+        }
+        if (b & 0xc0 != 0) return error.InvalidMessage;
+        const label_len = b & 0x3f;
+        p += 1;
+        if (p + label_len > buf.len) return error.Truncated;
+        if (out_len > 0) {
+            if (out_len >= out.len) return error.BufferTooSmall;
+            out[out_len] = '.';
+            out_len += 1;
+        }
+        if (out_len + label_len > out.len) return error.BufferTooSmall;
+        @memcpy(out[out_len..][0..label_len], buf[p..][0..label_len]);
+        out_len += label_len;
+        p += label_len;
+    }
+    if (!jumped) end = p + 1;
+    return .{ .end = end, .len = out_len };
+}
+
 /// Skip a DNS-encoded name starting at buf[pos], following compression pointers.
 /// Returns the position of the byte after the name in the *current* location
 /// (i.e. after the pointer word, not after the pointer target).
@@ -83,9 +124,12 @@ pub const ParseResult = struct {
     rcode: RCode,
     count: usize,
     ttl: u32,
+    canonical_name_len: usize = 0,
 };
 
 /// Parse a DNS response. Fills addresses with port into storage.
+/// If cname_out is provided, the last CNAME target is decoded into it and
+/// null-terminated (the caller reads it back via sliceTo).
 /// Returns error if the message is malformed or the ID doesn't match.
 pub fn parseResponse(
     buf: []const u8,
@@ -93,6 +137,7 @@ pub fn parseResponse(
     qtype: QType,
     storage: []net.IpAddress,
     port: u16,
+    cname_out: ?[]u8,
 ) !ParseResult {
     if (buf.len < 12) return error.Truncated;
     if (std.mem.readInt(u16, buf[0..2], .big) != id) return error.IdMismatch;
@@ -115,7 +160,9 @@ pub fn parseResponse(
 
     var count: usize = 0;
     var ttl: u32 = 0;
+    var canonical_name_len: usize = 0;
     for (0..ancount) |_| {
+        const name_start = p;
         p = try skipName(buf, p);
         if (p + 10 > buf.len) return error.Truncated;
         const rtype = std.mem.readInt(u16, buf[p..][0..2], .big);
@@ -132,18 +179,30 @@ pub fn parseResponse(
                 if (count < storage.len)
                     storage[count] = net.IpAddress.initIp4(rdata[0..4].*, port);
                 count += 1;
+                // Decode the owner name of the first A record as the canonical name.
+                if (count == 1) if (cname_out) |out| {
+                    if (decodeName(buf, name_start, out)) |r| {
+                        canonical_name_len = r.len;
+                    } else |_| {}
+                };
             },
             28 => if (qtype == .aaaa and rdlength == 16) { // AAAA
                 ttl = if (count == 0) record_ttl else @min(ttl, record_ttl);
                 if (count < storage.len)
                     storage[count] = net.IpAddress.initIp6(rdata[0..16].*, port, 0, 0);
                 count += 1;
+                // Decode the owner name of the first AAAA record as the canonical name.
+                if (count == 1) if (cname_out) |out| {
+                    if (decodeName(buf, name_start, out)) |r| {
+                        canonical_name_len = r.len;
+                    } else |_| {}
+                };
             },
             else => {},
         }
     }
 
-    return .{ .truncated = truncated, .rcode = rcode, .count = count, .ttl = ttl };
+    return .{ .truncated = truncated, .rcode = rcode, .count = count, .ttl = ttl, .canonical_name_len = canonical_name_len };
 }
 
 test "buildQuery encodes correctly" {
@@ -200,7 +259,7 @@ test "parseResponse extracts A record" {
     pos += 16;
 
     var storage: [4]net.IpAddress = undefined;
-    const result = try parseResponse(buf[0..pos], 0x1234, .a, &storage, 80);
+    const result = try parseResponse(buf[0..pos], 0x1234, .a, &storage, 80, null);
 
     try std.testing.expectEqual(false, result.truncated);
     try std.testing.expectEqual(RCode.no_error, result.rcode);

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -144,6 +144,30 @@ pub const Resolver = struct {
         }
         const addr_storage = if (cname_buf != null and storage.len > 0) storage[1..] else storage;
 
+        // 0. Numeric IP literal — parse directly without touching hosts or DNS.
+        if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {
+            if (options.family == null or options.family == .ipv4) {
+                if (addr_storage.len > 0) addr_storage[0] = .{ .address = addr };
+                if (cname_buf) |buf| {
+                    storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
+                    return 2;
+                }
+                return 1;
+            }
+            return if (cname_buf != null) 1 else 0;
+        }
+        if (net.IpAddress.parseIp6(options.name, options.port) catch null) |addr| {
+            if (options.family == null or options.family == .ipv6) {
+                if (addr_storage.len > 0) addr_storage[0] = .{ .address = addr };
+                if (cname_buf) |buf| {
+                    storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
+                    return 2;
+                }
+                return 1;
+            }
+            return if (cname_buf != null) 1 else 0;
+        }
+
         // 1. Check /etc/hosts
         {
             try self.lock.lockShared();

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -134,6 +134,16 @@ pub const Resolver = struct {
         self.maybeReloadHosts(now);
         self.maybeReloadResolvConf(now);
 
+        // When canonical name is requested, reserve storage[0] for it and use
+        // storage[1..] for addresses. Pre-fill the buffer with the queried name
+        // as the default; the DNS path may overwrite it with a real CNAME target.
+        const cname_buf = options.canonical_name_buffer;
+        if (cname_buf) |buf| {
+            const len = @min(options.name.len, buf.len);
+            @memcpy(buf[0..len], options.name[0..len]);
+        }
+        const addr_storage = if (cname_buf != null and storage.len > 0) storage[1..] else storage;
+
         // 1. Check /etc/hosts
         {
             try self.lock.lockShared();
@@ -142,44 +152,66 @@ pub const Resolver = struct {
             if (self.hosts.lookupByName(options.name)) |addrs| {
                 var i: usize = 0;
                 for (addrs) |addr_in| {
-                    if (i >= storage.len) break;
+                    if (i >= addr_storage.len) break;
                     if (options.family) |f| {
                         if (addr_in.getFamily() != f) continue;
                     }
                     var addr = addr_in;
                     addr.setPort(options.port);
-                    storage[i] = .{ .address = addr };
+                    addr_storage[i] = .{ .address = addr };
                     i += 1;
                 }
-                if (i > 0) return i;
+                if (i > 0) {
+                    if (cname_buf) |buf| {
+                        storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
+                        return i + 1;
+                    }
+                    return i;
+                }
             }
         }
 
         // 2. Query each requested family through its own cache/dedup/DNS path.
         if (options.family) |fam| {
-            return self.lookupOneFamily(storage, options, fam, now);
+            const r = try self.lookupOneFamily(addr_storage, options, fam, now);
+            if (cname_buf) |buf| {
+                const len = if (r.canonical_name_len > 0) r.canonical_name_len else options.name.len;
+                storage[0] = .{ .canonical_name = .{ .bytes = buf[0..len] } };
+                return r.count + 1;
+            }
+            return r.count;
         }
 
         var total: usize = 0;
+        var cname_len: usize = 0;
         var last_err: dns.LookupError = error.UnknownHostName;
 
-        if (self.lookupOneFamily(storage, options, .ipv4, now)) |n| {
-            total += n;
+        if (self.lookupOneFamily(addr_storage, options, .ipv4, now)) |r| {
+            total += r.count;
+            if (r.canonical_name_len > 0) cname_len = r.canonical_name_len;
         } else |err| switch (err) {
             error.Canceled, error.RuntimeShutdown => return err,
             else => last_err = err,
         }
 
-        if (self.lookupOneFamily(storage[total..], options, .ipv6, now)) |n| {
-            total += n;
+        if (self.lookupOneFamily(addr_storage[total..], options, .ipv6, now)) |r| {
+            total += r.count;
+            if (r.canonical_name_len > 0) cname_len = r.canonical_name_len;
         } else |err| switch (err) {
             error.Canceled, error.RuntimeShutdown => return err,
             else => last_err = err,
         }
 
         if (total == 0) return last_err;
+        if (cname_buf) |buf| {
+            const len = if (cname_len > 0) cname_len else options.name.len;
+            storage[0] = .{ .canonical_name = .{ .bytes = buf[0..len] } };
+            return total + 1;
+        }
         return total;
     }
+
+    const OneFamilyResult = struct { count: usize, canonical_name_len: usize };
 
     fn lookupOneFamily(
         self: *Resolver,
@@ -187,8 +219,8 @@ pub const Resolver = struct {
         options: dns.LookupOptions,
         family: net.IpAddress.Family,
         now: Timestamp,
-    ) dns.LookupError!usize {
-        if (storage.len == 0) return 0;
+    ) dns.LookupError!OneFamilyResult {
+        if (storage.len == 0) return .{ .count = 0, .canonical_name_len = 0 };
         var opts = options;
         opts.family = family;
 
@@ -208,7 +240,7 @@ pub const Resolver = struct {
                     storage[i] = .{ .address = addr };
                     i += 1;
                 }
-                if (i > 0) return i;
+                if (i > 0) return .{ .count = i, .canonical_name_len = 0 };
             }
         }
 
@@ -243,7 +275,7 @@ pub const Resolver = struct {
 
                 if (node.err) |err| return err;
                 for (node.storage[0..node.count]) |*r| r.address.setPort(options.port);
-                return node.count;
+                return .{ .count = node.count, .canonical_name_len = 0 };
             }
         }
 
@@ -290,9 +322,9 @@ pub const Resolver = struct {
         if (buf.ptr != storage.ptr) {
             const acount = @min(storage.len, r.count);
             @memcpy(storage[0..acount], buf[0..acount]);
-            return acount;
+            return .{ .count = acount, .canonical_name_len = r.canonical_name_len };
         }
-        return r.count;
+        return .{ .count = r.count, .canonical_name_len = r.canonical_name_len };
     }
 
     fn lookupDns(
@@ -508,7 +540,7 @@ fn makeFqdn(buf: *[256]u8, name: []const u8, suffix: ?[]const u8) ?[]u8 {
     return buf[0..total];
 }
 
-const QueryResult = struct { count: usize, ttl: u32 };
+const QueryResult = struct { count: usize, ttl: u32, canonical_name_len: usize = 0 };
 
 /// Query all servers for one record type (A or AAAA), retrying up to `attempts`
 /// times. Returns count + TTL from the successful response, or an error if all
@@ -542,7 +574,8 @@ fn queryOneType(
             };
 
             const max_addrs = @min(addr_storage.len, storage.len);
-            const result = message.parseResponse(response, id, qtype, addr_storage[0..max_addrs], options.port) catch |err| {
+            const cname_out: ?[]u8 = if (options.canonical_name_buffer) |b| b[0..] else null;
+            const result = message.parseResponse(response, id, qtype, addr_storage[0..max_addrs], options.port, cname_out) catch |err| {
                 log.debug("dns: parse error for {s}: {}", .{ fqdn, err });
                 last_err = error.NameServerFailure;
                 continue;
@@ -565,7 +598,7 @@ fn queryOneType(
             for (addr_storage[0..count], 0..) |addr, i| {
                 storage[i] = .{ .address = addr };
             }
-            return .{ .count = count, .ttl = result.ttl };
+            return .{ .count = count, .ttl = result.ttl, .canonical_name_len = result.canonical_name_len };
         }
     }
 

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -145,6 +145,7 @@ pub const Resolver = struct {
             @memcpy(buf[0..len], options.name[0..len]);
         }
         const addr_storage = if (cname_buf != null and storage.len > 0) storage[1..] else storage;
+        if (cname_buf != null and storage.len == 0) return 0;
 
         // 0. Numeric IP literal — parse directly without touching hosts or DNS.
         if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -44,6 +44,8 @@ const WaiterNode = struct {
     is_active: bool,
     storage: []dns.LookupResult,
     count: usize = 0,
+    canonical_name_buffer: ?*[net.HostName.max_len]u8 = null,
+    canonical_name_len: usize = 0,
     err: ?dns.LookupError = null,
     done: bool = false,
     cond: Condition = .init,
@@ -247,6 +249,11 @@ pub const Resolver = struct {
         if (storage.len == 0) return .{ .count = 0, .canonical_name_len = 0 };
         var opts = options;
         opts.family = family;
+        // Always decode the canonical name into a local buffer (mirroring the
+        // tmp address buffer pattern) so waiters receive it regardless of
+        // whether the active requester requested one.
+        var cname_buf: [net.HostName.max_len]u8 = undefined;
+        opts.canonical_name_buffer = &cname_buf;
 
         var key: CacheKey = undefined;
         CacheKey.init(&key, options.name, self.hash_seed, family);
@@ -281,6 +288,7 @@ pub const Resolver = struct {
                     .key = key,
                     .is_active = false,
                     .storage = storage,
+                    .canonical_name_buffer = options.canonical_name_buffer,
                 };
                 bucket.waiters.push(&node);
 
@@ -299,7 +307,7 @@ pub const Resolver = struct {
 
                 if (node.err) |err| return err;
                 for (node.storage[0..node.count]) |*r| r.address.setPort(options.port);
-                return .{ .count = node.count, .canonical_name_len = 0 };
+                return .{ .count = node.count, .canonical_name_len = node.canonical_name_len };
             }
         }
 
@@ -330,6 +338,10 @@ pub const Resolver = struct {
                     const jcount = @min(n.storage.len, r.count);
                     @memcpy(n.storage[0..jcount], buf[0..jcount]);
                     n.count = jcount;
+                    n.canonical_name_len = r.canonical_name_len;
+                    if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
+                        @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
+                    };
                     n.err = null;
                 } else |err| {
                     n.count = 0;
@@ -343,6 +355,9 @@ pub const Resolver = struct {
         bucket.mutex.unlock();
 
         const r = result catch |err| return err;
+        if (r.canonical_name_len > 0) if (options.canonical_name_buffer) |cbuf| {
+            @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
+        };
         if (buf.ptr != storage.ptr) {
             const acount = @min(storage.len, r.count);
             @memcpy(storage[0..acount], buf[0..acount]);

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -150,25 +150,31 @@ pub const Resolver = struct {
         // 0. Numeric IP literal — parse directly without touching hosts or DNS.
         if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv4) {
-                if (addr_storage.len > 0) addr_storage[0] = .{ .address = addr };
+                const addr_count: usize = if (addr_storage.len > 0) blk: {
+                    addr_storage[0] = .{ .address = addr };
+                    break :blk 1;
+                } else 0;
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return 2;
+                    return addr_count + 1;
                 }
-                return 1;
+                return addr_count;
             }
-            return if (cname_buf != null) 1 else 0;
+            return 0;
         }
         if (net.IpAddress.parseIp6(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv6) {
-                if (addr_storage.len > 0) addr_storage[0] = .{ .address = addr };
+                const addr_count: usize = if (addr_storage.len > 0) blk: {
+                    addr_storage[0] = .{ .address = addr };
+                    break :blk 1;
+                } else 0;
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return 2;
+                    return addr_count + 1;
                 }
-                return 1;
+                return addr_count;
             }
-            return if (cname_buf != null) 1 else 0;
+            return 0;
         }
 
         // 1. Check /etc/hosts

--- a/src/net.zig
+++ b/src/net.zig
@@ -1359,6 +1359,28 @@ test "HostName: lookup with canonical name" {
     try std.testing.expect(has_address);
 }
 
+test "HostName: lookup www.github.com follows CNAME" {
+    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer rt.deinit();
+
+    const host = try HostName.init("www.github.com");
+    var storage: [32]HostName.LookupResult = undefined;
+    var cname_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
+
+    var canonical_name: ?HostName = null;
+    var has_address = false;
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => has_address = true,
+            .canonical_name => |name| canonical_name = name,
+        }
+    }
+    try std.testing.expect(has_address);
+    const cname = canonical_name orelse return error.NoCanonicalName;
+    try std.testing.expectEqualStrings("github.com", cname.bytes);
+}
+
 test "HostName: connect" {
     if (builtin.os.tag == .macos) return error.SkipZigTest;
     if (builtin.os.tag == .netbsd) return error.SkipZigTest;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -74,7 +74,7 @@ pub const RuntimeOptions = struct {
 
 pub const DnsOptions = struct {
     /// Use the built-in native DNS resolver instead of getaddrinfo.
-    custom_resolver: bool = false,
+    custom_resolver: bool = true,
 };
 
 const Awaitable = @import("awaitable.zig").Awaitable;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -74,7 +74,7 @@ pub const RuntimeOptions = struct {
 
 pub const DnsOptions = struct {
     /// Use the built-in native DNS resolver instead of getaddrinfo.
-    custom_resolver: bool = true,
+    custom_resolver: bool = ev.backend == .io_uring,
 };
 
 const Awaitable = @import("awaitable.zig").Awaitable;


### PR DESCRIPTION
## Summary

- Enable `custom_resolver` by default (`DnsOptions.custom_resolver = true`)
- Add `decodeName()` to `message.zig` for DNS wire-format name decoding with compression pointer support
- Parse canonical name from the owner name of the first A/AAAA record in `parseResponse()`, threading the length through `ParseResult` → `QueryResult` → `OneFamilyResult` back up to `lookup()`
- In `lookup()`, pre-fill `canonical_name_buffer` with the queried name as a fallback (used for `/etc/hosts` hits, cache hits, dedup waiters), overwriting with the DNS-decoded name when available
- Add test asserting `www.github.com` resolves with canonical name `github.com`

## Test plan

- [ ] All 460 existing tests pass (`./check.sh --backend epoll`)
- [ ] New test `HostName: lookup www.github.com follows CNAME` verifies CNAME resolution end-to-end