### PR TITLE
fs: add resolve_beneath support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,9 +13,17 @@ pub fn build(b: *std.Build) void {
         "Override the default event loop backend (io_uring, epoll, kqueue, iocp, poll)",
     );
 
+    const ResolveBeneathMode = enum { strict, best_effort };
+    const resolve_beneath_mode = b.option(
+        ResolveBeneathMode,
+        "resolve-beneath-mode",
+        "How to handle resolve_beneath on platforms without kernel support: strict (error.Unsupported) or best_effort (log warning, continue)",
+    ) orelse .strict;
+
     // Create options for backend selection
     var options = b.addOptions();
     options.addOption(?[]const u8, "backend", backend);
+    options.addOption(ResolveBeneathMode, "resolve_beneath_mode", resolve_beneath_mode);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const linux = std.os.linux;
 const net = @import("../../os/net.zig");
 const fs = @import("../../os/fs.zig");
+const linux_sys = @import("../../os/system/linux.zig");
 const time = @import("../../os/time.zig");
 const Duration = @import("../../time.zig").Duration;
 const common = @import("common.zig");
@@ -106,10 +107,12 @@ pub const NetSendMsgData = struct {
 
 pub const FileOpenData = struct {
     path: [:0]const u8 = "",
+    how: linux_sys.open_how = undefined,
 };
 
 pub const FileCreateData = struct {
     path: [:0]const u8 = "",
+    how: linux_sys.open_how = undefined,
 };
 
 pub const DirCreateDirData = struct {
@@ -411,8 +414,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                     return;
                 };
             }
-            const sqe = self.getSqeOrDefer(c) orelse return;
-            const flags = linux.O{
+            const oflags = linux.O{
                 .ACCMODE = switch (data.flags.mode) {
                     .read_only => .RDONLY,
                     .write_only => .WRONLY,
@@ -420,7 +422,17 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                 },
                 .CLOEXEC = true,
             };
-            sqe.prep_openat(data.dir, data.internal.path, flags, 0);
+            const sqe = self.getSqeOrDefer(c) orelse return;
+            if (data.flags.resolve_beneath) {
+                data.internal.how = .{
+                    .flags = @as(u64, @as(u32, @bitCast(oflags))),
+                    .mode = 0,
+                    .resolve = linux_sys.RESOLVE.BENEATH | linux_sys.RESOLVE.NO_MAGICLINKS,
+                };
+                prep_openat2(sqe, data.dir, data.internal.path, &data.internal.how);
+            } else {
+                sqe.prep_openat(data.dir, data.internal.path, oflags, 0);
+            }
             sqe.user_data = @intFromPtr(c);
         },
         .file_create => {
@@ -432,15 +444,24 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                     return;
                 };
             }
