### PR TITLE
Wire shared LoopGroup across executors

### DIFF
--- a/src/ev/root.zig
+++ b/src/ev/root.zig
@@ -15,6 +15,7 @@ pub const backend = @import("backend.zig").backend;
 pub const Backend = @import("backend.zig").Backend;
 
 pub const Loop = @import("loop.zig").Loop;
+pub const LoopGroup = @import("loop.zig").LoopGroup;
 pub const RunMode = @import("loop.zig").RunMode;
 pub const ThreadPool = @import("thread_pool.zig").ThreadPool;
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -332,6 +332,7 @@ pub const Executor = struct {
         try self.loop.init(.{
             .allocator = self.runtime.allocator,
             .thread_pool = &self.runtime.thread_pool,
+            .loop_group = &self.runtime.loop_group,
             .defer_callbacks = false,
         });
         errdefer self.loop.deinit();
@@ -730,6 +731,7 @@ pub const Runtime = struct {
     options: RuntimeOptions,
 
     executors: std.ArrayList(*Executor) = .empty,
+    loop_group: ev.LoopGroup = .{},
     main_executor: Executor,
     next_executor_index: std.atomic.Value(usize) = .init(0),
     workers: std.ArrayList(Worker) = .empty,


### PR DESCRIPTION
## Problem

`LoopGroup` / backend `SharedState` is plumbed through `Loop`, but nothing ever passes `Options.loop_group` — the runtime's `loop.init` call omitted it (confirmed: `loop_group` was never referenced outside `src/ev/loop.zig`, and `git log -S loop_group -- src/runtime.zig` is empty). So every executor's `Loop` fell back to its own `internal_loop_group`, and the `SharedState` was per-loop, never actually shared.

On IOCP this is a correctness bug, not just a missed optimization. The design is **one completion port per runtime** — a handle binds to exactly one IOCP port for its lifetime. With a per-loop `SharedState`, each executor creates its own port. With `enable_task_migration` on by default, a task that starts I/O on executor A can resume on B; the handle stays bound to A's port, so completions are dequeued by a loop that didn't submit them. That's the wrong-`LoopState` underflow #480 worked around with shared atomic counters — but those counters were also per-loop, so the fix was inert as wired.

## Fix

Give `Runtime` a single `LoopGroup` and pass `&self.runtime.loop_group` into every executor's `loop.init`, so all loops share one `SharedState` (one IOCP port), which the backend already assumes. `SharedState.acquire`/`release` are already mutex-protected and refcounted for concurrent use.

Non-IOCP backends have an empty `SharedState{}` and ignore it, so this is a no-op for them. The `internal_loop_group` fallback stays for standalone `ev.Loop` use outside a runtime.

This also lays the groundwork for sharing the io_uring work queue (`IORING_SETUP_ATTACH_WQ`), which needs a real shared `SharedState` to hold the primary ring fd.

## Testing

- `./check.sh` — 479/479 pass (Linux)
- `./check.sh --target x86_64-windows --wine` — 422/422 pass (IOCP)