### PR TITLE
fs: use renameatx_np on Darwin for atomic non-replacing rename

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -193,6 +193,14 @@ pub const Dir = struct {
         try op.getResult();
     }
 
+    pub const RenamePreserveError = os.fs.DirRenamePreserveError || Cancelable;
+
+    pub fn renamePreserve(self: Dir, old_path: []const u8, new_dir: Dir, new_path: []const u8) RenamePreserveError!void {
+        var op = ev.DirRenamePreserve.init(self.fd, old_path, new_dir.fd, new_path);
+        try waitForIo(&op.c);
+        try op.getResult();
+    }
+
     pub const StatError = os.fs.FileStatError || Cancelable;
 
     pub fn stat(self: Dir) StatError!os.fs.FileStatInfo {
@@ -1124,6 +1132,32 @@ test "Dir: rename" {
         return;
     };
     return error.TestExpectedError;
+}
+
+test "Dir: renamePreserve" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const dir = Dir.cwd();
+    const old_path = "test_rename_preserve_old.txt";
+    const new_path = "test_rename_preserve_new.txt";
+
+    var file = try dir.createFile(old_path, .{});
+    file.close();
+
+    // Rename to a path that doesn't exist yet — should succeed.
+    try dir.renamePreserve(old_path, dir, new_path);
+    defer dir.deleteFile(new_path) catch {};
+
+    // Old path should be gone.
+    try std.testing.expectError(error.FileNotFound, dir.openFile(old_path, .{}));
+
+    // Rename again to an existing destination — should fail.
+    var file2 = try dir.createFile(old_path, .{});
+    file2.close();
+    defer dir.deleteFile(old_path) catch {};
+
+    try std.testing.expectError(error.PathAlreadyExists, dir.renamePreserve(old_path, dir, new_path));
 }
 
 test "Dir: access" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -3158,6 +3158,32 @@ test "io: dir rename" {
     try std.testing.expectError(error.FileNotFound, dir.rename(old_path, dir, new_path, io));
 }
 
+test "io: dir renamePreserve" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const old_path = "test_io_rename_preserve_old.txt";
+    const new_path = "test_io_rename_preserve_new.txt";
+    defer dir.deleteFile(io, old_path) catch {};
+    defer dir.deleteFile(io, new_path) catch {};
+
+    var file = try dir.createFile(io, old_path, .{});
+    file.close(io);
+
+    // Rename to a free path — should succeed.
+    try dir.renamePreserve(old_path, dir, new_path, io);
+    try std.testing.expectError(error.FileNotFound, dir.openFile(io, old_path, .{}));
+    var moved = try dir.openFile(io, new_path, .{});
+    moved.close(io);
+
+    // Rename onto an existing destination — should fail.
+    var file2 = try dir.createFile(io, old_path, .{});
+    file2.close(io);
+    try std.testing.expectError(error.PathAlreadyExists, dir.renamePreserve(old_path, dir, new_path, io));
+}
+
 test "io: dir create/delete" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();

--- a/src/os/darwin.zig
+++ b/src/os/darwin.zig
@@ -59,6 +59,22 @@ pub extern "c" fn mach_msg(
     notify: std.c.mach_port_name_t,
 ) std.c.kern_return_t;
 
+// renameatx_np - atomic rename with flags (macOS 10.12+, iOS 10.0+)
+// RENAME_EXCL prevents overwriting an existing destination (equivalent to Linux RENAME_NOREPLACE).
+// Reference: https://www.unix.com/man_page/mojave/2/renameatx_np/
+
+pub const RENAME = packed struct(u32) {
+    SECLUDE: bool = false,
+    SWAP: bool = false,
+    EXCL: bool = false,
+    RESERVED1: bool = false,
+    NOFOLLOW_ANY: bool = false,
+    RESOLVE_BENEATH: bool = false,
+    _: u26 = 0,
+};
+
+pub extern "c" fn renameatx_np(fromfd: c_int, from: [*:0]const u8, tofd: c_int, to: [*:0]const u8, flags: RENAME) c_int;
+
 // libinfo async DNS resolution
 
 pub const getaddrinfo_async_callback = *const fn (i32, ?*std.c.addrinfo, ?*anyopaque) callconv(.c) void;

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1114,12 +1114,16 @@ pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: [
                 .SUCCESS => return,
                 .INTR => continue,
                 .EXIST => return error.PathAlreadyExists,
+                // ENOTSUP (= 45 on Darwin, aliased as OPNOTSUPP in Zig's std.c.E):
+                // filesystem doesn't support RENAME_EXCL — fall through to hardlink+delete.
+                .OPNOTSUPP => break,
                 else => |err| return errnoToDirRenameError(err),
             }
         }
     }
 
-    // Fallback for other POSIX: hardlink + delete
+    // Fallback for other POSIX and Darwin filesystems that don't support renameatx_np(RENAME_EXCL):
+    // hardlink + delete
     try dirHardLink(allocator, old_dir, old_path, new_dir, new_path, .{});
     dirDeleteFile(allocator, old_dir, old_path) catch {};
 }

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = @import("posix.zig");
+const darwin = @import("darwin.zig");
 const w = @import("windows.zig");
 
 const unexpectedError = @import("base.zig").unexpectedError;
@@ -1106,7 +1107,19 @@ pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: [
         }
     }
 
-    // Fallback for macOS and other POSIX: hardlink + delete
+    if (comptime builtin.os.tag.isDarwin()) {
+        while (true) {
+            const rc = darwin.renameatx_np(@intCast(old_dir), old_path_z.ptr, @intCast(new_dir), new_path_z.ptr, .{ .EXCL = true });
+            switch (posix.errno(rc)) {
+                .SUCCESS => return,
+                .INTR => continue,
+                .EXIST => return error.PathAlreadyExists,
+                else => |err| return errnoToDirRenameError(err),
+            }
+        }
+    }
+
+    // Fallback for other POSIX: hardlink + delete
     try dirHardLink(allocator, old_dir, old_path, new_dir, new_path, .{});
     dirDeleteFile(allocator, old_dir, old_path) catch {};
 }


### PR DESCRIPTION
## Summary

- Declares `renameatx_np` and `RENAME` flags in `src/os/darwin.zig` (macOS 10.12+, ref: https://www.unix.com/man_page/mojave/2/renameatx_np/)
- Replaces the non-atomic hardlink+delete fallback in `renameatPreserve` on Darwin with `renameatx_np(RENAME_EXCL)`, matching the atomicity of `renameat2(RENAME_NOREPLACE)` on Linux
- Adds `Dir.renamePreserve` to the native API
- Adds tests for `Dir.renamePreserve` (native API) and `Io.Dir.renamePreserve` (std.Io API)

## Test plan

- [ ] `./check.sh` passes on Linux
- [ ] `./check.sh --target aarch64-macos` compiles cleanly
- [ ] Manually test on macOS (success path + `PathAlreadyExists` on conflict)