### PR TITLE
ev/iocp: use shared atomic counters for active/inflight_io

### DIFF
--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -317,7 +317,7 @@ fn getHandle(completion: *Completion) NetHandle {
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.active += 1;
+    state.incrActive();
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -245,7 +245,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     const is_new = c.state == .new;
     if (is_new) {
         c.state = .running;
-        state.active += 1;
+        state.incrActive();
     } else {
         std.debug.assert(c.state == .running);
     }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -201,6 +201,12 @@ pub const SharedState = struct {
     refcount: usize = 0,
     iocp: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
 
+    /// Multi-threaded counters: multiple loops may submit and
+    /// complete I/O on the same IOCP port, so active/inflight_io
+    /// are shared atomics rather than per-LoopState fields.
+    active: std.atomic.Value(u64) = .init(0),
+    inflight_io: std.atomic.Value(u64) = .init(0),
+
     // Extension functions loaded once globally (family-independent)
     exts: ExtensionFunctions = undefined,
 
@@ -346,7 +352,7 @@ pub fn wake(self: *Self, state: *LoopState) void {
 
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.active += 1;
+    state.incrActive();
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -223,6 +223,11 @@ pub const SharedState = struct {
                 0, // Use default number of concurrent threads
             ) orelse return error.Unexpected;
 
+            // Reset shared accounting in case this SharedState is being
+            // reused after a previous teardown that left stale counters.
+            self.active.store(0, .release);
+            self.inflight_io.store(0, .release);
+
             // Load all extension functions using a temporary socket
             // Socket family/type doesn't matter - use AF_INET SOCK_STREAM
             const sock = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -273,7 +273,7 @@ fn removeFromPollQueue(self: *Self, completion: *Completion) void {
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.active += 1;
+    state.incrActive();
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -281,7 +281,7 @@ fn getHandle(completion: *Completion) NetHandle {
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.active += 1;
+    state.incrActive();
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -130,10 +130,66 @@ pub const LoopState = struct {
     pub const wake_async: u32 = 2;
     pub const wake_cancel: u32 = 4;
 
+    /// Increment the inflight I/O counter. On multi-threaded backends
+    /// (IOCP) this routes to a shared atomic; on single-threaded backends
+    /// it's a simple local increment.
+    pub fn incrInflight(self: *LoopState) void {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            _ = self.loop.loop_group.shared.inflight_io.fetchAdd(1, .monotonic);
+        } else {
+            self.inflight_io += 1;
+        }
+    }
+
+    /// Decrement the inflight I/O counter.
+    pub fn decrInflight(self: *LoopState) void {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            _ = self.loop.loop_group.shared.inflight_io.fetchSub(1, .monotonic);
+        } else {
+            self.inflight_io -= 1;
+        }
+    }
+
+    /// Read the inflight I/O counter.
+    pub fn loadInflight(self: *const LoopState) usize {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            return @intCast(self.loop.loop_group.shared.inflight_io.load(.monotonic));
+        } else {
+            return self.inflight_io;
+        }
+    }
+
+    /// Increment the active (not-yet-finished) completion counter.
+    pub fn incrActive(self: *LoopState) void {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            _ = self.loop.loop_group.shared.active.fetchAdd(1, .monotonic);
+        } else {
+            self.active += 1;
+        }
+    }
+
+    /// Decrement the active (not-yet-finished) completion counter.
+    pub fn decrActive(self: *LoopState) void {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            _ = self.loop.loop_group.shared.active.fetchSub(1, .monotonic);
+        } else {
+            self.active -= 1;
+        }
+    }
+
+    /// Read the active completion counter.
+    pub fn loadActive(self: *const LoopState) usize {
+        if (comptime Backend.capabilities.is_multi_threaded) {
+            return @intCast(self.loop.loop_group.shared.active.load(.monotonic));
+        } else {
+            return self.active;
+        }
+    }
+
     /// Called by backends when an I/O operation completes.
     /// Decrements inflight_io counter and marks the completion done.
     pub fn markCompletedFromBackend(self: *LoopState, completion: *Completion) void {
-        self.inflight_io -= 1;
+        self.decrInflight();
         self.markCompleted(completion);
     }
 
@@ -167,7 +223,7 @@ pub const LoopState = struct {
         std.debug.assert(completion.state == .completed);
 
         completion.state = .dead;
-        self.active -= 1;
+        self.decrActive();
 
         // Notify group/queue owner if this completion belongs to one
         if (completion.group.owner_callback) |cb| {
@@ -198,7 +254,7 @@ pub const LoopState = struct {
         if (timer.deadline.value > 0) {
             self.timers.remove(timer);
         } else {
-            self.active += 1;
+            self.incrActive();
         }
         switch (timer.timeout) {
             .none => timer.deadline = .{ .value = std.math.maxInt(time.TimeInt) },
@@ -288,7 +344,7 @@ pub const Loop = struct {
     }
 
     pub fn done(self: *const Loop) bool {
-        return self.state.stopped or (self.state.active == 0 and self.state.completions.empty());
+        return self.state.stopped or (self.state.loadActive() == 0 and self.state.completions.empty());
     }
 
     /// Get the current monotonic timestamp
@@ -333,7 +389,7 @@ pub const Loop = struct {
             timer.c.state = .new;
             timer.c.has_result = false;
             timer.c.err = null;
-            self.state.active -= 1;
+            self.state.decrActive();
         }
     }
 
@@ -509,7 +565,7 @@ pub const Loop = struct {
         if (completion.cancel_state.load(.acquire).requested) {
             // Directly mark it as canceled
             completion.setError(error.Canceled);
-            self.state.active += 1;
+            self.state.incrActive();
             completion.state = .running;
             self.state.markCompleted(completion);
             return;
@@ -525,7 +581,7 @@ pub const Loop = struct {
                 }
 
                 group.c.state = .running;
-                self.state.active += 1;
+                self.state.incrActive();
 
                 if (group.remaining.load(.acquire) == 0) {
                     // Empty group - complete immediately
@@ -553,7 +609,7 @@ pub const Loop = struct {
             .async => {
                 const async = completion.cast(Async);
                 async.c.state = .running;
-                self.state.active += 1;
+                self.state.incrActive();
 
                 // Check if already notified before submission
                 if (checkAndSetAsyncResult(async)) {
@@ -570,7 +626,7 @@ pub const Loop = struct {
                 work.completion_fn = loopWorkComplete;
                 work.completion_context = @ptrCast(self);
                 work.c.state = .running;
-                self.state.active += 1;
+                self.state.incrActive();
                 if (self.thread_pool) |thread_pool| {
                     thread_pool.submit(work);
                 } else {
@@ -583,9 +639,9 @@ pub const Loop = struct {
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
                 completion.state = .running;
-                self.state.active += 1;
+                self.state.incrActive();
                 if (comptime Backend.capabilities.net_send_file) {
-                    self.state.inflight_io += 1;
+                    self.state.incrInflight();
                     self.backend.submit(&self.state, completion);
                 } else {
                     netSendFileStart(self, op);
@@ -610,7 +666,7 @@ pub const Loop = struct {
                             // Route pollable fds to the backend readiness/overlapped path;
                             // seekable fds (regular files, block devices) to the thread pool.
                             if (pollable) {
-                                self.state.inflight_io += 1;
+                                self.state.incrInflight();
                                 self.backend.submit(&self.state, completion);
                             } else {
                                 self.submitFileOpToThreadPool(completion);
@@ -634,7 +690,7 @@ pub const Loop = struct {
                     },
                 }
 
-                self.state.inflight_io += 1;
+                self.state.incrInflight();
                 self.backend.submit(&self.state, completion);
                 return;
             },
@@ -768,14 +824,14 @@ pub const Loop = struct {
             // No thread pool - complete with error
             log.err("No thread pool available for file operation", .{});
             completion.state = .running;
-            self.state.active += 1;
+            self.state.incrActive();
             completion.setError(error.Unexpected);
             self.state.markCompleted(completion);
             return;
         };
 
         completion.state = .running;
-        self.state.active += 1;
+        self.state.incrActive();
 
         switch (completion.op) {
             inline .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .file_size, .file_stat, .dir_open, .dir_close, .dir_read, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control, .process_wait => |op| {
@@ -997,7 +1053,7 @@ pub const Loop = struct {
 
         // Skip backend poll in no_wait mode if there's nothing to retrieve.
         // This avoids syscall overhead for pure CPU-bound workloads.
-        const should_poll = wait or self.state.inflight_io > 0;
+        const should_poll = wait or self.state.loadInflight() > 0;
         const wake_flags = self.state.wake_requested.swap(0, .acq_rel);
         const timed_out = if (should_poll) try self.backend.poll(&self.state, if (wake_flags != 0) .zero else timeout) else false;
 


### PR DESCRIPTION
When multiple loops (executor workers) share the same IOCP port, a completion packet may be dequeued by a thread that did not submit the I/O. `processCompletion` then decrements `inflight_io` and `active` on the wrong `LoopState`, causing a `usize` underflow (integer overflow panic in ReleaseSafe) and a stranded counter on the source loop.

Move `active` and `inflight_io` into `iocp.SharedState` as `atomic(u64)` and add six helpers on `LoopState` (`incrActive`, `decrActive`, `loadActive`, `incrInflight`, `decrInflight`, `loadInflight`) that dispatch compile-time on `Backend.capabilities.is_multi_threaded`: IOCP uses the shared atomics, all other backends continue using the local counters.

All increment/decrement sites in `loop.zig` and every backend were replaced with the helper calls. Non-IOCP backends see zero codegen change.

Fixes the UAF-free regression test crash on Windows IOCP.