### PR TITLE
Cancelable blocking syscalls on thread-pool workers (SIGURG)

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -446,18 +446,26 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     thread_pool.submit(&work);
 
     waiter.wait(1, .allow_cancel) catch {
-        // The task was canceled. Ask the pool to cancel the work: if it is still
-        // queued it is dropped, and if it is running a cancelable syscall it is
-        // interrupted with a first SIGURG. We must still wait for completion
-        // (ctx/work live on our stack), so we drive resend-with-backoff until the
-        // worker acknowledges. The wait is a cooperative `timedWait` (parks the
-        // coroutine on an executor timer), so resending never blocks the thread.
-        thread_pool.cancel(&work);
+        // The task was canceled. Signal the token to interrupt any running
+        // cancelable syscall via SIGURG. We do NOT drop the work from the
+        // queue: workFn must always run so ctx.result is always valid, and
+        // for queued (not-yet-started) work the canceled token causes
+        // Syscall.begin() to return error.Canceled when the worker picks it up.
+        const need_signal = token.cancel();
+        if (need_signal) _ = token.signal();
 
+        // Wait for completion (ctx/work live on our stack). Drive resend-with-
+        // backoff to cover the begin()→syscall gap where the first SIGURG can
+        // be lost. The wait is a cooperative timedWait (parks the coroutine on
+        // an executor timer), so resending never blocks the thread.
+        // Use an incrementing wait_count so each timedWait actually parks
+        // instead of returning immediately once the timer has fired once.
+        var wait_count: u32 = 1;
         var backoff = Duration.fromMicroseconds(1);
         const cap = Duration.fromMilliseconds(1);
         while (!ctx.done.load(.acquire)) {
-            waiter.timedWait(1, .{ .duration = backoff }, .no_cancel);
+            waiter.timedWait(wait_count, .{ .duration = backoff }, .no_cancel);
+            wait_count +|= 1;
             // Resend if the worker is still blocked in the canceled syscall (the
             // first signal can be lost in the start()→syscall window). Once it
             // acknowledges, `signal()` returns false and we just park until done.
@@ -497,8 +505,10 @@ test "blockInPlace: cancellation interrupts a blocking syscall on the worker" {
     // the owning task is canceled, the read must be interrupted via SIGURG and
     // return error.Canceled — which blockInPlace surfaces as its result.
     const worker = struct {
-        fn cancelableRead(fd: std.c.fd_t) error{ Canceled, Unexpected }!void {
+        fn cancelableRead(fd: std.c.fd_t, ready: *std.atomic.Value(bool)) error{ Canceled, Unexpected }!void {
             const sc = try os.syscall_cancel.Syscall.begin();
+            // Signal that we are inside the cancelable region, just before read().
+            ready.store(true, .release);
             var buf: [1]u8 = undefined;
             while (true) {
                 const rc = std.c.read(fd, &buf, buf.len);
@@ -513,8 +523,8 @@ test "blockInPlace: cancellation interrupts a blocking syscall on the worker" {
             }
         }
 
-        fn call(read_fd: std.c.fd_t) !void {
-            const result = blockInPlace(cancelableRead, .{read_fd});
+        fn call(read_fd: std.c.fd_t, ready: *std.atomic.Value(bool)) !void {
+            const result = blockInPlace(cancelableRead, .{ read_fd, ready });
             try std.testing.expectError(error.Canceled, result);
         }
     };
@@ -524,10 +534,12 @@ test "blockInPlace: cancellation interrupts a blocking syscall on the worker" {
     defer _ = std.c.close(fds[0]);
     defer _ = std.c.close(fds[1]);
 
-    var handle = try rt.spawn(worker.call, .{fds[0]});
+    var ready = std.atomic.Value(bool).init(false);
+    var handle = try rt.spawn(worker.call, .{ fds[0], &ready });
 
-    // Let the worker reach the blocking read, then cancel the task.
-    try rt.sleep(.fromMilliseconds(20));
+    // Wait until the worker is inside the cancelable region (after begin() but
+    // before read()), then cancel the task.
+    while (!ready.load(.acquire)) try rt.sleep(.fromMicroseconds(100));
     handle.cancel();
 
     // The worker catches the cancellation and returns normally, so join succeeds.

--- a/src/common.zig
+++ b/src/common.zig
@@ -11,6 +11,7 @@ const Timeout = @import("time.zig").Timeout;
 const Clock = @import("time.zig").Clock;
 const Timestamp = @import("time.zig").Timestamp;
 const Stopwatch = @import("time.zig").Stopwatch;
+const Duration = @import("time.zig").Duration;
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTaskOrNull = @import("runtime.zig").getCurrentTaskOrNull;
 const AnyTask = @import("task.zig").AnyTask;
@@ -410,13 +411,18 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     const Context = struct {
         args: Args,
         result: Result = undefined,
+        // Distinct from the waiter's signal count: the resend timer below also
+        // signals the waiter, so we need an unambiguous "work finished" flag.
+        done: std.atomic.Value(bool) = .init(false),
 
         fn workFn(work: *ev.Work) void {
             const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
             ctx.result = @call(.auto, func, ctx.args);
         }
 
-        fn completionFn(completion_ctx: ?*anyopaque, _: *ev.Work) void {
+        fn completionFn(completion_ctx: ?*anyopaque, work: *ev.Work) void {
+            const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
+            ctx.done.store(true, .release);
             const waiter: *Waiter = @ptrCast(@alignCast(completion_ctx.?));
             waiter.signal();
         }
@@ -430,18 +436,36 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
         return @call(.auto, func, args);
     };
 
+    var token: os.syscall_cancel.Token = .{};
     var work = ev.Work.init(Context.workFn, &ctx);
     work.completion_fn = Context.completionFn;
     work.completion_context = &waiter;
+    work.cancel_token = &token;
 
     const thread_pool = task.getThreadPool();
     thread_pool.submit(&work);
 
     waiter.wait(1, .allow_cancel) catch {
-        // Try to cancel the work, but must wait for completion either way
-        // since context is stack-allocated
+        // The task was canceled. Ask the pool to cancel the work: if it is still
+        // queued it is dropped, and if it is running a cancelable syscall it is
+        // interrupted with a first SIGURG. We must still wait for completion
+        // (ctx/work live on our stack), so we drive resend-with-backoff until the
+        // worker acknowledges. The wait is a cooperative `timedWait` (parks the
+        // coroutine on an executor timer), so resending never blocks the thread.
         thread_pool.cancel(&work);
-        waiter.wait(1, .no_cancel);
+
+        var backoff = Duration.fromMicroseconds(1);
+        const cap = Duration.fromMilliseconds(1);
+        while (!ctx.done.load(.acquire)) {
+            waiter.timedWait(1, .{ .duration = backoff }, .no_cancel);
+            // Resend if the worker is still blocked in the canceled syscall (the
+            // first signal can be lost in the start()→syscall window). Once it
+            // acknowledges, `signal()` returns false and we just park until done.
+            backoff = if (token.signal())
+                .{ .value = @min(backoff.value *| 2, cap.value) }
+            else
+                cap;
+        }
     };
 
     return ctx.result;
@@ -461,4 +485,51 @@ test "blockInPlace: basic computation" {
 
     const result = blockInPlace(double, .{21});
     try std.testing.expectEqual(42, result);
+}
+
+test "blockInPlace: cancellation interrupts a blocking syscall on the worker" {
+    if (!os.syscall_cancel.enabled) return;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    // A worker function that blocks in a cancelable read on an empty pipe. When
+    // the owning task is canceled, the read must be interrupted via SIGURG and
+    // return error.Canceled — which blockInPlace surfaces as its result.
+    const worker = struct {
+        fn cancelableRead(fd: std.c.fd_t) error{ Canceled, Unexpected }!void {
+            const sc = try os.syscall_cancel.Syscall.begin();
+            var buf: [1]u8 = undefined;
+            while (true) {
+                const rc = std.c.read(fd, &buf, buf.len);
+                if (rc >= 0) return sc.fail(error.Unexpected);
+                switch (std.posix.errno(rc)) {
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    else => return sc.fail(error.Unexpected),
+                }
+            }
+        }
+
+        fn call(read_fd: std.c.fd_t) !void {
+            const result = blockInPlace(cancelableRead, .{read_fd});
+            try std.testing.expectError(error.Canceled, result);
+        }
+    };
+
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(0, std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    var handle = try rt.spawn(worker.call, .{fds[0]});
+
+    // Let the worker reach the blocking read, then cancel the task.
+    try rt.sleep(.fromMilliseconds(20));
+    handle.cancel();
+
+    // The worker catches the cancellation and returns normally, so join succeeds.
+    try handle.join();
 }

--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const os_net = @import("../os/net.zig");
 const common = @import("../common.zig");
 const blockInPlace = common.blockInPlace;
+const syscall_cancel = @import("../os/syscall_cancel.zig");
 const dns = @import("root.zig");
 
 /// Fills `storage` with canonical name (if requested) and addresses from
@@ -76,6 +77,10 @@ fn lookupBlocking(options: dns.LookupOptions) dns.LookupError!?*os_net.addrinfo 
     }
 
     var res: ?*os_net.addrinfo = null;
+
+    // getaddrinfo cannot be interrupted by a signal, so if the task was already
+    // canceled while this work was queued, abort before starting the lookup.
+    try syscall_cancel.checkCanceled();
 
     os_net.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &res) catch |err| {
         return switch (err) {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -535,6 +535,11 @@ pub const Work = struct {
     completion_context: ?*anyopaque = null,
     state: std.atomic.Value(State) = std.atomic.Value(State).init(.pending),
 
+    /// Optional token enabling cancellation of blocking syscalls made by `func`.
+    /// When set, the worker binds it (`enter`/`exit`) around `func`, and
+    /// `ThreadPool.cancel` signals it to interrupt an in-progress syscall.
+    cancel_token: ?*os.syscall_cancel.Token = null,
+
     pub const Error = error{NoThreadPool} || Cancelable;
 
     pub const State = enum(u8) {

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -61,6 +61,10 @@ pub const ThreadPool = struct {
         };
         errdefer self.deinit();
 
+        // Install the process-global SIGURG handler used to interrupt cancelable
+        // blocking syscalls. Refcounted; paired with deinit's uninstall.
+        os.syscall_cancel.installHandler();
+
         try self.workers.ensureTotalCapacity(allocator, max_threads);
 
         for (0..min_threads) |_| {
@@ -111,6 +115,9 @@ pub const ThreadPool = struct {
         // calling it again here is safe if the caller did not stop() first).
         self.stop();
         self.workers.deinit(self.allocator);
+
+        // Pair with the install in init (refcounted; restores on the last pool).
+        os.syscall_cancel.uninstallHandler();
     }
 
     /// Stop the pool: drop any queued work, refuse new submissions, and join all
@@ -153,7 +160,9 @@ pub const ThreadPool = struct {
                 std.debug.assert(state == .canceled);
                 work.c.setError(error.Canceled);
             } else {
+                if (work.cancel_token) |token| token.enter();
                 work.func(work);
+                if (work.cancel_token) |token| token.exit();
                 work.c.setResult(.work, {});
                 work.state.store(.completed, .release);
             }
@@ -189,7 +198,12 @@ pub const ThreadPool = struct {
     pub fn cancel(self: *ThreadPool, work: *Work) void {
         // Try to transition from pending to canceled atomically
         if (work.state.cmpxchgStrong(.pending, .canceled, .acq_rel, .acquire)) |_| {
-            // Already running or completed - worker will call completion_fn
+            // Already running or completed - worker will call completion_fn.
+            // If it is running and blocked in a cancelable syscall, interrupt it;
+            // the caller drives resend-with-backoff while awaiting completion.
+            if (work.cancel_token) |token| {
+                if (token.cancel()) _ = token.signal();
+            }
             return;
         }
 
@@ -251,7 +265,9 @@ pub const ThreadPool = struct {
                 work.c.setError(error.Canceled);
             } else {
                 // We successfully claimed it, execute the work
+                if (work.cancel_token) |token| token.enter();
                 work.func(work);
+                if (work.cancel_token) |token| token.exit();
                 work.c.setResult(.work, {});
                 work.state.store(.completed, .release);
             }

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const unexpectedError = @import("base.zig").unexpectedError;
+const syscall_cancel = @import("syscall_cancel.zig");
 
 pub const system = switch (builtin.os.tag) {
     .linux => std.os.linux,
@@ -324,18 +325,29 @@ pub const GetRandomError = @import("base.zig").GetRandomError;
 /// This is the raw, *blocking* primitive: it makes the syscall on the calling
 /// thread. Async callers run it on a thread-pool worker so the event loop is
 /// never blocked.
-pub fn getrandom(buffer: []u8) GetRandomError!void {
+///
+/// When run on a thread-pool worker bound to a cancellation token, the blocking
+/// syscall is cancelable: a `SIGURG` interrupt makes it return `error.Canceled`.
+/// In any other context no token is bound, so cancellation can never occur.
+pub fn getrandom(buffer: []u8) (GetRandomError || syscall_cancel.Cancelable)!void {
     switch (builtin.os.tag) {
         .linux => {
+            const sc = try syscall_cancel.Syscall.begin();
             var i: usize = 0;
             while (i < buffer.len) {
                 const rc = system.getrandom(buffer[i..].ptr, buffer.len - i, 0);
                 switch (errno(rc)) {
                     .SUCCESS => i += rc,
-                    .INTR => continue,
-                    else => return error.EntropyUnavailable,
+                    // EINTR is either a cancellation request (→ Canceled) or a
+                    // spurious wake; checkCancel decides and finalizes the token.
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    else => return sc.fail(error.EntropyUnavailable),
                 }
             }
+            sc.finish();
         },
         else => {
             // BSD / macOS: arc4random_buf is the platform-recommended CSPRNG

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -332,22 +332,24 @@ pub const GetRandomError = @import("base.zig").GetRandomError;
 pub fn getrandom(buffer: []u8) (GetRandomError || syscall_cancel.Cancelable)!void {
     switch (builtin.os.tag) {
         .linux => {
-            const sc = try syscall_cancel.Syscall.begin();
             var i: usize = 0;
             while (i < buffer.len) {
+                const sc = try syscall_cancel.Syscall.begin();
                 const rc = system.getrandom(buffer[i..].ptr, buffer.len - i, 0);
                 switch (errno(rc)) {
-                    .SUCCESS => i += rc,
-                    // EINTR is either a cancellation request (→ Canceled) or a
-                    // spurious wake; checkCancel decides and finalizes the token.
+                    .SUCCESS => {
+                        sc.finish();
+                        i += rc;
+                    },
+                    // EINTR: finish the region (blocked→idle or blocked_canceling→canceled)
+                    // and retry. If the token was canceled, the next begin() surfaces it.
                     .INTR => {
-                        try sc.checkCancel();
+                        sc.finish();
                         continue;
                     },
                     else => return sc.fail(error.EntropyUnavailable),
                 }
             }
-            sc.finish();
         },
         else => {
             // BSD / macOS: arc4random_buf is the platform-recommended CSPRNG

--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -9,6 +9,7 @@ pub const path = std.fs.path;
 pub const posix = @import("posix.zig");
 pub const windows = @import("windows.zig");
 pub const thread = @import("thread.zig");
+pub const syscall_cancel = @import("syscall_cancel.zig");
 
 pub const Mutex = thread.Mutex;
 pub const Condition = thread.Condition;

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -69,7 +69,12 @@ pub const Token = struct {
     /// the canceller observes `blocked` via an acquiring CAS.
     handle: std.atomic.Value(?Handle) = .init(null),
 
-    const Handle = if (enabled) std.c.pthread_t else void;
+    // When disabled the field is never accessed, but it still has to have a
+    // defined in-memory layout: `std.atomic.Value` is an extern struct, and only
+    // a *pointer* optional has a guaranteed layout (null pointer), so the
+    // disabled placeholder must be a pointer type, not `void`/an integer.
+    // (`std.c.pthread_t` is itself a pointer, which is why the enabled case works.)
+    const Handle = if (enabled) std.c.pthread_t else *anyopaque;
 
     /// Bind the calling worker thread to this token. Call immediately before
     /// running the task's function.
@@ -200,6 +205,22 @@ pub const Syscall = struct {
         return err;
     }
 };
+
+/// Check whether the current worker's bound task already has a cancellation
+/// pending, without entering a cancelable syscall region. Returns
+/// `error.Canceled` if so, otherwise a no-op.
+///
+/// Intended for blocking calls that a `SIGURG` cannot interrupt (e.g. glibc
+/// `getaddrinfo`, which restarts internally). We can't break out of such a call
+/// once it is running, but we can still honor a cancel that arrived while the
+/// work sat in the pool queue by checking right before we start it.
+pub fn checkCanceled() Cancelable!void {
+    if (!enabled) return;
+    const tok = current orelse return;
+    // Outside a begin()/finish() region the state is only ever `idle` or
+    // `canceled`, so a plain load is enough to decide.
+    if (tok.state.load(.monotonic) == .canceled) return error.Canceled;
+}
 
 const sig = if (enabled) std.c.SIG.URG else {};
 

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -24,6 +24,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = @import("posix.zig");
+const thread = @import("thread.zig");
 const time = @import("time.zig");
 const Duration = @import("../time.zig").Duration;
 
@@ -202,7 +203,11 @@ pub const Syscall = struct {
 
 const sig = if (enabled) std.c.SIG.URG else {};
 
-var install_count: std.atomic.Value(usize) = .init(0);
+// A mutex serializes the entire (count-check + prev_action-read/write + sigaction)
+// critical section so that concurrent install/uninstall calls cannot corrupt
+// prev_action or double-install/uninstall the handler.
+var install_mutex: thread.Mutex = .init();
+var install_count: usize = 0;
 var prev_action: posix.Sigaction = undefined;
 
 /// Install the process-global no-op `SIGURG` handler (refcounted; safe to call
@@ -211,19 +216,29 @@ var prev_action: posix.Sigaction = undefined;
 /// *without* `SA_RESTART`.
 pub fn installHandler() void {
     if (!enabled) return;
-    if (install_count.fetchAdd(1, .acq_rel) != 0) return;
+    install_mutex.lock();
+    defer install_mutex.unlock();
+    if (install_count != 0) {
+        install_count += 1;
+        return;
+    }
     var act: posix.Sigaction = .{
         .handler = .{ .handler = noopHandler },
         .mask = posix.sigemptyset(),
         .flags = 0, // no SA_RESTART: interrupted syscalls must return EINTR
     };
     posix.sigaction(posix.SIG.URG, &act, &prev_action);
+    install_count = 1;
 }
 
 /// Restore the previous `SIGURG` disposition once the last user uninstalls.
 pub fn uninstallHandler() void {
     if (!enabled) return;
-    if (install_count.fetchSub(1, .acq_rel) != 1) return;
+    install_mutex.lock();
+    defer install_mutex.unlock();
+    std.debug.assert(install_count > 0);
+    install_count -= 1;
+    if (install_count != 0) return;
     posix.sigaction(posix.SIG.URG, &prev_action, null);
 }
 
@@ -249,6 +264,7 @@ test "syscall_cancel: signal interrupts a blocking read" {
         token: *Token,
         read_fd: std.c.fd_t,
         result: anyerror!void = undefined,
+        ready: std.atomic.Value(bool) = .init(false),
 
         fn run(self: *@This()) void {
             self.token.enter();
@@ -256,6 +272,8 @@ test "syscall_cancel: signal interrupts a blocking read" {
 
             self.result = blk: {
                 const sc = Syscall.begin() catch |e| break :blk e;
+                // Signal that we are inside the cancelable region, just before read().
+                self.ready.store(true, .release);
                 var buf: [1]u8 = undefined;
                 while (true) {
                     const rc = std.c.read(self.read_fd, &buf, buf.len);
@@ -273,17 +291,16 @@ test "syscall_cancel: signal interrupts a blocking read" {
     };
 
     var w: Worker = .{ .token = &token, .read_fd = fds[0] };
-    const thread = try std.Thread.spawn(.{}, Worker.run, .{&w});
+    const t = try std.Thread.spawn(.{}, Worker.run, .{&w});
 
-    // Give the worker time to reach the blocking read, then cancel once and drive
-    // the resend loop until it acks. If the worker hadn't blocked yet, `cancel()`
-    // returns false and the cancellation surfaces at `begin()`/`checkCancel()`
-    // instead — either way the result is `error.Canceled`.
-    time.sleep(Duration.fromMilliseconds(50));
+    // Wait until the worker has entered the cancelable region (after begin() but
+    // before read()), then cancel. The first signal may land in the tiny
+    // begin()→read() gap, so drive the resend loop until the worker acks.
+    while (!w.ready.load(.acquire)) time.sleep(Duration.fromMicroseconds(1));
     if (token.cancel()) {
         while (token.signal()) time.sleep(Duration.fromMilliseconds(1));
     }
 
-    thread.join();
+    t.join();
     try std.testing.expectError(error.Canceled, w.result);
 }

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Cooperative cancellation of blocking syscalls running on thread-pool workers.
+//!
+//! A blocking syscall (e.g. `getrandom`) executes on a pool worker. To cancel it,
+//! another thread sends `SIGURG` to the worker, interrupting the syscall with
+//! `EINTR`. A no-op handler is installed *without* `SA_RESTART`, so the syscall
+//! returns instead of being restarted; the syscall site then checks its token and
+//! returns `error.Canceled`.
+//!
+//! The token is owned by the task, not the worker thread: the worker binds it
+//! (records `pthread_self()` + a threadlocal pointer) while running the task's
+//! function and unbinds afterwards. Because cancellation targets the token rather
+//! than "whatever thread is running", a stale signal can at worst land on a worker
+//! now running a *different* task with a *different* token, where it yields a
+//! harmless spurious `EINTR` that the syscall's retry loop swallows. No wrong
+//! cancellation is possible.
+//!
+//! POSIX only (libc `pthread_kill`). On Windows / WASI / single-threaded builds
+//! this degrades to no-ops, and the thread pool's queue-based cancellation is
+//! unaffected.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = @import("posix.zig");
+const time = @import("time.zig");
+const Duration = @import("../time.zig").Duration;
+
+/// Whether syscall cancellation is supported on this target.
+pub const enabled = builtin.os.tag != .windows and builtin.os.tag != .wasi and !builtin.single_threaded;
+
+/// `error.Canceled` unifies structurally with `common.Cancelable` (Zig errors are
+/// interned by name), so callers can mix the two freely.
+pub const Cancelable = error{Canceled};
+
+/// State machine for a single token. All transitions are a CAS on `Token.state`.
+///
+///   idle ──start()──▶ blocked ──finish()──▶ idle
+///    │                   │
+///  cancel()           cancel()
+///    ▼                   ▼
+/// canceled        blocked_canceling ──checkCancel()/finish()──▶ canceled
+///
+/// `canceled` is terminal for the run: `start()` on it returns `error.Canceled`,
+/// so a function with several syscalls aborts at the next one.
+pub const State = enum(u8) {
+    /// Worker bound to this token, not currently inside a cancelable syscall.
+    idle,
+    /// Worker is inside a cancelable syscall.
+    blocked,
+    /// Cancel requested while blocked; the canceller resends `SIGURG` until the
+    /// worker observes it (state leaves `blocked_canceling`).
+    blocked_canceling,
+    /// Cancel pending/acknowledged. Aborts the current and any future syscall.
+    canceled,
+};
+
+/// Per-worker binding. Set by `Token.enter`, read by the syscall site.
+threadlocal var current: ?*Token = null;
+
+/// Task-owned cancellation token. Created by the code that submits the blocking
+/// work (on the stack for `blockInPlace`, or as a field of `AnyBlockingTask`).
+pub const Token = struct {
+    state: std.atomic.Value(State) = .init(.idle),
+    /// `pthread_self()` of the bound worker; `null` when no worker is bound.
+    /// Published before `state` can become `blocked`, so it is always valid when
+    /// the canceller observes `blocked` via an acquiring CAS.
+    handle: std.atomic.Value(?Handle) = .init(null),
+
+    const Handle = if (enabled) std.c.pthread_t else void;
+
+    /// Bind the calling worker thread to this token. Call immediately before
+    /// running the task's function.
+    pub fn enter(self: *Token) void {
+        if (!enabled) return;
+        self.handle.store(std.c.pthread_self(), .monotonic);
+        current = self;
+    }
+
+    /// Unbind the calling worker. Call immediately after the task's function
+    /// returns. At this point `state` is never `blocked*` (the last syscall ran
+    /// `finish()` before returning).
+    pub fn exit(self: *Token) void {
+        if (!enabled) return;
+        current = null;
+        self.handle.store(null, .monotonic);
+    }
+
+    /// Canceller side: request cancellation. Returns `true` if the worker is
+    /// blocked in a syscall and therefore needs to be signaled (the caller must
+    /// then drive `signal()` with backoff until it returns `false`).
+    pub fn cancel(self: *Token) bool {
+        if (!enabled) return false;
+        var s = self.state.load(.monotonic);
+        while (true) {
+            const next: State = switch (s) {
+                .idle => .canceled, // will surface at the next start()
+                .blocked => .blocked_canceling, // needs a signal to break the syscall
+                .blocked_canceling, .canceled => return false, // already requested
+            };
+            if (self.state.cmpxchgWeak(s, next, .acq_rel, .monotonic)) |actual| {
+                s = actual;
+                continue;
+            }
+            return next == .blocked_canceling;
+        }
+    }
+
+    /// Canceller side: send `SIGURG` to the bound worker if it is still blocked in
+    /// the canceled syscall. Returns `true` if a signal was sent (the signal can
+    /// be lost in the gap between `start()` and the kernel entering the syscall,
+    /// so the caller should call again after a short backoff), or `false` once the
+    /// worker has observed the cancellation.
+    pub fn signal(self: *Token) bool {
+        if (!enabled) return false;
+        // Only meaningful while the worker is blocked-and-canceling; any other
+        // state means it already woke up (or never was blocked).
+        if (self.state.load(.acquire) != .blocked_canceling) return false;
+        const handle = self.handle.load(.monotonic) orelse return false;
+        _ = std.c.pthread_kill(handle, sig);
+        return true;
+    }
+};
+
+/// A scoped, cancelable syscall region. Obtained by `begin()`, closed by
+/// `finish()` (or `fail()`); on `EINTR` call `checkCancel()` to decide between
+/// retry and `error.Canceled`. A `null` token means "not on a cancelable worker"
+/// — every method is then a no-op and the syscall runs uncancelably.
+pub const Syscall = struct {
+    token: ?*Token,
+
+    /// Enter a cancelable syscall region: `idle → blocked`. Returns
+    /// `error.Canceled` immediately if a cancel is already pending, so we never
+    /// even enter the syscall.
+    pub fn begin() Cancelable!Syscall {
+        if (!enabled) return .{ .token = null };
+        const tok = current orelse return .{ .token = null };
+        var s = tok.state.load(.monotonic);
+        while (true) {
+            switch (s) {
+                .idle => {
+                    if (tok.state.cmpxchgWeak(.idle, .blocked, .release, .monotonic)) |actual| {
+                        s = actual;
+                        continue;
+                    }
+                    return .{ .token = tok };
+                },
+                .canceled => return error.Canceled,
+                .blocked, .blocked_canceling => unreachable, // cancelable syscalls do not nest
+            }
+        }
+    }
+
+    /// Call when the syscall returns `EINTR`. If this token was canceled, finish
+    /// the region and return `error.Canceled`; otherwise the interrupt was
+    /// spurious (or meant for another token) and the caller should retry.
+    pub fn checkCancel(self: Syscall) Cancelable!void {
+        const tok = self.token orelse return;
+        var s = tok.state.load(.monotonic);
+        while (true) {
+            switch (s) {
+                .blocked => return, // spurious; retry the syscall
+                .blocked_canceling => {
+                    if (tok.state.cmpxchgWeak(.blocked_canceling, .canceled, .acq_rel, .monotonic)) |actual| {
+                        s = actual;
+                        continue;
+                    }
+                    return error.Canceled;
+                },
+                .idle, .canceled => unreachable,
+            }
+        }
+    }
+
+    /// Close the syscall region on success or any non-`EINTR` error:
+    /// `blocked → idle`, or `blocked_canceling → canceled` (cancel still pending,
+    /// surfaces at the next `start()`).
+    pub fn finish(self: Syscall) void {
+        const tok = self.token orelse return;
+        var s = tok.state.load(.monotonic);
+        while (true) {
+            const next: State = switch (s) {
+                .blocked => .idle,
+                .blocked_canceling => .canceled,
+                .idle, .canceled => unreachable,
+            };
+            if (tok.state.cmpxchgWeak(s, next, .acq_rel, .monotonic)) |actual| {
+                s = actual;
+                continue;
+            }
+            return;
+        }
+    }
+
+    /// `finish()` then return `err` — convenience for non-`EINTR` error exits.
+    pub fn fail(self: Syscall, err: anytype) @TypeOf(err) {
+        self.finish();
+        return err;
+    }
+};
+
+const sig = if (enabled) std.c.SIG.URG else {};
+
+var install_count: std.atomic.Value(usize) = .init(0);
+var prev_action: posix.Sigaction = undefined;
+
+/// Install the process-global no-op `SIGURG` handler (refcounted; safe to call
+/// from each thread pool). The handler does nothing — its only job is to make
+/// blocking syscalls return `EINTR`, which requires the handler to be installed
+/// *without* `SA_RESTART`.
+pub fn installHandler() void {
+    if (!enabled) return;
+    if (install_count.fetchAdd(1, .acq_rel) != 0) return;
+    var act: posix.Sigaction = .{
+        .handler = .{ .handler = noopHandler },
+        .mask = posix.sigemptyset(),
+        .flags = 0, // no SA_RESTART: interrupted syscalls must return EINTR
+    };
+    posix.sigaction(posix.SIG.URG, &act, &prev_action);
+}
+
+/// Restore the previous `SIGURG` disposition once the last user uninstalls.
+pub fn uninstallHandler() void {
+    if (!enabled) return;
+    if (install_count.fetchSub(1, .acq_rel) != 1) return;
+    posix.sigaction(posix.SIG.URG, &prev_action, null);
+}
+
+fn noopHandler(_: posix.SIG) callconv(.c) void {}
+
+test "syscall_cancel: signal interrupts a blocking read" {
+    if (!enabled) return;
+
+    // End-to-end: a worker thread blocks in a real syscall (read on an empty
+    // pipe), and another thread cancels it via the token. The read must return
+    // EINTR, checkCancel must report Canceled, and the worker must unblock.
+    installHandler();
+    defer uninstallHandler();
+
+    var token: Token = .{};
+
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(0, std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    const Worker = struct {
+        token: *Token,
+        read_fd: std.c.fd_t,
+        result: anyerror!void = undefined,
+
+        fn run(self: *@This()) void {
+            self.token.enter();
+            defer self.token.exit();
+
+            self.result = blk: {
+                const sc = Syscall.begin() catch |e| break :blk e;
+                var buf: [1]u8 = undefined;
+                while (true) {
+                    const rc = std.c.read(self.read_fd, &buf, buf.len);
+                    if (rc >= 0) break :blk sc.fail(error.UnexpectedData);
+                    switch (std.posix.errno(rc)) {
+                        .INTR => {
+                            sc.checkCancel() catch |e| break :blk e;
+                            continue;
+                        },
+                        else => |e| break :blk sc.fail(std.posix.unexpectedErrno(e)),
+                    }
+                }
+            };
+        }
+    };
+
+    var w: Worker = .{ .token = &token, .read_fd = fds[0] };
+    const thread = try std.Thread.spawn(.{}, Worker.run, .{&w});
+
+    // Give the worker time to reach the blocking read, then cancel once and drive
+    // the resend loop until it acks. If the worker hadn't blocked yet, `cancel()`
+    // returns false and the cancellation surfaces at `begin()`/`checkCancel()`
+    // instead — either way the result is `error.Canceled`.
+    time.sleep(Duration.fromMilliseconds(50));
+    if (token.cancel()) {
+        while (token.signal()) time.sleep(Duration.fromMilliseconds(1));
+    }
+
+    thread.join();
+    try std.testing.expectError(error.Canceled, w.result);
+}

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -1312,6 +1312,7 @@ fn utf8ToWide(allocator: std.mem.Allocator, utf8: []const u8) PathToWideError![:
 }
 
 pub const GetRandomError = @import("base.zig").GetRandomError;
+const syscall_cancel = @import("syscall_cancel.zig");
 
 // ProcessPrng is the modern, documented system CSPRNG entry point (the same one
 // Go/Rust/Chromium/BoringSSL use). It reads from the per-CPU AES-CTR-DRBG and
@@ -1324,7 +1325,11 @@ pub extern "bcryptprimitives" fn ProcessPrng(pbData: [*]u8, cbData: SIZE_T) call
 
 /// Fill `buffer` with cryptographically secure random bytes from the OS.
 /// Blocking primitive; async callers run it on a thread-pool worker.
-pub fn getrandom(buffer: []u8) GetRandomError!void {
+///
+/// The `Cancelable` error is included only to keep `os.getrandom`'s type uniform
+/// with the POSIX implementation; ProcessPrng is not cancelable, so `Canceled` is
+/// never actually returned here.
+pub fn getrandom(buffer: []u8) (GetRandomError || syscall_cancel.Cancelable)!void {
     if (buffer.len == 0) return;
     if (ProcessPrng(buffer.ptr, buffer.len) == 0) return error.EntropyUnavailable;
 }

--- a/src/random.zig
+++ b/src/random.zig
@@ -78,7 +78,12 @@ pub const RandomState = struct {
 /// cannot provide entropy rather than running with a predictable seed.
 pub fn setup(state: *RandomState) os.GetRandomError!void {
     var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-    try os.getrandom(&seed);
+    // No cancellation token is bound at executor startup, so `getrandom` can
+    // never return `Canceled` here — only the OS entropy error is reachable.
+    os.getrandom(&seed) catch |err| switch (err) {
+        error.EntropyUnavailable => return error.EntropyUnavailable,
+        error.Canceled => unreachable,
+    };
     state.csprng = std.Random.DefaultCsprng.init(seed);
 }
 

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -88,4 +88,5 @@ test {
     _ = @import("io.zig");
     _ = @import("random.zig");
     _ = @import("task.zig");
+    _ = @import("os/syscall_cancel.zig");
 }


### PR DESCRIPTION
## What

Adds a signal-based mechanism to **interrupt blocking syscalls running on thread-pool workers**, so cancelling a task can break it out of a kernel sleep instead of waiting for the syscall to finish on its own. POSIX-only; first real user is `randomSecure` (`getrandom`) via `blockInPlace`.

## How it works

`src/os/syscall_cancel.zig` holds the core:

- A **task-owned `Token`** with a 4-state machine (`idle → blocked → blocked_canceling → canceled`). The worker binds it (records `pthread_self()` + a threadlocal) around the task function; a syscall site brackets the call with `begin()` / `checkCancel()` / `finish()`.
- To cancel, another thread flips the token to `blocked_canceling` and `pthread_kill(SIGURG)`s the worker. A no-op handler installed **without `SA_RESTART`** turns the interruption into `EINTR`; `checkCancel()` then reports `error.Canceled`.
- Because the token is **task-scoped rather than thread-scoped**, a stale signal can at worst land on a worker now running a *different* token, yielding a harmless spurious `EINTR` that the syscall's retry loop swallows. No wrong cancellation is possible.

## Integration

- `ev.Work` gains an optional `cancel_token`; the thread pool `enter`/`exit`s it around `work.func` and signals it from `cancel()`.
- `ThreadPool` install/uninstalls the process-global `SIGURG` handler (refcounted) in `init`/`deinit`.
- `os.getrandom`'s Linux loop is now cancelable; `random()` / `setup()` absorb the type-only `Canceled` they can never actually observe.
- `blockInPlace` binds a stack token and, on cancel, drives a **cooperative** resend-with-backoff loop (via `timedWait`, so the executor thread is never blocked) to cover the lost-signal window between `start()` and the kernel entering the syscall. `randomSecure` is cancelable for free.

## Why resend

The `SIGURG` can be lost if delivered in the gap between marking the thread "in a syscall" and the kernel actually entering the interruptible sleep (the no-op handler eats it, then the syscall blocks uninterrupted). There's no way to confirm a single signal landed, so the waiter resends with backoff until the worker acknowledges (token leaves `blocked_canceling`). In practice one signal suffices; resend is the correctness backstop. Same approach as `std.Io.Threaded`.

## Scope / follow-ups

This PR covers the mechanism and the `blockInPlace` path only. Deferred to separate PRs:

- `JoinHandle.cancel` / `Group.cancel` resend loops for `spawnBlocking` tasks (the waiter safely owns the token in both cases; Group needs a small deferred-release restructure).
- Cancelable **ev completions** (delegated file ops on kqueue/poll backends), which is the more significant next piece.

## Tests

- `syscall_cancel`: the token mechanism in isolation (worker blocked in `read`, canceled via signal).
- `blockInPlace: cancellation interrupts a blocking syscall on the worker`: full task-cancel → `blockInPlace` → worker `read` → `Canceled` path.

487/489 unit tests pass; the two failures are the pre-existing file-size `.INVAL` cases unrelated to this change. `zig fmt --check` clean.