### PR TITLE
task: remove dead errdefer in AnyTask.create

### DIFF
--- a/src/task.zig
+++ b/src/task.zig
@@ -498,9 +498,9 @@ pub const AnyTask = struct {
             .closure = alloc_result.closure,
         };
 
-        // Acquire stack from pool and initialize context
+        // Acquire stack from pool and initialize context. Nothing below can
+        // fail, so the acquired stack needs no errdefer release here.
         self.coro.context.stack_info = try executor.runtime.stack_pool.acquire();
-        errdefer executor.runtime.stack_pool.release(self.coro.context.stack_info);
 
         // Copy context data into the allocation
         const context_dest = self.closure.getContextSlice(AnyTask, self);


### PR DESCRIPTION
## Problem

`AnyTask.create` registers an `errdefer` that calls `stack_pool.release` with a single argument:

```zig
self.coro.context.stack_info = try executor.runtime.stack_pool.acquire();
errdefer executor.runtime.stack_pool.release(self.coro.context.stack_info);
```

but `release` takes two parameters besides `self`:

```zig
pub fn release(self: *StackPool, stack_info: StackInfo, timestamp: Timestamp) void
```

This compiles today only by accident: the `errdefer` is registered right after the only `try` in the function, and **nothing after it is fallible**, so there is no error-return path through its scope. Zig therefore never instantiates the `errdefer` body and never type-checks the call. The moment a `try` is added below it, the build breaks with a confusing "expected 3 argument(s), found 2" — or, unnoticed, the intended stack cleanup silently never existed.

## Fix

Since nothing after the stack acquire can fail, no release-on-error is needed. Remove the dead `errdefer` and add a comment noting why.

## Testing

`zig build test` passes (the two pre-existing `setSize` / `file length` failures are unrelated and also fail on a clean tree).