### PR TITLE
os/time: drive clock_gettime through the vDSO without libc

### DIFF
--- a/src/os/time.zig
+++ b/src/os/time.zig
@@ -48,6 +48,15 @@ pub fn now(clock: Clock) Timestamp {
                 .monotonic => posix.system.CLOCK.MONOTONIC,
                 .realtime => posix.system.CLOCK.REALTIME,
             };
+            // std.posix.system.clock_gettime serves the read from the
+            // kernel vDSO (userspace, no syscall) — but only once
+            // std.os.linux.elf_aux_maybe points at the ELF aux vector.
+            // Zig sets that from its own _start; when the program links
+            // libc (zio does), glibc owns _start and leaves it null, so
+            // every read falls back to a real clock_gettime syscall.
+            // now() is the event loop's hottest call, so recover the aux
+            // vector ourselves (pure syscalls, no libc) on first use.
+            if (builtin.os.tag == .linux) ensureVdsoAux();
             // TODO: use our posix layer, not std.posix
             // https://codeberg.org/ziglang/zig/pulls/35506
             var tp: std.posix.system.timespec = undefined;
@@ -63,6 +72,55 @@ pub fn now(clock: Clock) Timestamp {
         },
     }
     unreachable;
+}
+
+// Recovering the ELF aux vector lets std.posix.system.clock_gettime
+// (= std.os.linux.clock_gettime) resolve the kernel vDSO. Zig sets
+// std.os.linux.elf_aux_maybe from its own _start; when the program
+// links libc (zio does, see build.zig), glibc owns _start and leaves it
+// null, so the vDSO lookup fails and clock_gettime falls back to a real
+// syscall on every read. now() recovers it from /proc/self/auxv (pure
+// syscalls, no libc, no reliance on Zig owning _start) on first use.
+const aux_unstarted: u8 = 0;
+const aux_filling: u8 = 1;
+const aux_done: u8 = 2;
+var aux_state = std.atomic.Value(u8).init(aux_unstarted);
+// Backing store for the aux vector handed to elf_aux_maybe; must outlive
+// the call, so module-static. 1 KiB holds far more Auxv entries than any
+// kernel emits (~20 × 16 B).
+var aux_buf: [1024]u8 align(@alignOf(std.elf.Auxv)) = undefined;
+
+/// Idempotent and thread-safe. The winner fills aux_buf and publishes
+/// `aux_done` with release; every other caller acquires `aux_done`
+/// before returning, so the buffer and elf_aux_maybe are visible before
+/// clock_gettime can run its one-time vDSO lookup (which reads
+/// elf_aux_maybe with a plain load). Best effort: if /proc is
+/// unavailable the pointer stays null and clock_gettime keeps using the
+/// syscall (correct, just slower).
+fn ensureVdsoAux() void {
+    if (aux_state.load(.acquire) == aux_done) return;
+    if (aux_state.cmpxchgStrong(aux_unstarted, aux_filling, .acq_rel, .monotonic) != null) {
+        while (aux_state.load(.acquire) != aux_done) std.atomic.spinLoopHint();
+        return;
+    }
+    fillAuxFromProc();
+    aux_state.store(aux_done, .release);
+}
+
+fn fillAuxFromProc() void {
+    const fd_us = std.os.linux.open("/proc/self/auxv", .{ .ACCMODE = .RDONLY }, 0);
+    if (@as(isize, @bitCast(fd_us)) < 0) return;
+    const fd: i32 = @intCast(fd_us);
+    defer _ = std.os.linux.close(fd);
+    var off: usize = 0;
+    while (off < aux_buf.len) {
+        const r = std.os.linux.read(fd, aux_buf[off..].ptr, aux_buf.len - off);
+        const sr: isize = @bitCast(r);
+        if (sr <= 0) break;
+        off += @intCast(r);
+    }
+    if (off < @sizeOf(std.elf.Auxv)) return;
+    std.os.linux.elf_aux_maybe = @ptrCast(@alignCast(&aux_buf));
 }
 
 pub fn sleep(duration: Duration) void {

--- a/src/time.zig
+++ b/src/time.zig
@@ -627,6 +627,21 @@ test "Timestamp: untilNow" {
     try std.testing.expect(elapsed.toNanoseconds() < ns_per_s);
 }
 
+// Regression: now() must read the clock from the kernel vDSO, not a
+// syscall. std.os.linux.clock_gettime only reaches the vDSO once
+// std.os.linux.elf_aux_maybe points at the ELF aux vector — Zig sets
+// that from its own _start, but this test binary links libc (see
+// build.zig), so libc owns _start and leaves it null. Without the
+// recovery in os/time.zig, clock_gettime falls back to a real syscall
+// on every read and this assertion fails (elf_aux_maybe stays null).
+test "Timestamp: now() resolves the vDSO under libc" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+    _ = Timestamp.now(.monotonic); // first use recovers the aux vector
+    try std.testing.expect(std.os.linux.elf_aux_maybe != null);
+    // The recovered table must actually carry the vDSO base address.
+    try std.testing.expect(std.os.linux.getauxval(std.elf.AT_SYSINFO_EHDR) != 0);
+}
+
 test "Timestamp: addDuration, subDuration, durationTo" {
     const t1 = Timestamp.fromNanoseconds(1_000_000_000);
     const t2 = t1.addDuration(.fromSeconds(5));


### PR DESCRIPTION
now() reads the monotonic clock once per event-loop tick via std.posix.system.clock_gettime (= std.os.linux.clock_gettime). That serves the read from the kernel vDSO (userspace, no syscall) only once std.os.linux.elf_aux_maybe points at the ELF aux vector. Zig populates it from its own _start, but zio links libc (build.zig), so glibc owns _start and leaves elf_aux_maybe null — the vDSO lookup then fails and every clock read falls back to a real clock_gettime syscall. Under a high wakeup rate the process burns most of its CPU in that syscall.

Recover the aux vector from /proc/self/auxv (pure syscalls, no libc, no reliance on Zig owning _start) on first use and hand it to elf_aux_maybe; arch-specific vDSO symbol resolution is left to std's existing lookup, so x86_64 and aarch64 are both covered. The one-time fill is guarded by a state machine so concurrent now() callers synchronize before clock_gettime runs its one-shot lookup. Best effort: if /proc is unavailable the read stays on the syscall path.

Adds a regression test: because the test binary links libc, elf_aux_maybe is null without the fix and the test fails.

Measured on a libc-linked QUIC download client: clock_gettime syscalls per 32 MB transfer dropped from ~43k to 0; loopback throughput +8% (GSO sender) to +26% (paced sender).