### PR TITLE
os: add MutexNoop and ConditionNoop for single-threaded builds

### DIFF
--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -11,6 +11,8 @@ pub const thread = @import("thread.zig");
 
 pub const Mutex = thread.Mutex;
 pub const Condition = thread.Condition;
+pub const MutexNoop = thread.MutexNoop;
+pub const ConditionNoop = thread.ConditionNoop;
 pub const ResetEvent = thread.ResetEvent;
 
 pub const iovec = fs.iovec;

--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -11,8 +11,6 @@ pub const thread = @import("thread.zig");
 
 pub const Mutex = thread.Mutex;
 pub const Condition = thread.Condition;
-pub const MutexNoop = thread.MutexNoop;
-pub const ConditionNoop = thread.ConditionNoop;
 pub const ResetEvent = thread.ResetEvent;
 
 pub const iovec = fs.iovec;

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -135,6 +135,7 @@ pub const ConditionNoop = struct {
     pub fn wait(self: *ConditionNoop, mutex: *Mutex) void {
         _ = self;
         _ = mutex;
+        @panic("ConditionNoop.wait: cannot wait on a condition variable in single-threaded builds");
     }
 
     pub fn timedWait(self: *ConditionNoop, mutex: *Mutex, timeout: Timeout) error{Timeout}!void {

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -142,7 +142,7 @@ pub const ConditionNoop = struct {
         _ = self;
         _ = mutex;
         _ = timeout;
-        return error.Timeout;
+        @panic("ConditionNoop.timedWait: cannot wait on a condition variable in single-threaded builds");
     }
 
     pub fn signal(self: *ConditionNoop) void {

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -92,6 +92,66 @@ pub const Notify = switch (builtin.os.tag) {
     else => NotifyFutex,
 };
 
+/// No-op mutex for single-threaded builds.
+///
+/// When building with -fsingle-threaded, there are no other threads to contend
+/// with, so all mutex operations are no-ops.
+pub const MutexNoop = struct {
+    pub fn init() MutexNoop {
+        return .{};
+    }
+
+    pub fn deinit(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn lock(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn unlock(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn tryLock(self: *MutexNoop) bool {
+        _ = self;
+        return true;
+    }
+};
+
+/// No-op condition variable for single-threaded builds.
+///
+/// When building with -fsingle-threaded, condition variable operations are
+/// no-ops since there are no other threads to signal or wait on.
+pub const ConditionNoop = struct {
+    pub fn init() ConditionNoop {
+        return .{};
+    }
+
+    pub fn deinit(self: *ConditionNoop) void {
+        _ = self;
+    }
+
+    pub fn wait(self: *ConditionNoop, mutex: *Mutex) void {
+        _ = self;
+        _ = mutex;
+    }
+
+    pub fn timedWait(self: *ConditionNoop, mutex: *Mutex, timeout: Timeout) error{Timeout}!void {
+        _ = self;
+        _ = mutex;
+        _ = timeout;
+    }
+
+    pub fn signal(self: *ConditionNoop) void {
+        _ = self;
+    }
+
+    pub fn broadcast(self: *ConditionNoop) void {
+        _ = self;
+    }
+};
+
 /// Mutex for thread synchronization.
 ///
 /// A blocking mutex that uses platform-specific optimal primitives:
@@ -109,7 +169,7 @@ pub const Notify = switch (builtin.os.tag) {
 /// defer mutex.unlock();
 /// // critical section
 /// ```
-pub const Mutex = switch (builtin.os.tag) {
+pub const Mutex = if (builtin.single_threaded) MutexNoop else switch (builtin.os.tag) {
     .windows => MutexWindows,
     .freebsd => MutexFreeBSD,
     .netbsd => MutexNotify,
@@ -145,7 +205,7 @@ pub const Mutex = switch (builtin.os.tag) {
 /// mutex.unlock();
 /// cond.signal();
 /// ```
-pub const Condition = switch (builtin.os.tag) {
+pub const Condition = if (builtin.single_threaded) ConditionNoop else switch (builtin.os.tag) {
     .windows => ConditionWindows,
     .freebsd => ConditionFreeBSD,
     else => if (Futex == void) ConditionNotify else ConditionFutex,

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -135,14 +135,21 @@ pub const ConditionNoop = struct {
     pub fn wait(self: *ConditionNoop, mutex: *Mutex) void {
         _ = self;
         _ = mutex;
-        @panic("ConditionNoop.wait: cannot wait on a condition variable in single-threaded builds");
+        while (true) {
+            os_time.sleep(.fromSeconds(3600));
+        }
     }
 
     pub fn timedWait(self: *ConditionNoop, mutex: *Mutex, timeout: Timeout) error{Timeout}!void {
         _ = self;
         _ = mutex;
-        _ = timeout;
-        @panic("ConditionNoop.timedWait: cannot wait on a condition variable in single-threaded builds");
+        if (timeout == .none) {
+            return self.wait(mutex);
+        }
+        const remaining = timeout.durationFromNow();
+        if (remaining.value <= 0) return error.Timeout;
+        os_time.sleep(remaining);
+        return error.Timeout;
     }
 
     pub fn signal(self: *ConditionNoop) void {

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -141,6 +141,7 @@ pub const ConditionNoop = struct {
         _ = self;
         _ = mutex;
         _ = timeout;
+        return error.Timeout;
     }
 
     pub fn signal(self: *ConditionNoop) void {


### PR DESCRIPTION
When building with -fsingle-threaded, os.Mutex and os.Condition now resolve to no-op implementations (MutexNoop and ConditionNoop) since there are no other threads to contend with. Both noop types are also exported directly for explicit use.

Fixes #439
