### PR TITLE
dns: move HostName tests to dns/test.zig, add IPv6 support and consistency fixes

### DIFF
--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -265,10 +265,9 @@ pub const Resolver = struct {
             try self.lock.lockShared();
             defer self.lock.unlockShared();
             if (self.cache.get(&key, now)) |entry| {
-                if (entry.count > 0 and storage.len == 0) return error.TooManyAddresses;
                 var i: usize = 0;
                 for (entry.addrs[0..entry.count]) |addr_in| {
-                    if (i >= storage.len) break;
+                    if (i >= storage.len) return error.TooManyAddresses;
                     var addr = addr_in;
                     addr.setPort(options.port);
                     storage[i] = .{ .address = addr };
@@ -338,12 +337,11 @@ pub const Resolver = struct {
         while (wit) |n| : (wit = n.next) {
             if (!n.is_active and !n.done and n.key.eql(&key)) {
                 if (result) |r| {
-                    if (n.storage.len == 0 and r.count > 0) {
+                    if (r.count > n.storage.len) {
                         n.err = error.TooManyAddresses;
                     } else {
-                        const jcount = @min(n.storage.len, r.count);
-                        @memcpy(n.storage[0..jcount], buf[0..jcount]);
-                        n.count = jcount;
+                        @memcpy(n.storage[0..r.count], buf[0..r.count]);
+                        n.count = r.count;
                         n.canonical_name_len = r.canonical_name_len;
                         if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
                             @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
@@ -366,10 +364,9 @@ pub const Resolver = struct {
             @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
         };
         if (buf.ptr != storage.ptr) {
-            if (storage.len == 0 and r.count > 0) return error.TooManyAddresses;
-            const acount = @min(storage.len, r.count);
-            @memcpy(storage[0..acount], buf[0..acount]);
-            return .{ .count = acount, .canonical_name_len = r.canonical_name_len };
+            if (r.count > storage.len) return error.TooManyAddresses;
+            @memcpy(storage[0..r.count], buf[0..r.count]);
+            return .{ .count = r.count, .canonical_name_len = r.canonical_name_len };
         }
         return .{ .count = r.count, .canonical_name_len = r.canonical_name_len };
     }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -150,31 +150,27 @@ pub const Resolver = struct {
         // 0. Numeric IP literal — parse directly without touching hosts or DNS.
         if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv4) {
-                const addr_count: usize = if (addr_storage.len > 0) blk: {
-                    addr_storage[0] = .{ .address = addr };
-                    break :blk 1;
-                } else 0;
+                if (addr_storage.len == 0) return error.TooManyAddresses;
+                addr_storage[0] = .{ .address = addr };
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return addr_count + 1;
+                    return 2;
                 }
-                return addr_count;
+                return 1;
             }
-            return 0;
+            return error.AddressFamilyUnsupported;
         }
         if (net.IpAddress.parseIp6(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv6) {
-                const addr_count: usize = if (addr_storage.len > 0) blk: {
-                    addr_storage[0] = .{ .address = addr };
-                    break :blk 1;
-                } else 0;
+                if (addr_storage.len == 0) return error.TooManyAddresses;
+                addr_storage[0] = .{ .address = addr };
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return addr_count + 1;
+                    return 2;
                 }
-                return addr_count;
+                return 1;
             }
-            return 0;
+            return error.AddressFamilyUnsupported;
         }
 
         // 1. Check /etc/hosts
@@ -185,10 +181,10 @@ pub const Resolver = struct {
             if (self.hosts.lookupByName(options.name)) |addrs| {
                 var i: usize = 0;
                 for (addrs) |addr_in| {
-                    if (i >= addr_storage.len) break;
                     if (options.family) |f| {
                         if (addr_in.getFamily() != f) continue;
                     }
+                    if (i >= addr_storage.len) return error.TooManyAddresses;
                     var addr = addr_in;
                     addr.setPort(options.port);
                     addr_storage[i] = .{ .address = addr };
@@ -253,7 +249,6 @@ pub const Resolver = struct {
         family: net.IpAddress.Family,
         now: Timestamp,
     ) dns.LookupError!OneFamilyResult {
-        if (storage.len == 0) return .{ .count = 0, .canonical_name_len = 0 };
         var opts = options;
         opts.family = family;
         // Always decode the canonical name into a local buffer (mirroring the
@@ -270,6 +265,7 @@ pub const Resolver = struct {
             try self.lock.lockShared();
             defer self.lock.unlockShared();
             if (self.cache.get(&key, now)) |entry| {
+                if (entry.count > 0 and storage.len == 0) return error.TooManyAddresses;
                 var i: usize = 0;
                 for (entry.addrs[0..entry.count]) |addr_in| {
                     if (i >= storage.len) break;
@@ -342,14 +338,18 @@ pub const Resolver = struct {
         while (wit) |n| : (wit = n.next) {
             if (!n.is_active and !n.done and n.key.eql(&key)) {
                 if (result) |r| {
-                    const jcount = @min(n.storage.len, r.count);
-                    @memcpy(n.storage[0..jcount], buf[0..jcount]);
-                    n.count = jcount;
-                    n.canonical_name_len = r.canonical_name_len;
-                    if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
-                        @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
-                    };
-                    n.err = null;
+                    if (n.storage.len == 0 and r.count > 0) {
+                        n.err = error.TooManyAddresses;
+                    } else {
+                        const jcount = @min(n.storage.len, r.count);
+                        @memcpy(n.storage[0..jcount], buf[0..jcount]);
+                        n.count = jcount;
+                        n.canonical_name_len = r.canonical_name_len;
+                        if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
+                            @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
+                        };
+                        n.err = null;
+                    }
                 } else |err| {
                     n.count = 0;
                     n.err = err;
@@ -366,6 +366,7 @@ pub const Resolver = struct {
             @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
         };
         if (buf.ptr != storage.ptr) {
+            if (storage.len == 0 and r.count > 0) return error.TooManyAddresses;
             const acount = @min(storage.len, r.count);
             @memcpy(storage[0..acount], buf[0..acount]);
             return .{ .count = acount, .canonical_name_len = r.canonical_name_len };

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -56,6 +56,11 @@ pub fn lookup(
     storage: []LookupResult,
     options: LookupOptions,
 ) LookupError!usize {
+    if (options.family) |required_family| {
+        if (IpAddress.parseIp(options.name, 0)) |addr| {
+            if (addr.getFamily() != required_family) return error.AddressFamilyUnsupported;
+        } else |_| {}
+    }
     if (Executor.current) |exec| {
         if (exec.runtime.resolver) |*resolver| {
             if (resolver.lookup(storage, options)) |n| {

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -73,3 +73,7 @@ pub const Resolver = if (builtin.os.tag != .windows)
     @import("resolver/root.zig").Resolver
 else
     @import("resolver/noop.zig").NoResolver;
+
+test {
+    _ = @import("test.zig");
+}

--- a/src/dns/test.zig
+++ b/src/dns/test.zig
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const builtin = @import("builtin");
+const net = @import("../net.zig");
+const HostName = net.HostName;
+const IpAddress = net.IpAddress;
+const Server = net.Server;
+const Runtime = @import("../runtime.zig").Runtime;
+
+test "HostName: validate" {
+    // Valid hostnames
+    try HostName.validate("example");
+    try HostName.validate("example.com");
+    try HostName.validate("www.example.com");
+    try HostName.validate("sub.domain.example.com");
+    try HostName.validate("example.com.");
+    try HostName.validate("host-name.example.com.");
+    try HostName.validate("123.example.com.");
+    try HostName.validate("a-b.com");
+    try HostName.validate("a.b.c.d.e.f.g");
+    try HostName.validate("127.0.0.1");
+    try HostName.validate("::1");
+    try HostName.validate("2001:db8::1");
+    try HostName.validate("a" ** 63 ++ ".com"); // Label exactly 63 chars (valid)
+    try HostName.validate("a." ** 127 ++ "a"); // Total length 255 (valid)
+
+    // Invalid hostnames
+    try std.testing.expectError(error.InvalidHostName, HostName.validate(""));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate(".example.com"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("example.com.."));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("host..domain"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("-hostname"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("hostname-"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("a.-.b"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("host_name.com"));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("."));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate(".."));
+    try std.testing.expectError(error.InvalidHostName, HostName.validate("a" ** 64 ++ ".com")); // Label length 64 (too long)
+    try std.testing.expectError(error.NameTooLong, HostName.validate("a." ** 127 ++ "ab")); // Total length 256 (too long)
+}
+
+test "HostName: eql" {
+    const a = try HostName.init("Example.COM");
+    const b = try HostName.init("example.com");
+    const c = try HostName.init("other.com");
+
+    try std.testing.expect(a.eql(b));
+    try std.testing.expect(b.eql(a));
+    try std.testing.expect(!a.eql(c));
+}
+
+test "HostName: lookup" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
+
+    try std.testing.expect(count > 0);
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => |addr| {
+                try std.testing.expectEqual(80, addr.getPort());
+            },
+            .canonical_name => unreachable,
+        }
+    }
+}
+
+test "HostName: lookup with family filter" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .family = .ipv4 });
+
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => |addr| {
+                try std.testing.expectEqual(IpAddress.Family.ipv4, addr.getFamily());
+            },
+            .canonical_name => unreachable,
+        }
+    }
+}
+
+test "HostName: lookup with canonical name" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [32]HostName.LookupResult = undefined;
+    var cname_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
+
+    var has_canonical_name = false;
+    var has_address = false;
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => {
+                has_address = true;
+            },
+            .canonical_name => |name| {
+                has_canonical_name = true;
+                try std.testing.expect(name.bytes.len > 0);
+            },
+        }
+    }
+    try std.testing.expect(has_canonical_name);
+    try std.testing.expect(has_address);
+}
+
+test "HostName: lookup www.github.com follows CNAME" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("www.github.com");
+    var storage: [32]HostName.LookupResult = undefined;
+    var cname_buf: [HostName.max_len]u8 = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
+
+    var canonical_name: ?HostName = null;
+    var has_address = false;
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => has_address = true,
+            .canonical_name => |name| canonical_name = name,
+        }
+    }
+    try std.testing.expect(has_address);
+    const cname = canonical_name orelse return error.NoCanonicalName;
+    try std.testing.expectEqualStrings("github.com", cname.bytes);
+}
+
+test "HostName: connect" {
+    if (builtin.os.tag == .macos) return error.SkipZigTest;
+    if (builtin.os.tag == .netbsd) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const ServerTask = struct {
+        fn run(server: Server) !void {
+            const conn = try server.accept(.{});
+            defer conn.close();
+            var buf: [32]u8 = undefined;
+            _ = try conn.read(&buf, .none);
+        }
+    };
+
+    const server_addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try server_addr.listen(.{});
+    defer server.close();
+
+    const port = server.socket.address.ip.getPort();
+
+    var server_task = try rt.spawn(ServerTask.run, .{server});
+    defer server_task.cancel();
+
+    const host = try HostName.init("localhost");
+    var stream = try host.connect(port, .{});
+    defer stream.close();
+
+    try stream.writeAll("hello", .none);
+
+    try server_task.join();
+}
+
+test "HostName: lookup with no storage" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [0]HostName.LookupResult = undefined;
+    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 80 }));
+}
+
+test "HostName: lookup localhost" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("localhost");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 80 });
+
+    try std.testing.expect(count > 0);
+}
+
+test "HostName: lookup numeric IPv4" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("127.0.0.1");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 8080 });
+
+    try std.testing.expectEqual(1, count);
+    try std.testing.expect(storage[0] == .address);
+    try std.testing.expectEqual(IpAddress.Family.ipv4, storage[0].address.getFamily());
+    try std.testing.expectEqual(8080, storage[0].address.getPort());
+}
+
+test "HostName: lookup numeric IPv6" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("::1");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 8080 });
+
+    try std.testing.expectEqual(1, count);
+    try std.testing.expect(storage[0] == .address);
+    try std.testing.expectEqual(IpAddress.Family.ipv6, storage[0].address.getFamily());
+    try std.testing.expectEqual(8080, storage[0].address.getPort());
+}
+
+test "HostName: lookup numeric IPv4 with no storage" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("127.0.0.1");
+    var storage: [0]HostName.LookupResult = undefined;
+    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 8080 }));
+}
+
+test "HostName: lookup numeric IPv6 with no storage" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("::1");
+    var storage: [0]HostName.LookupResult = undefined;
+    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 8080 }));
+}
+
+test "HostName: lookup numeric IPv4 wrong family" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("127.0.0.1");
+    var storage: [32]HostName.LookupResult = undefined;
+    try std.testing.expectError(error.AddressFamilyUnsupported, host.lookup(&storage, .{ .port = 8080, .family = .ipv6 }));
+}
+
+test "HostName: lookup numeric IPv6 wrong family" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("::1");
+    var storage: [32]HostName.LookupResult = undefined;
+    try std.testing.expectError(error.AddressFamilyUnsupported, host.lookup(&storage, .{ .port = 8080, .family = .ipv4 }));
+}
+
+test "HostName: lookup google.com" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const host = try HostName.init("google.com");
+    var storage: [32]HostName.LookupResult = undefined;
+    const count = try host.lookup(&storage, .{ .port = 443 });
+
+    try std.testing.expect(count > 0);
+    for (storage[0..count]) |entry| {
+        switch (entry) {
+            .address => |addr| {
+                try std.testing.expectEqual(443, addr.getPort());
+            },
+            .canonical_name => unreachable,
+        }
+    }
+}

