### PR TITLE
io: implement lockStderr, tryLockStderr, unlockStderr

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -52,6 +52,8 @@ const zio_options = @import("zio_options");
 /// the caller more than std.Io's reader/writer is prepared to handle.
 const max_iovecs_len = 8;
 
+pub const debug_io: Io = .{ .userdata = null, .vtable = &vtable };
+
 /// Read the pollable-cache state from `File.Flags`.
 ///
 /// When hacks are enabled, the `nonblocking` bool byte is overloaded:
@@ -1639,10 +1641,10 @@ fn lockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Ca
 
 fn tryLockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!?Io.LockedStderr {
     if (!stderr_mutex.tryLock()) return null;
-    return try initLockedStderr(userdata, terminal_mode);
+    return initLockedStderr(userdata, terminal_mode);
 }
 
-fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
+fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.LockedStderr {
     if (!stderr_writer_initialized) {
         const io = Io{ .userdata = userdata, .vtable = &vtable };
         const zfile = zio_fs.stderr();
@@ -1656,6 +1658,7 @@ fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.
         }
         stderr_writer_initialized = true;
     }
+    beginShield();
     return .{
         .file_writer = &stderr_writer,
         .terminal_mode = terminal_mode orelse .no_color,
@@ -1665,6 +1668,7 @@ fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.
 fn unlockStderrImpl(_: ?*anyopaque) void {
     if (stderr_writer.err == null) stderr_writer.interface.flush() catch {};
     stderr_writer.err = null;
+    endShield();
     stderr_mutex.unlock();
 }
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -15,7 +15,6 @@ const Alignment = std.mem.Alignment;
 const runtime_mod = @import("runtime.zig");
 const Runtime = runtime_mod.Runtime;
 const getCurrentTask = runtime_mod.getCurrentTask;
-const getCurrentTaskOrNull = runtime_mod.getCurrentTaskOrNull;
 const getCurrentExecutor = runtime_mod.getCurrentExecutor;
 const beginShield = runtime_mod.beginShield;
 const endShield = runtime_mod.endShield;
@@ -1629,51 +1628,17 @@ fn processExecutablePathImpl(_: ?*anyopaque, buffer: []u8) std.process.Executabl
     return io.vtable.processExecutablePath(io.userdata, buffer);
 }
 
-const StderrOwner = union(enum) {
-    none,
-    task: *AnyTask,
-    thread: std.Thread.Id,
-};
-
-var stderr_mutex: Mutex = .init;
-var stderr_owner: StderrOwner = .none;
-var stderr_lock_count: usize = 0;
+var stderr_mutex: Mutex.Recursive = .init;
 var stderr_writer_initialized = false;
 var stderr_writer: Io.File.Writer = undefined;
 
-fn stderrIsOwner() bool {
-    return switch (stderr_owner) {
-        .task => |t| getCurrentTaskOrNull() == t,
-        .thread => |id| getCurrentTaskOrNull() == null and std.Thread.getCurrentId() == id,
-        .none => false,
-    };
-}
-
 fn lockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
-    if (stderrIsOwner()) {
-        stderr_lock_count += 1;
-        return initLockedStderr(userdata, terminal_mode);
-    }
     try stderr_mutex.lock();
-    errdefer stderr_mutex.unlock();
-    beginShield();
-    errdefer endShield();
-    stderr_owner = if (getCurrentTaskOrNull()) |task| StderrOwner{ .task = task } else StderrOwner{ .thread = std.Thread.getCurrentId() };
-    stderr_lock_count = 1;
     return initLockedStderr(userdata, terminal_mode);
 }
 
 fn tryLockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!?Io.LockedStderr {
-    if (stderrIsOwner()) {
-        stderr_lock_count += 1;
-        return try initLockedStderr(userdata, terminal_mode);
-    }
     if (!stderr_mutex.tryLock()) return null;
-    errdefer stderr_mutex.unlock();
-    beginShield();
-    errdefer endShield();
-    stderr_owner = if (getCurrentTaskOrNull()) |task| StderrOwner{ .task = task } else StderrOwner{ .thread = std.Thread.getCurrentId() };
-    stderr_lock_count = 1;
     return try initLockedStderr(userdata, terminal_mode);
 }
 
@@ -1700,12 +1665,7 @@ fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.
 fn unlockStderrImpl(_: ?*anyopaque) void {
     if (stderr_writer.err == null) stderr_writer.interface.flush() catch {};
     stderr_writer.err = null;
-    stderr_lock_count -= 1;
-    if (stderr_lock_count == 0) {
-        stderr_owner = .none;
-        stderr_mutex.unlock();
-        endShield();
-    }
+    stderr_mutex.unlock();
 }
 
 fn processCurrentPathImpl(_: ?*anyopaque, buffer: []u8) std.process.CurrentPathError!usize {

--- a/src/io.zig
+++ b/src/io.zig
@@ -15,6 +15,7 @@ const Alignment = std.mem.Alignment;
 const runtime_mod = @import("runtime.zig");
 const Runtime = runtime_mod.Runtime;
 const getCurrentTask = runtime_mod.getCurrentTask;
+const getCurrentTaskOrNull = runtime_mod.getCurrentTaskOrNull;
 const getCurrentExecutor = runtime_mod.getCurrentExecutor;
 const beginShield = runtime_mod.beginShield;
 const endShield = runtime_mod.endShield;
@@ -27,6 +28,7 @@ const Group = @import("group.zig").Group;
 const groupSpawnTask = @import("group.zig").groupSpawnTask;
 const select = @import("select.zig");
 const Futex = @import("sync/Futex.zig");
+const Mutex = @import("sync/Mutex.zig");
 const time = @import("time.zig");
 const common = @import("common.zig");
 const Waiter = common.Waiter;
@@ -37,6 +39,7 @@ const waitForIoUncancelable = common.waitForIoUncancelable;
 const ev = @import("ev/root.zig");
 const os_net = @import("os/net.zig");
 const os_fs = @import("os/fs.zig");
+const zio_fs = @import("fs.zig");
 const os_posix = @import("os/posix.zig");
 const process_impl = @import("process.zig");
 const zio_net = @import("net.zig");
@@ -1626,16 +1629,83 @@ fn processExecutablePathImpl(_: ?*anyopaque, buffer: []u8) std.process.Executabl
     return io.vtable.processExecutablePath(io.userdata, buffer);
 }
 
