### PR TITLE
Map ESPIPE to error.Unseekable for file reads/writes

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -396,7 +396,7 @@ fn fileReadStreamingImpl(
     var op = ev.FileReadStreaming.init(stdIoHandleToZio(file.handle), .{ .iovecs = iovecs[0..count] });
     try timedWaitForIo(&op.c, timeout);
     const n = op.getResult() catch |err| switch (err) {
-        error.BrokenPipe => return error.Unexpected,
+        error.BrokenPipe, error.Unseekable => return error.Unexpected,
         else => |e| return e,
     };
     return if (n == 0) error.EndOfStream else n;
@@ -421,7 +421,10 @@ fn fileWriteStreamingImpl(
 
     var op = ev.FileWriteStreaming.init(stdIoHandleToZio(file.handle), wbuf);
     try timedWaitForIo(&op.c, timeout);
-    return try op.getResult();
+    return op.getResult() catch |err| switch (err) {
+        error.Unseekable => error.Unexpected,
+        else => |e| e,
+    };
 }
 
 /// Data for a single concurrent batch operation.
@@ -739,14 +742,14 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
     return switch (tag) {
         .file_read_streaming => .{ .file_read_streaming = blk: {
             const n = data.file_read_streaming.op.getResult() catch |err| switch (err) {
-                error.BrokenPipe, error.Canceled => break :blk error.Unexpected,
+                error.BrokenPipe, error.Canceled, error.Unseekable => break :blk error.Unexpected,
                 else => |e| break :blk e,
             };
             break :blk if (n == 0) error.EndOfStream else n;
         } },
         .file_write_streaming => .{ .file_write_streaming = blk: {
             break :blk data.file_write_streaming.op.getResult() catch |err| switch (err) {
-                error.Canceled => error.Unexpected,
+                error.Canceled, error.Unseekable => error.Unexpected,
                 else => |e| e,
             };
         } },

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -178,6 +178,7 @@ pub const FileReadError = error{
     BrokenPipe,
     SystemResources,
     NotOpenForReading,
+    Unseekable,
     Canceled,
     Unexpected,
 };
@@ -193,6 +194,7 @@ pub const FileWriteError = error{
     DiskQuota,
     FileTooBig,
     LockViolation,
+    Unseekable,
     Canceled,
     Unexpected,
 };
@@ -1274,6 +1276,7 @@ pub fn errnoToFileReadError(err: E) FileReadError {
                 .PIPE => error.BrokenPipe,
                 .NOMEM => error.SystemResources,
                 .BADF => error.NotOpenForReading,
+                .SPIPE => error.Unseekable,
                 else => |e| unexpectedError(e) catch error.Unexpected,
             };
         },
@@ -1309,6 +1312,7 @@ pub fn errnoToFileWriteError(err: E) FileWriteError {
                 .BADF => error.NotOpenForWriting,
                 .DQUOT => error.DiskQuota,
                 .FBIG => error.FileTooBig,
+                .SPIPE => error.Unseekable,
                 else => |e| unexpectedError(e) catch error.Unexpected,
             };
         },


### PR DESCRIPTION
Maps `ESPIPE` to `error.Unseekable` in `errnoToFileReadError` and `errnoToFileWriteError`, so that `pread`/`pwrite` on non-seekable file descriptors (pipes, sockets, FIFOs) returns `error.Unseekable` rather than falling through to `error.Unexpected`.

This is the error `std.Io.File.Reader` watches for to automatically downgrade from positional to streaming mode (`readv`/`writev`), as defined in `File.ReadPositionalError` and `File.WritePositionalError`.

#450