### PR TITLE
ev/iocp: close IOCP handle if first-loop setup fails in acquire()

### DIFF
--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -257,6 +257,13 @@ pub const SharedState = struct {
                 0,
                 0, // Use default number of concurrent threads
             ) orelse return error.Unexpected;
+            // If first-loop setup below fails, close the freshly created
+            // handle so this SharedState stays reusable (refcount is still 0,
+            // so the caller's errdefer release() does not run).
+            errdefer {
+                _ = windows.CloseHandle(self.iocp);
+                self.iocp = windows.INVALID_HANDLE_VALUE;
+            }
 
             // Reset shared accounting in case this SharedState is being
             // reused after a previous teardown that left stale counters.


### PR DESCRIPTION
## Summary

Fixes a handle leak in `SharedState.acquire()` (`src/ev/backends/iocp.zig`) surfaced while reviewing the `errdefer` chain in `init()` (#483).

On the first loop, `acquire()` creates the IOCP handle and then performs several fallible steps before incrementing `refcount`:

```zig
self.iocp = windows.CreateIoCompletionPort(...) orelse return error.Unexpected;
// ...
const sock = try net.socket(...);                 // fallible
self.exts = .{ .acceptex = try loadWinsockExtension(...), ... };  // 6 fallible loads
// ...
self.refcount += 1;  // only reached on full success
```

If `net.socket` or any `loadWinsockExtension` call fails **after** the handle is created, the handle leaks: `refcount` is still `0`, so the caller's `errdefer shared_state.release()` in `init()` never runs (the `try acquire()` fails before that errdefer registers). A subsequent `acquire()` then overwrites `self.iocp` with a fresh handle, leaking the previous one permanently.

## Fix

Add an `errdefer` immediately after `CreateIoCompletionPort` that closes the handle and resets `self.iocp` to `INVALID_HANDLE_VALUE` if the remaining first-loop setup fails. This keeps the `SharedState` reusable and composes with `release()`'s existing `INVALID_HANDLE_VALUE` guard, so there is no double-close.

The `errdefer` chain in `init()` itself was reviewed and found correct — no changes needed there.

## Testing

`zig build-obj src/zio.zig -target x86_64-windows` compiles cleanly.

Closes #483