### PR TITLE
io/ev: make general std.Io stdio work on Windows

### DIFF
--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -658,6 +658,15 @@ pub const Loop = struct {
                         // reused op (or the caller) can skip re-probing.
                         const data = completion.cast(op.toType());
                         const pollable = data.pollable orelse blk: {
+                            if (builtin.os.tag == .windows) {
+                                // A streaming op reaching the lazy path on Windows is a
+                                // handle zio did not open/classify (foreign, e.g. inherited
+                                // stdio reached via std.Io). Such handles are not associated
+                                // with our IOCP port, so the loop cannot drive them — route
+                                // to the thread pool's blocking read/write.
+                                data.pollable = false;
+                                break :blk false;
+                            }
                             const p = common.probePollable(data.handle);
                             data.pollable = p;
                             break :blk p;

--- a/src/io.zig
+++ b/src/io.zig
@@ -81,6 +81,24 @@ fn flagsWritePollable(flags: *Io.File.Flags, pollable: bool) void {
     @as(*u8, @ptrCast(flags)).* = if (pollable) 0x01 else 0xCC;
 }
 
+/// Whether a positional (offset-based) op on `file` cannot be served by the
+/// async backend and should be reported as `Unseekable` so the std.Io
+/// Reader/Writer falls back to streaming.
+///
+/// On Windows, IOCP-driven positional I/O only works on handles zio opened and
+/// associated with its completion port (their pollable verdict is recorded in
+/// the flags). A handle whose verdict is unknown here was not opened by us
+/// (e.g. an inherited stdio handle obtained via `std.Io.File.stdin()`); an
+/// overlapped ReadFile/WriteFile on it would block the loop thread or never
+/// complete. Reporting `Unseekable` makes the reader/writer switch to the
+/// streaming path, which routes to the thread pool's blocking I/O. This relies
+/// on the flag-smuggling tri-state, so it is disabled under `no_hacks`.
+fn positionalUnsupported(file: Io.File) bool {
+    if (comptime builtin.os.tag != .windows) return false;
+    if (zio_options.no_hacks) return false;
+    return flagsReadPollable(&file.flags) == null;
+}
+
 /// Construct a `std.Io` instance backed by `rt`.
 pub fn fromRuntime(rt: *Runtime) Io {
     return .{
@@ -1449,6 +1467,8 @@ fn fileCloseImpl(_: ?*anyopaque, files: []const Io.File) void {
 }
 
 fn fileWritePositionalImpl(_: ?*anyopaque, file: Io.File, header: []const u8, data: []const []const u8, splat: usize, offset: u64) Io.File.WritePositionalError!usize {
+    if (positionalUnsupported(file)) return error.Unseekable;
+
     var slices: [max_iovecs_len][]const u8 = undefined;
     var splat_buf: [64]u8 = undefined;
     const n = fillBuf(&slices, header, data, splat, &splat_buf);
@@ -1463,6 +1483,8 @@ fn fileWritePositionalImpl(_: ?*anyopaque, file: Io.File, header: []const u8, da
 }
 
 fn fileReadPositionalImpl(_: ?*anyopaque, file: Io.File, data: []const []u8, offset: u64) Io.File.ReadPositionalError!usize {
+    if (positionalUnsupported(file)) return error.Unseekable;
+
     var iovecs: [max_iovecs_len]os_fs.iovec = undefined;
     var count: usize = 0;
     for (data) |buf| {


### PR DESCRIPTION
Follow-up to #495 / #497.

## Problem

#497 fixed zio's own `zio.stdin()`/`stdout()`/`stderr()`, but the **general `std.Io` path** still blocks the event loop on Windows:

```zig
var f = std.Io.File.stdin();
var r = f.reader(io, &buf);   // foreign handle zio never opened
```

These are foreign handles — zio didn't open them, so they're not associated with the IOCP port and the event loop can't drive them. `std.Io.File.stdin()` also hands back `nonblocking=false` (an unknown verdict in our smuggled flags), and `file.reader()` starts in positional mode, so the first read issues a blocking overlapped `ReadFile` on the loop thread.

## Principle

On Windows, async IOCP I/O only works on handles **zio opened and associated** with its completion port (their pollable verdict is recorded in the smuggled `File.Flags`). A handle whose verdict is *unknown* at op time is foreign and must use the thread pool's blocking I/O. No new smuggling is needed — we just interpret the existing tri-state correctly.

## Changes

- **Positional path** (`src/io.zig`): `positionalUnsupported()` returns `error.Unseekable` for foreign handles on Windows. Both std's `File.Reader`/`Writer` and zio's own readers already fall back to streaming on `Unseekable`, so no new fallback machinery is required. Gated off under `no_hacks` (where the tri-state collapses to a single bool) and compiled out on non-Windows.
- **Streaming routing** (`src/ev/loop.zig`): a streaming op reaching the lazy classifier on Windows is by definition a foreign handle (zio always seeds `pollable` for its own), so route it to the thread pool instead of probing — which would mis-classify a console as loop-drivable.

Net effect for `std.Io.File.stdin().reader()` on a Windows console: first positional read → `Unseekable` → reader flips to streaming → thread-pool blocking `ReadFile` → loop stays free. zio-opened files keep their fast IOCP positional/random-access path (verdict is *known*, not *unknown*).

## Testing

- host + `x86_64-windows` (incl. `-Dno-hacks=true`) compile.
- `zig build test -Dbackend=epoll`: 479/479 pass.
- Verified on Windows via Wine: `std.Io.File.stdin().reader(io, ...)` reads lines while a background ticker keeps firing.