### PR TITLE
net: fix UnixAddress.init buffer overflow on platforms with smaller sun_path

### DIFF
--- a/src/net.zig
+++ b/src/net.zig
@@ -630,7 +630,12 @@ pub const UnixAddress = extern union {
     any: os.net.sockaddr,
     un: if (has_unix_sockets) os.net.sockaddr.un else void,
 
-    pub const max_len = 108;
+    // Derive the limit from the platform's actual sun_path size, reserving one
+    // byte for the NUL terminator that pathname sockets and format() rely on.
+    pub const max_len = if (has_unix_sockets)
+        @typeInfo(@FieldType(os.net.sockaddr.un, "path")).array.len - 1
+    else
+        0;
 
     pub fn init(path: []const u8) !UnixAddress {
         if (!has_unix_sockets) unreachable;


### PR DESCRIPTION
## Problem

`UnixAddress.max_len` was hard-coded to `108`, the Linux `sun_path` size. But `sockaddr.un.path` is only **104 bytes on Darwin and the BSDs** (FreeBSD/NetBSD/OpenBSD/DragonFly/Haiku), per the toolchain's `std/c.zig`.

As a result, in `UnixAddress.init`:

```zig
if (path.len > max_len) return error.NameTooLong; // allowed up to 108
var un: sockaddr.un = .{ ..., .path = @splat(0) };
@memcpy(un.path[0..path.len], path);              // path is [104]u8 on Darwin/BSD
```

a caller-supplied unix socket path of length 105–108 passed the guard and overflowed `un.path`:
- **safe builds:** panic (DoS),
- **ReleaseFast/ReleaseSmall:** stack buffer overwrite of up to 4 bytes.

Reachable wherever user/config-controlled socket paths flow into `net.listen`/`net.connect`.

There was also no byte reserved for the NUL terminator even on Linux, so a maximal-length path left `format()`'s `sliceTo(&path, 0)` reading off the end.

## Fix

Derive `max_len` from the platform's actual `sun_path` field size, reserving one byte for the NUL terminator:

```zig
pub const max_len = if (has_unix_sockets)
    @typeInfo(@FieldType(os.net.sockaddr.un, "path")).array.len - 1
else
    0;
```

This yields 107 on Linux/illumos/Serenity and 103 on Darwin/BSD, and the over-long path can no longer overflow.

## Testing

`./check.sh` passes (the two pre-existing `setSize`/`file length` failures are unrelated to this change and also fail on a clean tree).