### PR TITLE
examples: add std_options_debug_io = zio.debug_io

### DIFF
--- a/examples/http_client.zig
+++ b/examples/http_client.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const Zio = @import("zio");
+
+pub const std_options_debug_io = Zio.debug_io;
+
+pub fn main(init: std.process.Init) !void {
+    var zio = try Zio.Runtime.init(init.gpa, .{ .thread_pool = .{ .min_threads = 1 } });
+    defer zio.deinit();
+
+    var http_client: std.http.Client = .{ .allocator = init.gpa, .io = zio.io() };
+    defer http_client.deinit();
+
+    std.debug.print("TEST http client: {any}\n", .{http_client});
+
+    var request = try http_client.request(.GET, try std.Uri.parse("https://httpbin.org/get"), .{});
+    defer request.deinit();
+
+    std.debug.print("TEST request headers: {any}\n", .{request.headers});
+
+    try request.sendBodiless();
+
+    std.debug.print("TEST request body\n", .{});
+
+    var redirect_buffer: [1024]u8 = undefined;
+    const response = try request.receiveHead(&redirect_buffer);
+
+    std.log.info("received {d} {s}", .{ response.head.status, response.head.reason });
+}

--- a/examples/http_server.zig
+++ b/examples/http_server.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const zio = @import("zio");
 
+// Use zio for std.log.* and std.debug.print
+pub const std_options_debug_io = zio.debug_io;
+
 // Maximum size of the request headers
 const MAX_REQUEST_HEADER_SIZE = 64 * 1024;
 

--- a/examples/mutex_demo.zig
+++ b/examples/mutex_demo.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 const SharedData = struct {
     counter: i32 = 0,
     mutex: zio.Mutex,

--- a/examples/ntp_client.zig
+++ b/examples/ntp_client.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 // --8<-- [start:lookup]
 fn lookupHost(hostname: []const u8, port: u16) !zio.net.Address {
     const host = try zio.net.HostName.init(hostname);

--- a/examples/parallel_grep.zig
+++ b/examples/parallel_grep.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 const SearchResult = struct {
     file_path: []const u8,
     line_number: usize,

--- a/examples/ping.zig
+++ b/examples/ping.zig
@@ -7,6 +7,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 // ICMP Echo Request/Reply structures
 const IcmpHeader = extern struct {
     type: u8,

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 fn producer(channel: *zio.Channel(i32), id: u32) zio.Cancelable!void {
     for (0..5) |i| {
         const item = @as(i32, @intCast(id * 100 + i));

--- a/examples/signal_demo.zig
+++ b/examples/signal_demo.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 /// Demonstration of graceful shutdown using signal handling.
 /// Press Ctrl+C to trigger a graceful shutdown.
 fn serverTask(shutdown: *std.atomic.Value(bool)) !void {

--- a/examples/sleep.zig
+++ b/examples/sleep.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 pub fn main(init: std.process.Init) !void {
     var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();

--- a/examples/tcp_client.zig
+++ b/examples/tcp_client.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 pub fn main(init: std.process.Init) !void {
     var rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();

--- a/examples/tcp_echo_server.zig
+++ b/examples/tcp_echo_server.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 // --8<-- [start:handleClient]
 fn handleClient(stream: zio.net.Stream) !void {
     defer stream.close();

--- a/examples/tcp_echo_server_stdio.zig
+++ b/examples/tcp_echo_server_stdio.zig
@@ -8,6 +8,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 const Io = std.Io;
 
 fn handleClient(io: Io, stream: Io.net.Stream) Io.Cancelable!void {

--- a/examples/udp_echo_server.zig
+++ b/examples/udp_echo_server.zig
@@ -6,6 +6,8 @@
 const std = @import("std");
 const zio = @import("zio");
 
+pub const std_options_debug_io = zio.debug_io;
+
 pub fn main(init: std.process.Init) !void {
     const rt = try zio.Runtime.init(init.gpa, .{});
     defer rt.deinit();


### PR DESCRIPTION
Add `pub const std_options_debug_io = zio.debug_io;` to all runtime-based examples so that `std.log.*` and `std.debug.print` output goes through zio's debug I/O layer.\n\nExcludes low-level `coro_demo.zig` and `ev_demo.zig` which don't use the zio Runtime.