### PR TITLE
fs: don't block the event loop on Windows console/stdio reads

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -79,21 +79,35 @@ pub fn createPipe() (os.fs.PipeError || Cancelable)!PipePair {
 }
 
 pub fn stdin() File {
-    const fd = os.fs.stdin();
-    const pollable = probePollable(fd);
-    return .{ .fd = fd, .pollable = pollable };
+    return stdioFile(os.fs.stdin());
 }
 
 pub fn stdout() File {
-    const fd = os.fs.stdout();
-    const pollable = probePollable(fd);
-    return .{ .fd = fd, .pollable = pollable };
+    return stdioFile(os.fs.stdout());
 }
 
 pub fn stderr() File {
-    const fd = os.fs.stderr();
-    const pollable = probePollable(fd);
-    return .{ .fd = fd, .pollable = pollable };
+    return stdioFile(os.fs.stderr());
+}
+
+/// Build a File for an inherited standard handle.
+///
+/// On Windows the std handles are not opened with FILE_FLAG_OVERLAPPED and are
+/// not associated with the IOCP port, so the event loop cannot drive them:
+/// force `pollable = false` to route streaming I/O to the thread pool (blocking
+/// ReadFile/WriteFile), while keeping the Reader/Writer mode tied to actual
+/// seekability (console/pipe -> streaming, file -> positional). Without this a
+/// console read would issue a blocking overlapped ReadFile on the loop thread
+/// and stall every task. On POSIX the std handles behave like any other fd.
+fn stdioFile(fd: Handle) File {
+    if (builtin.os.tag == .windows) {
+        return .{
+            .fd = fd,
+            .pollable = false,
+            .preferred_mode = if (probePollable(fd)) .streaming else .positional,
+        };
+    }
+    return .{ .fd = fd, .pollable = probePollable(fd) };
 }
 
 pub fn stat(path: []const u8) Dir.StatError!os.fs.FileStatInfo {
@@ -287,11 +301,28 @@ pub const Dir = struct {
     }
 };
 
+/// Whether the Reader/Writer issues positional (offset-based) or streaming
+/// (current-position) I/O ops. Independent of `File.pollable`, which decides
+/// event-loop vs thread-pool routing: a console, for example, is `.streaming`
+/// yet not loop-drivable.
+pub const Mode = enum {
+    /// Use positional I/O (pread/pwrite) with explicit offset.
+    positional,
+    /// Use streaming I/O (read/write) at the current file position.
+    streaming,
+};
+
 pub const File = struct {
     fd: Handle,
-    /// Whether `fd` is pollable (non-seekable). Set from the open/create result;
-    /// `null` when unknown (e.g. constructed via `fromFd`).
+    /// Whether `fd` is pollable (non-seekable) and can be driven by the event
+    /// loop for streaming I/O. Set from the open/create result; `null` when
+    /// unknown (e.g. constructed via `fromFd`). When false, streaming ops are
+    /// routed to the thread pool.
     pollable: ?bool = null,
+    /// Explicit Reader/Writer `Mode` hint. `null` means infer from `pollable`.
+    /// Set when seekability and loop-drivability disagree (e.g. a Windows
+    /// console: non-seekable, so `.streaming`, but not loop-drivable).
+    preferred_mode: ?Mode = null,
 
     pub const ReadError = os.fs.FileReadError || Cancelable;
     pub const WriteError = os.fs.FileWriteError || Cancelable;
@@ -455,18 +486,22 @@ pub const File = struct {
     }
 };
 
+/// Pick the Reader/Writer mode for a file: an explicit `preferred_mode` wins,
+/// otherwise infer from `pollable` (non-seekable -> streaming, seekable or
+/// unknown -> positional).
+fn resolveMode(file: File) Mode {
+    if (file.preferred_mode) |m| return m;
+    return if (file.pollable) |p|
+        if (p) .streaming else .positional
+    else
+        .positional;
+}
+
 /// File reader that implements std.Io.Reader interface.
 /// Dispatches between positional I/O (regular files) and streaming I/O
