### PR TITLE
thread_pool: allow max_threads=0 to disable the pool

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Setting `max_threads = 0` in the thread pool options now disables the thread pool, executing
+  blocking work inline on the calling thread (the same behavior as a single-threaded build).
+
 ## [0.13.0] - 2026-05-31
 
 ### Added

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -43,20 +43,14 @@ pub const ThreadPool = struct {
     };
 
     pub fn init(self: *ThreadPool, allocator: std.mem.Allocator, options: Options) !void {
-        if (builtin.single_threaded) {
-            self.* = .{
-                .allocator = allocator,
-                .min_threads = 0,
-                .max_threads = 0,
-                .idle_timeout_ns = 0,
-                .scale_threshold = options.scale_threshold,
-            };
-            return;
-        }
+        // A max_threads of 0 (explicit, or implied by a single-threaded build)
+        // disables the pool: work is executed inline in submit().
+        const max_threads = if (builtin.single_threaded)
+            0
+        else
+            options.max_threads orelse (try std.Thread.getCpuCount()) * 2;
 
-        const cpu_count = try std.Thread.getCpuCount();
-        const max_threads = options.max_threads orelse (cpu_count * 2);
-        const min_threads = options.min_threads;
+        const min_threads = @min(options.min_threads, max_threads);
 
         self.* = .{
             .allocator = allocator,
@@ -140,7 +134,7 @@ pub const ThreadPool = struct {
     }
 
     pub fn submit(self: *ThreadPool, work: *Work) void {
-        if (builtin.single_threaded) {
+        if (builtin.single_threaded or self.max_threads == 0) {
             if (work.state.cmpxchgStrong(.pending, .running, .acq_rel, .acquire)) |state| {
                 std.debug.assert(state == .canceled);
                 work.c.setError(error.Canceled);


### PR DESCRIPTION
Setting `max_threads = 0` in the thread pool options now disables the pool: submitted work runs inline on the calling thread, identical to a single-threaded build.

## Changes

- `submit()` takes the inline-execution path when `builtin.single_threaded or self.max_threads == 0`. The comptime check stays first so the threaded path is still fully eliminated in single-threaded builds.
- `init()` collapses to a single code path. `max_threads` resolves to `0` for single-threaded builds (or an explicit `0`), and the existing setup handles it naturally: `min_threads` clamps to `0`, capacity reservation is a no-op, and no threads are spawned.
- `min_threads` is clamped to `max_threads` so a contradictory `min > max` can't be requested.
- Changelog entry added.

## Testing

`./check.sh` — all 471 tests pass.