### PR TITLE
ev/io_uring: arm boot/real timers natively

### DIFF
--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -15,6 +15,8 @@ const Cancel = @import("../completion.zig").Cancel;
 // Special user_data values for internal operations
 const USER_DATA_WAKER: u64 = 0; // Waker eventfd multishot poll
 const USER_DATA_CANCEL: u64 = 1; // Cancel SQE operations (should be skipped)
+const USER_DATA_WALL_BOOT: u64 = 2; // boot-clock (CLOCK_BOOTTIME) timeout
+const USER_DATA_WALL_REAL: u64 = 3; // real-clock (CLOCK_REALTIME) timeout
 
 const NetOpen = @import("../completion.zig").NetOpen;
 const NetConnect = @import("../completion.zig").NetConnect;
@@ -74,6 +76,7 @@ pub const capabilities: BackendCapabilities = .{
     .dir_open = true,
     .dir_close = true,
     .process_wait = true,
+    .native_wall_timers = true,
 };
 
 pub const SharedState = struct {};
@@ -160,6 +163,17 @@ ring: linux.IoUring,
 waker_eventfd: i32,
 waker_needs_rearm: bool,
 pending: Queue(Completion) = .{},
+/// Currently-armed absolute deadline (ns, in the clock's epoch) for the
+/// boot/real wall-clock timeout SQEs, or null if disarmed. Indexed by
+/// `wallIndex` (0 = boot, 1 = real).
+wall_armed: [2]?u64 = .{ null, null },
+/// Backing storage for the wall timeout `kernel_timespec`s; must outlive the
+/// SQE until the next `io_uring_enter2` reads it.
+wall_ts: [2]linux.kernel_timespec = undefined,
+/// Set when a wall-timer (re)arm couldn't get an SQE because the SQ was full.
+/// Like `waker_needs_rearm`, this forces the next poll not to block so the SQ
+/// drains and the arm retries on the following scan.
+wall_needs_rearm: bool = false,
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
     _ = shared_state;
@@ -740,6 +754,51 @@ fn getSqeOrDefer(self: *Self, c: *Completion) ?*linux.io_uring_sqe {
     };
 }
 
+/// Arm/update/disarm the native boot and real wall-clock timeout SQEs to the
+/// given absolute deadlines (ns in each clock's epoch; null = none). Called by
+/// the loop when the boot/real timer-heap minimums change; the SQEs ride the
+/// next `io_uring_enter2`.
+pub fn syncWallTimers(self: *Self, boot: ?u64, real: ?u64) void {
+    self.wall_needs_rearm = false;
+    self.armWall(0, USER_DATA_WALL_BOOT, linux.IORING_TIMEOUT_BOOTTIME, boot);
+    self.armWall(1, USER_DATA_WALL_REAL, linux.IORING_TIMEOUT_REALTIME, real);
+}
+
+fn armWall(self: *Self, idx: usize, sentinel: u64, clock_flag: u32, deadline: ?u64) void {
+    if (self.wall_armed[idx] == deadline) return; // unchanged (incl. both null)
+
+    // Remove the existing timeout (if any) before re-arming. The removed
+    // timeout's CQE and the remove op's CQE are both ignored in poll(). If the
+    // SQ is full, flag a rearm so poll() drains it and we retry next scan,
+    // leaving wall_armed unchanged so the old timeout stays valid meanwhile.
+    if (self.wall_armed[idx] != null) {
+        const sqe = self.ring.get_sqe() catch {
+            self.wall_needs_rearm = true;
+            return;
+        };
+        sqe.prep_timeout_remove(sentinel, 0);
+        sqe.user_data = USER_DATA_CANCEL;
+    }
+
+    if (deadline) |d| {
+        const sqe = self.ring.get_sqe() catch {
+            // Remove was queued (or nothing was armed), but we can't arm the
+            // new timeout now. Forget it and retry next scan after the drain.
+            self.wall_armed[idx] = null;
+            self.wall_needs_rearm = true;
+            return;
+        };
+        self.wall_ts[idx] = .{
+            .sec = @intCast(d / time.ns_per_s),
+            .nsec = @intCast(d % time.ns_per_s),
+        };
+        sqe.prep_timeout(&self.wall_ts[idx], 0, linux.IORING_TIMEOUT_ABS | clock_flag);
+        sqe.user_data = sentinel;
+    }
+
+    self.wall_armed[idx] = deadline;
+}
+
 pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
     const linux_os = @import("../../os/linux.zig");
 
