### PR TITLE
Resolve merge conflicts introduced to 0.17 branch

### DIFF
--- a/src/ev/queue.zig
+++ b/src/ev/queue.zig
@@ -131,7 +131,7 @@ test Queue {
     try std.testing.expect(q.empty());
 
     // Elems
-    var elems: [10]Elem = @splat(Elem{});
+    var elems: [10]Elem = @splat(.{});
 
     // One
     try std.testing.expect(q.pop() == null);

--- a/src/ev/test/dgram_server.zig
+++ b/src/ev/test/dgram_server.zig
@@ -67,7 +67,7 @@ pub fn EchoServer(comptime domain: net.Domain, comptime sockaddr: type) type {
                 .ipv6 => {
                     self.server_addr = .{
                         .family = net.AF.INET6,
-                        .addr = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+                        .addr = @as([15]u8, @splat(0)) ++ [_]u8{1},
                         .port = 0,
                         .flowinfo = 0,
                         .scope_id = 0,

--- a/src/ev/test/dgram_server_msg.zig
+++ b/src/ev/test/dgram_server_msg.zig
@@ -71,7 +71,7 @@ pub fn EchoServer(comptime domain: net.Domain, comptime sockaddr: type) type {
                 .ipv6 => {
                     self.server_addr = .{
                         .family = net.AF.INET6,
-                        .addr = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+                        .addr = @as([15]u8, @splat(0)) ++ [_]u8{1},
                         .port = 0,
                         .flowinfo = 0,
                         .scope_id = 0,

--- a/src/ev/test/poll_server.zig
+++ b/src/ev/test/poll_server.zig
@@ -77,7 +77,7 @@ pub fn EchoServer(comptime domain: net.Domain, comptime sockaddr: type) type {
                 .ipv6 => {
                     self.server_addr = .{
                         .family = net.AF.INET6,
-                        .addr = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+                        .addr = @as([15]u8, @splat(0)) ++ [_]u8{1},
                         .port = 0,
                         .flowinfo = 0,
                         .scope_id = 0,

--- a/src/ev/test/stream_server.zig
+++ b/src/ev/test/stream_server.zig
@@ -73,7 +73,7 @@ pub fn EchoServer(comptime domain: net.Domain, comptime sockaddr: type) type {
                 .ipv6 => {
                     self.server_addr = .{
                         .family = net.AF.INET6,
-                        .addr = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 },
+                        .addr = @as([15]u8, @splat(0)) ++ [_]u8{1},
                         .port = 0,
                         .flowinfo = 0,
                         .scope_id = 0,

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -48,7 +48,7 @@ const HandlerRegistryUnix = struct {
     handlers: [MAX_HANDLERS]HandlerEntry = @splat(.{}),
     // Reference count for each signal value (0-255)
     // Each signal type has its own OS-level handler that needs tracking
-    installed_handlers: [256]std.atomic.Value(u8) = @splat(std.atomic.Value(u8).init(0)),
+    installed_handlers: [256]std.atomic.Value(u8) = @splat(.init(0)),
     // Store previous signal handlers to restore when refcount reaches 0
     prev_handlers: [256]posix.Sigaction = undefined,
 


### PR DESCRIPTION
resolve conflicts of "Use splat instead of **", tested with zig-x86_64-linux-0.17.0-dev.389+f5a1968f6

Sorry about those conflicts, noticed that it was already implemented in another branch little bit too late. There is one more in iocp.zig if main was to be merged to 0.17 branch, but there are more conflicts that I am not confident in solving.