### PR TITLE
dns: reject over-long names in Resolver.lookup to prevent OOB slice

### DIFF
--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -136,6 +136,11 @@ pub const Resolver = struct {
         storage: []dns.LookupResult,
         options: dns.LookupOptions,
     ) dns.ResolverError!usize {
+        // A name longer than the DNS limit is unresolvable and would overflow
+        // the canonical-name buffer (sized to net.HostName.max_len) and the
+        // cache key below, so reject it up front.
+        if (options.name.len > net.HostName.max_len) return error.UnknownHostName;
+
         const now = getCurrentTime();
         self.maybeReloadHosts(now);
         self.maybeReloadResolvConf(now);


### PR DESCRIPTION
## Problem

`Resolver.lookup` pre-fills `canonical_name_buffer` with a **clamped** copy of the queried name:

```zig
const len = @min(options.name.len, buf.len);
@memcpy(buf[0..len], options.name[0..len]);
```

but every place it *returns* the canonical name slices to the **unclamped** `options.name.len`:

```zig
storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
```

`canonical_name_buffer` is `*[net.HostName.max_len]u8` (255 bytes). `Resolver.lookup` / `dns.lookup` are public and do not validate name length (only the `HostName` wrapper does). A caller passing a name longer than 255 bytes produces an **out-of-bounds slice**: a panic in safe builds, or a slice whose `.bytes` points past the buffer handed back to the caller in release.

Separately, `CacheKey.init`'s `assert(name.len <= 255)` is compiled out in release builds, leaving `@intCast(name.len)` to panic or silently truncate the cache key.

## Fix

Reject names longer than `net.HostName.max_len` at the top of `Resolver.lookup`:

```zig
if (options.name.len > net.HostName.max_len) return error.UnknownHostName;
```

A name beyond the DNS limit is unresolvable, so `UnknownHostName` is the natural error and matches what `HostName.init` already returns for over-long names (no error-set / public-API change). After the guard, `options.name.len <= buf.len` always holds, so every downstream slice is in-bounds and the cache key cannot be truncated.

## Testing

`./check.sh` passes (the two pre-existing `setSize` / `file length` failures are unrelated and also fail on a clean tree).