### PR TITLE
ev/completion: fix race-group use-after-free when children complete on different loops

### DIFF
--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -417,9 +417,21 @@ pub const Group = struct {
 
     fn groupCallback(loop: *Loop, completion: *Completion) void {
         const self: *Group = @ptrCast(@alignCast(completion.group.owner.?));
-        const prev = self.remaining.fetchSub(1, .acq_rel);
 
-        // Race mode: first to clear the flag wins, cancels siblings
+        // Race mode: first to clear the flag wins, cancels siblings.
+        //
+        // This MUST run before the `remaining` decrement below. With a
+        // multi-threaded backend (IOCP, or epoll/kqueue once a socket op is
+        // serviced cross-loop) the children of a race group can complete
+        // concurrently on different loops - e.g. the I/O on the owner loop and
+        // its timeout timer on the submitting loop. Whichever thread drives
+        // `remaining` to zero completes the group and wakes its waiter, which
+        // frees the stack frame the Group (and the sibling completions) live on.
+        // If we decremented first, that free could happen while this thread is
+        // still walking `self.head` to cancel siblings -> use-after-free. By
+        // cancelling before decrementing, `remaining` stays >= 1 for the duration
+        // of this loop, so the frame cannot be freed until the final decrementer
+        // runs - by which point every sibling cancellation has completed.
         if (self.race.swap(false, .acq_rel)) {
             var node = self.head;
             while (node) |n| {
@@ -432,6 +444,7 @@ pub const Group = struct {
             }
         }
 
+        const prev = self.remaining.fetchSub(1, .acq_rel);
         if (prev == 1) {
             if (self.c.cancel_state.load(.acquire).requested) {
                 self.c.setError(error.Canceled);

--- a/src/net.zig
+++ b/src/net.zig
@@ -2417,3 +2417,199 @@ test "Stream.Reader/Writer.fromStd" {
     try std.testing.expectEqual(stdIoHandleToZio(stream.socket.handle), reader.handle);
     try std.testing.expectEqual(stdIoHandleToZio(stream.socket.handle), writer.handle);
 }
+
+// Multi-executor socket stress: drives concurrent socket I/O across several
+// executors with byte-level verification (task migration on). Besides exercising
+// cross-loop socket usage, it is a regression test for the race-group
+// use-after-free fixed in completion.zig: on a multi-threaded backend (IOCP, and
+// epoll/kqueue once a socket op is serviced cross-loop) a timed op's I/O and its
+// timeout timer can complete on different loops at once, which the fix makes
+// safe. It stresses:
+//
+//   * concurrent full-duplex - each connection's reader and writer run as
+//     separate tasks that may land on different executors, so recv and send for
+//     the same fd are driven from different loops at once;
+//   * migration mid-connection - each echo handler spawns+joins a tiny task
+//     every round, bouncing across executors, so one socket's reads/writes move
+//     between loops over the connection's life;
+//   * fd reuse across loops - many short connections in waves, so closed fd
+//     numbers get reused by new sockets, possibly on different loops.
+//
+// A lost wakeup (the failure mode of a per-loop readiness backend on a fd whose
+// loop changed) would stall the op until its finite timeout, which is counted as
+// an error; std.testing.allocator also fails on any leak, exercising the shared
+// table teardown.
+test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    const H = struct {
+        const executors = 3;
+        const waves = 5;
+        const per_wave = 12;
+        const total = 8 * 1024;
+        const chunk = 2048;
+        const io_timeout = Timeout.fromMilliseconds(5_000);
+
+        const Shared = struct {
+            conns: std.atomic.Value(u32) = .init(0),
+            verified: std.atomic.Value(u32) = .init(0),
+            errors: std.atomic.Value(u32) = .init(0),
+            done: std.atomic.Value(bool) = .init(false),
+        };
+
+        fn pat(id: usize, i: usize) u8 {
+            return @truncate(id *% 31 +% i);
+        }
+
+        fn nudge() void {}
+
+        fn handler(stream: Stream, sh: *Shared) void {
+            defer stream.close();
+            var buf: [chunk]u8 = undefined;
+            while (true) {
+                const n = stream.read(&buf, io_timeout) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+                if (n == 0) return; // peer closed its send side
+                stream.writeAll(buf[0..n], io_timeout) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+                // Spawning round-robins to another executor; joining wakes us
+                // from there, migrating this handler (and the socket's next op)
+                // to a different loop.
+                var h = runtime_mod.spawn(nudge, .{}) catch return;
+                h.join();
+            }
+        }
+
+        fn server(port_ch: *Channel(u16), sh: *Shared) void {
+            const addr = IpAddress.parseIp4("127.0.0.1", 0) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                port_ch.send(0) catch {};
+                return;
+            };
+            const srv = addr.listen(.{ .reuse_address = true }) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                port_ch.send(0) catch {};
+                return;
+            };
+            defer srv.close();
+            port_ch.send(srv.socket.address.ip.getPort()) catch return;
+
+            var handlers: Group = .init;
+            defer handlers.wait() catch {};
+            while (!sh.done.load(.acquire)) {
+                const stream = srv.accept(.{ .timeout = Timeout.fromMilliseconds(50) }) catch |err| {
+                    if (err == error.Timeout) continue; // re-check the done flag
+                    break;
+                };
+                handlers.spawn(handler, .{ stream, sh }) catch {
+                    stream.close();
+                };
+            }
+        }
+
+        fn writer(stream: Stream, id: usize, sh: *Shared) void {
+            var buf: [chunk]u8 = undefined;
+            var sent: usize = 0;
+            while (sent < total) {
+                const this = @min(chunk, total - sent);
+                for (0..this) |i| buf[i] = pat(id, sent + i);
+                stream.writeAll(buf[0..this], io_timeout) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+                sent += this;
+            }
+        }
+
+        fn reader(stream: Stream, id: usize, sh: *Shared) void {
+            var buf: [chunk]u8 = undefined;
+            var got: usize = 0;
+            while (got < total) {
+                const want = @min(chunk, total - got);
+                var off: usize = 0;
+                while (off < want) {
+                    const n = stream.read(buf[off..want], io_timeout) catch {
+                        _ = sh.errors.fetchAdd(1, .monotonic);
+                        return;
+                    };
+                    if (n == 0) {
+                        _ = sh.errors.fetchAdd(1, .monotonic); // premature EOF
+                        return;
+                    }
+                    for (0..n) |k| {
+                        if (buf[off + k] != pat(id, got + off + k)) {
+                            _ = sh.errors.fetchAdd(1, .monotonic);
+                            return;
+                        }
+                    }
+                    off += n;
+                }
+                got += want;
+            }
+            _ = sh.verified.fetchAdd(1, .monotonic);
+        }
+
+        fn client(port: u16, id: usize, sh: *Shared) void {
+            const addr = IpAddress.parseIp4("127.0.0.1", port) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                return;
+            };
+            const stream = addr.connect(.{ .timeout = io_timeout }) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                return;
+            };
+            defer stream.close();
+
+            // Reader and writer on the same fd, on (likely) different executors.
+            var dup: Group = .init;
+            dup.spawn(writer, .{ stream, id, sh }) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                return;
+            };
+            dup.spawn(reader, .{ stream, id, sh }) catch {
+                _ = sh.errors.fetchAdd(1, .monotonic);
+                dup.wait() catch {};
+                return;
+            };
+            dup.wait() catch {};
+            _ = sh.conns.fetchAdd(1, .monotonic);
+        }
+    };
+
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(H.executors) });
+    defer runtime.deinit();
+
+    var sh: H.Shared = .{};
+    var port_buf: [1]u16 = undefined;
+    var port_ch = Channel(u16).init(&port_buf);
+
+    var server_group: Group = .init;
+    try server_group.spawn(H.server, .{ &port_ch, &sh });
+    // Signal the acceptor to stop *before* draining it, so an early return from
+    // any `try` below can't leave it looping forever.
+    defer {
+        sh.done.store(true, .release);
+        server_group.wait() catch {};
+    }
+
+    const port = try port_ch.receive();
+    try std.testing.expect(port != 0);
+
+    var id: usize = 0;
+    for (0..H.waves) |_| {
+        var clients: Group = .init;
+        for (0..H.per_wave) |_| {
+            try clients.spawn(H.client, .{ port, id, &sh });
+            id += 1;
+        }
+        try clients.wait();
+    }
+
+    try std.testing.expectEqual(@as(u32, 0), sh.errors.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, H.waves * H.per_wave), sh.conns.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, H.waves * H.per_wave), sh.verified.load(.monotonic));
+}


