### PR TITLE
iocp: handle synchronous HANDLE_EOF in file/pipe read submission

### DIFF
--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1056,7 +1056,13 @@ fn submitFileRead(self: *Self, state: *LoopState, data: *FileRead) !void {
     // the completion will be posted to the IOCP port.
     if (result == .FALSE) {
         const err = windows.GetLastError();
-        if (err != .IO_PENDING) {
+        if (err == .HANDLE_EOF) {
+            // Synchronous EOF - read 0 bytes. No completion packet is queued
+            // in this case, so we must complete it here.
+            data.c.setResult(.file_read, 0);
+            state.markCompletedFromBackend(&data.c);
+            return;
+        } else if (err != .IO_PENDING) {
             // Real error - complete immediately with error
             log.err("ReadFile failed: {}", .{err});
             data.c.setError(fs.errnoToFileReadError(@enumFromInt(@intFromEnum(err))));
@@ -1168,8 +1174,10 @@ fn submitPipeRead(self: *Self, state: *LoopState, data: *PipeRead) !void {
     // the completion will be posted to the IOCP port.
     if (result == .FALSE) {
         const err = windows.GetLastError();
-        if (err == .BROKEN_PIPE) {
-            // Write end closed - this is EOF, not an error
+        if (err == .HANDLE_EOF or err == .BROKEN_PIPE) {
+            // Write end closed (BROKEN_PIPE) or EOF reached (HANDLE_EOF) -
+            // this is EOF, not an error. No completion packet is queued in this
+            // case, so we must complete it here.
             data.c.setResult(.pipe_read, 0);
             state.markCompletedFromBackend(&data.c);
             return;


### PR DESCRIPTION
## Problem

Intermittent Windows CI failures in `ev.test.fs.test.File: read EOF`:

```
"ev.test.fs.test.File: read EOF" - InputOutput
(zio/err): ReadFile failed: .HANDLE_EOF
```

## Root cause

On an overlapped file handle, `ReadFile` at EOF can complete **synchronously**, returning `FALSE` with `GetLastError() == ERROR_HANDLE_EOF` and *without* queuing a completion packet to the IOCP. Whether this happens (vs. returning `IO_PENDING` and posting a packet) is timing/version dependent — hence the random failures.

The submission paths (`submitFileRead`, `submitPipeRead`) only special-cased `ERROR_IO_PENDING`, so a synchronous EOF fell through to the generic error branch and was mapped to `InputOutput` instead of a 0-byte read. The matching completion paths already handle `HANDLE_EOF` (and `BROKEN_PIPE` for pipes) as EOF.

## Fix

Mirror the completion-path handling in the submission paths: treat a synchronous `HANDLE_EOF` as a 0-byte read and complete the operation inline (no completion packet is queued in this case). `submitPipeRead` already handled `BROKEN_PIPE`; this adds `HANDLE_EOF` alongside it.

This is not a recent regression — the gap has existed since the original IOCP implementation; CI timing simply started exposing it.