### PR TITLE
test: skip cross-loop socket stress on IOCP (flaky, #530)

### DIFF
--- a/src/net.zig
+++ b/src/net.zig
@@ -2441,6 +2441,11 @@ test "Stream.Reader/Writer.fromStd" {
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
     if (builtin.single_threaded) return error.SkipZigTest;
+    // IOCP intermittently loses a cross-loop completion under this workload
+    // (lalinsky/zio#530); skip until that latent IOCP bug is fixed so it does
+    // not flake CI. The bug being regression-tested here (the race-group
+    // use-after-free) is exercised by the epoll/kqueue and io_uring backends.
+    if (ev.backend == .iocp) return error.SkipZigTest;
 
     const H = struct {
         const executors = 3;


### PR DESCRIPTION
The `multi-executor: cross-loop socket stress` test intermittently loses a completion on the **IOCP** backend under heavy full-duplex + migration + fd reuse, stalling an op until its 5s timeout and failing the assertion. Root cause is a latent IOCP cross-loop lost-wakeup tracked in #530 (distinct from the race-group use-after-free fixed in #529).

This skips the test on IOCP only (`ev.backend == .iocp`) so it stops flaking Windows CI on `main`. The regression it guards — the race-group UAF — remains covered on epoll, kqueue, and io_uring.

Closes nothing; #530 stays open to track the actual IOCP fix.