@@ -747,7 +806,9 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
     // re-arming in the rare case the kernel dropped the multishot; if the SQ is
     // full then, don't block — a non-blocking enter2 drains it so the next poll
     // can arm.
-    const effective_timeout: Duration = if (self.armWaker()) timeout else .zero;
+    // Don't block if a critical internal SQE (waker or a wall timer) still
+    // needs arming — a zero-timeout enter2 drains the SQ so the next scan can.
+    const effective_timeout: Duration = if (self.armWaker() and !self.wall_needs_rearm) timeout else .zero;
 
     const to_submit = self.ring.flush_sq();
     var ts: linux.kernel_timespec = undefined;
@@ -785,6 +846,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
         return true; // Timed out
     }
 
+    var wall_fired = false;
     for (cqes[0..count]) |cqe| {
         // Handle internal operations with special user_data values
         if (cqe.user_data == USER_DATA_WAKER) {
@@ -794,6 +856,18 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
 
         if (cqe.user_data == USER_DATA_CANCEL) {
             // Cancel SQE completion - just skip it
+            continue;
+        }
+
+        // Wall-clock (boot/real) timeout. A fire (-ETIME) means a boot/real
+        // timer is due, so report a timeout below to re-run checkTimers; the
+        // kernel auto-removed the one-shot, so forget our armed deadline. A
+        // -ECANCELED is from re-arming and is simply ignored.
+        if (cqe.user_data == USER_DATA_WALL_BOOT or cqe.user_data == USER_DATA_WALL_REAL) {
+            if (cqe.res == -@as(i32, @intFromEnum(linux.E.TIME))) {
+                wall_fired = true;
+                self.wall_armed[if (cqe.user_data == USER_DATA_WALL_BOOT) 0 else 1] = null;
+            }
             continue;
         }
 
@@ -824,7 +898,9 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
 
     self.drainPending(state);
 
-    return false; // Did not timeout, woke up due to events
+    // A fired wall timer is reported as a timeout so the loop re-runs
+    // checkTimers and fires the due boot/real timers.
+    return wall_fired;
 }
 
 fn drainPending(self: *Self, state: *LoopState) void {

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -6,17 +6,40 @@ const fs = @import("../../os/fs.zig");
 const linux_sys = @import("../../os/system/linux.zig");
 const time = @import("../../os/time.zig");
 const Duration = @import("../../time.zig").Duration;
+const Clock = @import("../../time.zig").Clock;
 const common = @import("common.zig");
 const LoopState = @import("../loop.zig").LoopState;
 const Completion = @import("../completion.zig").Completion;
 const Queue = @import("../queue.zig").Queue;
 const Cancel = @import("../completion.zig").Cancel;
 
-// Special user_data values for internal operations
-const USER_DATA_WAKER: u64 = 0; // Waker eventfd multishot poll
-const USER_DATA_CANCEL: u64 = 1; // Cancel SQE operations (should be skipped)
-const USER_DATA_WALL_BOOT: u64 = 2; // boot-clock (CLOCK_BOOTTIME) timeout
-const USER_DATA_WALL_REAL: u64 = 3; // real-clock (CLOCK_REALTIME) timeout
+// user_data encoding. A *Completion pointer is aligned, so its low bit is 0;
+// internal ops set the low bit and pack a kind (bits 1-2) plus, for the wall
+// timers, a generation counter (bits 3+) so a stale timeout CQE that arrives
+// after a re-arm can be told apart from the current one and ignored.
+const UD_SPECIAL: u64 = 1;
+
+const SpecialKind = enum(u2) { waker = 0, cancel = 1, wall_boot = 2, wall_real = 3 };
+
+fn specialUd(kind: SpecialKind, generation: u32) u64 {
+    return UD_SPECIAL | (@as(u64, @intFromEnum(kind)) << 1) | (@as(u64, generation) << 3);
+}
+
+fn udIsSpecial(ud: u64) bool {
+    return ud & UD_SPECIAL != 0;
+}
+
+fn udKind(ud: u64) SpecialKind {
+    return @enumFromInt(@as(u2, @truncate(ud >> 1)));
+}
+
+fn udGeneration(ud: u64) u32 {
+    return @truncate(ud >> 3);
+}
+
+fn wallKind(idx: usize) SpecialKind {
+    return if (idx == 0) .wall_boot else .wall_real;
+}
 
 const NetOpen = @import("../completion.zig").NetOpen;
 const NetConnect = @import("../completion.zig").NetConnect;
@@ -167,13 +190,12 @@ pending: Queue(Completion) = .{},
 /// boot/real wall-clock timeout SQEs, or null if disarmed. Indexed by
 /// `wallIndex` (0 = boot, 1 = real).
 wall_armed: [2]?u64 = .{ null, null },
+/// Generation of each wall timer's current SQE, encoded in its user_data and
+/// bumped on every (re)arm, so a stale timeout CQE is ignored.
+wall_generation: [2]u32 = .{ 0, 0 },
 /// Backing storage for the wall timeout `kernel_timespec`s; must outlive the
 /// SQE until the next `io_uring_enter2` reads it.
 wall_ts: [2]linux.kernel_timespec = undefined,
-/// Set when a wall-timer (re)arm couldn't get an SQE because the SQ was full.
-/// Like `waker_needs_rearm`, this forces the next poll not to block so the SQ
-/// drains and the arm retries on the following scan.
-wall_needs_rearm: bool = false,
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
     _ = shared_state;
@@ -219,7 +241,7 @@ fn armWaker(self: *Self) bool {
     const sqe = self.ring.get_sqe() catch return false;
     sqe.prep_poll_add(self.waker_eventfd, linux.POLL.IN);
     sqe.len = linux.IORING_POLL_ADD_MULTI;
-    sqe.user_data = USER_DATA_WAKER;
+    sqe.user_data = specialUd(.waker, 0);
     self.waker_needs_rearm = false;
     return true;
 }
@@ -735,7 +757,7 @@ pub fn cancel(self: *Self, _: *LoopState, target: *Completion) void {
                 return;
             };
             sqe.prep_cancel(@intFromPtr(target), 0);
-            sqe.user_data = USER_DATA_CANCEL;
+            sqe.user_data = specialUd(.cancel, 0);
         },
         .completed, .dead => {
             // Target already completed (has result) or fully finished (callback called).
@@ -758,45 +780,43 @@ fn getSqeOrDefer(self: *Self, c: *Completion) ?*linux.io_uring_sqe {
 /// given absolute deadlines (ns in each clock's epoch; null = none). Called by
 /// the loop when the boot/real timer-heap minimums change; the SQEs ride the
 /// next `io_uring_enter2`.
-pub fn syncWallTimers(self: *Self, boot: ?u64, real: ?u64) void {
-    self.wall_needs_rearm = false;
-    self.armWall(0, USER_DATA_WALL_BOOT, linux.IORING_TIMEOUT_BOOTTIME, boot);
-    self.armWall(1, USER_DATA_WALL_REAL, linux.IORING_TIMEOUT_REALTIME, real);
-}
+pub fn syncWallTimer(self: *Self, clock: Clock, deadline: ?u64) bool {
+    const idx: usize, const clock_flag: u32 = switch (clock) {
+        .boot => .{ 0, linux.IORING_TIMEOUT_BOOTTIME },
+        .real => .{ 1, linux.IORING_TIMEOUT_REALTIME },
+        else => unreachable,
+    };
 
-fn armWall(self: *Self, idx: usize, sentinel: u64, clock_flag: u32, deadline: ?u64) void {
-    if (self.wall_armed[idx] == deadline) return; // unchanged (incl. both null)
+    if (self.wall_armed[idx] == deadline) return true; // unchanged (incl. both null)
 
     // Remove the existing timeout (if any) before re-arming. The removed
     // timeout's CQE and the remove op's CQE are both ignored in poll(). If the
-    // SQ is full, flag a rearm so poll() drains it and we retry next scan,
-    // leaving wall_armed unchanged so the old timeout stays valid meanwhile.
+    // SQ is full, leave wall_armed unchanged (old timeout stays valid) and
+    // report failure so the loop folds this clock into the capped poll timeout.
     if (self.wall_armed[idx] != null) {
-        const sqe = self.ring.get_sqe() catch {
-            self.wall_needs_rearm = true;
-            return;
-        };
-        sqe.prep_timeout_remove(sentinel, 0);
-        sqe.user_data = USER_DATA_CANCEL;
+        const sqe = self.ring.get_sqe() catch return false;
+        sqe.prep_timeout_remove(specialUd(wallKind(idx), self.wall_generation[idx]), 0);
+        sqe.user_data = specialUd(.cancel, 0);
     }
 
     if (deadline) |d| {
         const sqe = self.ring.get_sqe() catch {
-            // Remove was queued (or nothing was armed), but we can't arm the
-            // new timeout now. Forget it and retry next scan after the drain.
+            // Remove was queued but we can't arm the new timeout now. Forget it
+            // (the next scan re-arms) and report failure so the loop folds.
             self.wall_armed[idx] = null;
-            self.wall_needs_rearm = true;
-            return;
+            return false;
         };
+        self.wall_generation[idx] +%= 1;
         self.wall_ts[idx] = .{
             .sec = @intCast(d / time.ns_per_s),
             .nsec = @intCast(d % time.ns_per_s),
         };
         sqe.prep_timeout(&self.wall_ts[idx], 0, linux.IORING_TIMEOUT_ABS | clock_flag);
-        sqe.user_data = sentinel;
+        sqe.user_data = specialUd(wallKind(idx), self.wall_generation[idx]);
     }
 
     self.wall_armed[idx] = deadline;
+    return true;
 }
 
 pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
@@ -808,7 +828,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
     // can arm.
     // Don't block if a critical internal SQE (waker or a wall timer) still
     // needs arming — a zero-timeout enter2 drains the SQ so the next scan can.
-    const effective_timeout: Duration = if (self.armWaker() and !self.wall_needs_rearm) timeout else .zero;
+    const effective_timeout: Duration = if (self.armWaker()) timeout else .zero;
 
     const to_submit = self.ring.flush_sq();
     var ts: linux.kernel_timespec = undefined;
@@ -848,25 +868,26 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
 
     var wall_fired = false;
     for (cqes[0..count]) |cqe| {
-        // Handle internal operations with special user_data values
-        if (cqe.user_data == USER_DATA_WAKER) {
-            self.drainWaker(cqe);
-            continue;
-        }
-
-        if (cqe.user_data == USER_DATA_CANCEL) {
-            // Cancel SQE completion - just skip it
-            continue;
-        }
-
-        // Wall-clock (boot/real) timeout. A fire (-ETIME) means a boot/real
-        // timer is due, so report a timeout below to re-run checkTimers; the
-        // kernel auto-removed the one-shot, so forget our armed deadline. A
-        // -ECANCELED is from re-arming and is simply ignored.
-        if (cqe.user_data == USER_DATA_WALL_BOOT or cqe.user_data == USER_DATA_WALL_REAL) {
-            if (cqe.res == -@as(i32, @intFromEnum(linux.E.TIME))) {
-                wall_fired = true;
-                self.wall_armed[if (cqe.user_data == USER_DATA_WALL_BOOT) 0 else 1] = null;
+        // Internal ops carry the special low bit; completions are pointers.
+        if (udIsSpecial(cqe.user_data)) {
+            switch (udKind(cqe.user_data)) {
+                .waker => self.drainWaker(cqe),
+                .cancel => {}, // cancel/remove op completion — skip
+                // Wall-clock (boot/real) timeout. A fire (-ETIME) of the current
+                // generation means the timer is due: report a timeout below to
+                // re-run checkTimers, and forget the armed deadline (the kernel
+                // auto-removed the one-shot). A stale generation or -ECANCELED
+                // (from re-arming) is ignored.
+                .wall_boot, .wall_real => {
+                    const idx: usize = if (udKind(cqe.user_data) == .wall_boot) 0 else 1;
+                    if (cqe.res == -@as(i32, @intFromEnum(linux.E.TIME)) and
+                        udGeneration(cqe.user_data) == self.wall_generation[idx] and
+                        self.wall_armed[idx] != null)
+                    {
+                        wall_fired = true;
+                        self.wall_armed[idx] = null;
+                    }
+                },
             }
             continue;
         }

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -59,6 +59,10 @@ pub const BackendCapabilities = struct {
     /// When true, completions submitted to one loop in a group may be completed
     /// on another loop's thread. Timer operations are protected by a mutex.
     is_multi_threaded: bool = false,
+    /// When true, the backend arms boot/real (wall-clock) timers natively via
+    /// `syncWallTimers`, so the loop must not fold them into the poll timeout.
+    /// When false, the loop falls back to the capped poll-timeout re-evaluation.
+    native_wall_timers: bool = false,
 
     pub fn supportsNonBlockingFileIo(comptime self: BackendCapabilities) bool {
         return self.file_read or self.file_write or self.file_read_streaming or self.file_write_streaming;

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -876,9 +876,11 @@ pub const Loop = struct {
 
         var fired = false;
         var next_timeout: ?Duration = null;
-        // Earliest pending absolute deadline per heap; only the boot/real
-        // entries are used, and only when the backend arms them natively.
+        // For native boot/real clocks: the earliest pending absolute deadline to
+        // hand the backend, plus its capped remaining (computed during the scan
+        // under the lock) to fold into the poll timeout if the backend can't arm.
         var wall_deadline: [wall_clock_count]?u64 = .{ null, null, null };
+        var wall_remaining: [wall_clock_count]Duration = .{ .zero, .zero, .zero };
 
         // Advance the scan once and refresh the awake snapshot; this also
         // invalidates the lazily-cached boot/real values for this scan.
@@ -908,8 +910,14 @@ pub const Loop = struct {
                     if (timer.deadline.value > now_clock.value) {
                         if (native_wall and clock != .awake) {
                             // Backend arms this clock natively; record its
-                            // earliest deadline instead of folding into the poll.
+                            // earliest deadline, plus a capped remaining to fold
+                            // only if the backend later reports it couldn't arm.
                             wall_deadline[idx] = timer.deadline.value;
+                            var remaining = now_clock.durationTo(timer.deadline);
+                            if (remaining.value > self.wall_clock_cap.value) {
+                                remaining = self.wall_clock_cap;
+                            }
+                            wall_remaining[idx] = remaining;
                         } else {
                             var remaining = now_clock.durationTo(timer.deadline);
                             // boot/real can't be tracked by the awake poll clock,
@@ -942,9 +950,19 @@ pub const Loop = struct {
             }
         }
 
-        // Hand the boot/real minimums to the backend's native wall-clock timers.
+        // Hand each boot/real minimum to the backend's native wall-clock timer.
+        // syncWallTimer returns false only when it couldn't arm a pending
+        // deadline (e.g. SQ full); then fold that clock's capped remaining into
+        // the poll timeout so it's still re-evaluated within the cap.
         if (comptime native_wall) {
-            self.backend.syncWallTimers(wall_deadline[1], wall_deadline[2]);
+            for ([_]usize{ 1, 2 }) |idx| {
+                const clock = indexClock(idx);
+                if (self.backend.syncWallTimer(clock, wall_deadline[idx])) continue;
+                const remaining = wall_remaining[idx];
+                if (next_timeout == null or remaining.value < next_timeout.?.value) {
+                    next_timeout = remaining;
+                }
+            }
         }
 
         return .{ .next_timeout = next_timeout, .fired = fired };

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -872,8 +872,13 @@ pub const Loop = struct {
     };
 
     fn checkTimers(self: *Loop) TimerCheckResult {
+        const native_wall = Backend.capabilities.native_wall_timers;
+
         var fired = false;
         var next_timeout: ?Duration = null;
+        // Earliest pending absolute deadline per heap; only the boot/real
+        // entries are used, and only when the backend arms them natively.
+        var wall_deadline: [wall_clock_count]?u64 = .{ null, null, null };
 
         // Advance the scan once and refresh the awake snapshot; this also
         // invalidates the lazily-cached boot/real values for this scan.
@@ -901,14 +906,20 @@ pub const Loop = struct {
                 while (self.state.timers[idx].peek()) |timer| {
                     const now_clock = self.state.nowFor(clock);
                     if (timer.deadline.value > now_clock.value) {
-                        var remaining = now_clock.durationTo(timer.deadline);
-                        // boot/real can't be tracked by the awake poll clock, so
-                        // bound the wait to re-evaluate them across suspend/steps.
-                        if (clock != .awake and remaining.value > self.wall_clock_cap.value) {
-                            remaining = self.wall_clock_cap;
-                        }
-                        if (next_timeout == null or remaining.value < next_timeout.?.value) {
-                            next_timeout = remaining;
+                        if (native_wall and clock != .awake) {
+                            // Backend arms this clock natively; record its
+                            // earliest deadline instead of folding into the poll.
+                            wall_deadline[idx] = timer.deadline.value;
+                        } else {
+                            var remaining = now_clock.durationTo(timer.deadline);
+                            // boot/real can't be tracked by the awake poll clock,
+                            // so bound the wait to re-evaluate across suspend/steps.
+                            if (clock != .awake and remaining.value > self.wall_clock_cap.value) {
+                                remaining = self.wall_clock_cap;
+                            }
+                            if (next_timeout == null or remaining.value < next_timeout.?.value) {
+                                next_timeout = remaining;
+                            }
                         }
                         break;
                     }
@@ -929,6 +940,11 @@ pub const Loop = struct {
                 // If we didn't fill the batch, we're done with this domain
                 if (batch_count < batch.len) break;
             }
+        }
+
+        // Hand the boot/real minimums to the backend's native wall-clock timers.
+        if (comptime native_wall) {
+            self.backend.syncWallTimers(wall_deadline[1], wall_deadline[2]);
         }
 
         return .{ .next_timeout = next_timeout, .fired = fired };

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -139,7 +139,7 @@ test "timer with explicit deadline" {
     std.log.info("deadline timer: expected=100ms, actual={f}", .{elapsed});
 }
 
-test "timer on boot clock fires (duration, fallback path)" {
+test "timer on boot clock fires (duration)" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();
@@ -158,7 +158,7 @@ test "timer on boot clock fires (duration, fallback path)" {
     std.log.info("boot timer: expected=100ms, actual={f}", .{elapsed});
 }
 
-test "timer on real clock fires (absolute deadline, fallback path)" {
+test "timer on real clock fires (absolute deadline)" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();


### PR DESCRIPTION
Follows the per-clock timer heaps work (#515). With those, boot/real timers fire correctly on every backend via a capped poll-timeout fallback. This makes io_uring arm them **natively** so they're exact rather than bounded by the cap.

## What
- New `native_wall_timers` backend capability. When set, `checkTimers` stops folding boot/real deadlines into the poll timeout (no 10s cap) and instead hands the per-clock heap minimums to `backend.syncWallTimers(boot, real)`.
- io_uring arms one `IORING_OP_TIMEOUT` SQE per active wall clock with `IORING_TIMEOUT_ABS | BOOTTIME/REALTIME`. The kernel re-evaluates these across suspend and clock steps, so boot/real fire exactly. A fired timeout (`-ETIME`) makes `poll` report a timeout so the loop re-runs `checkTimers`; re-arming on a changed deadline cancels the old SQE first.
- All gated by the comptime capability — other backends keep the capped fallback untouched.

## SQ-full handling
Mirrors the existing waker: if `armWall` can't get an SQE, it sets `wall_needs_rearm` and `poll` uses a zero timeout so the `enter2` drains the SQ and the next scan re-arms. Per-timer armed state lives in `wall_armed[idx]`; the bool is only the "don't block" gate (an OR over the two timers), so a partial failure stays flagged and the already-armed timer is left untouched. Bounded to one non-blocking cycle, never a blocking wait or a spin.

## Kernel requirement
No extra gate: the ring already requires ≥6.1 (`DEFER_TASKRUN`), and the `BOOTTIME`/`REALTIME` timeout flags are ≥5.15, so they're always available where this backend runs.

## Testing
- io_uring (native) and epoll (fallback): full suite 492/492 on each.
- The boot/real/deadline sleep + timer tests now exercise the native SQE path on io_uring.

## Not covered
The "exact across suspend/clock-step" behavior relies on the kernel's hrtimer semantics and isn't unit-tested (suspend isn't reproducible in a unit test). epoll/kqueue/IOCP native arming remain future work.