### PR TITLE
dns: don't abort search-domain loop on transient batch failure

### DIFF
--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -424,8 +424,12 @@ pub const Resolver = struct {
         // Enough dots: try unsuffixed first (Go's nameList logic).
         if (has_enough_dots) {
             if (makeFqdn(&fqdn_buf, name, null)) |fqdn| {
-                const r = try queryBatch(self, storage, options, fqdn, shape, srvs, attempts, timeout);
-                if (r.count > 0) return r;
+                if (queryBatch(self, storage, options, fqdn, shape, srvs, attempts, timeout)) |r| {
+                    if (r.count > 0) return r;
+                } else |err| switch (err) {
+                    error.Canceled => return err,
+                    else => last_err = err,
+                }
             }
         }
 
@@ -433,8 +437,12 @@ pub const Resolver = struct {
         for (0..search_count) |i| {
             const suffix = search_store[i][0..search_lens[i]];
             if (makeFqdn(&fqdn_buf, name, suffix)) |fqdn| {
-                const r = try queryBatch(self, storage, options, fqdn, shape, srvs, attempts, timeout);
-                if (r.count > 0) return r;
+                if (queryBatch(self, storage, options, fqdn, shape, srvs, attempts, timeout)) |r| {
+                    if (r.count > 0) return r;
+                } else |err| switch (err) {
+                    error.Canceled => return err,
+                    else => last_err = err,
+                }
             }
         }
 


### PR DESCRIPTION
A SERVFAIL from either family in a batched A+AAAA query causes `queryBatch` to return `error.TemporaryNameServerFailure` (the family never reached a definitive answer). The `try` that was used in the `has_enough_dots` and search-domain paths propagated that immediately, skipping all remaining search suffixes for both families.

This is a regression from the pre-batching behavior. Previously each family ran through the search list independently, so a transient failure on A at suffix N was non-fatal — AAAA continued through the remaining suffixes and could still find records.

The fix mirrors the existing `!has_enough_dots` fallback path: catch errors from `queryBatch`, record them in `last_err`, and continue to the next candidate. Cancellation is still propagated immediately.