### PR TITLE
fs: add File.stdReader / File.stdWriter

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -18,6 +18,10 @@ const Timeout = @import("time.zig").Timeout;
 
 pub const Handle = os.fs.fd_t;
 
+/// zio's std.Io integration. Imported for `debug_io` and `zioFileToStd`; the
+/// mutual fs<->io import is fine (no comptime cycle).
+const zio_io = @import("io.zig");
+
 pub const max_vecs = switch (builtin.os.tag) {
     .windows => 1,
     else => 16,
@@ -482,6 +486,21 @@ pub const File = struct {
 
     pub fn writer(self: File, buffer: []u8) FileWriter {
         return FileWriter.init(self, buffer);
+    }
+
+    /// Wrap this file as a `std.Io.File.Reader`, for std.Io APIs that require
+    /// that exact type (e.g. `std.Io.Writer.sendFileAll`). Unlike `reader`,
+    /// which returns zio's own `FileReader`, this returns std's reader bound to
+    /// zio's `std.Io`. I/O through it still goes through zio's runtime: it
+    /// suspends on the current task's loop when called from a zio task, and runs
+    /// synchronously otherwise.
+    pub fn stdReader(self: File, buffer: []u8) std.Io.File.Reader {
+        return zio_io.zioFileToStd(self).reader(zio_io.debug_io, buffer);
+    }
+
+    /// Like `stdReader`, but returns a `std.Io.File.Writer`.
+    pub fn stdWriter(self: File, buffer: []u8) std.Io.File.Writer {
+        return zio_io.zioFileToStd(self).writer(zio_io.debug_io, buffer);
     }
 };
 
@@ -992,6 +1011,27 @@ test "File: reader and writer interface" {
 
     try std.testing.expectEqual(10, bytes_read);
     try std.testing.expectEqualStrings("xxxxxxxxxx", result[0..bytes_read]);
+}
+
+test "File: stdReader and stdWriter round-trip" {
+    var t = try TestFile.create("test_file_std_rw.txt", .{});
+    defer t.deinit();
+
+    // Write via std.Io.File.Writer (zio file -> std reader/writer).
+    var write_buffer: [256]u8 = undefined;
+    var writer = t.file.stdWriter(&write_buffer);
+    try writer.interface.writeAll("hello std.Io");
+    try writer.interface.flush();
+
+    // Reopen and read back via std.Io.File.Reader.
+    t.file.close();
+    t.file = try t.dir.openFile(t.path, .{});
+
+    var read_buffer: [256]u8 = undefined;
+    var reader = t.file.stdReader(&read_buffer);
+    var result: [32]u8 = undefined;
+    const n = try reader.interface.readSliceShort(&result);
+    try std.testing.expectEqualStrings("hello std.Io", result[0..n]);
 }
 
 test "Dir: setPermissions" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -81,6 +81,17 @@ fn flagsWritePollable(flags: *Io.File.Flags, pollable: bool) void {
     @as(*u8, @ptrCast(flags)).* = if (pollable) 0x01 else 0xCC;
 }
 
+/// Build a `std.Io.File` from a zio `fs.File`, carrying its pollable verdict in
+/// the (possibly hack-encoded) flags so the std Reader/Writer picks the right
+/// streaming-vs-positional path. A `null` verdict is left unknown (probed
+/// lazily). Used by `fs.File.stdReader` / `fs.File.stdWriter`.
+pub fn zioFileToStd(file: zio_fs.File) Io.File {
+    // nonblocking=false is the "unknown" encoding in both hack modes.
+    var f: Io.File = .{ .handle = file.fd, .flags = .{ .nonblocking = false } };
+    if (file.pollable) |pollable| flagsWritePollable(&f.flags, pollable);
+    return f;
+}
+
 /// Whether a positional (offset-based) op on `file` cannot be served by the
 /// async backend and should be reported as `Unseekable` so the std.Io
 /// Reader/Writer falls back to streaming.


### PR DESCRIPTION
## Summary

Several `std.Io` file APIs are typed on the concrete `std.Io.File.Reader` / `std.Io.File.Writer` — most notably `std.Io.Writer.sendFileAll`, which `Stream.Writer.sendFileImpl` consumes. zio's own `fs.FileReader` / `fs.FileWriter` are a *different* type (a plain `std.Io.Reader`/`Writer`), so to feed one of those APIs you had to open the file through `std.Io` (`Io.Dir.openFile(io, …)`) rather than zio's native `fs`.

This adds `File.stdReader(buffer)` and `File.stdWriter(buffer)` that wrap a zio-opened `File` as the std types.

```zig
var f = try zio.Dir.cwd().openFile("data", .{});
defer f.close();
var fr = f.stdReader(&buf);
_ = try writer.interface.sendFileAll(&fr, .unlimited); // std.Io API, zio-native file
```

## No `io` parameter

They bind to zio's process-wide `std.Io` instance (`debug_io`) rather than taking an `io` argument. That instance has no event loop of its own, but it doesn't need one: file I/O locates the runtime via the **current task** (thread-local), not via `io.userdata`. So reads/writes through the returned reader/writer **suspend on the loop when called inside a zio task**, and run **blocking** when called outside one — both correct.

## Reuse

The `std.Io.File` is built via a shared `zioFileToStd` helper in `io.zig`, reusing the same `flagsWritePollable` encoding the vtable already uses. This carries zio's `pollable` verdict into the (possibly hack-encoded) `Flags`, so the std Reader/Writer still picks the right streaming-vs-positional path (matters on Windows/IOCP). The mutual `fs`↔`io` import is fine in Zig (no comptime cycle).

## Tests

- `fs`: stdWriter→stdReader round-trip.
- Full suite passes on epoll (481/481), including the `-Dno-hacks=true` variant that exercises the non-smuggling flag path.