### PR TITLE
ev/completion: fix race-group UAF when children complete on different loops

### DIFF
--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -417,9 +417,21 @@ pub const Group = struct {
 
     fn groupCallback(loop: *Loop, completion: *Completion) void {
         const self: *Group = @ptrCast(@alignCast(completion.group.owner.?));
-        const prev = self.remaining.fetchSub(1, .acq_rel);
 
-        // Race mode: first to clear the flag wins, cancels siblings
+        // Race mode: first to clear the flag wins, cancels siblings.
+        //
+        // This MUST run before the `remaining` decrement below. With a
+        // multi-threaded backend (IOCP, or epoll/kqueue once a socket op is
+        // serviced cross-loop) the children of a race group can complete
+        // concurrently on different loops - e.g. the I/O on the owner loop and
+        // its timeout timer on the submitting loop. Whichever thread drives
+        // `remaining` to zero completes the group and wakes its waiter, which
+        // frees the stack frame the Group (and the sibling completions) live on.
+        // If we decremented first, that free could happen while this thread is
+        // still walking `self.head` to cancel siblings -> use-after-free. By
+        // cancelling before decrementing, `remaining` stays >= 1 for the duration
+        // of this loop, so the frame cannot be freed until the final decrementer
+        // runs - by which point every sibling cancellation has completed.
         if (self.race.swap(false, .acq_rel)) {
             var node = self.head;
             while (node) |n| {
@@ -432,6 +444,7 @@ pub const Group = struct {
             }
         }
 
+        const prev = self.remaining.fetchSub(1, .acq_rel);
         if (prev == 1) {
             if (self.c.cancel_state.load(.acquire).requested) {
                 self.c.setError(error.Canceled);


### PR DESCRIPTION
Stacked on #526. Fixes the cross-loop race-group use-after-free that surfaced as the NetBSD-debug segfault in #526's cross-loop stress test (fault value == a freed timer's timeout).

`Group.groupCallback` decremented `remaining` before the race-winner walked `self.head` to cancel siblings. Once children complete concurrently on different loops (any `is_multi_threaded` backend — IOCP, and epoll/kqueue with cross-loop socket servicing), the thread that drives `remaining` to 0 completes the group and frees the stack frame while the winner is still iterating → UAF. Fix: cancel siblings **before** decrementing.

Root-caused by reading the code + the decisive #527 experiment (the test passes on `main` (not multi_threaded) and only fails with the cross-loop backend). Likely also fixes the Windows/IOCP failure (IOCP is already multi_threaded). Verifying on full CI, NetBSD especially.