### PR TITLE
Re-enable task migration

### DIFF
--- a/src/coro/coroutines.zig
+++ b/src/coro/coroutines.zig
@@ -14,7 +14,16 @@ const stackFree = @import("stack.zig").stackFree;
 
 /// Current coroutine context for this thread. Used by the SIGSEGV signal handler
 /// to determine if a fault is from a coroutine stack and to access stack metadata.
-pub threadlocal var current_context: ?*Context = null;
+pub threadlocal var current_context_DO_NOT_ACCESS_DIRECTLY: ?*Context = null;
+
+/// Get the current coroutine context for this thread, or null if not in coroutine context.
+pub noinline fn getCurrentContext() ?*Context {
+    return current_context_DO_NOT_ACCESS_DIRECTLY;
+}
+
+noinline fn setCurrentContext(current: ?*Context) void {
+    current_context_DO_NOT_ACCESS_DIRECTLY = current;
+}
 
 pub const Context = switch (builtin.cpu.arch) {
     .x86_64 => extern struct {
@@ -153,7 +162,7 @@ pub inline fn switchContext(
 ) void {
     // Update current context pointer for SIGSEGV handler
     // After the switch, we'll be executing in new_context
-    current_context = new_context;
+    setCurrentContext(new_context);
 
     const is_windows = builtin.os.tag == .windows;
     switch (builtin.cpu.arch) {
@@ -1190,7 +1199,7 @@ pub const Coroutine = struct {
 
     /// Returns the current coroutine for this thread, or null if not in a coroutine.
     pub fn getCurrent() ?*Coroutine {
-        if (current_context) |context| {
+        if (getCurrentContext()) |context| {
             return @alignCast(@fieldParentPtr("context", context));
         }
         return null;
@@ -1198,12 +1207,12 @@ pub const Coroutine = struct {
 
     /// Set the current coroutine context for this thread.
     pub fn setCurrent(self: *Coroutine) void {
-        current_context = &self.context;
+        setCurrentContext(&self.context);
     }
 
     /// Clear the current coroutine context for this thread.
     pub fn clearCurrent() void {
-        current_context = null;
+        setCurrentContext(null);
     }
 
     /// Step into the coroutine

--- a/src/coro/stack.zig
+++ b/src/coro/stack.zig
@@ -425,7 +425,7 @@ fn stackFaultHandler(sig: SigInt, info: *const posix.siginfo_t, ctx: ?*anyopaque
     const fault_addr = getFaultAddress(info);
 
     // Get current_context from coroutines module
-    const current_ctx = coroutines.current_context orelse {
+    const current_ctx = coroutines.getCurrentContext() orelse {
         // Not in a coroutine context - propagate to previous handler
         invokePreviousHandler(sig, info, ctx);
     };
@@ -660,7 +660,7 @@ test "Stack: recycle" {
 pub fn panicHandler(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
     _ = error_return_trace;
 
-    if (coroutines.current_context) |ctx| {
+    if (coroutines.getCurrentContext()) |ctx| {
         stackExtend(&ctx.stack_info, .full) catch {};
     }
 

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const net = @import("../net.zig");
+const runtime = @import("../runtime.zig");
 
 pub const IpAddress = net.IpAddress;
 pub const HostName = net.HostName;
@@ -61,7 +62,7 @@ pub fn lookup(
             if (addr.getFamily() != required_family) return error.AddressFamilyUnsupported;
         } else |_| {}
     }
-    if (Executor.current) |exec| {
+    if (runtime.getCurrentExecutorOrNull()) |exec| {
         if (exec.runtime.resolver) |*resolver| {
             if (resolver.lookup(storage, options)) |n| {
                 return n;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -68,6 +68,8 @@ pub const RuntimeOptions = struct {
     },
     /// Number of executor threads to run (including main).
     executors: ExecutorCount = .exact(1),
+    /// Allow tasks to migrate between executors when true.
+    enable_task_migration: bool = true,
     /// DNS resolver configuration.
     dns: DnsOptions = .{},
 };
@@ -278,14 +280,15 @@ pub const Executor = struct {
     current_task: *AnyTask,
 
     // Executor dedicated to this thread. Written once on init, never updated.
-    pub threadlocal var current: ?*Executor = null;
+    pub threadlocal var current_DO_NOT_ACCESS_DIRECTLY: ?*Executor = null;
 
     /// Get the Executor instance from any coroutine that belongs to it.
     /// Coroutines have parent_context_ptr pointing to main_task.coro.context,
     /// so we navigate: context -> coro -> main_task -> executor.
     /// Only valid on the executor thread that is currently running the coroutine.
     pub fn fromCoroutine(coro: *Coroutine) *Executor {
-        const main_coro: *Coroutine = @fieldParentPtr("context", coro.parent_context_ptr);
+        const parent_context_ptr = @atomicLoad(*Context, &coro.parent_context_ptr, .acquire);
+        const main_coro: *Coroutine = @fieldParentPtr("context", parent_context_ptr);
         const main_task: *AnyTask = @fieldParentPtr("coro", main_coro);
         return @alignCast(@fieldParentPtr("main_task", main_task));
     }
@@ -315,7 +318,7 @@ pub const Executor = struct {
             .runtime = runtime,
             .closure = undefined, // main_task has no closure
         };
-        self.main_task.coro.parent_context_ptr = &self.main_task.coro.context;
+        @atomicStore(*Context, &self.main_task.coro.parent_context_ptr, &self.main_task.coro.context, .release);
 
         try setupStackGrowth();
         errdefer cleanupStackGrowth();
@@ -338,12 +341,12 @@ pub const Executor = struct {
         }
 
         self.main_task.coro.setCurrent();
-        Executor.current = self;
+        setCurrentExecutor(self);
         self.current_task = &self.main_task;
     }
 
     pub fn deinit(self: *Executor) void {
-        Executor.current = null;
+        setCurrentExecutor(null);
         Coroutine.clearCurrent();
 
         self.loop.deinit();
@@ -394,10 +397,7 @@ pub const Executor = struct {
         while (true) {
             // Process ready coroutines
             while (self.getNextTask()) |next_task| {
-                // Store parent_context_ptr just before stepping into the coroutine.
-                // Both the store and the subsequent load in fromCoroutine() happen on
-                // the same executor thread, so no cross-thread ordering is needed.
-                next_task.coro.parent_context_ptr = &self.main_task.coro.context;
+                @atomicStore(*Context, &next_task.coro.parent_context_ptr, &self.main_task.coro.context, .release);
                 self.current_task = next_task;
                 next_task.coro.step();
                 self.current_task = &self.main_task;
@@ -534,20 +534,20 @@ pub const Executor = struct {
         // main_task is never queued - it just checks state in run().
         if (task.coro.parent_context_ptr == &task.coro.context) {
             const home_executor: *Executor = @alignCast(@fieldParentPtr("main_task", task));
-            if (Executor.current != home_executor) {
+            if (getCurrentExecutorOrNull() != home_executor) {
                 home_executor.loop.wake();
             }
             return;
         }
 
         // Normal scheduling
-        if (Executor.current) |current_exec| {
+        if (getCurrentExecutorOrNull()) |current_exec| {
             // TODO: for now, we are forcing .new tasks to be remotely scheduled
             //       to distribute them across executors, until we have work stealing
             //       for re-balancing them
             if (current_exec.runtime == task.runtime and old.tag != .new) {
                 const home_exec = Executor.fromCoroutine(&task.coro);
-                if (current_exec == home_exec or task.canMigrate()) {
+                if (current_exec == home_exec or task.runtime.options.enable_task_migration) {
                     task.last_run_tick = 0; // Allow immediate execution on new executor
                     current_exec.scheduleTaskLocal(task);
                 } else {
@@ -559,7 +559,7 @@ pub const Executor = struct {
 
         // Non-migratable tasks must go home, even when scheduled from a foreign
         // thread or a different runtime. Only .new tasks get round-robin distribution.
-        if (old.tag != .new and !task.canMigrate()) {
+        if (old.tag != .new and !task.getRuntime().options.enable_task_migration) {
             Executor.fromCoroutine(&task.coro).scheduleTaskRemote(task);
             return;
         }
@@ -633,10 +633,7 @@ pub const Executor = struct {
     /// Sets current_task for the target and performs the context switch.
     pub fn switchOut(self: *Executor, coro: *Coroutine) void {
         if (self.getNextTask()) |next_task| {
-            // Store parent_context_ptr just before switching into the coroutine.
-            // Both the store and the subsequent load in fromCoroutine() happen on
-            // the same executor thread, so no cross-thread ordering is needed.
-            next_task.coro.parent_context_ptr = &self.main_task.coro.context;
+            @atomicStore(*Context, &next_task.coro.parent_context_ptr, &self.main_task.coro.context, .release);
             self.current_task = next_task;
             coro.yieldTo(&next_task.coro);
         } else {
@@ -646,15 +643,19 @@ pub const Executor = struct {
     }
 };
 
+/// Get the current thread's executor, or null if not in executor context.
+pub noinline fn getCurrentExecutorOrNull() ?*Executor {
+    return Executor.current_DO_NOT_ACCESS_DIRECTLY;
+}
+
+noinline fn setCurrentExecutor(current: ?*Executor) void {
+    Executor.current_DO_NOT_ACCESS_DIRECTLY = current;
+}
+
 /// Get the current thread's executor.
 /// Panics if called from a thread without an active executor context.
 pub fn getCurrentExecutor() *Executor {
-    return Executor.current orelse @panic("no current executor");
-}
-
-/// Get the current thread's executor, or null if not in executor context.
-pub fn getCurrentExecutorOrNull() ?*Executor {
-    return Executor.current;
+    return getCurrentExecutorOrNull() orelse @panic("no current executor");
 }
 
 /// Get the currently executing task.
@@ -665,7 +666,7 @@ pub fn getCurrentTask() *AnyTask {
 
 /// Get the currently executing task, or null if not in task context.
 pub fn getCurrentTaskOrNull() ?*AnyTask {
-    const exec = Executor.current orelse return null;
+    const exec = getCurrentExecutorOrNull() orelse return null;
     return exec.current_task;
 }
 

--- a/src/task.zig
+++ b/src/task.zig
@@ -7,6 +7,7 @@ const ev = @import("ev/root.zig");
 
 const Runtime = @import("runtime.zig").Runtime;
 const Executor = @import("runtime.zig").Executor;
+const runtime = @import("runtime.zig");
 const Awaitable = @import("awaitable.zig").Awaitable;
 const Coroutine = @import("coro/coroutines.zig").Coroutine;
 const WaitNode = @import("utils/wait_queue.zig").WaitNode;
@@ -166,11 +167,10 @@ pub const AnyTask = struct {
     // Reset to 0 when stolen, allowing immediate execution on the thief.
     last_run_tick: u32 = 0,
 
-    // Runtime this task belongs to (set at creation, never changes)
-    runtime: *Runtime,
-
     // Closure for the task
     closure: Closure,
+
+    runtime: *Runtime,
 
     /// Task state and park token, packed into a single byte for atomic operations.
     ///
@@ -224,15 +224,10 @@ pub const AnyTask = struct {
         return Executor.fromCoroutine(&self.coro);
     }
 
-    /// Check if this task can be migrated to a different executor.
-    // TODO: Enable migration once we have work-stealing for re-balancing
-    pub inline fn canMigrate(self: *const AnyTask) bool {
-        _ = self;
-        return false;
-    }
-
+    /// Migration of tasks is controlled by Runtime.options.enable_task_migration.
+    /// Use task.getRuntime().options.enable_task_migration to check at runtime.
     pub inline fn getRuntime(self: *AnyTask) *Runtime {
-        return self.runtime;
+        return self.getExecutor().runtime;
     }
 
     pub inline fn getThreadPool(self: *AnyTask) *ev.ThreadPool {
@@ -533,7 +528,7 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
 
     Executor.scheduleTask(task);
 
-    if (Executor.current) |current_executor| {
+    if (runtime.getCurrentExecutorOrNull()) |current_executor| {
         if (current_executor.runtime == task.runtime) {
             current_executor.maybeYield(.reschedule, .no_cancel);
         }


### PR DESCRIPTION
- Prevent the compiler from caching TLS access
- Add config option for controlling task migration
- Enable by default