### PR TITLE
task: add TaskLocal task-local storage

### DIFF
--- a/src/task.zig
+++ b/src/task.zig
@@ -654,7 +654,7 @@ pub fn TaskLocal(comptime T: type) type {
         /// The node lives on the stack, so this allocates nothing, and `func` is
         /// invoked via `@call` (any comptime-known callable, no fn-pointer
         /// indirection). Returns whatever `func` returns.
-        pub fn scoped(self: *Self, value: T, func: anytype, args: anytype) @TypeOf(@call(.auto, func, args)) {
+        pub fn scoped(self: *Self, value: T, func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) @TypeOf(@call(.auto, func, args)) {
             var node: Node = .unset;
             self.set(&node, value);
             defer self.clear(&node);

--- a/src/task.zig
+++ b/src/task.zig
@@ -167,8 +167,10 @@ pub const CancelKind = enum { user, auto };
 /// which executor currently runs the task (tasks keep their identity across
 /// migration).
 pub const TaskLocalNode = struct {
-    /// The `TaskLocal` instance this binding belongs to (its address is the key).
-    key: *const anyopaque = undefined,
+    /// The `TaskLocal` instance this binding belongs to (its address is the key),
+    /// or null when the node is unbound. Doubles as the "is this node linked?"
+    /// marker, so `set`/`clear` can catch misuse cheaply.
+    key: ?*const anyopaque = null,
     /// The task whose chain this node is linked into.
     owner: *AnyTask = undefined,
     prev: ?*TaskLocalNode = null,
@@ -555,7 +557,7 @@ pub const AnyTask = struct {
 /// var trace_id: zio.TaskLocal(u64) = .{};
 ///
 /// fn handler() void {
-///     var node: @TypeOf(trace_id).Node = undefined;
+///     var node: @TypeOf(trace_id).Node = .unset;
 ///     trace_id.set(&node, 42);
 ///     defer trace_id.clear(&node);
 ///     // trace_id.get() returns *u64 (== 42) here and in any callee,
@@ -582,24 +584,25 @@ pub fn TaskLocal(comptime T: type) type {
         /// declared instance a distinct address; it is otherwise unused.
         _key_marker: u8 = 0,
 
-        /// Caller-provided storage for one binding. Declare it `undefined`; it is
-        /// fully initialized by `set`.
+        /// Caller-provided storage for one binding. Declare it `.unset`; `set`
+        /// fills it in and `clear` returns it to `.unset` so it can be reused.
         pub const Node = struct {
-            base: TaskLocalNode,
-            value: T,
+            base: TaskLocalNode = .{},
+            value: T = undefined,
+
+            /// A node that holds no binding. Declaring nodes with this (rather
+            /// than `undefined`) makes a stray `clear` before `set`, or a double
+            /// `clear`, an assertion failure instead of chain corruption.
+            pub const unset: Node = .{};
         };
 
         /// Bind `value` in the current task using caller-provided `node` storage.
-        /// Visible to `get` until `clear(node)`. `node` must stay alive and
-        /// unmoved until then. Panics if called outside a task.
+        /// Visible to `get` until `clear(node)`. `node` must be `.unset` (freshly
+        /// declared or previously cleared) and must stay alive and unmoved until
+        /// it is cleared. Panics if called outside a task.
         pub fn set(self: *Self, node: *Node, value: T) void {
             const task = runtime.getCurrentTask();
-
-            if (std.debug.runtime_safety) {
-                // The same node must not already be linked (a double `set`).
-                var cur = task.tls_head;
-                while (cur) |n| : (cur = n.next) std.debug.assert(n != &node.base);
-            }
+            std.debug.assert(node.base.key == null); // node already in use
 
             node.value = value;
             node.base = .{
@@ -612,25 +615,24 @@ pub fn TaskLocal(comptime T: type) type {
             task.tls_head = &node.base;
         }
 
-        /// Remove a binding established with `set`. May be interleaved with other
-        /// bindings in any order.
+        /// Remove a binding established with `set`, returning `node` to `.unset`.
+        /// May be interleaved with other bindings in any order.
         pub fn clear(self: *Self, node: *Node) void {
             const b = &node.base;
+            std.debug.assert(b.key == @as(?*const anyopaque, self)); // bound by this TaskLocal
             if (std.debug.runtime_safety) {
-                std.debug.assert(b.key == @as(*const anyopaque, self)); // node belongs to this TaskLocal
                 std.debug.assert(b.owner == runtime.getCurrentTask()); // same task
             }
             if (b.prev) |p| p.next = b.next else b.owner.tls_head = b.next;
             if (b.next) |n| n.prev = b.prev;
-            // Poison so a double `clear` or use-after-clear trips the asserts above.
-            b.* = .{};
+            b.* = .{}; // back to .unset
         }
 
         /// Pointer to the value bound in the current task (the innermost active
         /// binding), or null if unbound or called outside a task.
         pub fn get(self: *Self) ?*T {
             const task = runtime.getCurrentTaskOrNull() orelse return null;
-            const key: *const anyopaque = self;
+            const key: ?*const anyopaque = self;
             var cur = task.tls_head;
             while (cur) |n| : (cur = n.next) {
                 if (n.key == key) {
@@ -767,7 +769,7 @@ test "TaskLocal: set/get/clear and mutation within a task" {
         fn run() !void {
             try std.testing.expect(tl.get() == null);
 
-            var node: @TypeOf(tl).Node = undefined;
+            var node: @TypeOf(tl).Node = .unset;
             tl.set(&node, 123);
             defer tl.clear(&node);
 
@@ -792,13 +794,13 @@ test "TaskLocal: nested bindings shadow and restore" {
         var tl: TaskLocal(u32) = .{};
 
         fn run() !void {
-            var outer: @TypeOf(tl).Node = undefined;
+            var outer: @TypeOf(tl).Node = .unset;
             tl.set(&outer, 1);
             defer tl.clear(&outer);
             try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
 
             {
-                var inner: @TypeOf(tl).Node = undefined;
+                var inner: @TypeOf(tl).Node = .unset;
                 tl.set(&inner, 2);
                 defer tl.clear(&inner);
                 try std.testing.expectEqual(@as(u32, 2), tl.get().?.*);
@@ -823,8 +825,8 @@ test "TaskLocal: non-LIFO clear unlinks a middle node" {
         var b: TaskLocal(u32) = .{};
 
         fn run() !void {
-            var na: @TypeOf(a).Node = undefined;
-            var nb: @TypeOf(b).Node = undefined;
+            var na: @TypeOf(a).Node = .unset;
+            var nb: @TypeOf(b).Node = .unset;
             a.set(&na, 10);
             b.set(&nb, 20);
 
@@ -851,7 +853,7 @@ test "TaskLocal: bindings are isolated per task and survive yielding" {
         var tl: TaskLocal(u32) = .{};
 
         fn run(r: *Runtime, id: u32) !void {
-            var node: @TypeOf(tl).Node = undefined;
+            var node: @TypeOf(tl).Node = .unset;
             tl.set(&node, id);
             defer tl.clear(&node);
 
@@ -871,6 +873,33 @@ test "TaskLocal: bindings are isolated per task and survive yielding" {
     try h2.join();
 }
 
+test "TaskLocal: a node is reusable after clear" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var tl: TaskLocal(u32) = .{};
+
+        fn run() !void {
+            var node: @TypeOf(tl).Node = .unset;
+
+            tl.set(&node, 1);
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+            tl.clear(&node);
+            try std.testing.expect(tl.get() == null);
+
+            // clear() returned the node to .unset, so it can be set again.
+            tl.set(&node, 2);
+            defer tl.clear(&node);
+            try std.testing.expectEqual(@as(u32, 2), tl.get().?.*);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}
+
 test "TaskLocal: unbound key reads back null" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
@@ -880,7 +909,7 @@ test "TaskLocal: unbound key reads back null" {
         var other: TaskLocal(u8) = .{};
 
         fn run() !void {
-            var node: @TypeOf(bound).Node = undefined;
+            var node: @TypeOf(bound).Node = .unset;
             bound.set(&node, 7);
             defer bound.clear(&node);
 

--- a/src/task.zig
+++ b/src/task.zig
@@ -154,6 +154,27 @@ pub const CanceledStatus = packed struct(u32) {
 // Kind of cancellation
 pub const CancelKind = enum { user, auto };
 
+/// Intrusive node for a single task-local binding (see `TaskLocal`).
+///
+/// The storage for a node is provided by the caller — on the stack for a scoped
+/// binding, embedded in a longer-lived struct, or heap-allocated — so a binding
+/// lives exactly as long as its node. A node must stay alive and unmoved while
+/// linked (between `set` and `clear`).
+///
+/// Nodes form a per-task doubly-linked stack rooted at `AnyTask.tls_head`. It is
+/// only ever touched by the owning task itself, so no synchronization is needed,
+/// and because the node records its `owner` it unlinks correctly regardless of
+/// which executor currently runs the task (tasks keep their identity across
+/// migration).
+pub const TaskLocalNode = struct {
+    /// The `TaskLocal` instance this binding belongs to (its address is the key).
+    key: *const anyopaque = undefined,
+    /// The task whose chain this node is linked into.
+    owner: *AnyTask = undefined,
+    prev: ?*TaskLocalNode = null,
+    next: ?*TaskLocalNode = null,
+};
+
 pub const AnyTask = struct {
     awaitable: Awaitable,
     coro: Coroutine,
@@ -171,6 +192,10 @@ pub const AnyTask = struct {
     closure: Closure,
 
     runtime: *Runtime,
+
+    /// Head of this task's intrusive task-local binding chain (see `TaskLocal`).
+    /// Only ever accessed by the task itself, so it needs no synchronization.
+    tls_head: ?*TaskLocalNode = null,
 
     /// Task state and park token, packed into a single byte for atomic operations.
     ///
@@ -457,6 +482,13 @@ pub const AnyTask = struct {
         // Run the task's function
         self.closure.call(AnyTask, self);
 
+        // Every task-local binding must be cleared before the task body returns;
+        // a leftover node points into storage that is about to die. Catch the
+        // missing `clear` here, at the task that leaked it.
+        if (std.debug.runtime_safety) {
+            std.debug.assert(self.tls_head == null);
+        }
+
         // Re-fetch executor — task may have migrated during execution
         executor = getCurrentExecutor();
         executor.pending_cleanup = .{ .finish = self };
@@ -511,6 +543,105 @@ pub const AnyTask = struct {
         return self;
     }
 };
+
+/// Task-local storage: a per-task binding for a value of type `T`, keyed by the
+/// address of the `TaskLocal` instance itself. The analogue of a thread-local,
+/// but scoped to a task and carried across task migration.
+///
+/// Declare an instance at container scope and bind it for as long as the
+/// caller-provided node lives:
+///
+/// ```zig
+/// var trace_id: zio.TaskLocal(u64) = .{};
+///
+/// fn handler() void {
+///     var node: @TypeOf(trace_id).Node = undefined;
+///     trace_id.set(&node, 42);
+///     defer trace_id.clear(&node);
+///     // trace_id.get() returns *u64 (== 42) here and in any callee,
+///     // across yields and executor migration.
+/// }
+/// ```
+///
+/// Because the node storage is caller-owned, the binding lives exactly as long
+/// as that storage: put the node on the stack for a scoped binding, or embed it
+/// in a longer-lived struct (or heap-allocate it) to keep the binding for the
+/// task's lifetime. The node must not move while linked and must be `clear`ed
+/// before its storage dies — the usual acquire/`defer`-release discipline. In
+/// safety builds a task that returns with a binding still live trips an assert.
+///
+/// Bindings nest and shadow: the most recent `set` for a key wins until cleared,
+/// and `clear` may interleave bindings in any order (not just LIFO). All access
+/// is from the owning task only, so it needs no locking.
+pub fn TaskLocal(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        /// The instance's address is its key, so the type must not be zero-sized
+        /// (distinct zero-sized vars can share an address). This marker gives each
+        /// declared instance a distinct address; it is otherwise unused.
+        _key_marker: u8 = 0,
+
+        /// Caller-provided storage for one binding. Declare it `undefined`; it is
+        /// fully initialized by `set`.
+        pub const Node = struct {
+            base: TaskLocalNode,
+            value: T,
+        };
+
+        /// Bind `value` in the current task using caller-provided `node` storage.
+        /// Visible to `get` until `clear(node)`. `node` must stay alive and
+        /// unmoved until then. Panics if called outside a task.
+        pub fn set(self: *Self, node: *Node, value: T) void {
+            const task = runtime.getCurrentTask();
+
+            if (std.debug.runtime_safety) {
+                // The same node must not already be linked (a double `set`).
+                var cur = task.tls_head;
+                while (cur) |n| : (cur = n.next) std.debug.assert(n != &node.base);
+            }
+
+            node.value = value;
+            node.base = .{
+                .key = self,
+                .owner = task,
+                .prev = null,
+                .next = task.tls_head,
+            };
+            if (task.tls_head) |h| h.prev = &node.base;
+            task.tls_head = &node.base;
+        }
+
+        /// Remove a binding established with `set`. May be interleaved with other
+        /// bindings in any order.
+        pub fn clear(self: *Self, node: *Node) void {
+            const b = &node.base;
+            if (std.debug.runtime_safety) {
+                std.debug.assert(b.key == @as(*const anyopaque, self)); // node belongs to this TaskLocal
+                std.debug.assert(b.owner == runtime.getCurrentTask()); // same task
+            }
+            if (b.prev) |p| p.next = b.next else b.owner.tls_head = b.next;
+            if (b.next) |n| n.prev = b.prev;
+            // Poison so a double `clear` or use-after-clear trips the asserts above.
+            b.* = .{};
+        }
+
+        /// Pointer to the value bound in the current task (the innermost active
+        /// binding), or null if unbound or called outside a task.
+        pub fn get(self: *Self) ?*T {
+            const task = runtime.getCurrentTaskOrNull() orelse return null;
+            const key: *const anyopaque = self;
+            var cur = task.tls_head;
+            while (cur) |n| : (cur = n.next) {
+                if (n.key == key) {
+                    const node: *Node = @fieldParentPtr("base", n);
+                    return &node.value;
+                }
+            }
+            return null;
+        }
+    };
+}
 
 const getNextExecutor = @import("runtime.zig").getNextExecutor;
 
@@ -625,3 +756,141 @@ pub const TaskPool = struct {
         }
     }
 };
+
+test "TaskLocal: set/get/clear and mutation within a task" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var tl: TaskLocal(u64) = .{};
+
+        fn run() !void {
+            try std.testing.expect(tl.get() == null);
+
+            var node: @TypeOf(tl).Node = undefined;
+            tl.set(&node, 123);
+            defer tl.clear(&node);
+
+            try std.testing.expectEqual(@as(u64, 123), tl.get().?.*);
+
+            // Mutation through the returned pointer is visible to later reads.
+            tl.get().?.* = 456;
+            try std.testing.expectEqual(@as(u64, 456), tl.get().?.*);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}
+
+test "TaskLocal: nested bindings shadow and restore" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var tl: TaskLocal(u32) = .{};
+
+        fn run() !void {
+            var outer: @TypeOf(tl).Node = undefined;
+            tl.set(&outer, 1);
+            defer tl.clear(&outer);
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+
+            {
+                var inner: @TypeOf(tl).Node = undefined;
+                tl.set(&inner, 2);
+                defer tl.clear(&inner);
+                try std.testing.expectEqual(@as(u32, 2), tl.get().?.*);
+            }
+
+            // Inner cleared: the outer binding is visible again.
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}
+
+test "TaskLocal: non-LIFO clear unlinks a middle node" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var a: TaskLocal(u32) = .{};
+        var b: TaskLocal(u32) = .{};
+
+        fn run() !void {
+            var na: @TypeOf(a).Node = undefined;
+            var nb: @TypeOf(b).Node = undefined;
+            a.set(&na, 10);
+            b.set(&nb, 20);
+
+            // Clear the older (non-head) binding first.
+            a.clear(&na);
+            try std.testing.expect(a.get() == null);
+            try std.testing.expectEqual(@as(u32, 20), b.get().?.*);
+
+            b.clear(&nb);
+            try std.testing.expect(b.get() == null);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}
+
+test "TaskLocal: bindings are isolated per task and survive yielding" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var tl: TaskLocal(u32) = .{};
+
+        fn run(r: *Runtime, id: u32) !void {
+            var node: @TypeOf(tl).Node = undefined;
+            tl.set(&node, id);
+            defer tl.clear(&node);
+
+            // Yield so both tasks have a live binding at the same time; if the
+            // chain were shared/global this would observe the other task's value.
+            try r.sleep(.fromMilliseconds(5));
+
+            try std.testing.expectEqual(id, tl.get().?.*);
+        }
+    };
+
+    var h1 = try rt.spawn(S.run, .{ rt, 1 });
+    defer h1.cancel();
+    var h2 = try rt.spawn(S.run, .{ rt, 2 });
+    defer h2.cancel();
+    try h1.join();
+    try h2.join();
+}
+
+test "TaskLocal: unbound key reads back null" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var bound: TaskLocal(u8) = .{};
+        var other: TaskLocal(u8) = .{};
+
+        fn run() !void {
+            var node: @TypeOf(bound).Node = undefined;
+            bound.set(&node, 7);
+            defer bound.clear(&node);
+
+            // A different instance is a different key, even of the same type.
+            try std.testing.expect(other.get() == null);
+            try std.testing.expectEqual(@as(u8, 7), bound.get().?.*);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}

--- a/src/task.zig
+++ b/src/task.zig
@@ -560,8 +560,8 @@ pub const AnyTask = struct {
 ///     var node: @TypeOf(trace_id).Node = .unset;
 ///     trace_id.set(&node, 42);
 ///     defer trace_id.clear(&node);
-///     // trace_id.get() returns *u64 (== 42) here and in any callee,
-///     // across yields and executor migration.
+///     // trace_id.get() returns 42 here and in any callee, across yields
+///     // and executor migration.
 /// }
 /// ```
 ///
@@ -631,9 +631,12 @@ pub fn TaskLocal(comptime T: type) type {
             b.* = .{}; // back to .unset
         }
 
-        /// Pointer to the value bound in the current task (the innermost active
-        /// binding), or null if unbound or called outside a task.
-        pub fn get(self: *Self) ?*T {
+        /// The value bound in the current task (the innermost active binding),
+        /// or null if unbound or called outside a task. Returns a copy — for
+        /// mutable per-task state, bind a pointer (`TaskLocal(*T)`) and mutate
+        /// through it, so the lifetime of the mutable storage is yours and not
+        /// tied to the node.
+        pub fn get(self: *Self) ?T {
             const task = runtime.getCurrentTaskOrNull() orelse return null;
             const key: ?*const anyopaque = self;
             var cur = task.tls_head;
@@ -643,7 +646,7 @@ pub fn TaskLocal(comptime T: type) type {
                     // Node-aligned even though the chain is typed `*TaskLocalNode`
                     // (lower alignment on 32-bit targets).
                     const node: *Node = @alignCast(@fieldParentPtr("base", n));
-                    return &node.value;
+                    return node.value;
                 }
             }
             return null;
@@ -777,7 +780,7 @@ pub const TaskPool = struct {
     }
 };
 
-test "TaskLocal: set/get/clear and mutation within a task" {
+test "TaskLocal: set/get/clear returns the bound value" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -791,11 +794,35 @@ test "TaskLocal: set/get/clear and mutation within a task" {
             tl.set(&node, 123);
             defer tl.clear(&node);
 
-            try std.testing.expectEqual(@as(u64, 123), tl.get().?.*);
+            try std.testing.expectEqual(@as(u64, 123), tl.get().?);
+        }
+    };
 
-            // Mutation through the returned pointer is visible to later reads.
-            tl.get().?.* = 456;
-            try std.testing.expectEqual(@as(u64, 456), tl.get().?.*);
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
+}
+
+test "TaskLocal: mutable per-task state via a bound pointer" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var counter: TaskLocal(*u64) = .{};
+
+        fn bump() void {
+            counter.get().?.* += 1;
+        }
+
+        fn run() !void {
+            var n: u64 = 0;
+            var node: @TypeOf(counter).Node = .unset;
+            counter.set(&node, &n);
+            defer counter.clear(&node);
+
+            bump();
+            bump();
+            try std.testing.expectEqual(@as(u64, 2), n);
         }
     };
 
@@ -815,17 +842,17 @@ test "TaskLocal: nested bindings shadow and restore" {
             var outer: @TypeOf(tl).Node = .unset;
             tl.set(&outer, 1);
             defer tl.clear(&outer);
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
 
             {
                 var inner: @TypeOf(tl).Node = .unset;
                 tl.set(&inner, 2);
                 defer tl.clear(&inner);
-                try std.testing.expectEqual(@as(u32, 2), tl.get().?.*);
+                try std.testing.expectEqual(@as(u32, 2), tl.get().?);
             }
 
             // Inner cleared: the outer binding is visible again.
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
         }
     };
 
@@ -851,7 +878,7 @@ test "TaskLocal: non-LIFO clear unlinks a middle node" {
             // Clear the older (non-head) binding first.
             a.clear(&na);
             try std.testing.expect(a.get() == null);
-            try std.testing.expectEqual(@as(u32, 20), b.get().?.*);
+            try std.testing.expectEqual(@as(u32, 20), b.get().?);
 
             b.clear(&nb);
             try std.testing.expect(b.get() == null);
@@ -879,7 +906,7 @@ test "TaskLocal: bindings are isolated per task and survive yielding" {
             // chain were shared/global this would observe the other task's value.
             try r.sleep(.fromMilliseconds(5));
 
-            try std.testing.expectEqual(id, tl.get().?.*);
+            try std.testing.expectEqual(id, tl.get().?);
         }
     };
 
@@ -899,7 +926,7 @@ test "TaskLocal: scoped binds for the call and restores after" {
         var tl: TaskLocal(u32) = .{};
 
         fn inner(addend: u32) u32 {
-            return tl.get().?.* + addend;
+            return tl.get().? + addend;
         }
 
         fn run() !void {
@@ -930,14 +957,14 @@ test "TaskLocal: a node is reusable after clear" {
             var node: @TypeOf(tl).Node = .unset;
 
             tl.set(&node, 1);
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?.*);
+            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
             tl.clear(&node);
             try std.testing.expect(tl.get() == null);
 
             // clear() returned the node to .unset, so it can be set again.
             tl.set(&node, 2);
             defer tl.clear(&node);
-            try std.testing.expectEqual(@as(u32, 2), tl.get().?.*);
+            try std.testing.expectEqual(@as(u32, 2), tl.get().?);
         }
     };
 
@@ -961,7 +988,7 @@ test "TaskLocal: unbound key reads back null" {
 
             // A different instance is a different key, even of the same type.
             try std.testing.expect(other.get() == null);
-            try std.testing.expectEqual(@as(u8, 7), bound.get().?.*);
+            try std.testing.expectEqual(@as(u8, 7), bound.get().?);
         }
     };
 

--- a/src/task.zig
+++ b/src/task.zig
@@ -575,6 +575,9 @@ pub const AnyTask = struct {
 /// Bindings nest and shadow: the most recent `set` for a key wins until cleared,
 /// and `clear` may interleave bindings in any order (not just LIFO). All access
 /// is from the owning task only, so it needs no locking.
+///
+/// `scoped(value, func, args)` is a convenience that binds for the duration of a
+/// single call without a caller-managed node; see below.
 pub fn TaskLocal(comptime T: type) type {
     return struct {
         const Self = @This();
@@ -636,11 +639,26 @@ pub fn TaskLocal(comptime T: type) type {
             var cur = task.tls_head;
             while (cur) |n| : (cur = n.next) {
                 if (n.key == key) {
-                    const node: *Node = @fieldParentPtr("base", n);
+                    // `base` is at offset 0 of a `Node`, so the node is really
+                    // Node-aligned even though the chain is typed `*TaskLocalNode`
+                    // (lower alignment on 32-bit targets).
+                    const node: *Node = @alignCast(@fieldParentPtr("base", n));
                     return &node.value;
                 }
             }
             return null;
+        }
+
+        /// Bind `value` for the dynamic extent of `func(args...)`, then restore
+        /// the previous state — the `defer`-free convenience over `set`/`clear`.
+        /// The node lives on the stack, so this allocates nothing, and `func` is
+        /// invoked via `@call` (any comptime-known callable, no fn-pointer
+        /// indirection). Returns whatever `func` returns.
+        pub fn scoped(self: *Self, value: T, func: anytype, args: anytype) @TypeOf(@call(.auto, func, args)) {
+            var node: Node = .unset;
+            self.set(&node, value);
+            defer self.clear(&node);
+            return @call(.auto, func, args);
         }
     };
 }
@@ -871,6 +889,34 @@ test "TaskLocal: bindings are isolated per task and survive yielding" {
     defer h2.cancel();
     try h1.join();
     try h2.join();
+}
+
+test "TaskLocal: scoped binds for the call and restores after" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const S = struct {
+        var tl: TaskLocal(u32) = .{};
+
+        fn inner(addend: u32) u32 {
+            return tl.get().?.* + addend;
+        }
+
+        fn run() !void {
+            try std.testing.expect(tl.get() == null);
+
+            // Value is visible inside the call and the return value flows back.
+            const r = tl.scoped(40, inner, .{2});
+            try std.testing.expectEqual(@as(u32, 42), r);
+
+            // Binding is gone once scoped returns.
+            try std.testing.expect(tl.get() == null);
+        }
+    };
+
+    var h = try rt.spawn(S.run, .{});
+    defer h.cancel();
+    try h.join();
 }
 
 test "TaskLocal: a node is reusable after clear" {

--- a/src/task.zig
+++ b/src/task.zig
@@ -794,7 +794,7 @@ test "TaskLocal: set/get/clear returns the bound value" {
             tl.set(&node, 123);
             defer tl.clear(&node);
 
-            try std.testing.expectEqual(@as(u64, 123), tl.get().?);
+            try std.testing.expectEqual(123, tl.get().?);
         }
     };
 
@@ -822,7 +822,7 @@ test "TaskLocal: mutable per-task state via a bound pointer" {
 
             bump();
             bump();
-            try std.testing.expectEqual(@as(u64, 2), n);
+            try std.testing.expectEqual(2, n);
         }
     };
 
@@ -842,17 +842,17 @@ test "TaskLocal: nested bindings shadow and restore" {
             var outer: @TypeOf(tl).Node = .unset;
             tl.set(&outer, 1);
             defer tl.clear(&outer);
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
+            try std.testing.expectEqual(1, tl.get().?);
 
             {
                 var inner: @TypeOf(tl).Node = .unset;
                 tl.set(&inner, 2);
                 defer tl.clear(&inner);
-                try std.testing.expectEqual(@as(u32, 2), tl.get().?);
+                try std.testing.expectEqual(2, tl.get().?);
             }
 
             // Inner cleared: the outer binding is visible again.
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
+            try std.testing.expectEqual(1, tl.get().?);
         }
     };
 
@@ -878,7 +878,7 @@ test "TaskLocal: non-LIFO clear unlinks a middle node" {
             // Clear the older (non-head) binding first.
             a.clear(&na);
             try std.testing.expect(a.get() == null);
-            try std.testing.expectEqual(@as(u32, 20), b.get().?);
+            try std.testing.expectEqual(20, b.get().?);
 
             b.clear(&nb);
             try std.testing.expect(b.get() == null);
@@ -934,7 +934,7 @@ test "TaskLocal: scoped binds for the call and restores after" {
 
             // Value is visible inside the call and the return value flows back.
             const r = tl.scoped(40, inner, .{2});
-            try std.testing.expectEqual(@as(u32, 42), r);
+            try std.testing.expectEqual(42, r);
 
             // Binding is gone once scoped returns.
             try std.testing.expect(tl.get() == null);
@@ -957,14 +957,14 @@ test "TaskLocal: a node is reusable after clear" {
             var node: @TypeOf(tl).Node = .unset;
 
             tl.set(&node, 1);
-            try std.testing.expectEqual(@as(u32, 1), tl.get().?);
+            try std.testing.expectEqual(1, tl.get().?);
             tl.clear(&node);
             try std.testing.expect(tl.get() == null);
 
             // clear() returned the node to .unset, so it can be set again.
             tl.set(&node, 2);
             defer tl.clear(&node);
-            try std.testing.expectEqual(@as(u32, 2), tl.get().?);
+            try std.testing.expectEqual(2, tl.get().?);
         }
     };
 
@@ -988,7 +988,7 @@ test "TaskLocal: unbound key reads back null" {
 
             // A different instance is a different key, even of the same type.
             try std.testing.expect(other.get() == null);
-            try std.testing.expectEqual(@as(u8, 7), bound.get().?);
+            try std.testing.expectEqual(7, bound.get().?);
         }
     };
 

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -28,6 +28,8 @@ pub const AutoCancel = @import("autocancel.zig").AutoCancel;
 pub const Group = @import("group.zig").Group;
 pub const CompletionQueue = @import("completion_queue.zig").CompletionQueue;
 
+pub const TaskLocal = @import("task.zig").TaskLocal;
+
 const common = @import("common.zig");
 pub const Cancelable = common.Cancelable;
 pub const Timeoutable = common.Timeoutable;
@@ -85,4 +87,5 @@ test {
     std.testing.refAllDecls(@This());
     _ = @import("io.zig");
     _ = @import("random.zig");
+    _ = @import("task.zig");
 }


### PR DESCRIPTION
Adds `zio.TaskLocal(T)` — per-task key/value storage, the task-scoped analogue of a thread-local. Closes the "store data on the current task" gap without `context.Context`-style explicit threading.

## API

Manual binding with caller-provided node storage:

```zig
var trace_id: zio.TaskLocal(u64) = .{};

fn handler() void {
    var node: @TypeOf(trace_id).Node = .unset;
    trace_id.set(&node, 42);
    defer trace_id.clear(&node);
    // trace_id.get() returns 42 here and in any callee,
    // across yields and executor migration.
}
```

Or `scoped` for a single call (no node to manage):

```zig
const out = trace_id.scoped(42, handler, .{args});
```

- `set(node, value)` — bind a value using **caller-provided** node storage.
- `clear(node)` — remove a binding and return the node to `.unset` (reusable). May interleave with other bindings in any order, not just LIFO.
- `get()` — `?T`, the innermost active binding by value, or null if unbound / outside a task. For mutable per-task state, bind a pointer (`TaskLocal(*T)`) and mutate through it.
- `scoped(value, func, args)` — bind for the dynamic extent of one call, then restore. The node lives on the stack (no allocation) and `func` is invoked via `@call`, so it takes any comptime-known callable (`args: std.meta.ArgsTuple(@TypeOf(func))`), not a fn pointer.

## Design

- **Keyed by the instance address.** `&trace_id` is the key, so multiple instances of the same `T` are distinct, and a library can declare its own without any central registry. (The type carries a 1-byte marker so distinct instances get distinct addresses — a zero-sized type would let two instances share one.)
- **Caller-owned node storage ⇒ no allocation, no cleanup policy.** The binding lives exactly as long as the node: stack node for a scoped binding, embedded/heap node for a task-lifetime one. No per-task map, no allocator involvement, no registry.
- **Intrusive doubly-linked chain on `AnyTask`.** Carried across task migration for free (the chain hangs off the task, not the executor), and only ever touched by the owning task, so no locking. Bindings nest and shadow.
- **`get` returns by value.** Handing out `*T` into the node would dangle once the binding is cleared or its frame returns, and leak internal storage; mutable state is expressed by binding a pointer instead.
- **`scoped` uses a comptime callable + `@call`**, not a fn pointer, so the convenience form allocates nothing either.

## Node lifecycle & safety

Nodes are declared `.unset` (a known unbound state) rather than `undefined`. The node's `key` doubles as the "is it linked?" marker, which makes the misuse checks cheap and read no uninitialized memory:

- The node must stay alive and unmoved between `set` and `clear`.
- `set` asserts the node is `.unset` (O(1)) — catches reusing a still-bound node.
- `clear` asserts the node is bound by this `TaskLocal` — catches a stray clear-before-set and double-clear (both leave the node `.unset`), then resets it to `.unset` for reuse.
- A task that **returns with a binding still live** trips an assert in safety builds — catching a forgotten `clear` at the task that leaked it.

## Tests

Eight tests in `task.zig`: set/get/clear by value, mutable state via a bound pointer, nested shadowing/restore, non-LIFO middle-node unlink, `scoped` bind/restore + return value, node reuse after clear, per-task isolation across a yield, and unbound-key/distinct-instance lookup. Green across all CI targets including 32-bit (riscv32/arm/thumb). (Any lone red on `release riscv32` is a pre-existing qemu flake in `ev.ThreadPool: one task` — eventfd `.BADF` — unrelated to this change.)

## Open questions for review

- Naming: `set`/`clear`/`get`/`scoped`, `TaskLocal`/`Node`/`.unset`.