### PR TITLE
Wall-clock timers: per-clock heaps + std.Io sleep/futex/batch integration

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -8,6 +8,7 @@ pub const log = std.log.scoped(.zio);
 
 const ev = @import("ev/root.zig");
 const Timeout = @import("time.zig").Timeout;
+const Clock = @import("time.zig").Clock;
 const Stopwatch = @import("time.zig").Stopwatch;
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTaskOrNull = @import("runtime.zig").getCurrentTaskOrNull;
@@ -152,6 +153,13 @@ pub const Waiter = struct {
     /// (e.g., by trying to remove from a wait queue).
     /// Only valid for direct waiters.
     pub fn timedWait(self: *Waiter, expected: u32, timeout: Timeout, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
+        return self.timedWaitClock(expected, timeout, .awake, cancel_mode);
+    }
+
+    /// Like `timedWait`, but the timeout is measured against `clock`. The
+    /// no-task futex fallback only supports the monotonic (`awake`) clock, so
+    /// boot/real timeouts there degrade to awake semantics.
+    pub fn timedWaitClock(self: *Waiter, expected: u32, timeout: Timeout, clock: Clock, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
         if (timeout == .none) {
             return self.wait(expected, cancel_mode);
         }
@@ -159,7 +167,7 @@ pub const Waiter = struct {
         const d = &self.mode.direct;
         const task = d.task orelse return timedWaitFutex(d, expected, timeout);
 
-        var timer: ev.Timer = .init(timeout);
+        var timer: ev.Timer = .initClock(timeout, clock);
         timer.c.userdata = self;
         timer.c.callback = callback;
 

--- a/src/common.zig
+++ b/src/common.zig
@@ -304,12 +304,17 @@ pub fn waitForIoUncancelable(c: *ev.Completion) void {
 /// If the timeout expires before the I/O completes, returns `error.Timeout`.
 /// If the timeout is `.none`, waits indefinitely (just calls `waitForIo`).
 pub fn timedWaitForIo(c: *ev.Completion, timeout: Timeout) (Timeoutable || Cancelable)!void {
+    return timedWaitForIoClock(c, timeout, .awake);
+}
+
+/// Like `timedWaitForIo`, but the timeout is measured against `clock`.
+pub fn timedWaitForIoClock(c: *ev.Completion, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
     if (timeout == .none) {
         return waitForIo(c);
     }
 
     var group = ev.Group.init(.race);
-    var timer = ev.Timer.init(timeout);
+    var timer = ev.Timer.initClock(timeout, clock);
 
     group.add(c);
     group.add(&timer.c);

--- a/src/common.zig
+++ b/src/common.zig
@@ -9,6 +9,7 @@ pub const log = std.log.scoped(.zio);
 const ev = @import("ev/root.zig");
 const Timeout = @import("time.zig").Timeout;
 const Clock = @import("time.zig").Clock;
+const Timestamp = @import("time.zig").Timestamp;
 const Stopwatch = @import("time.zig").Stopwatch;
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTaskOrNull = @import("runtime.zig").getCurrentTaskOrNull;
@@ -165,7 +166,7 @@ pub const Waiter = struct {
         }
 
         const d = &self.mode.direct;
-        const task = d.task orelse return timedWaitFutex(d, expected, timeout);
+        const task = d.task orelse return timedWaitFutex(d, expected, futexTimeout(timeout, clock));
 
         var timer: ev.Timer = .initClock(timeout, clock);
         timer.c.userdata = self;
@@ -183,6 +184,23 @@ pub const Waiter = struct {
             if (current >= expected) return;
             d.notify.wait(current);
         }
+    }
+
+    /// Collapse a wall-clock (boot/real) deadline into a monotonic-relative
+    /// duration for the no-task futex fallback, which can only wait on the
+    /// monotonic clock. Without this, `timedWaitFutex` would compare an
+    /// absolute realtime timestamp (~ns since 1970) against monotonic time and
+    /// wait for decades. Best-effort: it snapshots the remaining time once and
+    /// loses suspend/step semantics.
+    ///
+    /// TODO: support boot/real natively on this path. The Linux futex can wait
+    /// against CLOCK_REALTIME (FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME), so a
+    /// no-task wait on a real deadline could be exact rather than converted.
+    fn futexTimeout(timeout: Timeout, clock: Clock) Timeout {
+        return switch (timeout) {
+            .none, .duration => timeout,
+            .deadline => |deadline| .{ .duration = Timestamp.now(clock).durationTo(deadline) },
+        };
     }
 
     fn timedWaitFutex(d: *Direct, expected: u32, timeout: Timeout) void {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -12,6 +12,7 @@ const net = @import("../os/net.zig");
 const fs = @import("../os/fs.zig");
 const Timestamp = @import("../time.zig").Timestamp;
 const Timeout = @import("../time.zig").Timeout;
+const Clock = @import("../time.zig").Clock;
 
 pub const BackendCapabilities = struct {
     file_read: bool = false,
@@ -446,6 +447,10 @@ pub const Timer = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
     timeout: Timeout,
+    /// Clock the `timeout`/`deadline` is measured against. Only the wall-clock
+    /// clocks are valid for a timer; the CPU-time clocks are rejected when the
+    /// timer is set. Defaults to `.awake` (monotonic), the historical behavior.
+    clock: Clock = .awake,
     deadline: Timestamp = .zero,
     heap: HeapNode(Timer) = .{},
 
@@ -455,6 +460,14 @@ pub const Timer = struct {
         return .{
             .c = .init(.timer),
             .timeout = timeout,
+        };
+    }
+
+    pub fn initClock(timeout: Timeout, clock: Clock) Timer {
+        return .{
+            .c = .init(.timer),
+            .timeout = timeout,
+            .clock = clock,
         };
     }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -9,6 +9,7 @@ const Async = @import("completion.zig").Async;
 const Duration = @import("../time.zig").Duration;
 const Timestamp = @import("../time.zig").Timestamp;
 const Timeout = @import("../time.zig").Timeout;
+const Clock = @import("../time.zig").Clock;
 const Queue = @import("queue.zig").Queue;
 const Heap = @import("heap.zig").Heap;
 const Work = @import("completion.zig").Work;
@@ -141,6 +142,22 @@ fn timerDeadlineLess(_: void, a: *Timer, b: *Timer) bool {
 
 const TimerHeap = Heap(Timer, void, timerDeadlineLess);
 
+/// Timers are kept in one heap per wall-clock domain, since their deadlines
+/// live in different epochs and can only be compared within a clock. The
+/// CPU-time clocks are not valid for timers. `Clock` numbers the wall clocks
+/// 0..wall_clock_count contiguously, so the enum value is the heap index.
+const wall_clock_count = 3;
+
+fn clockIndex(clock: Clock) usize {
+    const idx = @intFromEnum(clock);
+    if (idx >= wall_clock_count) @panic("timers cannot use CPU-time clocks");
+    return idx;
+}
+
+fn indexClock(index: usize) Clock {
+    return @enumFromInt(index);
+}
+
 pub fn SimpleStack(comptime T: type) type {
     return struct {
         head: ?*T = null,
@@ -203,8 +220,19 @@ pub const LoopState = struct {
 
     wake_requested: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
-    now: Timestamp = .zero,
-    timers: TimerHeap = .{ .context = {} },
+    /// Cached "now" per wall clock, indexed by `clockIndex`. `awake` is
+    /// refreshed eagerly once per scan (`updateNow`); `boot`/`real` are
+    /// refreshed lazily on first use within a scan and cached for the rest of
+    /// it. `tick` is a monotonically increasing scan counter; `now_tick[i]`
+    /// records the scan that `now[i]` was last filled, so a mismatch refreshes.
+    tick: u64 = 0,
+    now: [wall_clock_count]Timestamp = .{ .zero, .zero, .zero },
+    now_tick: [wall_clock_count]u64 = .{ 0, 0, 0 },
+    timers: [wall_clock_count]TimerHeap = .{
+        .{ .context = {} },
+        .{ .context = {} },
+        .{ .context = {} },
+    },
     // TODO: Linked timers optimization
     // Instead of mutex-protected cross-thread timer cancellation, link timers to their
     // associated operations. When an operation completes, its linked timer is cleared
@@ -217,6 +245,9 @@ pub const LoopState = struct {
     //   - On timer fire: cancel linked operation (same thread, direct)
     // The cross-thread cancel mechanism remains for general cancellation (task migration,
     // external cancellation), but timeouts become zero-overhead pointer unlinking.
+    /// Protects all timer heaps and the cached `now` values. A single lock is
+    /// enough: it's local to the loop and effectively uncontended, only ever
+    /// held for O(log n) heap ops with callbacks run outside it.
     timer_mutex: os.Mutex = .init(),
 
     async_handles: Queue(Completion) = .{},
@@ -336,8 +367,26 @@ pub const LoopState = struct {
         completion.state = .running;
     }
 
+    /// Advance the scan counter and refresh the awake snapshot. Bumping `tick`
+    /// invalidates the lazily-cached boot/real values for the new scan.
     pub fn updateNow(self: *LoopState) void {
-        self.now = time.now(.monotonic);
+        self.tick +%= 1;
+        self.now[0] = time.now(.monotonic);
+        self.now_tick[0] = self.tick;
+    }
+
+    /// Current time on the given clock, indexed by `clockIndex`. `awake` is a
+    /// cache hit (primed eagerly by `updateNow`); `boot`/`real` are read fresh
+    /// at most once per scan (cheap VDSO `clock_gettime`) and cached. Reading
+    /// them per scan rather than per iteration is what lets the poll cap bound
+    /// oversleep across suspend/steps.
+    fn nowFor(self: *LoopState, clock: Clock) Timestamp {
+        const idx = clockIndex(clock);
+        if (self.now_tick[idx] != self.tick) {
+            self.now[idx] = time.now(clock);
+            self.now_tick[idx] = self.tick;
+        }
+        return self.now[idx];
     }
 
     pub fn lockTimers(self: *LoopState) void {
@@ -349,24 +398,25 @@ pub const LoopState = struct {
     }
 
     pub fn setTimer(self: *LoopState, timer: *Timer) void {
+        const idx = clockIndex(timer.clock);
         if (timer.deadline.value > 0) {
-            self.timers.remove(timer);
+            self.timers[idx].remove(timer);
         } else {
             self.incrActive();
         }
         switch (timer.timeout) {
             .none => timer.deadline = .{ .value = std.math.maxInt(time.TimeInt) },
-            .duration => |d| timer.deadline = self.now.addDuration(d),
+            .duration => |d| timer.deadline = self.nowFor(timer.clock).addDuration(d),
             .deadline => |ts| timer.deadline = ts,
         }
         timer.c.state = .running;
-        self.timers.insert(timer);
+        self.timers[idx].insert(timer);
     }
 
     pub fn clearTimer(self: *LoopState, timer: *Timer) void {
         const was_active = timer.deadline.value > 0;
         if (was_active) {
-            self.timers.remove(timer);
+            self.timers[clockIndex(timer.clock)].remove(timer);
         }
         timer.deadline = .zero;
     }
@@ -383,6 +433,12 @@ pub const Loop = struct {
     internal_loop_group: LoopGroup = .{},
 
     max_wait: Duration = .fromSeconds(60),
+    /// Upper bound on the poll wait while a boot/real timer is pending on a
+    /// backend without native wall-clock timers. The poll clock (`awake`)
+    /// can't track suspend or wall-clock steps, so we re-evaluate boot/real
+    /// deadlines at least this often; this bounds how late such a timer can
+    /// fire after a suspend/step. Unused once a backend arms them natively.
+    wall_clock_cap: Duration = .fromSeconds(10),
     defer_callbacks: bool = true,
 
     /// Cross-thread cancel queue (lock-free MPSC)
@@ -447,7 +503,7 @@ pub const Loop = struct {
 
     /// Get the current monotonic timestamp
     pub fn now(self: *const Loop) Timestamp {
-        return self.state.now;
+        return self.state.now[0];
     }
 
     /// Wake up the loop from another thread (thread-safe)
@@ -470,6 +526,8 @@ pub const Loop = struct {
     pub fn setTimer(self: *Loop, timer: *Timer, timeout: Timeout) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        // Advance the scan so this timer's deadline is computed against a fresh
+        // `now` in its own clock (via `nowFor` in `setTimer`).
         self.state.updateNow();
         timer.c.loop = self;
         timer.timeout = timeout;
@@ -813,35 +871,60 @@ pub const Loop = struct {
         var fired = false;
         var next_timeout: ?Duration = null;
 
-        // Process fired timers in batches to avoid holding the lock during callbacks.
-        // This prevents deadlock when callbacks try to set/clear timers.
-        while (true) {
-            var batch: [4]*Timer = undefined;
-            var batch_count: usize = 0;
+        // Advance the scan once and refresh the awake snapshot; this also
+        // invalidates the lazily-cached boot/real values for this scan.
+        self.state.lockTimers();
+        self.state.updateNow();
+        self.state.unlockTimers();
 
-            self.state.lockTimers();
-            self.state.updateNow();
-            while (self.state.timers.peek()) |timer| {
-                if (timer.deadline.value > self.state.now.value) {
-                    next_timeout = self.state.now.durationTo(timer.deadline);
-                    break;
+        // Each wall-clock domain has its own heap, compared against `now` in
+        // that clock. The earliest remaining across all domains becomes the
+        // poll timeout; `tick`'s caller caps it at `max_wait`, which bounds how
+        // far a boot/real timer can oversleep after a suspend or clock step
+        // (the re-read of `now(clock)` on the next scan corrects it).
+        for (0..wall_clock_count) |idx| {
+            const clock = indexClock(idx);
+
+            // Process fired timers in batches to avoid holding the lock during
+            // callbacks. This prevents deadlock when callbacks set/clear timers.
+            while (true) {
+                var batch: [4]*Timer = undefined;
+                var batch_count: usize = 0;
+
+                self.state.lockTimers();
+                // `nowFor` is read inside the loop, so an empty heap reads no
+                // clock at all; for boot/real the first read fills the cache.
+                while (self.state.timers[idx].peek()) |timer| {
+                    const now_clock = self.state.nowFor(clock);
+                    if (timer.deadline.value > now_clock.value) {
+                        var remaining = now_clock.durationTo(timer.deadline);
+                        // boot/real can't be tracked by the awake poll clock, so
+                        // bound the wait to re-evaluate them across suspend/steps.
+                        if (clock != .awake and remaining.value > self.wall_clock_cap.value) {
+                            remaining = self.wall_clock_cap;
+                        }
+                        if (next_timeout == null or remaining.value < next_timeout.?.value) {
+                            next_timeout = remaining;
+                        }
+                        break;
+                    }
+                    timer.c.setResult(.timer, {});
+                    self.state.clearTimer(timer);
+                    batch[batch_count] = timer;
+                    batch_count += 1;
+                    if (batch_count >= batch.len) break;
                 }
-                timer.c.setResult(.timer, {});
-                self.state.clearTimer(timer);
-                batch[batch_count] = timer;
-                batch_count += 1;
-                if (batch_count >= batch.len) break;
-            }
-            self.state.unlockTimers();
+                self.state.unlockTimers();
 
-            // Mark completions outside the lock
-            for (batch[0..batch_count]) |timer| {
-                self.state.markCompleted(&timer.c);
-                fired = true;
-            }
+                // Mark completions outside the lock
+                for (batch[0..batch_count]) |timer| {
+                    self.state.markCompleted(&timer.c);
+                    fired = true;
+                }
 
-            // If we didn't fill the batch, we're done
-            if (batch_count < batch.len) break;
+                // If we didn't fill the batch, we're done with this domain
+                if (batch_count < batch.len) break;
+            }
         }
 
         return .{ .next_timeout = next_timeout, .fired = fired };

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -399,7 +399,11 @@ pub const LoopState = struct {
 
     pub fn setTimer(self: *LoopState, timer: *Timer) void {
         const idx = clockIndex(timer.clock);
-        if (timer.deadline.value > 0) {
+        // `.running` means the timer is already in its heap (resetting it);
+        // anything else means it's newly activated. Don't key this off
+        // `deadline.value`, which can legitimately be 0 for an absolute
+        // deadline at/at-before the epoch and would then leak/double-fire.
+        if (timer.c.state == .running) {
             self.timers[idx].remove(timer);
         } else {
             self.incrActive();
@@ -414,7 +418,7 @@ pub const LoopState = struct {
     }
 
     pub fn clearTimer(self: *LoopState, timer: *Timer) void {
-        const was_active = timer.deadline.value > 0;
+        const was_active = timer.c.state == .running;
         if (was_active) {
             self.timers[clockIndex(timer.clock)].remove(timer);
         }
@@ -538,7 +542,7 @@ pub const Loop = struct {
     pub fn clearTimer(self: *Loop, timer: *Timer) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
-        const was_active = timer.deadline.value > 0;
+        const was_active = timer.c.state == .running;
         self.state.clearTimer(timer);
         if (was_active) {
             // Reset state so timer can be reused

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -138,3 +138,44 @@ test "timer with explicit deadline" {
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("deadline timer: expected=100ms, actual={f}", .{elapsed});
 }
+
+test "timer on boot clock fires (duration, fallback path)" {
+    var loop: Loop = undefined;
+    try loop.init(.{});
+    defer loop.deinit();
+
+    var timer: Timer = .initClock(.{ .duration = .zero }, .boot);
+    loop.setTimer(&timer, .{ .duration = .fromMilliseconds(100) });
+    try std.testing.expectEqual(.running, timer.c.state);
+
+    var wall_timer = time.Stopwatch.start();
+    try loop.run(.until_done);
+    const elapsed = wall_timer.read();
+
+    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expect(elapsed.toMilliseconds() >= 90);
+    try std.testing.expect(elapsed.toMilliseconds() <= 250);
+    std.log.info("boot timer: expected=100ms, actual={f}", .{elapsed});
+}
+
+test "timer on real clock fires (absolute deadline, fallback path)" {
+    var loop: Loop = undefined;
+    try loop.init(.{});
+    defer loop.deinit();
+
+    // Absolute realtime deadline 100ms in the future. The deadline lives in the
+    // realtime epoch (ns since 1970), so it must be compared against now(real),
+    // not the monotonic clock.
+    const deadline = time.Timestamp.now(.real).addDuration(.fromMilliseconds(100));
+    var timer: Timer = .initClock(.{ .deadline = deadline }, .real);
+
+    var wall_timer = time.Stopwatch.start();
+    loop.add(&timer.c);
+    try loop.run(.until_done);
+    const elapsed = wall_timer.read();
+
+    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expect(elapsed.toMilliseconds() >= 90);
+    try std.testing.expect(elapsed.toMilliseconds() <= 250);
+    std.log.info("real timer: expected=100ms, actual={f}", .{elapsed});
+}

--- a/src/io.zig
+++ b/src/io.zig
@@ -35,6 +35,7 @@ const common = @import("common.zig");
 const Waiter = common.Waiter;
 const waitForIo = common.waitForIo;
 const timedWaitForIo = common.timedWaitForIo;
+const timedWaitForIoClock = common.timedWaitForIoClock;
 const waitForIoUncancelable = common.waitForIoUncancelable;
 
 const ev = @import("ev/root.zig");
@@ -396,16 +397,16 @@ fn futexWakeImpl(_: ?*anyopaque, ptr: *const u32, max_waiters: u32) void {
 }
 
 fn operateImpl(_: ?*anyopaque, operation: Io.Operation) Io.Cancelable!Io.Operation.Result {
-    return operateInner(operation, .none) catch |err| switch (err) {
+    return operateInner(operation, .none, .awake) catch |err| switch (err) {
         error.Canceled => error.Canceled,
         error.Timeout => unreachable,
     };
 }
 
-fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable || common.Timeoutable)!Io.Operation.Result {
+fn operateInner(operation: Io.Operation, timeout: time.Timeout, clock: time.Clock) (Io.Cancelable || common.Timeoutable)!Io.Operation.Result {
     switch (operation) {
         .file_read_streaming => |*o| return .{ .file_read_streaming = result: {
-            const n = fileReadStreamingImpl(o.file, o.data, timeout) catch |err| switch (err) {
+            const n = fileReadStreamingImpl(o.file, o.data, timeout, clock) catch |err| switch (err) {
                 error.Canceled => |e| return e,
                 error.Timeout => |e| return e,
                 else => |e| break :result e,
@@ -413,7 +414,7 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
             break :result n;
         } },
         .file_write_streaming => |*o| return .{ .file_write_streaming = result: {
-            const n = fileWriteStreamingImpl(o.file, o.header, o.data, o.splat, timeout) catch |err| switch (err) {
+            const n = fileWriteStreamingImpl(o.file, o.header, o.data, o.splat, timeout, clock) catch |err| switch (err) {
                 error.Canceled => |e| return e,
                 error.Timeout => |e| return e,
                 else => |e| break :result e,
@@ -425,11 +426,11 @@ fn operateInner(operation: Io.Operation, timeout: time.Timeout) (Io.Cancelable |
                 ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.in, o.out)
             else
                 ev.DeviceIoControl.init(stdIoHandleToZio(o.file.handle), o.code, o.arg);
-            try timedWaitForIo(&op.c, timeout);
+            try timedWaitForIoClock(&op.c, timeout, clock);
             break :result try op.getResult();
         } },
         .net_receive => |*o| return .{ .net_receive = result: {
-            netReceiveImpl(o.socket_handle, &o.message_buffer[0], o.data_buffer, o.flags, timeout) catch |err| switch (err) {
+            netReceiveImpl(o.socket_handle, &o.message_buffer[0], o.data_buffer, o.flags, timeout, clock) catch |err| switch (err) {
                 error.Canceled => |e| return e,
                 error.Timeout => |e| return e,
                 else => |e| break :result .{ e, 0 },
@@ -445,6 +446,7 @@ fn fileReadStreamingImpl(
     file: Io.File,
     data: []const []u8,
     timeout: time.Timeout,
+    clock: time.Clock,
 ) (Io.Operation.FileReadStreaming.Error || Io.Cancelable || common.Timeoutable)!usize {
     var iovecs: [max_iovecs_len]os_fs.iovec = undefined;
     var count: usize = 0;
@@ -459,7 +461,7 @@ fn fileReadStreamingImpl(
 
     var op = ev.FileReadStreaming.init(stdIoHandleToZio(file.handle), .{ .iovecs = iovecs[0..count] });
     op.pollable = flagsReadPollable(&file.flags);
-    try timedWaitForIo(&op.c, timeout);
+    try timedWaitForIoClock(&op.c, timeout, clock);
     const n = op.getResult() catch |err| switch (err) {
         error.BrokenPipe, error.Unseekable => return error.Unexpected,
         else => |e| return e,
@@ -475,6 +477,7 @@ fn fileWriteStreamingImpl(
     data: []const []const u8,
     splat: usize,
     timeout: time.Timeout,
+    clock: time.Clock,
 ) (Io.Operation.FileWriteStreaming.Error || Io.Cancelable || common.Timeoutable)!usize {
     var slices: [max_iovecs_len][]const u8 = undefined;
     var splat_buf: [64]u8 = undefined;
@@ -486,7 +489,7 @@ fn fileWriteStreamingImpl(
 
     var op = ev.FileWriteStreaming.init(stdIoHandleToZio(file.handle), wbuf);
     op.pollable = flagsReadPollable(&file.flags);
-    try timedWaitForIo(&op.c, timeout);
+    try timedWaitForIoClock(&op.c, timeout, clock);
     return op.getResult() catch |err| switch (err) {
         error.Unseekable => error.Unexpected,
         else => |e| e,
@@ -589,7 +592,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         const storage = &batch.storage[only.toIndex()];
         const operation = storage.submission.operation;
 
-        const result = try operateInner(operation, time.Timeout.fromStd(timeout));
+        const result = try operateInner(operation, .fromStd(timeout), .fromStdTimeout(timeout));
 
         batch.submitted = .empty;
         storage.* = .{ .completion = .{ .node = .{ .next = .none }, .result = result } };
@@ -672,7 +675,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         if (batch.completed.head != .none or batch.pending.head == .none) return;
 
         // Wait for ready_count to become non-zero
-        Futex.timedWait(&state.ready_count.raw, 0, .fromStd(timeout)) catch |err| switch (err) {
+        Futex.timedWaitClock(&state.ready_count.raw, 0, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
             error.Timeout => {
                 // Drain one more time before returning timeout
                 batchDrainReady(batch, state);
@@ -2332,6 +2335,7 @@ fn netReceiveImpl(
     data_buffer: []u8,
     flags: Io.net.ReceiveFlags,
     timeout: time.Timeout,
+    clock: time.Clock,
 ) (Io.net.Socket.ReceiveError || common.Timeoutable)!void {
     const zio_flags: os_net.RecvFlags = .{
         .peek = flags.peek,
@@ -2350,7 +2354,7 @@ fn netReceiveImpl(
         &addr_len,
         if (has_control) message.control else null,
     );
-    try timedWaitForIo(&op.c, timeout);
+    try timedWaitForIoClock(&op.c, timeout, clock);
     const result = op.getResult() catch |err| return recvMsgErrToReceiveErr(err);
     message.* = .{
         .from = zioIpToStdIo(storage.ip),

--- a/src/io.zig
+++ b/src/io.zig
@@ -379,7 +379,7 @@ fn checkCancelImpl(_: ?*anyopaque) Io.Cancelable!void {
 }
 
 fn futexWaitImpl(_: ?*anyopaque, ptr: *const u32, expected: u32, timeout: Io.Timeout) Io.Cancelable!void {
-    Futex.timedWait(ptr, expected, time.Timeout.fromStd(timeout)) catch |err| switch (err) {
+    Futex.timedWaitClock(ptr, expected, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
         error.Timeout => return,
         error.Canceled => return error.Canceled,
     };
@@ -1780,33 +1780,19 @@ fn progressParentFileImpl(_: ?*anyopaque) std.Progress.ParentFileError!Io.File {
 }
 
 fn nowImpl(_: ?*anyopaque, clock: Io.Clock) Io.Timestamp {
-    const ts = time.Timestamp.now(zioClock(clock));
+    const ts = time.Timestamp.now(.fromStd(clock));
     return .{ .nanoseconds = @intCast(ts.toNanoseconds()) };
 }
 
 fn clockResolutionImpl(_: ?*anyopaque, clock: Io.Clock) Io.Clock.ResolutionError!Io.Duration {
-    const res = time.Clock.resolution(zioClock(clock)) orelse return error.ClockUnavailable;
+    const res = time.Clock.resolution(.fromStd(clock)) orelse return error.ClockUnavailable;
     return .{ .nanoseconds = @intCast(res.toNanoseconds()) };
 }
 
-fn zioClock(clock: Io.Clock) time.Clock {
-    return switch (clock) {
-        .real => .real,
-        .awake => .awake,
-        .boot => .boot,
-        .cpu_process => .cpu_process,
-        .cpu_thread => .cpu_thread,
-    };
-}
-
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {
-    const clock: Io.Clock = switch (timeout) {
-        .none => return,
-        .duration => |d| d.clock,
-        .deadline => |d| d.clock,
-    };
+    if (timeout == .none) return;
     var waiter: Waiter = .init();
-    try waiter.timedWaitClock(1, time.Timeout.fromStd(timeout), zioClock(clock), .allow_cancel);
+    try waiter.timedWaitClock(1, .fromStd(timeout), .fromStdTimeout(timeout), .allow_cancel);
 }
 
 fn randomImpl(_: ?*anyopaque, buffer: []u8) void {

--- a/src/io.zig
+++ b/src/io.zig
@@ -1800,9 +1800,13 @@ fn zioClock(clock: Io.Clock) time.Clock {
 }
 
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {
-    if (timeout == .none) return;
+    const clock: Io.Clock = switch (timeout) {
+        .none => return,
+        .duration => |d| d.clock,
+        .deadline => |d| d.clock,
+    };
     var waiter: Waiter = .init();
-    try waiter.timedWait(1, time.Timeout.fromStd(timeout), .allow_cancel);
+    try waiter.timedWaitClock(1, time.Timeout.fromStd(timeout), zioClock(clock), .allow_cancel);
 }
 
 fn randomImpl(_: ?*anyopaque, buffer: []u8) void {
@@ -2779,6 +2783,35 @@ test "io: sleep with duration returns after delay" {
 
     var sw = time.Stopwatch.start();
     try io.sleep(.fromMilliseconds(20), .awake);
+    try std.testing.expect(sw.read().toMilliseconds() >= 20);
+}
+
+test "io: sleep honors boot and real clocks" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    for ([_]Io.Clock{ .boot, .real }) |clock| {
+        var sw = time.Stopwatch.start();
+        try io.sleep(.fromMilliseconds(20), clock);
+        try std.testing.expect(sw.read().toMilliseconds() >= 20);
+    }
+}
+
+test "io: sleep until an absolute realtime deadline" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    // A deadline carries the realtime epoch (ns since 1970); fromStd must keep
+    // it as an absolute deadline rather than mixing it with the monotonic clock.
+    const deadline: Io.Clock.Timestamp = .fromNow(io, .{
+        .raw = .fromMilliseconds(20),
+        .clock = .real,
+    });
+
+    var sw = time.Stopwatch.start();
+    try deadline.wait(io);
     try std.testing.expect(sw.read().toMilliseconds() >= 20);
 }
 

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -36,6 +36,7 @@ const Cancelable = @import("../common.zig").Cancelable;
 const Timeoutable = @import("../common.zig").Timeoutable;
 const Waiter = @import("../common.zig").Waiter;
 const Timeout = @import("../time.zig").Timeout;
+const Clock = @import("../time.zig").Clock;
 const SimpleQueue = @import("../utils/simple_queue.zig").SimpleQueue;
 const AutoCancel = @import("../autocancel.zig").AutoCancel;
 const os = @import("../os/root.zig");
@@ -131,6 +132,11 @@ const FutexWaiter = struct {
 
 /// Like `wait`, but also returns `error.Timeout` if the timeout elapses.
 pub fn timedWait(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable || Cancelable)!void {
+    return timedWaitClock(ptr, expect, timeout, .awake);
+}
+
+/// Like `timedWait`, but the timeout is measured against `clock`.
+pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
     // Fast path: check if value already changed
     if (@atomicLoad(u32, ptr, .acquire) != expect) {
         return;
@@ -160,7 +166,7 @@ pub fn timedWait(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable ||
     bucket.mutex.unlock();
 
     // Wait for signal or timeout, handling spurious wakeups internally
-    futex_waiter.waiter.timedWait(1, timeout, .allow_cancel) catch |err| {
+    futex_waiter.waiter.timedWaitClock(1, timeout, clock, .allow_cancel) catch |err| {
         // On cancellation, try to remove from queue
         const was_in_queue = removeFromBucket(bucket, &futex_waiter);
         if (!was_in_queue) {

--- a/src/time.zig
+++ b/src/time.zig
@@ -439,20 +439,25 @@ pub const Timeout = union(enum) {
     duration: Duration,
     deadline: Timestamp,
 
-    /// Convert a `std.Io.Timeout` into the zio equivalent.
-    ///
-    /// Deadlines are resolved against the monotonic clock regardless of the
-    /// deadline's `Clock` tag; the zio loop only exposes a single internal
-    /// clock. This matches `nowImpl` returning a monotonic `Io.Timestamp`.
+    /// Convert a `std.Io.Timeout` into the zio equivalent. The value is kept
+    /// clockless here — a duration stays a duration and a deadline stays an
+    /// absolute deadline (in its clock's epoch). The clock itself travels
+    /// separately on the `ev.Timer`, which compares the deadline against `now`
+    /// in that same clock, so no cross-epoch conversion is needed.
     pub fn fromStd(t: std.Io.Timeout) Timeout {
         return switch (t) {
             .none => .none,
             .duration => |d| fromSignedNanoseconds(d.raw.nanoseconds),
-            .deadline => |d| blk: {
-                const now_ns: i96 = @intCast(Timestamp.now(.monotonic).toNanoseconds());
-                break :blk fromSignedNanoseconds(d.raw.nanoseconds - now_ns);
-            },
+            .deadline => |d| .{ .deadline = .fromNanoseconds(clampNanos(d.raw.nanoseconds)) },
         };
+    }
+
+    /// Clamp a (possibly wider, possibly negative) nanosecond count into the
+    /// unsigned `TimeInt` range used by `Duration`/`Timestamp`.
+    fn clampNanos(ns: i96) TimeInt {
+        if (ns <= 0) return 0;
+        if (ns > std.math.maxInt(TimeInt)) return std.math.maxInt(TimeInt);
+        return @intCast(ns);
     }
 
     fn fromSignedNanoseconds(ns: i96) Timeout {

--- a/src/time.zig
+++ b/src/time.zig
@@ -38,17 +38,20 @@ const ns_per_unit: TimeInt = switch (time_unit) {
 /// Mirrors the clocks of `std.Io.Clock`. The wall-clock variants are always
 /// available; the CPU-time variants measure CPU consumed (user + kernel) and
 /// may be unsupported on some platforms.
-pub const Clock = enum {
+/// The wall-clock variants are ordered first with contiguous values so they
+/// can index per-clock timer heaps directly via `@intFromEnum`; the CPU-time
+/// variants follow.
+pub const Clock = enum(u8) {
     /// Excludes time the system is suspended (Linux `CLOCK_MONOTONIC`).
-    awake,
+    awake = 0,
     /// Includes time the system is suspended (Linux `CLOCK_BOOTTIME`).
-    boot,
+    boot = 1,
     /// Wall-clock time since the Unix epoch.
-    real,
+    real = 2,
     /// CPU time consumed by the whole process.
-    cpu_process,
+    cpu_process = 3,
     /// CPU time consumed by the calling thread.
-    cpu_thread,
+    cpu_thread = 4,
 
     /// Alias for the default monotonic clock.
     pub const monotonic = Clock.awake;

--- a/src/time.zig
+++ b/src/time.zig
@@ -58,6 +58,26 @@ pub const Clock = enum(u8) {
     /// Alias for the wall clock.
     pub const realtime = Clock.real;
 
+    /// Map a `std.Io.Clock` to the zio clock.
+    pub fn fromStd(clock: std.Io.Clock) Clock {
+        return switch (clock) {
+            .real => .real,
+            .awake => .awake,
+            .boot => .boot,
+            .cpu_process => .cpu_process,
+            .cpu_thread => .cpu_thread,
+        };
+    }
+
+    /// The clock a `std.Io.Timeout` is measured against (`awake` if none).
+    pub fn fromStdTimeout(t: std.Io.Timeout) Clock {
+        return switch (t) {
+            .none => .awake,
+            .duration => |d| fromStd(d.clock),
+            .deadline => |d| fromStd(d.clock),
+        };
+    }
+
     /// Granularity of the clock, i.e. the smallest interval it can distinguish.
     /// Null if the platform does not support the clock (only the CPU-time
     /// clocks can be unsupported).


### PR DESCRIPTION
Stacked on #513 (`clock-resolution`).

Makes `awake`/`boot`/`real` timers behave distinctly and wires the clock through every `std.Io` timeout, so boot/real sleeps and absolute realtime deadlines work end-to-end. Per-backend native arming (io_uring REALTIME/BOOTTIME, etc.) is intentionally **not** here — that's the next PR.

## Per-clock timer heaps (`ev`)
- `ev.Timer` carries a `clock`; timers live in one heap per wall-clock domain (`awake`/`boot`/`real`), since their deadlines are in different epochs and only comparable within a clock. CPU-time clocks are rejected (panic).
- `Clock` gets explicit contiguous values so it indexes the heaps and the cached `now[]` directly via `@intFromEnum`.
- `now` is cached per clock: `awake` refreshed eagerly each scan, `boot`/`real` lazily on first use and stamped with a scan counter — an idle heap reads no clock, an active one reads at most once per scan.
- No backend arms wall clocks natively yet, so `boot`/`real` fall back to folding their remaining into the poll timeout, bounded by `wall_clock_cap` (10s) so they re-evaluate across suspend/clock-steps. The per-poll re-read of `now(clock)` is what makes the cap bound oversleep.

## std.Io integration
The vtable has exactly three timeout entry points; all now thread the clock:
- **`sleep`** — `sleepImpl` carries the clock; `fromStd` now keeps a deadline as an absolute deadline (in its clock's epoch) instead of flattening it to a monotonic-relative duration. The old conversion subtracted the monotonic now from a possibly-foreign epoch, which mishandled realtime deadlines.
- **`futexWait`** — underlies every timed sync primitive (`Mutex.timedLock`, `Condition.timedWait`, `Event.timedWait`, timed `Future.await`); wiring it covers all of them.
- **`batchAwaitConcurrent`** — both the multi-op wait loop and the single-op fast path (`operateInner`) thread the clock.

Threading uses `*Clock` variants (`Waiter.timedWaitClock`, `Futex.timedWaitClock`, `timedWaitForIoClock`) that the existing `.awake` callers delegate to unchanged, plus `Clock.fromStd` / `Clock.fromStdTimeout` helpers.

## Testing
- ev: `boot` (duration) and `real` (absolute deadline) timers fire via the fallback path.
- std.Io: `io.sleep` on `boot`/`real`, and sleeping until an absolute realtime deadline (would have hung at `Duration.max` before the `fromStd` fix).
- Full suite green (492/492); Windows (wine) and macOS compile verified earlier in the series.

## Known minor gaps (acceptable, noted in comments)
- The no-task `timedWaitFutex` fallback is monotonic-only, so boot/real degrade to awake when there's no fiber.
- The frozen-slice `now` is anchored at sleep-time, not wake-time (deliberate).

## Next PR
Per-backend native wall-clock arming (io_uring `IORING_TIMEOUT_ABS|REALTIME/BOOTTIME`, epoll timerfd, IOCP waitable timer, kqueue `EVFILT_TIMER`), gated by a `native_wall_timers` capability that makes `checkTimers` stop folding boot/real into the poll timeout for that backend.