### PR TITLE
ev: use writer and reader buffers for sendfile fallback double-buffering

### DIFF
--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -761,6 +761,12 @@ pub const NetSendFile = struct {
     offset: u64,
     /// Bytes still allowed to send (use `maxInt(usize)` for the whole file).
     remaining: usize,
+    /// Up to two scratch buffers borrowed from the caller for the generic
+    /// fallback loop. If both are non-empty the loop double-buffers (read into
+    /// one while sending the other); if only `bufs[0]` is non-empty it runs a
+    /// serial read-then-send loop. The two buffers may differ in size (e.g. the
+    /// writer's buffer and the reader's buffer). Unused by native backends.
+    bufs: [2][]u8,
 
     internal: switch (Backend.capabilities.net_send_file) {
         true => if (@hasDecl(Backend, "NetSendFileData")) Backend.NetSendFileData else struct {},
@@ -773,8 +779,9 @@ pub const NetSendFile = struct {
         send: NetSend = undefined,
         /// Two ping-pong transfer buffers (userspace equivalent of the splice
         /// pipe). One is filled by a read while the other is drained by a send.
-        /// Split 2x8K to keep the same total size as the single-buffer version.
-        bufs: [2][8 * 1024]u8 = undefined,
+        /// Derived from the caller's buffers by `netSendFileStart`; an empty
+        /// `bufs[1]` means a single-buffer serial loop.
+        bufs: [2][]u8 = .{ &.{}, &.{} },
         /// Bytes available in each buffer (0 = empty/free).
         filled: [2]usize = .{ 0, 0 },
         /// Drain cursor within the buffer currently being sent.
@@ -800,13 +807,18 @@ pub const NetSendFile = struct {
 
     pub const Error = (net.SendError || fs.FileReadError) || Cancelable;
 
-    pub fn init(handle: Backend.NetHandle, file: fs.fd_t, offset: u64, limit: usize) NetSendFile {
+    /// `bufs` are borrowed for the generic fallback loop and must outlive the
+    /// operation. Provide two non-empty buffers for double-buffering, or one
+    /// (with `bufs[1]` empty) for a serial loop. `bufs[0]` must be non-empty.
+    /// Native backends ignore `bufs`.
+    pub fn init(handle: Backend.NetHandle, file: fs.fd_t, offset: u64, limit: usize, bufs: [2][]u8) NetSendFile {
         return .{
             .c = .init(.net_send_file),
             .handle = handle,
             .file = file,
             .offset = offset,
             .remaining = limit,
+            .bufs = bufs,
         };
     }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -27,6 +27,104 @@ const log = @import("../common.zig").log;
 
 const in_safe_mode = builtin.mode == .Debug or builtin.mode == .ReleaseSafe;
 
+/// How the NetSendFile fallback lays out its scratch from the (up to two)
+/// caller-provided buffers.
+const SendfileStrategy = enum {
+    /// Ping-pong between the two given buffers (read into one, send the other).
+    both,
+    /// Halve the larger buffer into two ping-pong buffers (the other is unused).
+    split,
+    /// Single buffer, serial read-then-send.
+    single,
+};
+
+/// The larger buffer must be at least this big before halving it for overlap
+/// beats just running serially over the whole thing.
+const sendfile_min_split = 64 * 1024;
+
+/// Pick a strategy from the two buffers' sizes (see `SendfileStrategy`).
+fn chooseSendfileStrategy(len0: usize, len1: usize) SendfileStrategy {
+    const small = @min(len0, len1);
+    const large = @max(len0, len1);
+    // Two buffers ping-ponging beats halving one whenever both are usable, so
+    // prefer that. Only fall back to halving the larger when the smaller is too
+    // small to be a useful second buffer (less than half the larger) *and* the
+    // larger is big enough that two halves still overlap well. An empty smaller
+    // buffer (only one buffer available) also lands here.
+    if (large >= sendfile_min_split and small < large / 2) return .split;
+    if (small > 0) return .both;
+    return .single;
+}
+
+/// Resolve the two caller buffers into the two working ping-pong buffers. A
+/// non-empty bufs[1] means double-buffering; an empty bufs[1] means serial.
+fn sendfileLayout(bufs: [2][]u8) [2][]u8 {
+    const big = if (bufs[0].len >= bufs[1].len) bufs[0] else bufs[1];
+    return switch (chooseSendfileStrategy(bufs[0].len, bufs[1].len)) {
+        .both => bufs,
+        .split => blk: {
+            const half = big.len / 2;
+            if (half == 0) break :blk .{ big, &.{} };
+            break :blk .{ big[0..half], big[half..] };
+        },
+        .single => .{ big, &.{} },
+    };
+}
+
+test chooseSendfileStrategy {
+    const S = SendfileStrategy;
+    const expectEqual = std.testing.expectEqual;
+    const k = 1024;
+
+    // Balanced (incl. equal) pairs -> use both, regardless of size.
+    try expectEqual(S.both, chooseSendfileStrategy(64 * k, 64 * k));
+    try expectEqual(S.both, chooseSendfileStrategy(1 * k, 1 * k));
+    try expectEqual(S.both, chooseSendfileStrategy(64 * k, 48 * k));
+
+    // Small second buffer, but the larger isn't big enough to bother splitting.
+    try expectEqual(S.both, chooseSendfileStrategy(32 * k, 1 * k));
+    try expectEqual(S.both, chooseSendfileStrategy(1 * k, 32 * k)); // order-independent
+
+    // Large buffer + a much smaller one -> halve the large into balanced halves.
+    try expectEqual(S.split, chooseSendfileStrategy(256 * k, 1 * k));
+    try expectEqual(S.split, chooseSendfileStrategy(1 * k, 256 * k));
+
+    // Only one buffer (other empty): split if big enough, else serial.
+    try expectEqual(S.split, chooseSendfileStrategy(256 * k, 0));
+    try expectEqual(S.single, chooseSendfileStrategy(32 * k, 0));
+    try expectEqual(S.single, chooseSendfileStrategy(0, 0));
+}
+
+test sendfileLayout {
+    const expectEqual = std.testing.expectEqual;
+    const k = 1024;
+    var a: [64 * k]u8 = undefined;
+    var b: [64 * k]u8 = undefined;
+
+    // Two balanced buffers -> returned as-is (double-buffer).
+    {
+        const r = sendfileLayout(.{ a[0 .. 32 * k], b[0 .. 32 * k] });
+        try expectEqual(32 * k, r[0].len);
+        try expectEqual(32 * k, r[1].len);
+        try std.testing.expect(r[0].ptr == a[0..].ptr);
+    }
+    // One large buffer -> two halves of it.
+    {
+        const r = sendfileLayout(.{ a[0..], &.{} });
+        try expectEqual(32 * k, r[0].len);
+        try expectEqual(32 * k, r[1].len);
+        try std.testing.expect(r[0].ptr == a[0..].ptr);
+        try std.testing.expect(r[1].ptr == a[32 * k ..].ptr);
+    }
+    // One small buffer -> serial (empty second slot).
+    {
+        var c: [4 * k]u8 = undefined;
+        const r = sendfileLayout(.{ c[0..], &.{} });
+        try expectEqual(4 * k, r[0].len);
+        try expectEqual(0, r[1].len);
+    }
+}
+
 pub const LoopGroup = struct {
     shared: Backend.SharedState = .{},
 };
@@ -923,6 +1021,10 @@ pub const Loop = struct {
     fn netSendFileStart(self: *Loop, op: *NetSendFile) void {
         op.internal = .{};
         op.internal.read_remaining = op.remaining;
+        // Lay out the working buffers from the (up to two) caller buffers. When
+        // the result's bufs[1] is empty the index flips are suppressed (see
+        // netSendFileStartRead / netSendFileOnSend), so the loop runs serially.
+        op.internal.bufs = sendfileLayout(op.bufs);
         self.netSendFileAdvance(op);
     }
 
@@ -931,7 +1033,7 @@ pub const Loop = struct {
         const idx = f.next_read;
         const want = @min(f.bufs[idx].len, f.read_remaining);
         f.reading = idx;
-        f.next_read ^= 1;
+        if (f.bufs[1].len != 0) f.next_read ^= 1;
         f.read = FileRead.init(op.file, ReadBuf.fromSlice(f.bufs[idx][0..want], &f.read_iov), op.offset);
         f.read.c.userdata = op;
         f.read.c.callback = netSendFileOnRead;
@@ -1032,7 +1134,7 @@ pub const Loop = struct {
         // Buffer fully drained; hand it back to the read side.
         f.filled[idx] = 0;
         f.sending = null;
-        f.next_send ^= 1;
+        if (f.bufs[1].len != 0) f.next_send ^= 1;
         loop.netSendFileAdvance(op);
     }
 

--- a/src/net.zig
+++ b/src/net.zig
@@ -1264,6 +1264,13 @@ pub const Stream = struct {
                 return io_w.consume(n);
             }
 
+            // Lend both the writer's and the reader's buffers to the fallback
+            // loop; both are free here (any buffered bytes were flushed above).
+            // The ev layer decides how to use them (double-buffer / split /
+            // serial). If neither is usable, defer to std's read/drain fallback.
+            const bufs: [2][]u8 = .{ io_w.buffer, file_reader.interface.buffer };
+            if (bufs[0].len == 0 and bufs[1].len == 0) return error.Unimplemented;
+
             // Stream the file body directly from the current read position.
             const want = @intFromEnum(limit);
             if (want == 0) return 0;
@@ -1273,6 +1280,7 @@ pub const Stream = struct {
                 stdIoFileHandleToZio(file_reader.file.handle),
                 file_reader.pos,
                 want,
+                bufs,
             );
             waitForIo(&op.c) catch {
                 w.err = error.Canceled;


### PR DESCRIPTION
## Summary

On backends without native sendfile (every POSIX backend — poll, epoll, kqueue, **and** io_uring), `ev.NetSendFile` falls back to a userspace read/send loop. It used two **fixed internal 8 KiB** buffers, which capped throughput and ignored the buffers the caller already has.

This makes `NetSendFile` take its scratch buffers from the caller. The stream writer (`Stream.Writer.sendFileImpl`) lends both **its own buffer** and the **file reader's buffer** — both are idle during the file-body phase — and the ev fallback chooses how to use them based on their sizes:

- **both non-empty & balanced** → ping-pong between the two full-size buffers (read one while sending the other)
- **one large + a much smaller/empty one** → halve the large into two balanced ping-pong buffers
- **otherwise** → single buffer, serial read-then-send

The policy lives entirely in the ev layer (`chooseSendfileStrategy` / `sendfileLayout` in `loop.zig`); `net.zig` just hands over both buffers. `NetSendFile` itself carries only `bufs: [2][]u8` — no mode flag.

## Why

Two full-size buffers (writer + reader) overlap the file read with the socket send while keeping large I/O sizes. On epoll loopback (256 MiB, median MiB/s, writer = reader buffer):

| buf | single (serial) | split (halve one) | **both (writer+reader)** | std read/drain |
|----:|----:|----:|----:|----:|
| 8 KiB | 176 | 118 | **357** | 232 |
| 32 KiB | 553 | 635 | **1197** | 599 |
| 64 KiB | 920 | 1054 | **1600** | 746 |
| 128 KiB | 1264 | 1523 | **1683** | 864 |

`both` wins at every size (~2× serial), so the auto policy prefers it whenever two usable buffers exist.

## Tests

- New unit tests for `chooseSendfileStrategy` and `sendfileLayout` (balanced/unbalanced/single-buffer cases).
- Full suite passes on epoll (482/482) and io_uring; the existing sendfile transfer/limit/cancellation tests now exercise the new path.

Closes #484