### PR TITLE
Honor follow_symlinks, path_only, allow_ctty in openFile

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Setting `max_threads = 0` in the thread pool options now disables the thread pool, executing
   blocking work inline on the calling thread (the same behavior as a single-threaded build).
+- `openFile` now honors the `follow_symlinks`, `path_only`, and `allow_ctty` options. Through the
+  `std.Io` interface these (along with `resolve_beneath`) previously panicked when set to a
+  non-default value. Opening with `follow_symlinks = false` fails with `error.SymLinkLoop` if the
+  final path component is a symlink (`O_NOFOLLOW`, or `FILE_FLAG_OPEN_REPARSE_POINT` on Windows).
 
 ## [0.13.0] - 2026-05-31
 

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -421,6 +421,9 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
                     .read_write => .RDWR,
                 },
                 .CLOEXEC = true,
+                .NOFOLLOW = !data.flags.follow_symlinks,
+                .NOCTTY = !data.flags.allow_ctty,
+                .PATH = data.flags.path_only,
             };
             const sqe = self.getSqeOrDefer(c) orelse return;
             if (data.flags.resolve_beneath) {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1396,6 +1396,39 @@ test "Dir: resolve_beneath blocks parent escape" {
     }
 }
 
+test "File: follow_symlinks=false rejects a symlink" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const cwd = Dir.cwd();
+
+    var target = try cwd.createFile("test-nofollow-target", .{});
+    target.close();
+    defer cwd.deleteFile("test-nofollow-target") catch {};
+
+    cwd.symLink("test-nofollow-target", "test-nofollow-link", .{}) catch |err| switch (err) {
+        // Some filesystems / sandboxes don't allow creating symlinks.
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    defer cwd.deleteFile("test-nofollow-link") catch {};
+
+    // Following the symlink (the default) opens the target.
+    var followed = try cwd.openFile("test-nofollow-link", .{});
+    followed.close();
+
+    // With follow_symlinks=false, opening the symlink itself must fail.
+    if (cwd.openFile("test-nofollow-link", .{ .follow_symlinks = false })) |file| {
+        file.close();
+        return error.TestUnexpectedResult;
+    } else |err| switch (err) {
+        error.SymLinkLoop => {},
+        else => return err,
+    }
+}
+
 test "File: blocking mode without runtime" {
     // This test verifies that file operations work in blocking mode
     // when called without an async runtime

--- a/src/io.zig
+++ b/src/io.zig
@@ -1128,13 +1128,13 @@ fn atomicFileInit(
 }
 
 fn dirOpenFileImpl(_: ?*anyopaque, dir: Io.Dir, sub_path: []const u8, options: Io.Dir.OpenFileOptions) Io.File.OpenError!Io.File {
-    if (options.path_only) @panic("TODO: openFile path_only");
-    if (options.allow_ctty) @panic("TODO: openFile allow_ctty");
-    if (!options.follow_symlinks) @panic("TODO: openFile follow_symlinks=false");
-    if (options.resolve_beneath) @panic("TODO: openFile resolve_beneath");
     var op = ev.FileOpen.init(stdIoHandleToZio(dir.handle), sub_path, .{
         .mode = stdIoModeToZio(options.mode),
         .allow_directory = options.allow_directory,
+        .follow_symlinks = options.follow_symlinks,
+        .path_only = options.path_only,
+        .allow_ctty = options.allow_ctty,
+        .resolve_beneath = options.resolve_beneath,
     });
     try waitForIo(&op.c);
     const fd = op.getResult() catch |err| return openErrToFileErr(err);

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1507,7 +1507,7 @@ pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError
         .PERM => error.PermissionDenied,
         .LOOP => error.SymLinkLoop,
         // BSD returns EMLINK (not ELOOP) when O_NOFOLLOW hits a symlink.
-        .MLINK => if (!flags.follow_symlinks) error.SymLinkLoop else unexpectedError(errno),
+        .MLINK => if (@hasField(@TypeOf(flags), "follow_symlinks") and !flags.follow_symlinks) error.SymLinkLoop else unexpectedError(errno),
         .MFILE => error.ProcessFdQuotaExceeded,
         .NFILE => error.SystemFdQuotaExceeded,
         .NODEV => error.NoDevice,

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1506,6 +1506,8 @@ pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError
         .ACCES => error.AccessDenied,
         .PERM => error.PermissionDenied,
         .LOOP => error.SymLinkLoop,
+        // BSD returns EMLINK (not ELOOP) when O_NOFOLLOW hits a symlink.
+        .MLINK => if (!flags.follow_symlinks) error.SymLinkLoop else unexpectedError(errno),
         .MFILE => error.ProcessFdQuotaExceeded,
         .NFILE => error.SystemFdQuotaExceeded,
         .NODEV => error.NoDevice,

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1501,6 +1501,9 @@ pub fn mkdirat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, mode: 
 }
 
 pub fn errnoToFileOpenError(errno: posix.system.E, flags: anytype) FileOpenError {
+    // NetBSD returns EFTYPE (not ELOOP) when O_NOFOLLOW hits a symlink.
+    if (@hasField(@TypeOf(errno), "FTYPE") and errno == .FTYPE)
+        return if (@hasField(@TypeOf(flags), "follow_symlinks") and !flags.follow_symlinks) error.SymLinkLoop else unexpectedError(errno);
     return switch (errno) {
         .SUCCESS => unreachable,
         .ACCES => error.AccessDenied,

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -114,6 +114,18 @@ pub const FileOpenFlags = struct {
     /// On Windows this is enforced without extra syscalls (no FILE_FLAG_BACKUP_SEMANTICS).
     /// On POSIX an extra fstat is required; defaults to true to avoid the overhead.
     allow_directory: bool = true,
+    /// When false, if the final path component is a symlink the open fails with
+    /// error.SymLinkLoop. Only the final component is affected; intermediate
+    /// symlinks are still followed. POSIX: O_NOFOLLOW. Windows: opens the reparse
+    /// point itself via FILE_FLAG_OPEN_REPARSE_POINT.
+    follow_symlinks: bool = true,
+    /// Open the file only for close/stat operations (POSIX O_PATH). Ignored on
+    /// platforms without an equivalent (e.g. Windows), where a normal handle is
+    /// returned that still supports close/stat.
+    path_only: bool = false,
+    /// Allow the opened file to become the controlling TTY for the process.
+    /// POSIX: clears O_NOCTTY. No effect on Windows.
+    allow_ctty: bool = false,
     /// Prevent path resolution from escaping the starting directory (e.g. via ".." or symlinks).
     /// Enforced by the kernel on Linux 5.6+ (openat2 RESOLVE_BENEATH) and FreeBSD 13+ (O_RESOLVE_BENEATH).
     /// On other platforms a warning is logged and the flag is ignored.
@@ -602,6 +614,10 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
         // Without it, opening a directory path fails with ACCESS_DENIED, which
         // gives us allow_directory=false semantics for free.
         if (flags.allow_directory) file_flags |= w.FILE_FLAG_BACKUP_SEMANTICS;
+        // Open the reparse point itself instead of following it. This is the
+        // closest Windows analogue to O_NOFOLLOW; allow_ctty and path_only have
+        // no Windows equivalent and are ignored.
+        if (!flags.follow_symlinks) file_flags |= w.FILE_FLAG_OPEN_REPARSE_POINT;
 
         const handle = w.CreateFileW(
             path_w.ptr,
@@ -632,7 +648,10 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
             .read_write => .RDWR,
         },
         .CLOEXEC = true,
+        .NOFOLLOW = !flags.follow_symlinks,
     };
+    if (@hasField(@TypeOf(open_flags), "NOCTTY")) open_flags.NOCTTY = !flags.allow_ctty;
+    if (@hasField(@TypeOf(open_flags), "PATH")) open_flags.PATH = flags.path_only;
 
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);


### PR DESCRIPTION
## What

`openFile` now honors the `follow_symlinks`, `path_only`, and `allow_ctty` options. Through the `std.Io` interface these (along with `resolve_beneath`) previously hit `@panic` stubs in `dirOpenFileImpl` when set to a non-default value; on the native `Dir.openFile` API they simply weren't represented in `FileOpenFlags`.

## How

The flags are added to `os.fs.FileOpenFlags` and implemented in both open paths:

- **POSIX `openat()`**: `O_NOFOLLOW` (set directly, standard), plus `@hasField`-guarded `O_NOCTTY` and `O_PATH` (Linux/FreeBSD only).
- **io_uring backend**: the same three bits added to the `oflags` literal, so they flow into both the `openat` and `openat2`/`resolve_beneath` SQEs.
- **Windows `openat()`**: `FILE_FLAG_OPEN_REPARSE_POINT` for `follow_symlinks = false` (opens the link itself, the closest analogue to `O_NOFOLLOW`). `allow_ctty` and `path_only` have no Windows equivalent and are ignored.

`resolve_beneath` is also now passed through the `std.Io` open path — it was already supported at the OS layer and used by `createFile`, just not plumbed in `dirOpenFileImpl`.

Both the native `Dir` and `std.Io.Dir` APIs funnel into the same `ev.FileOpen` → `FileOpenFlags` → OS layer, matching `std.Io.Threaded`'s semantics (`O_NOFOLLOW` affects only the final path component, surfacing as `error.SymLinkLoop`).

## Testing

Added `File: follow_symlinks=false rejects a symlink` (mirrors the existing `resolve_beneath` test). Verified with `./check.sh` on:
- default io_uring backend
- `--backend epoll` (blocking `fs.openat` path)
- `--target x86_64-windows --wine` (reparse-point branch)