### PR TITLE
dns: add resolver tests and fix TooManyAddresses consistency

### DIFF
--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -150,29 +150,25 @@ pub const Resolver = struct {
         // 0. Numeric IP literal — parse directly without touching hosts or DNS.
         if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv4) {
-                const addr_count: usize = if (addr_storage.len > 0) blk: {
-                    addr_storage[0] = .{ .address = addr };
-                    break :blk 1;
-                } else 0;
+                if (addr_storage.len == 0) return error.TooManyAddresses;
+                addr_storage[0] = .{ .address = addr };
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return addr_count + 1;
+                    return 2;
                 }
-                return addr_count;
+                return 1;
             }
             return 0;
         }
         if (net.IpAddress.parseIp6(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv6) {
-                const addr_count: usize = if (addr_storage.len > 0) blk: {
-                    addr_storage[0] = .{ .address = addr };
-                    break :blk 1;
-                } else 0;
+                if (addr_storage.len == 0) return error.TooManyAddresses;
+                addr_storage[0] = .{ .address = addr };
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return addr_count + 1;
+                    return 2;
                 }
-                return addr_count;
+                return 1;
             }
             return 0;
         }
@@ -185,10 +181,10 @@ pub const Resolver = struct {
             if (self.hosts.lookupByName(options.name)) |addrs| {
                 var i: usize = 0;
                 for (addrs) |addr_in| {
-                    if (i >= addr_storage.len) break;
                     if (options.family) |f| {
                         if (addr_in.getFamily() != f) continue;
                     }
+                    if (i >= addr_storage.len) return error.TooManyAddresses;
                     var addr = addr_in;
                     addr.setPort(options.port);
                     addr_storage[i] = .{ .address = addr };

--- a/src/dns/test.zig
+++ b/src/dns/test.zig
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const Runtime = @import("../runtime.zig").Runtime;
+const net = @import("../net.zig");
+const dns = @import("root.zig");
+const HostName = net.HostName;
+
+fn expectTag(comptime tag: std.meta.Tag(HostName.LookupResult), entry: HostName.LookupResult) !void {
+    try std.testing.expectEqual(tag, std.meta.activeTag(entry));
+}
+
+test "dns: IPv4 literal" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("127.0.0.1");
+    var storage: [8]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
+
+    try std.testing.expectEqual(1, count);
+    try expectTag(.address, storage[0]);
+    try std.testing.expectEqual(net.IpAddress.Family.ipv4, storage[0].address.getFamily());
+    try std.testing.expectEqual(@as(u16, 80), storage[0].address.getPort());
+}
+
+test "dns: IPv4 literal with canonical name" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("127.0.0.1");
+    var storage: [8]HostName.LookupResult = undefined;
+    var canon_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &canon_buf });
+
+    try std.testing.expectEqual(2, count);
+    try expectTag(.canonical_name, storage[0]);
+    try std.testing.expectEqualStrings("127.0.0.1", storage[0].canonical_name.bytes);
+    try expectTag(.address, storage[1]);
+    try std.testing.expectEqual(net.IpAddress.Family.ipv4, storage[1].address.getFamily());
+}
+
+test "dns: IPv6 literal" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var storage: [8]dns.LookupResult = undefined;
+    const count = try dns.lookup(&storage, .{ .name = "::1", .port = 80 });
+
+    try std.testing.expectEqual(1, count);
+    try expectTag(.address, storage[0]);
+    try std.testing.expectEqual(net.IpAddress.Family.ipv6, storage[0].address.getFamily());
+    try std.testing.expectEqual(@as(u16, 80), storage[0].address.getPort());
+}
+
+test "dns: IPv6 literal with canonical name" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var storage: [8]dns.LookupResult = undefined;
+    var canon_buf: [HostName.max_len]u8 = undefined;
+    const count = try dns.lookup(&storage, .{ .name = "::1", .port = 80, .canonical_name_buffer = &canon_buf });
+
+    try std.testing.expectEqual(2, count);
+    try expectTag(.canonical_name, storage[0]);
+    try std.testing.expectEqualStrings("::1", storage[0].canonical_name.bytes);
+    try expectTag(.address, storage[1]);
+    try std.testing.expectEqual(net.IpAddress.Family.ipv6, storage[1].address.getFamily());
+}
+
+test "dns: IPv4 literal with IPv6 family filter" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var storage: [8]dns.LookupResult = undefined;
+    const result = dns.lookup(&storage, .{ .name = "127.0.0.1", .port = 80, .family = .ipv6 });
+    // Custom resolver returns 0; getaddrinfo returns AddressFamilyUnsupported.
+    if (result) |count| {
+        try std.testing.expectEqual(0, count);
+    } else |err| {
+        try std.testing.expectEqual(error.AddressFamilyUnsupported, err);
+    }
+}
+
+test "dns: IPv6 literal with IPv4 family filter" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var storage: [8]dns.LookupResult = undefined;
+    const result = dns.lookup(&storage, .{ .name = "::1", .port = 80, .family = .ipv4 });
+    if (result) |count| {
+        try std.testing.expectEqual(0, count);
+    } else |err| {
+        try std.testing.expectEqual(error.AddressFamilyUnsupported, err);
+    }
+}
+
+test "dns: localhost" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [8]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
+
+    try std.testing.expect(count > 0);
+    for (storage[0..count]) |entry| {
+        try expectTag(.address, entry);
+    }
+}
+
+test "dns: localhost with canonical name" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [8]HostName.LookupResult = undefined;
+    var canon_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &canon_buf });
+
+    try std.testing.expect(count > 1);
+    try expectTag(.canonical_name, storage[0]);
+    try std.testing.expect(storage[0].canonical_name.bytes.len > 0);
+    for (storage[1..count]) |entry| {
+        try expectTag(.address, entry);
+    }
+}
+
+test "dns: IPv4 literal with no storage" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var storage: [0]dns.LookupResult = undefined;
+    try std.testing.expectError(
+        error.TooManyAddresses,
+        dns.lookup(&storage, .{ .name = "127.0.0.1", .port = 80 }),
+    );
+}
+
+test "dns: IPv4 literal with canonical name and only one storage slot" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    // slot 0 is reserved for canonical_name, leaving no room for the address
+    var storage: [1]dns.LookupResult = undefined;
+    var canon_buf: [HostName.max_len]u8 = undefined;
+    try std.testing.expectError(
+        error.TooManyAddresses,
+        dns.lookup(&storage, .{ .name = "127.0.0.1", .port = 80, .canonical_name_buffer = &canon_buf }),
+    );
+}