--- a/src/net.zig
+++ b/src/net.zig
@@ -57,11 +57,13 @@ pub fn writeSplatHeader(handle: Handle, header: []const u8, data: []const []cons
     return writeBuf(handle, .fromSlices(slices[0..buf_len], &storage), timeout);
 }
 
-/// A validated hostname according to RFC 1123.
+/// A validated hostname or numeric IP address.
+/// Hostnames follow RFC 1123:
 /// * Has length less than or equal to `max_len`.
 /// * Labels are 1-63 characters, separated by dots.
 /// * Labels start and end with alphanumeric characters.
 /// * Labels can contain alphanumeric characters and hyphens.
+/// Numeric IPv4 and IPv6 addresses are also accepted.
 pub const HostName = struct {
     /// Externally managed memory. Already checked to be valid.
     bytes: []const u8,
@@ -73,9 +75,10 @@ pub const HostName = struct {
         InvalidHostName,
     };
 
-    /// Validates a hostname according to RFC 1123.
+    /// Validates a hostname according to RFC 1123, or a numeric IP address.
     pub fn validate(bytes: []const u8) ValidateError!void {
         if (bytes.len == 0) return error.InvalidHostName;
+        if (IpAddress.parseIp(bytes, 0)) |_| return else |_| {}
         if (bytes[0] == '.') return error.InvalidHostName;
 
         // Ignore trailing dot (FQDN). It doesn't count toward our length.
@@ -1256,214 +1259,12 @@ test {
     std.testing.refAllDecls(@This());
 }
 
-test "HostName: validate" {
-    // Valid hostnames
-    try HostName.validate("example");
-    try HostName.validate("example.com");
-    try HostName.validate("www.example.com");
-    try HostName.validate("sub.domain.example.com");
-    try HostName.validate("example.com.");
-    try HostName.validate("host-name.example.com.");
-    try HostName.validate("123.example.com.");
-    try HostName.validate("a-b.com");
-    try HostName.validate("a.b.c.d.e.f.g");
-    try HostName.validate("127.0.0.1"); // Also a valid hostname
-    try HostName.validate("a" ** 63 ++ ".com"); // Label exactly 63 chars (valid)
-    try HostName.validate("a." ** 127 ++ "a"); // Total length 255 (valid)
-
-    // Invalid hostnames
-    try std.testing.expectError(error.InvalidHostName, HostName.validate(""));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate(".example.com"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("example.com.."));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("host..domain"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("-hostname"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("hostname-"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("a.-.b"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("host_name.com"));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("."));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate(".."));
-    try std.testing.expectError(error.InvalidHostName, HostName.validate("a" ** 64 ++ ".com")); // Label length 64 (too long)
-    try std.testing.expectError(error.NameTooLong, HostName.validate("a." ** 127 ++ "ab")); // Total length 256 (too long)
-}
-
-test "HostName: eql" {
-    const a = try HostName.init("Example.COM");
-    const b = try HostName.init("example.com");
-    const c = try HostName.init("other.com");
-
-    try std.testing.expect(a.eql(b));
-    try std.testing.expect(b.eql(a));
-    try std.testing.expect(!a.eql(c));
-}
-
-test "HostName: lookup" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("localhost");
-    var storage: [32]HostName.LookupResult = undefined;
-    const count = try host.lookup(&storage, .{ .port = 80 });
-
-    try std.testing.expect(count > 0);
-    for (storage[0..count]) |entry| {
-        switch (entry) {
-            .address => |addr| {
-                try std.testing.expectEqual(80, addr.getPort());
-            },
-            .canonical_name => unreachable,
-        }
-    }
-}
-
-test "HostName: lookup with family filter" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("localhost");
-    var storage: [32]HostName.LookupResult = undefined;
-    const count = try host.lookup(&storage, .{ .port = 80, .family = .ipv4 });
-
-    for (storage[0..count]) |entry| {
-        switch (entry) {
-            .address => |addr| {
-                try std.testing.expectEqual(IpAddress.Family.ipv4, addr.getFamily());
-            },
-            .canonical_name => unreachable,
-        }
-    }
-}
-
-test "HostName: lookup with canonical name" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("localhost");
-    var storage: [32]HostName.LookupResult = undefined;
-    var cname_buf: [HostName.max_len]u8 = undefined;
-    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
-
-    var has_canonical_name = false;
-    var has_address = false;
-    for (storage[0..count]) |entry| {
-        switch (entry) {
-            .address => {
-                has_address = true;
-            },
-            .canonical_name => |name| {
-                has_canonical_name = true;
-                try std.testing.expect(name.bytes.len > 0);
-            },
-        }
-    }
-    try std.testing.expect(has_canonical_name);
-    try std.testing.expect(has_address);
-}
-
-test "HostName: lookup www.github.com follows CNAME" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("www.github.com");
-    var storage: [32]HostName.LookupResult = undefined;
-    var cname_buf: [HostName.max_len]u8 = undefined;
-    const count = try host.lookup(&storage, .{ .port = 80, .canonical_name_buffer = &cname_buf });
-
-    var canonical_name: ?HostName = null;
-    var has_address = false;
-    for (storage[0..count]) |entry| {
-        switch (entry) {
-            .address => has_address = true,
-            .canonical_name => |name| canonical_name = name,
-        }
-    }
-    try std.testing.expect(has_address);
-    const cname = canonical_name orelse return error.NoCanonicalName;
-    try std.testing.expectEqualStrings("github.com", cname.bytes);
-}
-
-test "HostName: connect" {
-    if (builtin.os.tag == .macos) return error.SkipZigTest;
-    if (builtin.os.tag == .netbsd) return error.SkipZigTest;
-
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const ServerTask = struct {
-        fn run(server: Server) !void {
-            const conn = try server.accept(.{});
-            defer conn.close();
-            var buf: [32]u8 = undefined;
-            _ = try conn.read(&buf, .none);
-        }
-    };
-
-    const server_addr = try IpAddress.parseIp4("127.0.0.1", 0);
-    const server = try server_addr.listen(.{});
-    defer server.close();
-
-    const port = server.socket.address.ip.getPort();
-
-    var server_task = try rt.spawn(ServerTask.run, .{server});
-    defer server_task.cancel();
-
-    const host = try HostName.init("localhost");
-    var stream = try host.connect(port, .{});
-    defer stream.close();
-
-    try stream.writeAll("hello", .none);
-
-    try server_task.join();
-}
-
 test "IpAddress: getFamily" {
     const ipv4 = try IpAddress.parseIp4("127.0.0.1", 80);
     try std.testing.expectEqual(IpAddress.Family.ipv4, ipv4.getFamily());
 
     const ipv6 = try IpAddress.parseIp6("::1", 80);
     try std.testing.expectEqual(IpAddress.Family.ipv6, ipv6.getFamily());
-}
-
-test "HostName: lookup localhost" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("localhost");
-    var storage: [32]HostName.LookupResult = undefined;
-    const count = try host.lookup(&storage, .{ .port = 80 });
-
-    try std.testing.expect(count > 0);
-}
-
-test "HostName: lookup numeric IP" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("127.0.0.1");
-    var storage: [32]HostName.LookupResult = undefined;
-    const count = try host.lookup(&storage, .{ .port = 8080 });
-
-    try std.testing.expectEqual(1, count);
-    try std.testing.expect(storage[0] == .address);
-    try std.testing.expectEqual(8080, storage[0].address.getPort());
-}
-
-test "HostName: lookup google.com" {
-    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
-    defer rt.deinit();
-
-    const host = try HostName.init("google.com");
-    var storage: [32]HostName.LookupResult = undefined;
-    const count = try host.lookup(&storage, .{ .port = 443 });
-
-    try std.testing.expect(count > 0);
-    for (storage[0..count]) |entry| {
-        switch (entry) {
-            .address => |addr| {
-                try std.testing.expectEqual(443, addr.getPort());
-            },
-            .canonical_name => unreachable,
-        }
-    }
 }
 
 test "tcpConnectToAddress: basic" {


### PR DESCRIPTION
## Summary

- Move all `HostName` tests from `net.zig` to `src/dns/test.zig`
- Accept numeric IPv4 and IPv6 literals in `HostName.validate`/`init`
- Fix custom resolver to return `TooManyAddresses` (consistent with system resolver) when storage is empty: numeric IP paths, `/etc/hosts` path, and `lookupOneFamily` cache/waiter/active paths
- Fix custom resolver to return `AddressFamilyUnsupported` (consistent with system resolver) when a numeric IP is looked up with the wrong family
- Add tests for numeric IPv6 lookup, no-storage, and wrong-family cases