### PR TITLE
dns: increase TCP fallback recv_buf to 65535 bytes

### DIFF
--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -609,7 +609,7 @@ fn queryBatch(
         query_lens[i] = built.len;
     }
 
-    var recv_buf: [4096]u8 = undefined;
+    var recv_buf: [65535]u8 = undefined;
     var parse_addrs: [max_addrs_per_family]net.IpAddress = undefined;
 
     // The canonical name is decoded from the first family that yields records.


### PR DESCRIPTION
DNS-over-TCP uses a 2-byte length prefix, so responses can legally be up to 65535 bytes. The previous 4096-byte buffer caused `exchangeTcp` to return `error.MessageTooBig` for large responses (hosts with many address records), which was silently converted to `TemporaryNameServerFailure`. Since all servers return the same oversized response, every TCP retry fails and the name becomes permanently unresolvable once the UDP response is truncated.