### PR TITLE
Add http-client to examples list in build.zig (#491)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,6 +60,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "tcp-echo-server-stdio", .file = "examples/tcp_echo_server_stdio.zig" },
         .{ .name = "tcp-client", .file = "examples/tcp_client.zig" },
         .{ .name = "http-server", .file = "examples/http_server.zig" },
+        .{ .name = "http-client", .file = "examples/http_client.zig" },
         .{ .name = "mutex-demo", .file = "examples/mutex_demo.zig" },
         .{ .name = "producer-consumer", .file = "examples/producer_consumer.zig" },
         .{ .name = "parallel-grep", .file = "examples/parallel_grep.zig" },

--- a/examples/http_client.zig
+++ b/examples/http_client.zig
@@ -1,28 +1,55 @@
 const std = @import("std");
-const Zio = @import("zio");
+const zio = @import("zio");
 
-pub const std_options_debug_io = Zio.debug_io;
+// Use zio for std.log.* and std.debug.print
+pub const std_options_debug_io = zio.debug_io;
+
+// Maximum response body size we are willing to buffer
+const MAX_BODY_SIZE = 1 * 1024 * 1024;
 
 pub fn main(init: std.process.Init) !void {
-    var zio = try Zio.Runtime.init(init.gpa, .{ .thread_pool = .{ .min_threads = 1 } });
-    defer zio.deinit();
+    const gpa = init.gpa;
 
-    var http_client: std.http.Client = .{ .allocator = init.gpa, .io = zio.io() };
-    defer http_client.deinit();
+    var rt = try zio.Runtime.init(gpa, .{});
+    defer rt.deinit();
 
-    std.debug.print("TEST http client: {any}\n", .{http_client});
+    // Allow the URL to be passed as the first argument
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    const url = if (args.len > 1) args[1] else "https://httpbin.org/get";
 
-    var request = try http_client.request(.GET, try std.Uri.parse("https://httpbin.org/get"), .{});
+    // --8<-- [start:client]
+    // The HTTP client drives all I/O through zio's event loop
+    var client: std.http.Client = .{ .allocator = gpa, .io = rt.io() };
+    defer client.deinit();
+    // --8<-- [end:client]
+
+    std.log.info("GET {s}", .{url});
+
+    // --8<-- [start:request]
+    // Send the request headers (no request body for a GET)
+    var request = try client.request(.GET, try std.Uri.parse(url), .{});
     defer request.deinit();
-
-    std.debug.print("TEST request headers: {any}\n", .{request.headers});
 
     try request.sendBodiless();
 
-    std.debug.print("TEST request body\n", .{});
+    // Receive the response headers
+    var redirect_buffer: [4096]u8 = undefined;
+    var response = try request.receiveHead(&redirect_buffer);
+    // --8<-- [end:request]
 
-    var redirect_buffer: [1024]u8 = undefined;
-    const response = try request.receiveHead(&redirect_buffer);
+    std.log.info("{d} {s}", .{ @intFromEnum(response.head.status), response.head.reason });
 
-    std.log.info("received {d} {s}", .{ response.head.status, response.head.reason });
+    // --8<-- [start:body]
+    // Read the (possibly decompressed) response body
+    var transfer_buffer: [4096]u8 = undefined;
+    var decompress: std.http.Decompress = undefined;
+    var decompress_buffer: [std.compress.flate.max_window_len]u8 = undefined;
+    const reader = response.readerDecompressing(&transfer_buffer, &decompress, &decompress_buffer);
+
+    const body = try reader.allocRemaining(gpa, .limited(MAX_BODY_SIZE));
+    defer gpa.free(body);
+    // --8<-- [end:body]
+
+    std.log.info("Received {d} bytes:", .{body.len});
+    std.debug.print("{s}\n", .{body});
 }


### PR DESCRIPTION
Fixes #491.

`examples/http_client.zig` existed in the repo but was never referenced in the examples configuration list in `build.zig`, so it was never compiled or installed.

## Changes
- Wire `http-client` into the examples list in `build.zig`.
- Polish the example to match the house style of the other examples:
  - Use the lowercase `zio` alias (was `Zio`).
  - Replace the leftover `TEST ...` `std.debug.print` struct dumps with `std.log` output.
  - Accept an optional URL as the first argument (defaults to `https://httpbin.org/get`).
  - Read and print the response body, decompressing transparently via `readerDecompressing`.

## Testing
- `zig build examples` passes.
- Ran the binary against `https://httpbin.org/get` and `https://httpbin.org/uuid`: both return `200 OK` and print the decoded JSON body.