-fn lockStderrImpl(_: ?*anyopaque, _: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
-    @panic("lockStderr: not supported");
+const StderrOwner = union(enum) {
+    none,
+    task: *AnyTask,
+    thread: std.Thread.Id,
+};
+
+var stderr_mutex: Mutex = .init;
+var stderr_owner: StderrOwner = .none;
+var stderr_lock_count: usize = 0;
+var stderr_writer_initialized = false;
+var stderr_writer: Io.File.Writer = undefined;
+
+fn stderrIsOwner() bool {
+    return switch (stderr_owner) {
+        .task => |t| getCurrentTaskOrNull() == t,
+        .thread => |id| getCurrentTaskOrNull() == null and std.Thread.getCurrentId() == id,
+        .none => false,
+    };
 }
 
-fn tryLockStderrImpl(_: ?*anyopaque, _: ?Io.Terminal.Mode) Io.Cancelable!?Io.LockedStderr {
-    @panic("tryLockStderr: not supported");
+fn lockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
+    if (stderrIsOwner()) {
+        stderr_lock_count += 1;
+        return initLockedStderr(userdata, terminal_mode);
+    }
+    try stderr_mutex.lock();
+    errdefer stderr_mutex.unlock();
+    beginShield();
+    errdefer endShield();
+    stderr_owner = if (getCurrentTaskOrNull()) |task| StderrOwner{ .task = task } else StderrOwner{ .thread = std.Thread.getCurrentId() };
+    stderr_lock_count = 1;
+    return initLockedStderr(userdata, terminal_mode);
+}
+
+fn tryLockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!?Io.LockedStderr {
+    if (stderrIsOwner()) {
+        stderr_lock_count += 1;
+        return try initLockedStderr(userdata, terminal_mode);
+    }
+    if (!stderr_mutex.tryLock()) return null;
+    errdefer stderr_mutex.unlock();
+    beginShield();
+    errdefer endShield();
+    stderr_owner = if (getCurrentTaskOrNull()) |task| StderrOwner{ .task = task } else StderrOwner{ .thread = std.Thread.getCurrentId() };
+    stderr_lock_count = 1;
+    return try initLockedStderr(userdata, terminal_mode);
+}
+
+fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
+    if (!stderr_writer_initialized) {
+        const io = Io{ .userdata = userdata, .vtable = &vtable };
+        const zfile = zio_fs.stderr();
+        var file: Io.File = .{ .handle = zfile.fd, .flags = .{ .nonblocking = false } };
+        const pollable = zfile.pollable orelse false;
+        flagsWritePollable(&file.flags, pollable);
+        if (pollable) {
+            stderr_writer = Io.File.Writer.initStreaming(file, io, &.{});
+        } else {
+            stderr_writer = Io.File.Writer.init(file, io, &.{});
+        }
+        stderr_writer_initialized = true;
+    }
+    return .{
+        .file_writer = &stderr_writer,
+        .terminal_mode = terminal_mode orelse .no_color,
+    };
 }
 
 fn unlockStderrImpl(_: ?*anyopaque) void {
-    @panic("unlockStderr: not supported");
+    if (stderr_writer.err == null) stderr_writer.interface.flush() catch {};
+    stderr_writer.err = null;
+    stderr_lock_count -= 1;
+    if (stderr_lock_count == 0) {
+        stderr_owner = .none;
+        stderr_mutex.unlock();
+        endShield();
+    }
 }
 
 fn processCurrentPathImpl(_: ?*anyopaque, buffer: []u8) std.process.CurrentPathError!usize {

--- a/src/sync/Mutex/Recursive.zig
+++ b/src/sync/Mutex/Recursive.zig
@@ -343,5 +343,3 @@ test "Recursive cancel waiting on first acquisition" {
     // Should error with Canceled
     try std.testing.expectError(error.Canceled, handle.join());
 }
-
-

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -66,6 +66,8 @@ pub const wait = @import("select.zig").wait;
 pub const SelectResult = @import("select.zig").SelectResult;
 pub const WaitResult = @import("select.zig").WaitResult;
 
+pub const debug_io = @import("io.zig").debug_io;
+
 /// Low-level coroutine library.
 pub const coro = @import("coro/root.zig");
 


### PR DESCRIPTION
Supports reentrant locking (same task or thread) via a tagged-union owner tracking. Cancel-shielded via beginShield/endShield. Writer is lazily initialized on first lock using zio_fs.stderr() for pollable detection.