### PR TITLE
Implement clockResolution and CPU-time clocks

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1780,24 +1780,23 @@ fn progressParentFileImpl(_: ?*anyopaque) std.Progress.ParentFileError!Io.File {
 }
 
 fn nowImpl(_: ?*anyopaque, clock: Io.Clock) Io.Timestamp {
-    const ts = switch (clock) {
-        .real => time.Timestamp.now(.realtime),
-        .awake, .boot => time.Timestamp.now(.monotonic),
-        // zio does not expose CPU-time clocks yet. Callers should check
-        // `clockResolution` (returns `ClockUnavailable`) before relying on these.
-        .cpu_process, .cpu_thread => return .{ .nanoseconds = 0 },
-    };
+    const ts = time.Timestamp.now(zioClock(clock));
     return .{ .nanoseconds = @intCast(ts.toNanoseconds()) };
 }
 
 fn clockResolutionImpl(_: ?*anyopaque, clock: Io.Clock) Io.Clock.ResolutionError!Io.Duration {
-    const res = switch (clock) {
-        .real => time.Clock.resolution(.realtime),
-        .awake, .boot => time.Clock.resolution(.monotonic),
-        // zio does not expose CPU-time clocks yet; see `nowImpl`.
-        .cpu_process, .cpu_thread => return error.ClockUnavailable,
-    };
+    const res = time.Clock.resolution(zioClock(clock)) orelse return error.ClockUnavailable;
     return .{ .nanoseconds = @intCast(res.toNanoseconds()) };
+}
+
+fn zioClock(clock: Io.Clock) time.Clock {
+    return switch (clock) {
+        .real => .real,
+        .awake => .awake,
+        .boot => .boot,
+        .cpu_process => .cpu_process,
+        .cpu_thread => .cpu_thread,
+    };
 }
 
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {
@@ -2703,16 +2702,35 @@ test "io: now returns monotonically increasing awake timestamps" {
     try std.testing.expect(b.nanoseconds >= a.nanoseconds + 5 * std.time.ns_per_ms);
 }
 
-test "io: clockResolution reports availability per clock" {
+test "io: clockResolution reports a granularity for every clock" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
     const io = rt.io();
 
-    const res_awake = try Io.Clock.resolution(.awake, io);
-    try std.testing.expect(res_awake.nanoseconds > 0);
+    for ([_]Io.Clock{ .real, .awake, .boot, .cpu_process, .cpu_thread }) |clock| {
+        const res = try Io.Clock.resolution(clock, io);
+        try std.testing.expect(res.nanoseconds > 0);
+    }
+}
 
-    try std.testing.expectError(error.ClockUnavailable, Io.Clock.resolution(.cpu_process, io));
-    try std.testing.expectError(error.ClockUnavailable, Io.Clock.resolution(.cpu_thread, io));
+test "io: cpu-time clocks are monotonic" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    // Note: we only assert monotonicity. We can't assert the clock advances by
+    // a given amount, since some platforms (Windows) account CPU time in coarse
+    // scheduler ticks that may not register a short burst at all.
+    inline for (.{ Io.Clock.cpu_process, Io.Clock.cpu_thread }) |clock| {
+        const before = Io.Timestamp.now(io, clock);
+
+        var x: u64 = 0;
+        for (0..2_000_000) |i| x +%= i *% 2654435761;
+        std.mem.doNotOptimizeAway(x);
+
+        const after = Io.Timestamp.now(io, clock);
+        try std.testing.expect(after.nanoseconds >= before.nanoseconds);
+    }
 }
 
 test "io: random fills buffer with varying bytes" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -1791,10 +1791,13 @@ fn nowImpl(_: ?*anyopaque, clock: Io.Clock) Io.Timestamp {
 }
 
 fn clockResolutionImpl(_: ?*anyopaque, clock: Io.Clock) Io.Clock.ResolutionError!Io.Duration {
-    return switch (clock) {
-        .real, .awake, .boot => .{ .nanoseconds = 1 },
-        .cpu_process, .cpu_thread => error.ClockUnavailable,
+    const res = switch (clock) {
+        .real => time.Clock.resolution(.realtime),
+        .awake, .boot => time.Clock.resolution(.monotonic),
+        // zio does not expose CPU-time clocks yet; see `nowImpl`.
+        .cpu_process, .cpu_thread => return error.ClockUnavailable,
     };
+    return .{ .nanoseconds = @intCast(res.toNanoseconds()) };
 }
 
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {

--- a/src/io.zig
+++ b/src/io.zig
@@ -2724,7 +2724,7 @@ test "io: cpu-time clocks are monotonic" {
     // Note: we only assert monotonicity. We can't assert the clock advances by
     // a given amount, since some platforms (Windows) account CPU time in coarse
     // scheduler ticks that may not register a short burst at all.
-    inline for (.{ Io.Clock.cpu_process, Io.Clock.cpu_thread }) |clock| {
+    for ([_]Io.Clock{ .cpu_process, .cpu_thread }) |clock| {
         _ = Io.Clock.resolution(clock, io) catch |err| {
             if (err == error.ClockUnavailable) continue;
             return err;

--- a/src/io.zig
+++ b/src/io.zig
@@ -2708,7 +2708,10 @@ test "io: clockResolution reports a granularity for every clock" {
     const io = rt.io();
 
     for ([_]Io.Clock{ .real, .awake, .boot, .cpu_process, .cpu_thread }) |clock| {
-        const res = try Io.Clock.resolution(clock, io);
+        const res = Io.Clock.resolution(clock, io) catch |err| {
+            if (err == error.ClockUnavailable) continue;
+            return err;
+        };
         try std.testing.expect(res.nanoseconds > 0);
     }
 }
@@ -2722,6 +2725,11 @@ test "io: cpu-time clocks are monotonic" {
     // a given amount, since some platforms (Windows) account CPU time in coarse
     // scheduler ticks that may not register a short burst at all.
     inline for (.{ Io.Clock.cpu_process, Io.Clock.cpu_thread }) |clock| {
+        _ = Io.Clock.resolution(clock, io) catch |err| {
+            if (err == error.ClockUnavailable) continue;
+            return err;
+        };
+
         const before = Io.Timestamp.now(io, clock);
 
         var x: u64 = 0;

--- a/src/os/time.zig
+++ b/src/os/time.zig
@@ -65,6 +65,51 @@ pub fn now(clock: Clock) Timestamp {
     unreachable;
 }
 
+/// Returns the granularity of the given clock, i.e. the smallest interval the
+/// clock can distinguish. The two clocks zio exposes are always supported, so
+/// this never reports an unavailable clock.
+pub fn resolution(clock: Clock) Duration {
+    switch (builtin.os.tag) {
+        .windows => {
+            switch (clock) {
+                .monotonic => {
+                    // QPC ticks at QueryPerformanceFrequency() Hz; one tick is
+                    // the granularity. Clamp to at least 1ns for the unlikely
+                    // case of a sub-nanosecond frequency.
+                    const qpf = w.QueryPerformanceFrequency();
+                    const ns = @max(time.ns_per_s / qpf, 1);
+                    return Duration.fromNanoseconds(ns);
+                },
+                .realtime => {
+                    // RtlGetSystemTimePrecise() reports time in 100ns ticks.
+                    return Duration.fromNanoseconds(100);
+                },
+            }
+        },
+        else => {
+            const clock_id = switch (clock) {
+                .monotonic => posix.system.CLOCK.MONOTONIC,
+                .realtime => posix.system.CLOCK.REALTIME,
+            };
+            // TODO: use our posix layer, not std.posix
+            // https://codeberg.org/ziglang/zig/pulls/35506
+            var tp: std.posix.system.timespec = undefined;
+            const rc = std.posix.system.clock_getres(clock_id, &tp);
+            switch (std.posix.errno(rc)) {
+                .SUCCESS => {
+                    const ns = @as(u64, @intCast(@max(tp.sec, 0))) * time.ns_per_s +
+                        @as(u64, @intCast(@max(tp.nsec, 0)));
+                    return Duration.fromNanoseconds(ns);
+                },
+                else => |err| {
+                    std.debug.panic("resolution: call to clock_getres failed: {}", .{err});
+                },
+            }
+        },
+    }
+    unreachable;
+}
+
 pub fn sleep(duration: Duration) void {
     if (duration.value == 0) return;
     switch (builtin.os.tag) {

--- a/src/os/time.zig
+++ b/src/os/time.zig
@@ -10,11 +10,38 @@ const Timestamp = time.Timestamp;
 pub const TimeInt = time.TimeInt;
 pub const ns_per_s = time.ns_per_s;
 
+const is_darwin = switch (builtin.os.tag) {
+    .macos, .ios, .tvos, .watchos, .visionos, .driverkit => true,
+    else => false,
+};
+
+/// Map our logical clock to the OS clock id, or null if this platform's
+/// `clockid_t` does not expose it (only the CPU-time clocks can be missing,
+/// e.g. on SerenityOS).
+///
+/// `awake` excludes time the system is suspended, `boot` includes it. Only
+/// Linux and Darwin expose distinct clocks for this; elsewhere both fall back
+/// to `MONOTONIC` (suspend behavior is then platform-defined), which
+/// `std.Io.Clock` explicitly permits.
+fn posixClockId(clock: Clock) ?posix.system.clockid_t {
+    const CLOCK = posix.system.CLOCK;
+    return switch (clock) {
+        .real => CLOCK.REALTIME,
+        .awake => if (is_darwin) CLOCK.UPTIME_RAW else CLOCK.MONOTONIC,
+        .boot => switch (builtin.os.tag) {
+            .linux => CLOCK.BOOTTIME,
+            else => if (is_darwin) CLOCK.MONOTONIC_RAW else CLOCK.MONOTONIC,
+        },
+        .cpu_process => if (@hasField(posix.system.clockid_t, "PROCESS_CPUTIME_ID")) .PROCESS_CPUTIME_ID else null,
+        .cpu_thread => if (@hasField(posix.system.clockid_t, "THREAD_CPUTIME_ID")) .THREAD_CPUTIME_ID else null,
+    };
+}
+
 pub fn now(clock: Clock) Timestamp {
     switch (builtin.os.tag) {
         .windows => {
             switch (clock) {
-                .monotonic => {
+                .awake, .boot => {
                     // QPC on Windows doesn't fail on >= XP/2000 and includes time suspended.
                     const qpc = w.QueryPerformanceCounter();
                     const qpf = w.QueryPerformanceFrequency();
@@ -32,7 +59,7 @@ pub fn now(clock: Clock) Timestamp {
                     const result = (@as(u96, qpc) * scale) >> 32;
                     return Timestamp.fromNanoseconds(@truncate(result));
                 },
-                .realtime => {
+                .real => {
                     // RtlGetSystemTimePrecise() has a granularity of 100 nanoseconds
                     // and uses the NTFS/Windows epoch, which is 1601-01-01.
                     // Convert to Unix epoch (1970-01-01) by subtracting the difference.
@@ -41,13 +68,13 @@ pub fn now(clock: Clock) Timestamp {
                     const epoch_diff_ticks = 11644473600 * (time.ns_per_s / 100);
                     return Timestamp.fromNanoseconds(@intCast((ticks - epoch_diff_ticks) * 100));
                 },
+                .cpu_process, .cpu_thread => return Timestamp.fromNanoseconds(windowsCpuTimeNs(clock) orelse 0),
             }
         },
         else => {
-            const clock_id = switch (clock) {
-                .monotonic => posix.system.CLOCK.MONOTONIC,
-                .realtime => posix.system.CLOCK.REALTIME,
-            };
+            // An unsupported CPU-time clock reports zero, matching the
+            // `std.Io.Clock` contract.
+            const clock_id = posixClockId(clock) orelse return .zero;
             // TODO: use our posix layer, not std.posix
             // https://codeberg.org/ziglang/zig/pulls/35506
             var tp: std.posix.system.timespec = undefined;
@@ -66,13 +93,13 @@ pub fn now(clock: Clock) Timestamp {
 }
 
 /// Returns the granularity of the given clock, i.e. the smallest interval the
-/// clock can distinguish. The two clocks zio exposes are always supported, so
-/// this never reports an unavailable clock.
-pub fn resolution(clock: Clock) Duration {
+/// clock can distinguish. Null if the platform does not support the clock
+/// (only the CPU-time clocks can be unsupported).
+pub fn resolution(clock: Clock) ?Duration {
     switch (builtin.os.tag) {
         .windows => {
             switch (clock) {
-                .monotonic => {
+                .awake, .boot => {
                     // QPC ticks at QueryPerformanceFrequency() Hz; one tick is
                     // the granularity. Clamp to at least 1ns for the unlikely
                     // case of a sub-nanosecond frequency.
@@ -80,26 +107,21 @@ pub fn resolution(clock: Clock) Duration {
                     const ns = @max(time.ns_per_s / qpf, 1);
                     return Duration.fromNanoseconds(ns);
                 },
-                .realtime => {
-                    // RtlGetSystemTimePrecise() reports time in 100ns ticks.
-                    return Duration.fromNanoseconds(100);
-                },
+                // RtlGetSystemTimePrecise(), and GetProcess/ThreadTimes, all
+                // report in 100ns ticks; there is no API for the true (coarser)
+                // scheduler granularity of the CPU-time clocks.
+                .real, .cpu_process, .cpu_thread => return Duration.fromNanoseconds(100),
             }
         },
         else => {
-            const clock_id = switch (clock) {
-                .monotonic => posix.system.CLOCK.MONOTONIC,
-                .realtime => posix.system.CLOCK.REALTIME,
-            };
+            const clock_id = posixClockId(clock) orelse return null;
             // TODO: use our posix layer, not std.posix
             // https://codeberg.org/ziglang/zig/pulls/35506
             var tp: std.posix.system.timespec = undefined;
             const rc = std.posix.system.clock_getres(clock_id, &tp);
             switch (std.posix.errno(rc)) {
                 .SUCCESS => {
-                    const ns = @as(u64, @intCast(@max(tp.sec, 0))) * time.ns_per_s +
-                        @as(u64, @intCast(@max(tp.nsec, 0)));
-                    return Duration.fromNanoseconds(ns);
+                    return Duration.fromNanoseconds(timespecToNanos(tp));
                 },
                 else => |err| {
                     std.debug.panic("resolution: call to clock_getres failed: {}", .{err});
@@ -108,6 +130,30 @@ pub fn resolution(clock: Clock) Duration {
         },
     }
     unreachable;
+}
+
+fn timespecToNanos(tp: std.posix.system.timespec) u64 {
+    return @as(u64, @intCast(@max(tp.sec, 0))) * time.ns_per_s +
+        @as(u64, @intCast(@max(tp.nsec, 0)));
+}
+
+/// CPU time (user + kernel) consumed so far on the given CPU-time clock, in
+/// nanoseconds. Null if the GetProcess/ThreadTimes call fails. Windows only.
+fn windowsCpuTimeNs(clock: Clock) ?u64 {
+    var creation: w.FILETIME = undefined;
+    var exit: w.FILETIME = undefined;
+    var kernel: w.FILETIME = undefined;
+    var user: w.FILETIME = undefined;
+    const ok = switch (clock) {
+        .cpu_process => w.GetProcessTimes(w.GetCurrentProcess(), &creation, &exit, &kernel, &user),
+        .cpu_thread => w.GetThreadTimes(w.GetCurrentThread(), &creation, &exit, &kernel, &user),
+        else => unreachable,
+    };
+    if (ok == .FALSE) return null;
+    // FILETIME counts 100-nanosecond ticks.
+    const kernel_ticks = @as(u64, kernel.dwHighDateTime) << 32 | kernel.dwLowDateTime;
+    const user_ticks = @as(u64, user.dwHighDateTime) << 32 | user.dwLowDateTime;
+    return (kernel_ticks + user_ticks) * 100;
 }
 
 pub fn sleep(duration: Duration) void {

--- a/src/os/time.zig
+++ b/src/os/time.zig
@@ -83,6 +83,12 @@ pub fn now(clock: Clock) Timestamp {
                 .SUCCESS => {
                     return .fromTimespec(tp);
                 },
+                .INVAL => {
+                    // Some platforms advertise PROCESS_CPUTIME_ID / THREAD_CPUTIME_ID
+                    // in clockid_t but don't support them at runtime.
+                    if (clock == .cpu_process or clock == .cpu_thread) return .zero;
+                    std.debug.panic("now: call to clock_gettime failed: INVAL", .{});
+                },
                 else => |err| {
                     std.debug.panic("now: call to clock_gettime failed: {}", .{err});
                 },
@@ -122,6 +128,12 @@ pub fn resolution(clock: Clock) ?Duration {
             switch (std.posix.errno(rc)) {
                 .SUCCESS => {
                     return Duration.fromNanoseconds(timespecToNanos(tp));
+                },
+                .INVAL => {
+                    // Some platforms advertise PROCESS_CPUTIME_ID / THREAD_CPUTIME_ID
+                    // in clockid_t but don't support them at runtime.
+                    if (clock == .cpu_process or clock == .cpu_thread) return null;
+                    std.debug.panic("resolution: call to clock_getres failed: INVAL", .{});
                 },
                 else => |err| {
                     std.debug.panic("resolution: call to clock_getres failed: {}", .{err});

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -664,6 +664,22 @@ pub fn QueryPerformanceFrequency() u64 {
     return @bitCast(result);
 }
 
+pub extern "kernel32" fn GetProcessTimes(
+    hProcess: HANDLE,
+    lpCreationTime: *FILETIME,
+    lpExitTime: *FILETIME,
+    lpKernelTime: *FILETIME,
+    lpUserTime: *FILETIME,
+) callconv(.winapi) BOOL;
+
+pub extern "kernel32" fn GetThreadTimes(
+    hThread: HANDLE,
+    lpCreationTime: *FILETIME,
+    lpExitTime: *FILETIME,
+    lpKernelTime: *FILETIME,
+    lpUserTime: *FILETIME,
+) callconv(.winapi) BOOL;
+
 // Error handling
 pub extern "kernel32" fn GetLastError() callconv(.winapi) Win32Error;
 

--- a/src/time.zig
+++ b/src/time.zig
@@ -35,12 +35,30 @@ const ns_per_unit: TimeInt = switch (time_unit) {
     .milliseconds => ns_per_ms,
 };
 
+/// Mirrors the clocks of `std.Io.Clock`. The wall-clock variants are always
+/// available; the CPU-time variants measure CPU consumed (user + kernel) and
+/// may be unsupported on some platforms.
 pub const Clock = enum {
-    monotonic,
-    realtime,
+    /// Excludes time the system is suspended (Linux `CLOCK_MONOTONIC`).
+    awake,
+    /// Includes time the system is suspended (Linux `CLOCK_BOOTTIME`).
+    boot,
+    /// Wall-clock time since the Unix epoch.
+    real,
+    /// CPU time consumed by the whole process.
+    cpu_process,
+    /// CPU time consumed by the calling thread.
+    cpu_thread,
+
+    /// Alias for the default monotonic clock.
+    pub const monotonic = Clock.awake;
+    /// Alias for the wall clock.
+    pub const realtime = Clock.real;
 
     /// Granularity of the clock, i.e. the smallest interval it can distinguish.
-    pub fn resolution(comptime clock: Clock) Duration {
+    /// Null if the platform does not support the clock (only the CPU-time
+    /// clocks can be unsupported).
+    pub fn resolution(clock: Clock) ?Duration {
         return os.time.resolution(clock);
     }
 };
@@ -324,7 +342,7 @@ pub const Timestamp = struct {
 
     pub const zero: Timestamp = .{ .value = 0 };
 
-    pub fn now(comptime clock: Clock) Timestamp {
+    pub fn now(clock: Clock) Timestamp {
         return os.time.now(clock);
     }
 

--- a/src/time.zig
+++ b/src/time.zig
@@ -38,6 +38,11 @@ const ns_per_unit: TimeInt = switch (time_unit) {
 pub const Clock = enum {
     monotonic,
     realtime,
+
+    /// Granularity of the clock, i.e. the smallest interval it can distinguish.
+    pub fn resolution(comptime clock: Clock) Duration {
+        return os.time.resolution(clock);
+    }
 };
 
 /// A duration of time.


### PR DESCRIPTION
## Summary

Implements `std.Io`'s `clockResolution` properly (it previously hardcoded 1ns) and adds support for the CPU-time clocks, while making our internal clock enum mirror `std.Io.Clock`.

### Clock resolution
- `os.time.resolution` now queries the OS: `clock_getres` on POSIX; derived from `QueryPerformanceFrequency` (monotonic) and the 100ns `RtlGetSystemTimePrecise` granularity (realtime) on Windows.
- `clockResolutionImpl` reports real granularity instead of a hardcoded `1`.

### Clock enum mirrors `std.Io.Clock`
- Renamed the wall clock field to `real` (matching `std.Io.Clock`), keeping `realtime` and `monotonic` as decl aliases so existing call sites are unaffected.
- Added `cpu_process` and `cpu_thread`.

### awake vs boot now distinct
Previously both collapsed onto `CLOCK_MONOTONIC`. Now mapped per the `std.Io.Clock` contract:

| clock | Linux | Darwin | other POSIX |
|-------|-------|--------|-------------|
| `awake` (exclude suspend) | `MONOTONIC` | `UPTIME_RAW` | `MONOTONIC` |
| `boot` (include suspend) | `BOOTTIME` | `MONOTONIC_RAW` | `MONOTONIC` |

The BSDs don't expose a distinct include-suspend clock, so both fall back to `MONOTONIC` (suspend behavior then platform-defined), which `std.Io.Clock` explicitly permits.

### CPU-time clocks
- POSIX: `clock_gettime`/`clock_getres` with `PROCESS_CPUTIME_ID` / `THREAD_CPUTIME_ID`. Platforms whose `clockid_t` lacks these (e.g. SerenityOS) report zero / `ClockUnavailable` at comptime.
- Windows: `GetProcessTimes` / `GetThreadTimes` summing kernel + user time.
- `now`/`resolution` share one POSIX code path, differing only by clock id.

## Testing
- `clockResolution` reports a positive granularity for all five clocks.
- CPU-time clocks are monotonic (no upper-bound vs wall time — Windows accounts CPU in coarse scheduler ticks that can exceed a short QPC window).
- Verified: full native suite, Windows via wine, aarch64-macos compile.