-            const sqe = self.getSqeOrDefer(c) orelse return;
-            const flags = linux.O{
+            const oflags = linux.O{
                 .ACCMODE = if (data.flags.read) .RDWR else .WRONLY,
                 .CLOEXEC = true,
                 .CREAT = true,
                 .TRUNC = data.flags.truncate,
                 .EXCL = data.flags.exclusive,
             };
-            sqe.prep_openat(data.dir, data.internal.path, flags, data.flags.mode);
+            const sqe = self.getSqeOrDefer(c) orelse return;
+            if (data.flags.resolve_beneath) {
+                data.internal.how = .{
+                    .flags = @as(u64, @as(u32, @bitCast(oflags))),
+                    .mode = data.flags.mode,
+                    .resolve = linux_sys.RESOLVE.BENEATH | linux_sys.RESOLVE.NO_MAGICLINKS,
+                };
+                prep_openat2(sqe, data.dir, data.internal.path, &data.internal.how);
+            } else {
+                sqe.prep_openat(data.dir, data.internal.path, oflags, data.flags.mode);
+            }
             sqe.user_data = @intFromPtr(c);
         },
         .file_close => {
@@ -981,7 +1002,7 @@ fn storeResult(self: *Self, c: *Completion, res: i32) void {
             const data = c.cast(FileOpen);
             self.allocator.free(data.internal.path);
             if (res < 0) {
-                c.setError(fs.errnoToFileOpenError(@enumFromInt(-res)));
+                c.setError(fs.errnoToFileOpenError(@enumFromInt(-res), data.flags));
             } else {
                 c.setResult(.file_open, res);
             }
@@ -991,7 +1012,7 @@ fn storeResult(self: *Self, c: *Completion, res: i32) void {
             const data = c.cast(FileCreate);
             self.allocator.free(data.internal.path);
             if (res < 0) {
-                c.setError(fs.errnoToFileOpenError(@enumFromInt(-res)));
+                c.setError(fs.errnoToFileOpenError(@enumFromInt(-res), data.flags));
             } else {
                 c.setResult(.file_create, res);
             }
@@ -1140,7 +1161,7 @@ fn storeResult(self: *Self, c: *Completion, res: i32) void {
             const data = c.cast(DirOpen);
             self.allocator.free(data.internal.path);
             if (res < 0) {
-                c.setError(fs.errnoToFileOpenError(@enumFromInt(-res)));
+                c.setError(fs.errnoToDirOpenError(@enumFromInt(-res), data.flags));
             } else {
                 c.setResult(.dir_open, res);
             }
@@ -1253,4 +1274,23 @@ fn sendFlagsToMsg(flags: net.SendFlags) u32 {
     var msg_flags: u32 = 0;
     if (flags.no_signal) msg_flags |= linux.MSG.NOSIGNAL;
     return msg_flags;
+}
+
+fn prep_openat2(sqe: *linux.io_uring_sqe, fd: linux.fd_t, path: [*:0]const u8, how: *const linux_sys.open_how) void {
+    sqe.* = .{
+        .opcode = .OPENAT2,
+        .fd = fd,
+        .addr = @intFromPtr(path),
+        .len = @sizeOf(linux_sys.open_how),
+        .off = @intFromPtr(how),
+        .user_data = 0,
+        .flags = 0,
+        .ioprio = 0,
+        .rw_flags = 0,
+        .buf_index = 0,
+        .personality = 0,
+        .splice_fd_in = 0,
+        .addr3 = 0,
+        .resv = 0,
+    };
 }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1347,11 +1347,11 @@ test "Dir: resolve_beneath blocks parent escape" {
     defer dir2.close();
 
     // Opening ../file1 from dir2 without resolve_beneath succeeds
-    var f = try dir2.openFile("../file1", .{});
+    var f = try dir2.openFile(".." ++ std.fs.path.sep_str ++ "file1", .{});
     f.close();
 
     // Opening ../file1 from dir2 with resolve_beneath must fail
-    if (dir2.openFile("../file1", .{ .resolve_beneath = true })) |file| {
+    if (dir2.openFile(".." ++ std.fs.path.sep_str ++ "file1", .{ .resolve_beneath = true })) |file| {
         file.close();
         return error.TestUnexpectedResult;
     } else |err| switch (err) {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1324,6 +1324,36 @@ test "Pipe: half-close read end" {
     try std.testing.expectError(error.BrokenPipe, result);
 }
 
+test "Dir: resolve_beneath blocks parent escape" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = Dir.cwd();
+
+    try cwd.createDir("test-resolve-beneath-dir1", 0o755);
+    defer cwd.deleteDir("test-resolve-beneath-dir1") catch {};
+
+    const dir1 = try cwd.openDir("test-resolve-beneath-dir1", .{});
+    defer dir1.close();
+
+    var file1 = try dir1.createFile("file1", .{});
+    file1.close();
+    defer dir1.deleteFile("file1") catch {};
+
+    try dir1.createDir("dir2", 0o755);
+    defer dir1.deleteDir("dir2") catch {};
+
+    const dir2 = try dir1.openDir("dir2", .{});
+    defer dir2.close();
+
+    // Opening ../file1 from dir2 without resolve_beneath succeeds
+    var f = try dir2.openFile("../file1", .{});
+    f.close();
+
+    // Opening ../file1 from dir2 with resolve_beneath must fail
+    try std.testing.expectError(error.PathEscaped, dir2.openFile("../file1", .{ .resolve_beneath = true }));
+}
+
 test "File: blocking mode without runtime" {
     // This test verifies that file operations work in blocking mode
     // when called without an async runtime

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1351,7 +1351,7 @@ test "Dir: resolve_beneath blocks parent escape" {
     f.close();
 
     // Opening ../file1 from dir2 with resolve_beneath must fail
-    try std.testing.expectError(error.PathEscaped, dir2.openFile("../file1", .{ .resolve_beneath = true }));
+    try std.testing.expectError(error.AccessDenied, dir2.openFile("../file1", .{ .resolve_beneath = true }));
 }
 
 test "File: blocking mode without runtime" {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1325,6 +1325,8 @@ test "Pipe: half-close read end" {
 }
 
 test "Dir: resolve_beneath blocks parent escape" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1351,7 +1351,13 @@ test "Dir: resolve_beneath blocks parent escape" {
     f.close();
 
     // Opening ../file1 from dir2 with resolve_beneath must fail
-    try std.testing.expectError(error.AccessDenied, dir2.openFile("../file1", .{ .resolve_beneath = true }));
+    if (dir2.openFile("../file1", .{ .resolve_beneath = true })) |file| {
+        file.close();
+        return error.TestUnexpectedResult;
+    } else |err| switch (err) {
+        error.AccessDenied, error.Unsupported => {},
+        else => return err,
+    }
 }
 
 test "File: blocking mode without runtime" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -962,6 +962,7 @@ fn dirOpenErrToStdErr(err: ev.DirOpen.Error) Io.Dir.OpenError {
         error.NotDir => error.NotDir,
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
+        error.PathEscaped => error.AccessDenied,
         error.Canceled => error.Canceled,
         error.Unexpected => error.Unexpected,
     };
@@ -1021,6 +1022,7 @@ fn openErrToFileErr(err: ev.FileOpen.Error) Io.File.OpenError {
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
         error.FileBusy => error.FileBusy,
+        error.PathEscaped => error.AccessDenied,
         error.Canceled => error.Canceled,
         error.InvalidUtf8,
         error.InvalidWtf8,

--- a/src/io.zig
+++ b/src/io.zig
@@ -962,7 +962,6 @@ fn dirOpenErrToStdErr(err: ev.DirOpen.Error) Io.Dir.OpenError {
         error.NotDir => error.NotDir,
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
-        error.PathEscaped => error.AccessDenied,
         error.Canceled => error.Canceled,
         error.Unexpected => error.Unexpected,
     };
@@ -1022,7 +1021,6 @@ fn openErrToFileErr(err: ev.FileOpen.Error) Io.File.OpenError {
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
         error.FileBusy => error.FileBusy,
-        error.PathEscaped => error.AccessDenied,
         error.Canceled => error.Canceled,
         error.InvalidUtf8,
         error.InvalidWtf8,

--- a/src/io.zig
+++ b/src/io.zig
@@ -1043,11 +1043,11 @@ fn stdIoModeToZio(mode: Io.Dir.OpenFileOptions.Mode) os_fs.FileOpenMode {
 fn dirCreateFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: Io.Dir.CreateFileOptions) Io.File.OpenError!Io.File {
     if (options.lock != .none) @panic("TODO: createFile lock");
     if (options.lock_nonblocking) @panic("TODO: createFile lock_nonblocking");
-    if (options.resolve_beneath) @panic("TODO: createFile resolve_beneath");
     var op = ev.FileCreate.init(stdIoHandleToZio(dir.handle), sub_path, .{
         .read = options.read,
         .truncate = options.truncate,
         .exclusive = options.exclusive,
+        .resolve_beneath = options.resolve_beneath,
         .mode = permissionsToZioMode(options.permissions),
     });
     try waitForIo(&op.c);

--- a/src/io.zig
+++ b/src/io.zig
@@ -963,6 +963,7 @@ fn dirOpenErrToStdErr(err: ev.DirOpen.Error) Io.Dir.OpenError {
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
         error.Canceled => error.Canceled,
+        error.Unsupported => error.AccessDenied,
         error.Unexpected => error.Unexpected,
     };
 }
@@ -1022,6 +1023,7 @@ fn openErrToFileErr(err: ev.FileOpen.Error) Io.File.OpenError {
         error.NetworkNotFound => error.NetworkNotFound,
         error.FileBusy => error.FileBusy,
         error.Canceled => error.Canceled,
+        error.Unsupported => error.AccessDenied,
         error.InvalidUtf8,
         error.InvalidWtf8,
         error.ProcessNotFound,

--- a/src/io.zig
+++ b/src/io.zig
@@ -963,7 +963,7 @@ fn dirOpenErrToStdErr(err: ev.DirOpen.Error) Io.Dir.OpenError {
         error.BadPathName => error.BadPathName,
         error.NetworkNotFound => error.NetworkNotFound,
         error.Canceled => error.Canceled,
-        error.Unsupported => error.AccessDenied,
+        error.Unsupported => error.Unexpected,
         error.Unexpected => error.Unexpected,
     };
 }
@@ -1023,7 +1023,7 @@ fn openErrToFileErr(err: ev.FileOpen.Error) Io.File.OpenError {
         error.NetworkNotFound => error.NetworkNotFound,
         error.FileBusy => error.FileBusy,
         error.Canceled => error.Canceled,
-        error.Unsupported => error.AccessDenied,
+        error.Unsupported => error.Unexpected,
         error.InvalidUtf8,
         error.InvalidWtf8,
         error.ProcessNotFound,

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = @import("posix.zig");
 const w = @import("windows.zig");
+const options = @import("zio_options");
 
 const unexpectedError = @import("base.zig").unexpectedError;
 
@@ -163,6 +164,7 @@ pub const FileOpenError = error{
     ProcessNotFound,
     FileBusy,
     Canceled,
+    Unsupported,
     Unexpected,
 };
 
@@ -180,6 +182,7 @@ pub const DirOpenError = error{
     BadPathName,
     NetworkNotFound,
     Canceled,
+    Unsupported,
     Unexpected,
 };
 
@@ -643,16 +646,20 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
                     .INTR, .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
+                        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
                         std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
                         break;
                     },
                     else => |err| return errnoToFileOpenError(err, flags),
                 }
             }
+        } else if (options.resolve_beneath_mode == .strict) {
+            return error.Unsupported;
         }
     } else if (@hasField(posix.O, "RESOLVE_BENEATH") and flags.resolve_beneath) {
         open_flags.RESOLVE_BENEATH = true;
     } else if (flags.resolve_beneath) {
+        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
@@ -735,16 +742,20 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
                     .INTR, .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
+                        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
                         std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
                         break;
                     },
                     else => |err| return errnoToDirOpenError(err, flags),
                 }
             }
+        } else if (options.resolve_beneath_mode == .strict) {
+            return error.Unsupported;
         }
     } else if (builtin.os.tag == .freebsd and flags.resolve_beneath) {
         open_flags.RESOLVE_BENEATH = true;
     } else if (flags.resolve_beneath) {
+        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
@@ -838,16 +849,20 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
                     .INTR, .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
+                        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
                         std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
                         break;
                     },
                     else => |err| return errnoToFileOpenError(err, flags),
                 }
             }