--- a/src/net.zig
+++ b/src/net.zig
@@ -1254,6 +1254,7 @@ pub fn tcpConnectToAddress(addr: IpAddress, options: IpAddress.ConnectOptions) !
 
 test {
     std.testing.refAllDecls(@This());
+    _ = @import("dns/test.zig");
 }
 
 test "HostName: validate" {
@@ -1378,7 +1379,7 @@ test "HostName: lookup www.github.com follows CNAME" {
     }
     try std.testing.expect(has_address);
     const cname = canonical_name orelse return error.NoCanonicalName;
-    try std.testing.expectEqualStrings("github.com", cname.bytes);
+    try std.testing.expect(std.ascii.eqlIgnoreCase("github.com", cname.bytes));
 }
 
 test "HostName: connect" {


### PR DESCRIPTION
## Summary

- Add `src/dns/test.zig` with tests for DNS resolution covering IPv4/IPv6 literals with and without canonical name, family filters, localhost, and edge cases for empty/insufficient storage
- Wire tests into `net.zig` test block via `_ = @import("dns/test.zig")`
- Fix custom resolver to return `error.TooManyAddresses` (consistent with the posix/getaddrinfo path) when an address is found but `addr_storage` has no room — affects numeric IP and `/etc/hosts` paths
- Fix `www.github.com` canonical name test to use case-insensitive comparison since `getaddrinfo` may return mixed case

## Test plan

- [ ] All 470 tests pass (`./check.sh --backend epoll`)
- [ ] New tests cover IPv4/IPv6 literals, canonical names, family filters, and storage edge cases