### PR TITLE
runtime: add single-threaded build support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -79,6 +79,19 @@ pub fn build(b: *std.Build) void {
         examples_step.dependOn(&install_exe.step);
     }
 
+    // Single-threaded build of hello-world to verify single-threaded support
+    const hello_world_st = b.addExecutable(.{
+        .name = "hello-world-single-threaded",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/hello_world.zig"),
+            .target = target,
+            .optimize = optimize,
+            .single_threaded = true,
+        }),
+    });
+    hello_world_st.root_module.addImport("zio", zio);
+    examples_step.dependOn(&b.addInstallArtifact(hello_world_st, .{}).step);
+
     // Tests
     const emit_test_bin = b.option(bool, "emit-test-bin", "Build test binary without running") orelse false;
     const test_filter = b.option([]const u8, "test-filter", "Filter for test names");

--- a/examples/hello_world.zig
+++ b/examples/hello_world.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
-pub fn main() !void {
-    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     var out = zio.stdout().writer(&.{});

--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -59,8 +59,8 @@ fn handleClient(stream: zio.net.Stream) !void {
     std.log.info("HTTP client disconnected", .{});
 }
 
-pub fn main() !void {
-    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -24,8 +24,8 @@ fn incrementTask(data: *SharedData, id: u32) !void {
     }
 }
 
-pub fn main() !void {
-    var rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     var shared_data = SharedData{

--- a/examples/ntp_client.zig
+++ b/examples/ntp_client.zig
@@ -107,7 +107,7 @@ fn queryNtpServer(server: []const u8, port: u16, timeout: zio.Timeout) !void {
 }
 
 pub fn main(init: std.process.Init) !void {
-    const gpa = std.heap.smp_allocator;
+    const gpa = init.gpa;
 
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 

--- a/examples/parallel_grep.zig
+++ b/examples/parallel_grep.zig
@@ -100,7 +100,7 @@ fn collector(
 // --8<-- [end:collector]
 
 pub fn main(init: std.process.Init) !void {
-    const gpa = std.heap.smp_allocator;
+    const gpa = init.gpa;
 
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 

--- a/examples/ping.zig
+++ b/examples/ping.zig
@@ -43,7 +43,7 @@ fn calculateChecksum(data: []const u8) u16 {
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = std.heap.smp_allocator;
+    const allocator = init.gpa;
 
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -41,8 +41,8 @@ fn consumer(channel: *zio.Channel(i32), id: u32) zio.Cancelable!void {
     std.log.info("Consumer {} finished", .{id});
 }
 
-pub fn main() !void {
-    var rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     var buffer: [8]i32 = undefined;

--- a/examples/signal_demo.zig
+++ b/examples/signal_demo.zig
@@ -41,8 +41,8 @@ fn signalHandler(shutdown: *std.atomic.Value(bool)) !void {
     shutdown.store(true, .release);
 }
 
-pub fn main() !void {
-    var rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     // Create shutdown flag

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -4,8 +4,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
-pub fn main() !void {
-    var rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     for (0..10) |_| {

--- a/examples/tcp_client.zig
+++ b/examples/tcp_client.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
-pub fn main() !void {
-    var rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);

--- a/examples/tcp_echo_server.zig
+++ b/examples/tcp_echo_server.zig
@@ -38,8 +38,8 @@ fn handleClient(stream: zio.net.Stream) !void {
 }
 // --8<-- [end:handleClient]
 
-pub fn main() !void {
-    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     // --8<-- [start:setup]

--- a/examples/tcp_echo_server_stdio.zig
+++ b/examples/tcp_echo_server_stdio.zig
@@ -64,8 +64,8 @@ fn handleClient(io: Io, stream: Io.net.Stream) Io.Cancelable!void {
     std.log.info("Client disconnected", .{});
 }
 
-pub fn main() !void {
-    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     const io = rt.io();

--- a/examples/udp_echo_server.zig
+++ b/examples/udp_echo_server.zig
@@ -6,8 +6,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
-pub fn main() !void {
-    const rt = try zio.Runtime.init(std.heap.smp_allocator, .{});
+pub fn main(init: std.process.Init) !void {
+    const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();
 
     const addr = try zio.net.IpAddress.parseIp4("127.0.0.1", 8080);

--- a/src/common.zig
+++ b/src/common.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const log = std.log.scoped(.zio);
 
@@ -239,7 +240,7 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     // Blocking path: Execute synchronously without event loop
     const task = waiter.mode.direct.task orelse {
         // TODO: Don't use std.heap.smp_allocator - it should be passed as a parameter
-        ev.executeBlocking(c, std.heap.smp_allocator);
+        ev.executeBlocking(c, if (builtin.single_threaded) std.heap.c_allocator else std.heap.smp_allocator);
         return;
     };
 
@@ -282,7 +283,7 @@ pub fn waitForIoUncancelable(c: *ev.Completion) void {
     // Blocking path: Execute synchronously without event loop
     const task = waiter.mode.direct.task orelse {
         // TODO: Don't use std.heap.smp_allocator - it should be passed as a parameter
-        ev.executeBlocking(c, std.heap.smp_allocator);
+        ev.executeBlocking(c, if (builtin.single_threaded) std.heap.c_allocator else std.heap.smp_allocator);
         return;
     };
 

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Queue = @import("queue.zig").Queue;
 const Completion = @import("completion.zig").Completion;
 const Work = @import("completion.zig").Work;
@@ -42,6 +43,17 @@ pub const ThreadPool = struct {
     };
 
     pub fn init(self: *ThreadPool, allocator: std.mem.Allocator, options: Options) !void {
+        if (builtin.single_threaded) {
+            self.* = .{
+                .allocator = allocator,
+                .min_threads = 0,
+                .max_threads = 0,
+                .idle_timeout_ns = 0,
+                .scale_threshold = options.scale_threshold,
+            };
+            return;
+        }
+
         const cpu_count = try std.Thread.getCpuCount();
         const max_threads = options.max_threads orelse (cpu_count * 2);
         const min_threads = options.min_threads;
@@ -128,6 +140,21 @@ pub const ThreadPool = struct {
     }
 
     pub fn submit(self: *ThreadPool, work: *Work) void {
+        if (builtin.single_threaded) {
+            if (work.state.cmpxchgStrong(.pending, .running, .acq_rel, .acquire)) |state| {
+                std.debug.assert(state == .canceled);
+                work.c.setError(error.Canceled);
+            } else {
+                work.func(work);
+                work.c.setResult(.work, {});
+                work.state.store(.completed, .release);
+            }
+            if (work.completion_fn) |completion_fn| {
+                completion_fn(work.completion_context, work);
+            }
+            return;
+        }
+
         self.queue_mutex.lock();
         self.queue.push(&work.c);
         self.queue_size += 1;

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -109,7 +109,7 @@ pub const Notify = switch (builtin.os.tag) {
 /// defer mutex.unlock();
 /// // critical section
 /// ```
-pub const Mutex = switch (builtin.os.tag) {
+pub const Mutex = if (builtin.single_threaded) MutexNoop else switch (builtin.os.tag) {
     .windows => MutexWindows,
     .freebsd => MutexFreeBSD,
     .netbsd => MutexNotify,
@@ -145,7 +145,7 @@ pub const Mutex = switch (builtin.os.tag) {
 /// mutex.unlock();
 /// cond.signal();
 /// ```
-pub const Condition = switch (builtin.os.tag) {
+pub const Condition = if (builtin.single_threaded) ConditionNoop else switch (builtin.os.tag) {
     .windows => ConditionWindows,
     .freebsd => ConditionFreeBSD,
     else => if (Futex == void) ConditionNotify else ConditionFutex,
@@ -1111,6 +1111,66 @@ const ConditionNotify = struct {
             const waiter: *Waiter = @fieldParentPtr("wait_node", wait_node);
             waiter.notify.signal();
         }
+    }
+};
+
+/// No-op mutex for single-threaded builds.
+const MutexNoop = struct {
+    pub fn init() MutexNoop {
+        return .{};
+    }
+
+    pub fn deinit(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn lock(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn unlock(self: *MutexNoop) void {
+        _ = self;
+    }
+
+    pub fn tryLock(self: *MutexNoop) bool {
+        _ = self;
+        return true;
+    }
+};
+
+/// No-op condition variable for single-threaded builds.
+///
+/// signal() and broadcast() are no-ops since there are no waiting threads.
+/// wait() and timedWait() are unreachable — in a single-threaded program
+/// nothing can signal while a thread is blocked.
+const ConditionNoop = struct {
+    pub fn init() ConditionNoop {
+        return .{};
+    }
+
+    pub fn deinit(self: *ConditionNoop) void {
+        _ = self;
+    }
+
+    pub fn wait(self: *ConditionNoop, mutex: *Mutex) void {
+        _ = self;
+        _ = mutex;
+        unreachable;
+    }
+
+    pub fn timedWait(self: *ConditionNoop, mutex: *Mutex, timeout: Timeout) error{Timeout}!void {
+        _ = self;
+        _ = mutex;
+        _ = timeout;
+        unreachable;
+    }
+
+    pub fn signal(self: *ConditionNoop) void {
+        _ = self;
+    }
+
+    pub fn broadcast(self: *ConditionNoop) void {
+        _ = self;
     }
 };
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -793,21 +793,23 @@ pub const Runtime = struct {
 
         errdefer self.shutdownWorkers();
 
-        for (0..num_workers) |i| {
-            log.debug("Spawning worker thread {}", .{i + 1});
-            const worker = self.workers.addOneAssumeCapacity();
-            errdefer _ = self.workers.pop();
-            worker.* = .{};
-            worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(u6, @intCast(i + 1)) });
-        }
-
-        for (self.workers.items, 0..) |*worker, i| {
-            log.debug("Waiting for worker thread {}", .{i + 1});
-            worker.ready.wait();
-            if (worker.err) |e| {
-                return e;
+        if (!builtin.single_threaded) {
+            for (0..num_workers) |i| {
+                log.debug("Spawning worker thread {}", .{i + 1});
+                const worker = self.workers.addOneAssumeCapacity();
+                errdefer _ = self.workers.pop();
+                worker.* = .{};
+                worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(u6, @intCast(i + 1)) });
             }
-            self.executors.appendAssumeCapacity(&worker.executor);
+
+            for (self.workers.items, 0..) |*worker, i| {
+                log.debug("Waiting for worker thread {}", .{i + 1});
+                worker.ready.wait();
+                if (worker.err) |e| {
+                    return e;
+                }
+                self.executors.appendAssumeCapacity(&worker.executor);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `MutexNoop` and `ConditionNoop` to `os/thread.zig` — no-op lock/unlock, `tryLock` always returns `true`, `signal`/`broadcast` are no-ops, `wait`/`timedWait` are `unreachable`. The `Mutex` and `Condition` type aliases now select these when `builtin.single_threaded`.
- Guard `std.Thread.spawn` in `runtime.zig` (worker executor loop) and `ev/thread_pool.zig` (`spawnThread`, `getCpuCount`) with `if (!builtin.single_threaded)` so they are never referenced in single-threaded builds.
- `ThreadPool.submit` runs work inline synchronously in single-threaded mode instead of queuing it for a background thread.
- Replace `std.heap.smp_allocator` with `std.heap.c_allocator` in the blocking fallback path in `common.zig` — `smp_allocator` asserts multi-threaded at comptime.

## Test plan

- [ ] `zig build` succeeds on the main project (no regressions)
- [ ] A standalone example built with `single_threaded = true` in its root module compiles and runs correctly