+        } else if (options.resolve_beneath_mode == .strict) {
+            return error.Unsupported;
         }
     } else if (builtin.os.tag == .freebsd and flags.resolve_beneath) {
         open_flags.RESOLVE_BENEATH = true;
     } else if (flags.resolve_beneath) {
+        if (options.resolve_beneath_mode == .strict) return error.Unsupported;
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -162,8 +162,6 @@ pub const FileOpenError = error{
     NetworkNotFound,
     ProcessNotFound,
     FileBusy,
-    /// Path resolution attempted to escape the starting directory (resolve_beneath).
-    PathEscaped,
     Canceled,
     Unexpected,
 };
@@ -181,8 +179,6 @@ pub const DirOpenError = error{
     NotDir,
     BadPathName,
     NetworkNotFound,
-    /// Path resolution attempted to escape the starting directory (resolve_beneath).
-    PathEscaped,
     Canceled,
     Unexpected,
 };
@@ -667,8 +663,8 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
             .INTR => continue,
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
                 }
                 return errnoToFileOpenError(err, flags);
             },
@@ -759,8 +755,8 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
             .INTR => continue,
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
                 }
                 return errnoToDirOpenError(err, flags);
             },
@@ -862,8 +858,8 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
             .INTR => continue,
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
                 }
                 return errnoToFileOpenError(err, flags);
             },