### PR DESCRIPTION
## Bug

`Group.groupCallback` decremented `remaining` *before* the race-winner walked `self.head` to cancel the sibling completions. The `Group` (and its child completions / timer) live on the waiting fiber's stack. When a race group's children complete **concurrently on different loops** — which happens on any `is_multi_threaded` backend — the thread that drives `remaining` to 0 completes the group and wakes the waiter, freeing that stack frame **while the other thread is still iterating `self.head`** → use-after-free.

Every timed op is such a group: `timedWaitForIo` races the I/O completion against a timeout timer. Interleaving (I/O on loop B, timer on loop A):

```
B: groupCallback(io)    -> fetchSub 2->1, wins race, starts walking self.head
A: groupCallback(timer) -> fetchSub 1->0, completes group, wakes waiter
                           -> timedWaitForIo returns -> stack frame freed
B: still dereferencing self.head / the freed Timer -> UAF
   (fault address == the op's timeout: a freed Timer read as a pointer)
```

**IOCP already hits this on `main`** (it's `is_multi_threaded`); the new stress test reproduced it as a Windows crash and an NetBSD-kqueue segfault. On single-loop backends the two callbacks run sequentially, so the window never opens.

## Fix
Cancel siblings **before** the `remaining` decrement, so `remaining` stays ≥ 1 until the cancel loop finishes — the frame can only be freed by the final decrementer, after all sibling cancellation is done. Gather mode is unaffected (race flag false).

## Test
Adds a multi-executor cross-loop socket stress test (full-duplex + migration + fd reuse, byte-verified) that reproduces the race on multi-threaded backends. Green across all platforms with the fix (epoll, io_uring, kqueue macOS/FreeBSD/NetBSD, IOCP Windows, 32-bit qemu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of concurrent completion handling in race conditions, reducing the risk of stale access during shutdown.
  * Fixed ordering issues so overlapping completion work is handled safely before finalizing a group.

* **Tests**
  * Added a new high-load networking stress test covering simultaneous reads and writes, executor migration, and connection reuse across threads.
  * Expanded verification to ensure data integrity and detect transfer or I/O errors under heavy concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->