-/// (pipes, sockets, ttys) based on the File.pollable flag.
+/// (pipes, sockets, ttys) based on the File's mode.
 pub const FileReader = struct {
     pub const Error = os.fs.FileReadError || Cancelable || Timeoutable;
-
-    pub const Mode = enum {
-        /// Use positional I/O (pread/pwrite) with explicit offset.
-        positional,
-        /// Use streaming I/O (read/write) at the current file position.
-        streaming,
-    };
 
     file: File,
     mode: Mode,
@@ -476,10 +511,7 @@ pub const FileReader = struct {
     interface: std.Io.Reader,
 
     pub fn init(file: File, buffer: []u8) FileReader {
-        const mode: Mode = if (file.pollable) |p|
-            if (p) .streaming else .positional
-        else
-            .positional;
+        const mode: Mode = resolveMode(file);
         return .{
             .file = file,
             .mode = mode,
@@ -651,22 +683,19 @@ pub const FileReader = struct {
 
 /// File writer that implements std.Io.Writer interface.
 /// Dispatches between positional I/O (regular files) and streaming I/O
-/// (pipes, sockets, ttys) based on the File.pollable flag.
+/// (pipes, sockets, ttys) based on the File's mode.
 pub const FileWriter = struct {
     pub const Error = os.fs.FileWriteError || Cancelable || Timeoutable;
 
     file: File,
-    mode: FileReader.Mode,
+    mode: Mode,
     position: u64 = 0,
     timeout: Timeout = .none,
     err: ?Error = null,
     interface: std.Io.Writer,
 
     pub fn init(file: File, buffer: []u8) FileWriter {
-        const mode: FileReader.Mode = if (file.pollable) |p|
-            if (p) .streaming else .positional
-        else
-            .positional;
+        const mode: Mode = resolveMode(file);
         return .{
             .file = file,
             .mode = mode,

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -93,19 +93,18 @@ pub fn stderr() File {
 /// Build a File for an inherited standard handle.
 ///
 /// On Windows the std handles are not opened with FILE_FLAG_OVERLAPPED and are
-/// not associated with the IOCP port, so the event loop cannot drive them:
-/// force `pollable = false` to route streaming I/O to the thread pool (blocking
-/// ReadFile/WriteFile), while keeping the Reader/Writer mode tied to actual
-/// seekability (console/pipe -> streaming, file -> positional). Without this a
-/// console read would issue a blocking overlapped ReadFile on the loop thread
-/// and stall every task. On POSIX the std handles behave like any other fd.
+/// not associated with the IOCP port, so the event loop cannot drive them at
+/// all: both the overlapped streaming path and the positional file_read/
+/// file_write path would issue a blocking overlapped operation on the loop
+/// thread and stall every task. The only path that works is the thread pool's
+/// blocking ReadFile/WriteFile, reached by a streaming op with pollable=false.
+/// So force `pollable = false` (route to the thread pool) and `.streaming`
+/// (so the Reader/Writer issues streaming ops, never positional). This holds
+/// for consoles, inherited pipes, and file redirection alike. On POSIX the std
+/// handles behave like any other fd.
 fn stdioFile(fd: Handle) File {
     if (builtin.os.tag == .windows) {
-        return .{
-            .fd = fd,
-            .pollable = false,
-            .preferred_mode = if (probePollable(fd)) .streaming else .positional,
-        };
+        return .{ .fd = fd, .pollable = false, .preferred_mode = .streaming };
     }
     return .{ .fd = fd, .pollable = probePollable(fd) };
 }
@@ -489,7 +488,7 @@ pub const File = struct {
 /// Pick the Reader/Writer mode for a file: an explicit `preferred_mode` wins,
 /// otherwise infer from `pollable` (non-seekable -> streaming, seekable or
 /// unknown -> positional).
-fn resolveMode(file: File) Mode {
+pub fn resolveMode(file: File) Mode {
     if (file.preferred_mode) |m| return m;
     return if (file.pollable) |p|
         if (p) .streaming else .positional

--- a/src/io.zig
+++ b/src/io.zig
@@ -1652,9 +1652,11 @@ fn initLockedStderr(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.
         const io = Io{ .userdata = userdata, .vtable = &vtable };
         const zfile = zio_fs.stderr();
         var file: Io.File = .{ .handle = zfile.fd, .flags = .{ .nonblocking = false } };
-        const pollable = zfile.pollable orelse false;
-        flagsWritePollable(&file.flags, pollable);
-        if (pollable) {
+        // `pollable` controls routing (event loop vs thread pool); the mode
+        // (streaming vs positional) is resolved separately, since on Windows a
+        // console is streaming yet not loop-drivable.
+        flagsWritePollable(&file.flags, zfile.pollable orelse false);
+        if (zio_fs.resolveMode(zfile) == .streaming) {
             stderr_writer = Io.File.Writer.initStreaming(file, io, &.{});
         } else {
             stderr_writer = Io.File.Writer.init(file, io, &.{});


### PR DESCRIPTION
## Problem

Reading from stdin blocks every task on Windows (#495). The same code works on Linux.

On Windows the inherited standard handles (`hStdInput`/`hStdOutput`/`hStdError`) are **not** opened with `FILE_FLAG_OVERLAPPED` and are **not** associated with the IOCP port, so the event loop cannot drive them asynchronously. They are non-seekable, so `probePollable` reported `pollable = true`, which routed streaming reads to the IOCP backend's overlapped `ReadFile`. On a console that call runs **synchronously on the loop thread** and blocks until Enter is pressed — stalling every other task.

## Fix

`pollable` was conflating two independent properties:

1. **routing** — can the event loop drive streaming I/O on this fd? (loop vs thread pool)
2. **mode** — should the Reader/Writer issue streaming or positional ops?

These coincide on POSIX (and for Windows files/pipes), but diverge for a Windows console: non-seekable (so streaming mode) yet not loop-drivable (so thread pool).

This change decouples them:

- `pollable` now strictly means "can the event loop drive streaming I/O on this fd".
- A new generic `File.preferred_mode` explicitly selects the Reader/Writer `Mode`; `null` infers from `pollable` exactly as before.

On Windows the std handles are built with `pollable = false` (routing streaming I/O to the thread pool's blocking `ReadFile`/`WriteFile`, which works fine on consoles) and `preferred_mode` tied to actual seekability (console/pipe → `.streaming`, redirected file → `.positional`). POSIX behavior is unchanged.

No backend change is required: with `pollable = false` the console's streaming op simply takes the existing "non-pollable streaming → thread pool" path (`fileReadStreamingWork` → `fs.readv` → blocking `ReadFile`), the same route already used for all file I/O on Windows. This also fixes inherited **pipe** stdin redirection on Windows, which was broken for the same reason.

## Notes / limitations

- A blocked console read parks one thread-pool worker and cannot be interrupted mid-read on Win8.1+ (cancel marks intent only) — the same limitation libuv/tokio have.
- Console input still goes through `ReadFile` (ASCII); switching to `ReadConsoleW` for Unicode is a separate later improvement.

## Testing

- `zig build` and `zig build -Dtarget=x86_64-windows` compile.
- `zig build test -Dbackend=epoll`: 479/479 pass.
- Verified on Windows (via Wine) with a stdin-reader + background ticker: the ticker keeps running while stdin waits for input, and lines are echoed as typed.

Fixes #495