@@ -1377,7 +1373,7 @@ pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError
         .EXIST => error.PathAlreadyExists,
         .BUSY => error.DeviceBusy,
         .TXTBSY => error.FileBusy,
-        .XDEV => if (flags.resolve_beneath) error.PathEscaped else unexpectedError(errno),
+        .XDEV => if (flags.resolve_beneath) error.AccessDenied else unexpectedError(errno),
         .CANCELED => error.Canceled,
         else => |e| unexpectedError(e) catch error.Unexpected,
     };
@@ -1396,7 +1392,7 @@ pub fn errnoToDirOpenError(errno: posix.system.E, flags: DirOpenFlags) DirOpenEr
         .NAMETOOLONG => error.NameTooLong,
         .NOMEM => error.SystemResources,
         .NOTDIR => error.NotDir,
-        .XDEV => if (flags.resolve_beneath) error.PathEscaped else unexpectedError(errno),
+        .XDEV => if (flags.resolve_beneath) error.AccessDenied else unexpectedError(errno),
         .CANCELED => error.Canceled,
         else => |e| unexpectedError(e) catch error.Unexpected,
     };

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1375,7 +1375,7 @@ pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError
         .TXTBSY => error.FileBusy,
         .XDEV => if (flags.resolve_beneath) error.AccessDenied else unexpectedError(errno),
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1394,7 +1394,7 @@ pub fn errnoToDirOpenError(errno: posix.system.E, flags: DirOpenFlags) DirOpenEr
         .NOTDIR => error.NotDir,
         .XDEV => if (flags.resolve_beneath) error.AccessDenied else unexpectedError(errno),
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1412,7 +1412,7 @@ pub fn errnoToFileReadError(err: E) FileReadError {
                 .HANDLE_EOF => error.InputOutput,
                 .OPERATION_ABORTED => error.Canceled,
                 .NOT_ENOUGH_MEMORY, .OUTOFMEMORY => error.SystemResources,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
         else => {
@@ -1426,7 +1426,7 @@ pub fn errnoToFileReadError(err: E) FileReadError {
                 .NOMEM => error.SystemResources,
                 .BADF => error.NotOpenForReading,
                 .SPIPE => error.Unseekable,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
     }
@@ -1445,7 +1445,7 @@ pub fn errnoToFileWriteError(err: E) FileWriteError {
                 .OPERATION_ABORTED => error.Canceled,
                 .DISK_FULL, .HANDLE_DISK_FULL => error.NoSpaceLeft,
                 .NOT_ENOUGH_MEMORY, .OUTOFMEMORY => error.SystemResources,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
         else => {
@@ -1462,7 +1462,7 @@ pub fn errnoToFileWriteError(err: E) FileWriteError {
                 .DQUOT => error.DiskQuota,
                 .FBIG => error.FileTooBig,
                 .SPIPE => error.Unseekable,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
     }
@@ -1473,14 +1473,14 @@ pub fn errnoToFileCloseError(errno: E) FileCloseError {
         .windows => {
             return switch (errno) {
                 .SUCCESS => unreachable,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
         else => {
             return switch (errno) {
                 .SUCCESS => unreachable,
                 .CANCELED => error.Canceled,
-                else => |e| unexpectedError(e) catch error.Unexpected,
+                else => |e| unexpectedError(e),
             };
         },
     }
@@ -1494,7 +1494,7 @@ pub fn errnoToFileSyncError(errno: posix.system.E) FileSyncError {
         .DQUOT => error.DiskQuota,
         .ACCES, .PERM, .ROFS => error.AccessDenied,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1518,7 +1518,7 @@ pub fn errnoToDirRenameError(errno: posix.system.E) DirRenameError {
         .XDEV => error.CrossDevice,
         .NOTEMPTY => error.DirNotEmpty,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1536,7 +1536,7 @@ pub fn errnoToDirDeleteFileError(errno: posix.system.E) DirDeleteFileError {
         .NOMEM => error.SystemResources,
         .ROFS => error.ReadOnlyFileSystem,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1554,7 +1554,7 @@ pub fn errnoToDirDeleteDirError(errno: posix.system.E) DirDeleteDirError {
         .ROFS => error.ReadOnlyFileSystem,
         .NOTEMPTY => error.DirNotEmpty,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1574,7 +1574,7 @@ pub fn errnoToDirCreateDirError(errno: posix.system.E) DirCreateDirError {
         .NOTDIR => error.NotDir,
         .ROFS => error.ReadOnlyFileSystem,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1587,7 +1587,7 @@ pub fn fileSize(fd: fd_t) FileSizeError!u64 {
         if (success == w.FALSE) {
             switch (w.GetLastError()) {
                 .ACCESS_DENIED => return error.AccessDenied,
-                else => |err| return unexpectedError(err) catch error.Unexpected,
+                else => |err| return unexpectedError(err),
             }
         }
 
@@ -1624,7 +1624,7 @@ pub fn errnoToFileSizeError(errno: posix.system.E) FileSizeError {
         .ACCES => error.AccessDenied,
         .PERM => error.PermissionDenied,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1638,7 +1638,7 @@ pub fn fstat(fd: fd_t) FileStatError!FileStatInfo {
             switch (w.GetLastError()) {
                 .INVALID_HANDLE => return error.InvalidFileDescriptor,
                 .ACCESS_DENIED => return error.AccessDenied,
-                else => |err| return unexpectedError(err) catch error.Unexpected,
+                else => |err| return unexpectedError(err),
             }
         }
 
@@ -1715,7 +1715,7 @@ pub fn fstatat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
                 .FILE_NOT_FOUND => error.FileNotFound,
                 .PATH_NOT_FOUND => error.FileNotFound,
                 .ACCESS_DENIED => error.AccessDenied,
-                else => |err| return unexpectedError(err) catch error.Unexpected,
+                else => |err| return unexpectedError(err),
             };
         }
         defer _ = w.CloseHandle(handle);
@@ -1824,7 +1824,7 @@ pub fn errnoToFileStatError(errno: posix.system.E) FileStatError {
         .LOOP => error.SymLinkLoop,
         .NOMEM => error.SystemResources,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1837,7 +1837,7 @@ pub fn fileSetSize(fd: fd_t, length: u64) FileSetSizeError!void {
             return switch (w.GetLastError()) {
                 .INVALID_HANDLE => error.Unexpected,
                 .ACCESS_DENIED => error.AccessDenied,
-                else => |err| unexpectedError(err) catch error.Unexpected,
+                else => |err| unexpectedError(err),
             };
         }
 
@@ -1852,7 +1852,7 @@ pub fn fileSetSize(fd: fd_t, length: u64) FileSetSizeError!void {
             return switch (w.GetLastError()) {
                 .INVALID_HANDLE => error.Unexpected,
                 .ACCESS_DENIED => error.AccessDenied,
-                else => |err| unexpectedError(err) catch error.Unexpected,
+                else => |err| unexpectedError(err),
             };
         }
 
@@ -1862,7 +1862,7 @@ pub fn fileSetSize(fd: fd_t, length: u64) FileSetSizeError!void {
             _ = w.SetFilePointerEx(fd, current_pos, null, w.FILE_BEGIN);
             return switch (w.GetLastError()) {
                 .ACCESS_DENIED => error.AccessDenied,
-                else => |err| unexpectedError(err) catch error.Unexpected,
+                else => |err| unexpectedError(err),
             };
         }
 
@@ -1890,7 +1890,7 @@ pub fn errnoToFileSetSizeError(errno: posix.system.E) FileSetSizeError {
         .TXTBSY => error.FileBusy,
         .PERM => error.PermissionDenied,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1919,7 +1919,7 @@ pub fn errnoToFileSetPermissionsError(errno: posix.system.E) FileSetPermissionsE
         .PERM => error.PermissionDenied,
         .ROFS => error.ReadOnlyFileSystem,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1949,7 +1949,7 @@ pub fn errnoToFileSetOwnerError(errno: posix.system.E) FileSetOwnerError {
         .PERM => error.PermissionDenied,
         .ROFS => error.ReadOnlyFileSystem,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -1976,7 +1976,7 @@ pub fn fileSetTimestamps(fd: fd_t, timestamps: FileTimestamps) FileSetTimestamps
             return switch (w.GetLastError()) {
                 .INVALID_HANDLE => error.Unexpected,
                 .ACCESS_DENIED => error.AccessDenied,
-                else => |err| unexpectedError(err) catch error.Unexpected,
+                else => |err| unexpectedError(err),
             };
         }
         return;
@@ -2012,7 +2012,7 @@ pub fn errnoToFileSetTimestampsError(errno: posix.system.E) FileSetTimestampsErr
         .PERM => error.PermissionDenied,
         .ROFS => error.ReadOnlyFileSystem,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2162,7 +2162,7 @@ pub fn errnoToSymLinkError(errno: posix.system.E) SymLinkError {
         .NOSPC => error.NoSpaceLeft,
         .NOMEM => error.SystemResources,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2211,7 +2211,7 @@ pub fn errnoToReadLinkError(errno: posix.system.E) ReadLinkError {
         .NOTDIR => error.NotDir,
         .NOMEM => error.SystemResources,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2277,7 +2277,7 @@ pub fn errnoToHardLinkError(errno: posix.system.E) HardLinkError {
         .NOMEM => error.SystemResources,
         .XDEV => error.CrossDevice,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2402,7 +2402,7 @@ pub fn errnoToDirAccessError(errno: posix.system.E) DirAccessError {
         .NAMETOOLONG => error.NameTooLong,
         .NOTDIR => error.FileNotFound,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2446,7 +2446,7 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
         switch (posix.errno(rc)) {
             .SUCCESS => {},
             .BADF => return error.Unexpected,
-            else => |err| return unexpectedError(err) catch error.Unexpected,
+            else => |err| return unexpectedError(err),
         }
     }
 
@@ -2473,7 +2473,7 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
             .ACCES => return error.AccessDenied,
             .PERM => return error.PermissionDenied,
             .NOMEM => return error.SystemResources,
-            else => |err| return unexpectedError(err) catch error.Unexpected,
+            else => |err| return unexpectedError(err),
         }
     }
 }
@@ -2667,7 +2667,7 @@ fn errnoToDirRealPathFileError(errno: posix.system.E) DirRealPathFileError {
         .EXIST => error.PathAlreadyExists,
         .BUSY, .TXTBSY => error.DeviceBusy,
         .ILSEQ, .INVAL => error.BadPathName,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 
@@ -2685,7 +2685,7 @@ pub fn errnoToDirRealPathError(errno: posix.system.E) DirRealPathError {
         .BADF => error.FileNotFound,
         .NOSPC, .RANGE => error.NameTooLong,
         .CANCELED => error.Canceled,
-        else => |e| unexpectedError(e) catch error.Unexpected,
+        else => |e| unexpectedError(e),
     };
 }
 

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -5,6 +5,9 @@ const w = @import("windows.zig");
 
 const unexpectedError = @import("base.zig").unexpectedError;
 
+// Cached probe result: once we see ENOSYS from openat2, skip future attempts.
+var openat2_nosys: std.atomic.Value(bool) = .init(false);
+
 pub const fd_t = switch (builtin.os.tag) {
     .windows => w.HANDLE,
     else => posix.system.fd_t,
@@ -109,6 +112,10 @@ pub const FileOpenFlags = struct {
     /// On Windows this is enforced without extra syscalls (no FILE_FLAG_BACKUP_SEMANTICS).
     /// On POSIX an extra fstat is required; defaults to true to avoid the overhead.
     allow_directory: bool = true,
+    /// Prevent path resolution from escaping the starting directory (e.g. via ".." or symlinks).
+    /// Enforced by the kernel on Linux 5.6+ (openat2 RESOLVE_BENEATH) and FreeBSD 13+ (O_RESOLVE_BENEATH).
+    /// On other platforms a warning is logged and the flag is ignored.
+    resolve_beneath: bool = false,
 };
 
 pub const DirOpenFlags = struct {
@@ -116,6 +123,9 @@ pub const DirOpenFlags = struct {
     follow_symlinks: bool = true,
     /// Whether the directory will be iterated (affects O_PATH optimization on Linux)
     iterate: bool = false,
+    /// Prevent path resolution from escaping the starting directory.
+    /// See FileOpenFlags.resolve_beneath for platform support details.
+    resolve_beneath: bool = false,
 };
 
 pub const FileCreateFlags = struct {
@@ -124,6 +134,9 @@ pub const FileCreateFlags = struct {
     exclusive: bool = false,
     mode: mode_t = 0o664,
     nonblocking: bool = false,
+    /// Prevent path resolution from escaping the starting directory.
+    /// See FileOpenFlags.resolve_beneath for platform support details.
+    resolve_beneath: bool = false,
 };
 
 pub const FileOpenError = error{
@@ -149,6 +162,8 @@ pub const FileOpenError = error{
     NetworkNotFound,
     ProcessNotFound,
     FileBusy,
+    /// Path resolution attempted to escape the starting directory (resolve_beneath).
+    PathEscaped,
     Canceled,
     Unexpected,
 };
@@ -166,6 +181,8 @@ pub const DirOpenError = error{
     NotDir,
     BadPathName,
     NetworkNotFound,
+    /// Path resolution attempted to escape the starting directory (resolve_beneath).
+    PathEscaped,
     Canceled,
     Unexpected,
 };
@@ -604,7 +621,7 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
         return handle;
     }
 
-    const open_flags: posix.system.O = .{
+    var open_flags: posix.system.O = .{
         .ACCMODE = switch (flags.mode) {
             .read_only => .RDONLY,
             .write_only => .WRONLY,
@@ -616,12 +633,44 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    if (builtin.os.tag == .linux and flags.resolve_beneath) {
+        if (!openat2_nosys.load(.monotonic)) {
+            const how: posix.sys.open_how = .{
+                .flags = @as(u64, @as(u32, @bitCast(open_flags))),
+                .mode = 0,
+                .resolve = posix.sys.RESOLVE.BENEATH | posix.sys.RESOLVE.NO_MAGICLINKS,
+            };
+            while (true) {
+                const rc = posix.sys.openat2(dir, path_z.ptr, &how);
+                switch (posix.errno(rc)) {
+                    .SUCCESS => return @intCast(rc),
+                    .INTR, .AGAIN => continue,
+                    .NOSYS => {
+                        openat2_nosys.store(true, .monotonic);
+                        std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
+                        break;
+                    },
+                    else => |err| return errnoToFileOpenError(err, flags),
+                }
+            }
+        }
+    } else if (@hasField(posix.O, "RESOLVE_BENEATH") and flags.resolve_beneath) {
+        open_flags.RESOLVE_BENEATH = true;
+    } else if (flags.resolve_beneath) {
+        std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
+    }
+
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
-            else => |err| return errnoToFileOpenError(err),
+            else => |err| {
+                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
+                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                }
+                return errnoToFileOpenError(err, flags);
+            },
         }
     }
 }
@@ -675,12 +724,44 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    if (builtin.os.tag == .linux and flags.resolve_beneath) {
+        if (!openat2_nosys.load(.monotonic)) {
+            const how: posix.sys.open_how = .{
+                .flags = @as(u64, @as(u32, @bitCast(open_flags))),
+                .mode = 0,
+                .resolve = posix.sys.RESOLVE.BENEATH | posix.sys.RESOLVE.NO_MAGICLINKS,
+            };
+            while (true) {
+                const rc = posix.sys.openat2(dir, path_z.ptr, &how);
+                switch (posix.errno(rc)) {
+                    .SUCCESS => return @intCast(rc),
+                    .INTR, .AGAIN => continue,
+                    .NOSYS => {
+                        openat2_nosys.store(true, .monotonic);
+                        std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
+                        break;
+                    },
+                    else => |err| return errnoToDirOpenError(err, flags),
+                }
+            }
+        }
+    } else if (builtin.os.tag == .freebsd and flags.resolve_beneath) {
+        open_flags.RESOLVE_BENEATH = true;
+    } else if (flags.resolve_beneath) {
+        std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
+    }
+
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
-            else => |err| return errnoToDirOpenError(err),
+            else => |err| {
+                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
+                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                }
+                return errnoToDirOpenError(err, flags);
+            },
         }
     }
 }
@@ -745,12 +826,44 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    if (builtin.os.tag == .linux and flags.resolve_beneath) {
+        if (!openat2_nosys.load(.monotonic)) {
+            const how: posix.sys.open_how = .{
+                .flags = @as(u64, @as(u32, @bitCast(open_flags))),
+                .mode = flags.mode,
+                .resolve = posix.sys.RESOLVE.BENEATH | posix.sys.RESOLVE.NO_MAGICLINKS,
+            };
+            while (true) {
+                const rc = posix.sys.openat2(dir, path_z.ptr, &how);
+                switch (posix.errno(rc)) {
+                    .SUCCESS => return @intCast(rc),
+                    .INTR, .AGAIN => continue,
+                    .NOSYS => {
+                        openat2_nosys.store(true, .monotonic);
+                        std.log.warn("openat2 not available (requires Linux 5.6+), resolve_beneath will not be enforced", .{});
+                        break;
+                    },
+                    else => |err| return errnoToFileOpenError(err, flags),
+                }
+            }
+        }
+    } else if (builtin.os.tag == .freebsd and flags.resolve_beneath) {
+        open_flags.RESOLVE_BENEATH = true;
+    } else if (flags.resolve_beneath) {
+        std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
+    }
+
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, flags.mode);
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
-            else => |err| return errnoToFileOpenError(err),
+            else => |err| {
+                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
+                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                }
+                return errnoToFileOpenError(err, flags);
+            },
         }
     }
 }
@@ -1242,7 +1355,7 @@ pub fn mkdirat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, mode: 
     }
 }
 
-pub fn errnoToFileOpenError(errno: posix.system.E) FileOpenError {
+pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError {
     return switch (errno) {
         .SUCCESS => unreachable,
         .ACCES => error.AccessDenied,
@@ -1261,12 +1374,13 @@ pub fn errnoToFileOpenError(errno: posix.system.E) FileOpenError {
         .EXIST => error.PathAlreadyExists,
         .BUSY => error.DeviceBusy,
         .TXTBSY => error.FileBusy,
+        .XDEV => if (flags.resolve_beneath) error.PathEscaped else unexpectedError(errno),
         .CANCELED => error.Canceled,
         else => |e| unexpectedError(e) catch error.Unexpected,
     };
 }
 
-pub fn errnoToDirOpenError(errno: posix.system.E) DirOpenError {
+pub fn errnoToDirOpenError(errno: posix.system.E, flags: DirOpenFlags) DirOpenError {
     return switch (errno) {
         .SUCCESS => unreachable,
         .ACCES => error.AccessDenied,
@@ -1279,6 +1393,7 @@ pub fn errnoToDirOpenError(errno: posix.system.E) DirOpenError {
         .NAMETOOLONG => error.NameTooLong,
         .NOMEM => error.SystemResources,
         .NOTDIR => error.NotDir,
+        .XDEV => if (flags.resolve_beneath) error.PathEscaped else unexpectedError(errno),
         .CANCELED => error.Canceled,
         else => |e| unexpectedError(e) catch error.Unexpected,
     };

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -580,6 +580,10 @@ pub const FileSetTimestampsError = error{
 /// Open an existing file using openat() syscall
 pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: FileOpenFlags) FileOpenError!fd_t {
     if (builtin.os.tag == .windows) {
+        if (flags.resolve_beneath) {
+            if (options.resolve_beneath_mode == .strict) return error.Unsupported;
+            std.log.warn("resolve_beneath is not supported on Windows, path escapes will not be detected", .{});
+        }
         const path_w = try w.pathToWide(allocator, dir, path);
         defer allocator.free(path_w);
 
@@ -682,6 +686,10 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
 /// Open a directory using openat() syscall
 pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: DirOpenFlags) DirOpenError!fd_t {
     if (builtin.os.tag == .windows) {
+        if (flags.resolve_beneath) {
+            if (options.resolve_beneath_mode == .strict) return error.Unsupported;
+            std.log.warn("resolve_beneath is not supported on Windows, path escapes will not be detected", .{});
+        }
         const path_w = try w.pathToWide(allocator, dir, path);
         defer allocator.free(path_w);
 
@@ -780,6 +788,10 @@ pub const FileCreateError = FileOpenError;
 /// Create a file using openat() syscall
 pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: FileCreateFlags) FileCreateError!fd_t {
     if (builtin.os.tag == .windows) {
+        if (flags.resolve_beneath) {
+            if (options.resolve_beneath_mode == .strict) return error.Unsupported;
+            std.log.warn("resolve_beneath is not supported on Windows, path escapes will not be detected", .{});
+        }
         const path_w = try w.pathToWide(allocator, dir, path);
         defer allocator.free(path_w);
 

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -666,8 +666,9 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
             else => |err| {
-                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
-                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                if (flags.resolve_beneath) {
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
                 }
                 return errnoToFileOpenError(err, flags);
             },
@@ -757,8 +758,9 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
             else => |err| {
-                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
-                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                if (flags.resolve_beneath) {
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
                 }
                 return errnoToDirOpenError(err, flags);
             },
@@ -859,8 +861,9 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
             .SUCCESS => return @intCast(rc),
             .INTR => continue,
             else => |err| {
-                if (builtin.os.tag == .freebsd or builtin.os.tag.isDarwin()) {
-                    if (flags.resolve_beneath and err == .NOTCAPABLE) return error.PathEscaped;
+                if (flags.resolve_beneath) {
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.PathEscaped;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.PathEscaped;
                 }
                 return errnoToFileOpenError(err, flags);
             },

--- a/src/os/system/linux.zig
+++ b/src/os/system/linux.zig
@@ -437,3 +437,38 @@ pub fn mkdirat(dirfd: fd_t, path: [*:0]const u8, mode: mode_t) usize {
         mode,
     );
 }
+
+/// Resolve flags for openat2(2), available since Linux 5.6.
+/// From linux/openat2.h.
+pub const RESOLVE = struct {
+    /// Block mount-point crossings (bind-mounts, rbind-mounts, etc.)
+    pub const NO_XDEV: u64 = 0x01;
+    /// Block magic-link resolution (/proc/self/exe, /proc/self/fd/*, etc.)
+    pub const NO_MAGICLINKS: u64 = 0x02;
+    /// Block all symlink resolution
+    pub const NO_SYMLINKS: u64 = 0x04;
+    /// Block resolution of paths that would escape the starting dirfd
+    pub const BENEATH: u64 = 0x08;
+    /// Treat the dirfd as the filesystem root during resolution
+    pub const IN_ROOT: u64 = 0x10;
+    /// Use cached paths; fail with EAGAIN if a cached lookup is not possible
+    pub const CACHED: u64 = 0x20;
+};
+
+/// Arguments for the openat2(2) syscall, available since Linux 5.6.
+/// From linux/openat2.h (struct open_how).
+pub const open_how = extern struct {
+    flags: u64,
+    mode: u64,
+    resolve: u64,
+};
+
+pub fn openat2(dirfd: fd_t, path: [*:0]const u8, how: *const open_how) usize {
+    return linux.syscall4(
+        .openat2,
+        @as(usize, @bitCast(@as(isize, dirfd))),
+        @intFromPtr(path),
+        @intFromPtr(how),
+        @sizeOf(open_how),
+    );
+}


### PR DESCRIPTION
## Summary

- **Linux 5.6+**: uses `openat2(RESOLVE_BENEATH | NO_MAGICLINKS)` natively — via `IORING_OP_OPENAT2` in the io_uring backend or direct syscall in epoll/blocking backends; falls back with a warning on older kernels
- **FreeBSD 13+ / macOS**: uses `O_RESOLVE_BENEATH` flag in `openat` (both return `ENOTCAPABLE` on escape)
- **Other platforms**: logs a warning, no enforcement
- `EXDEV` (Linux openat2) and `ENOTCAPABLE` (FreeBSD/Darwin) are mapped to the new `error.PathEscaped` in `FileOpenError` and `DirOpenError`
- At the `std.Io` layer, `PathEscaped` maps to `error.AccessDenied` (matching the stdlib convention)

This goes further than `std.Io.Threaded`, which only handles FreeBSD/macOS via `O_RESOLVE_BENEATH` and has no Linux openat2 support.

Fixes https://github.com/lalinsky/zio/issues/385

## Test plan

- [ ] Test passes on Linux (io_uring and epoll backends)
- [ ] Check CI results for macOS and FreeBSD
- [ ] Check CI results for Windows and other platforms (should warn and not crash)