### PR TITLE
DEBUG: reproduce + instrument IOCP cross-loop stall (#530) — do not merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           -Demit-test-bin
         BIN=$(ls zig-out/bin/test* | head -1)
         echo "Looping $BIN"
-        for i in $(seq 1 40); do
+        for i in $(seq 1 15); do
           echo "=== iteration $i ==="
           "$BIN" || { echo "FAILED on iteration $i"; exit 1; }
         done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
       run: |
         zig build test -Dbackend=iocp \
           ${{ matrix.mode == 'release' && '-Doptimize=ReleaseSafe' || '' }} \
-          -Dtest-filter="multi-executor: cross-loop socket stress" \
+          -Dtest-filter="iocp repro: AcceptEx double-completion" \
           -Demit-test-bin
         BIN=$(ls zig-out/bin/test* | head -1)
         echo "Looping $BIN"
-        for i in $(seq 1 40); do
+        for i in $(seq 1 6); do
           echo "=== iteration $i ==="
           "$BIN" || { echo "FAILED on iteration $i"; exit 1; }
         done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,21 +34,23 @@ jobs:
         sudo apt-get update -q -y
         sudo apt-get install -q -y qemu-user-static
 
-    - name: Build and test for each backend
+    # DEBUG (iocp-debug branch): build the cross-loop test once, then run it in a
+    # loop to raise the chance of hitting the flaky #530 stall. Stops on first
+    # failure so the STALL/LATE warn lines are the tail of the log.
+    - name: Build and loop the cross-loop test
       shell: bash
       run: |
-        for backend in ${{ matrix.config.backends }}; do
-          echo "Building with backend: $backend"
-          ./check.sh --full --backend $backend \
-            ${{ matrix.config.target != 'native' && format('--target {0}', matrix.config.target) || '' }} \
-            ${{ matrix.config.qemu && '--qemu' || '' }} \
-            ${{ matrix.config.vm && '--no-exec' || '' }} \
-            ${{ matrix.mode == 'release' && '--release' || '' }}
-          if [ -n "${{ matrix.config.vm }}" ]; then
-            cp zig-out/bin/test zig-out/bin/test-$backend
-          fi
+        zig build test -Dbackend=iocp \
+          ${{ matrix.mode == 'release' && '-Doptimize=ReleaseSafe' || '' }} \
+          -Dtest-filter="multi-executor: cross-loop socket stress" \
+          -Demit-test-bin
+        BIN=$(ls zig-out/bin/test* | head -1)
+        echo "Looping $BIN"
+        for i in $(seq 1 40); do
+          echo "=== iteration $i ==="
+          "$BIN" || { echo "FAILED on iteration $i"; exit 1; }
         done
-      timeout-minutes: 10
+      timeout-minutes: 15
       env:
         TEST_VERBOSE: 2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,8 @@ jobs:
         zig_version: ['0.16.0']
         mode: [debug, release]
         config:
-          - { os: ubuntu-24.04, target: native, backends: 'io_uring epoll poll' }
-          - { os: ubuntu-24.04-arm, target: native, backends: 'io_uring epoll poll' }
-          - { os: macos-latest, target: native, backends: 'kqueue poll' }
-          - { os: macos-15-intel, target: native, backends: 'kqueue poll' }
-          - { os: windows-latest, target: native, backends: 'iocp poll' }
-          - { os: ubuntu-latest, target: arm-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: thumb-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv32-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: loongarch64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: powerpc64le-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: x86_64-freebsd, vm: freebsd, backends: 'kqueue poll' }
-          - { os: ubuntu-latest, target: x86_64-netbsd, vm: netbsd, backends: 'kqueue poll' }
+          # DEBUG (iocp-debug branch): Windows/IOCP only for fast iteration on #530.
+          - { os: windows-latest, target: native, backends: 'iocp' }
 
     runs-on: ${{ matrix.config.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
       run: |
         zig build test -Dbackend=iocp \
           ${{ matrix.mode == 'release' && '-Doptimize=ReleaseSafe' || '' }} \
-          -Dtest-filter="iocp repro: AcceptEx double-completion" \
+          -Dtest-filter="multi-executor: cross-loop socket stress" \
           -Demit-test-bin
         BIN=$(ls zig-out/bin/test* | head -1)
         echo "Looping $BIN"
-        for i in $(seq 1 6); do
+        for i in $(seq 1 40); do
           echo "=== iteration $i ==="
           "$BIN" || { echo "FAILED on iteration $i"; exit 1; }
         done

--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -9,6 +9,7 @@ const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const Waiter = @import("common.zig").Waiter;
 const GroupNode = @import("group.zig").GroupNode;
 const WaitQueue = @import("utils/wait_queue.zig").WaitQueue;
+const dbg = @import("debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 
 // Forward declaration - Runtime is defined in runtime.zig
 const Runtime = @import("runtime.zig").Runtime;
@@ -72,6 +73,7 @@ pub const Awaitable = struct {
     /// Waiting tasks may belong to different executors, so always uses `.maybe_remote` mode.
     /// Can be called from any context.
     pub fn markComplete(self: *Awaitable) void {
+        dbg.rec(.mark_complete, 0, @intFromPtr(self), @intFromBool(self.waiting_list.hasWaiters()), 0);
         // Pop and wake all waiters while setting the flag.
         // Break as soon as we pop the last waiter - signaling it can free `self`
         // if the awaitable is destroyed after being observed as complete.

--- a/src/common.zig
+++ b/src/common.zig
@@ -106,7 +106,7 @@ pub const Waiter = struct {
             .direct => |*d| {
                 if (d.task) |task| {
                     const n = d.notify.state.fetchAdd(1, .release);
-                    dbg.rec(.signal, 0, @intFromPtr(task), n + 1, 0);
+                    dbg.rec(.signal, 0, @intFromPtr(self), n + 1, @intFromPtr(task));
                     task.wake();
                 } else {
                     d.notify.signal();
@@ -246,6 +246,7 @@ pub const Waiter = struct {
     /// Callback for ev.Completion - signals this waiter.
     pub fn callback(_: *ev.Loop, c: *ev.Completion) void {
         const self: *Waiter = @ptrCast(@alignCast(c.userdata.?));
+        dbg.rec(.wcb, 0, @intFromPtr(self), @intFromPtr(c), 0);
         self.signal();
     }
 };
@@ -259,6 +260,7 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
     c.callback = Waiter.callback;
+    dbg.rec(.wait_io, 0, @intFromPtr(&waiter), @intFromPtr(c), if (waiter.mode.direct.task) |t| @intFromPtr(t) else 0);
 
     defer if (std.debug.runtime_safety) {
         c.callback = null;

--- a/src/common.zig
+++ b/src/common.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 pub const log = std.log.scoped(.zio);
 
 const ev = @import("ev/root.zig");
+const dbg = @import("debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 const Timeout = @import("time.zig").Timeout;
 const Clock = @import("time.zig").Clock;
 const Timestamp = @import("time.zig").Timestamp;
@@ -104,7 +105,8 @@ pub const Waiter = struct {
         switch (self.mode) {
             .direct => |*d| {
                 if (d.task) |task| {
-                    _ = d.notify.state.fetchAdd(1, .release);
+                    const n = d.notify.state.fetchAdd(1, .release);
+                    dbg.rec(.signal, 0, @intFromPtr(task), n + 1, 0);
                     task.wake();
                 } else {
                     d.notify.signal();

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -41,6 +41,7 @@ pub const Kind = enum(u8) {
     pc_entry, // processCompletion top: op=c.op, ptr=overlapped, val=completion
     acc_submit, // submitAccept after AcceptEx: ptr=overlapped, val=accept_socket, loop=completion
     acc_cancel, // iocp.cancel net_accept: ptr=overlapped, loop=completion
+    io_submit, // any net submit: op=c.op, ptr=overlapped, val=sync(1)/pending(0)/err(2), loop=completion
 };
 
 const Event = struct {
@@ -111,7 +112,7 @@ pub fn sockClose(h: usize) bool {
     return false; // not found = double-close / close of never-opened
 }
 
-const N = 8192;
+const N = 32768;
 var buf: [N]Event = undefined;
 var idx: std.atomic.Value(u64) = .init(0);
 
@@ -120,7 +121,7 @@ var idx: std.atomic.Value(u64) = .init(0);
 fn wanted(kind: Kind) bool {
     return switch (kind) {
         // Focused on the accept-completion lifecycle for #530.
-        .sock_open, .sock_close, .pc_entry, .acc_submit, .acc_cancel => true,
+        .sock_open, .sock_close, .pc_entry, .acc_submit, .acc_cancel, .io_submit => true,
         else => false,
     };
 }

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -22,6 +22,16 @@ pub const Kind = enum(u8) {
     timer_set, // setTimer: insert/reset (val = deadline)
     timer_clear, // clearTimer (val = was_active)
     timer_fire, // checkTimers: deadline passed, about to markCompleted (val = deadline)
+    // task scheduling (ptr = task)
+    park, // processCleanup: task transitioned to .waiting
+    park_prewoken, // processCleanup: awaken token consumed, rescheduled locally
+    signal, // Waiter.signal: direct waiter signalled (val = notify count)
+    sched_local, // scheduleTask -> local ready queue
+    sched_migrate, // scheduleTask -> migrate to current executor
+    sched_remote, // scheduleTask -> remote queue + wake (val = home loop)
+    sched_token, // scheduleTask -> task .ready, set awaken token (no schedule)
+    sched_main, // scheduleTask -> main task, loop.wake
+    sched_finished, // scheduleTask -> task already finished
 };
 
 const Event = struct {
@@ -33,7 +43,7 @@ const Event = struct {
     loop: usize = 0,
 };
 
-const N = 4096;
+const N = 8192;
 var buf: [N]Event = undefined;
 var idx: std.atomic.Value(u64) = .init(0);
 

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -32,6 +32,11 @@ pub const Kind = enum(u8) {
     sched_token, // scheduleTask -> task .ready, set awaken token (no schedule)
     sched_main, // scheduleTask -> main task, loop.wake
     sched_finished, // scheduleTask -> task already finished
+    // Waiter linking (ptr=waiter, loop=task unless noted)
+    wait_io, // waitForIo: park on a completion (val=completion)
+    wait_join, // waitInternal: park on a future/awaitable (val=future)
+    wcb, // Waiter.callback fired for a completion (val=completion, loop=0)
+    mark_complete, // Awaitable.markComplete entry (ptr=awaitable, val=has_waiter)
 };
 
 const Event = struct {

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -42,6 +42,8 @@ pub const Kind = enum(u8) {
     acc_submit, // submitAccept after AcceptEx: ptr=overlapped, val=accept_socket, loop=completion
     acc_cancel, // iocp.cancel net_accept: ptr=overlapped, loop=completion
     io_submit, // any net submit: op=c.op, ptr=overlapped, val=sync(1)/pending(0)/err(2), loop=completion
+    pc_detail, // processCompletion: op=c.op, ptr=overlapped, val=entry.Internal(NTSTATUS), loop=bytesTransferred
+    pc_ovl, // OVERLAPPED struct contents: ptr=overlapped, val=ovl.Internal, loop=ovl.hEvent
 };
 
 const Event = struct {
@@ -121,7 +123,7 @@ var idx: std.atomic.Value(u64) = .init(0);
 fn wanted(kind: Kind) bool {
     return switch (kind) {
         // Focused on the accept-completion lifecycle for #530.
-        .sock_open, .sock_close, .pc_entry, .acc_submit, .acc_cancel, .io_submit => true,
+        .sock_open, .sock_close, .pc_entry, .acc_submit, .acc_cancel, .io_submit, .pc_detail, .pc_ovl => true,
         else => false,
     };
 }

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -4,7 +4,6 @@
 //! hot paths. Do not merge.
 
 const std = @import("std");
-const log = @import("common.zig").log;
 
 pub const enabled = true;
 
@@ -68,16 +67,22 @@ pub inline fn rec(kind: Kind, op: u16, ptr: usize, val: u64, loop: usize) void {
     buf[i % N] = .{ .seq = i, .kind = kind, .op = op, .ptr = ptr, .val = val, .loop = loop };
 }
 
+var dumped = std.atomic.Value(bool).init(false);
+
 pub fn dump() void {
     if (!enabled) return;
+    // Only the first caller dumps (a crash + watchdog could both call).
+    if (dumped.swap(true, .acq_rel)) return;
+    // Write directly to stderr (std.debug.print locks + writes unbuffered) so the
+    // dump survives a hard crash where log/buffered output would be lost.
     const total = idx.load(.monotonic);
     const count = @min(total, @as(u64, N));
     const start = total - count;
-    log.warn("=== TRACE DUMP: last {} of {} events ===", .{ count, total });
+    std.debug.print("=== TRACE DUMP: last {d} of {d} events ===\n", .{ count, total });
     var s = start;
     while (s < total) : (s += 1) {
         const e = buf[s % N];
-        log.warn("T#{d} {s} op={d} c=0x{x} val={d} loop=0x{x}", .{ e.seq, @tagName(e.kind), e.op, e.ptr, e.val, e.loop });
+        std.debug.print("T#{d} {s} op={d} c=0x{x} val={d} loop=0x{x}\n", .{ e.seq, @tagName(e.kind), e.op, e.ptr, e.val, e.loop });
     }
-    log.warn("=== END TRACE DUMP ===", .{});
+    std.debug.print("=== END TRACE DUMP ===\n", .{});
 }

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -38,6 +38,9 @@ pub const Kind = enum(u8) {
     mark_complete, // Awaitable.markComplete entry (ptr=awaitable, val=has_waiter)
     sock_open, // net.socket created a handle (ptr=handle)
     sock_close, // net.close closed a handle (ptr=handle)
+    pc_entry, // processCompletion top: op=c.op, ptr=overlapped, val=completion
+    acc_submit, // submitAccept after AcceptEx: ptr=overlapped, val=accept_socket, loop=completion
+    acc_cancel, // iocp.cancel net_accept: ptr=overlapped, loop=completion
 };
 
 const Event = struct {
@@ -116,7 +119,8 @@ var idx: std.atomic.Value(u64) = .init(0);
 /// event perturbs timing enough to change the bug's manifestation (Heisenbug).
 fn wanted(kind: Kind) bool {
     return switch (kind) {
-        .wait_io, .wait_join, .wcb, .signal, .mark_complete, .park, .park_prewoken, .sched_local, .sched_migrate, .sched_remote, .sched_token, .sched_main, .sched_finished, .sock_open, .sock_close => true,
+        // Focused on the accept-completion lifecycle for #530.
+        .sock_open, .sock_close, .pc_entry, .acc_submit, .acc_cancel => true,
         else => false,
     };
 }

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -135,6 +135,12 @@ pub inline fn rec(kind: Kind, op: u16, ptr: usize, val: u64, loop: usize) void {
     buf[i % N] = .{ .seq = i, .kind = kind, .op = op, .ptr = ptr, .val = val, .loop = loop };
 }
 
+/// DEBUG (#530): monotonic generation stamped into each AcceptEx's OVERLAPPED
+/// (Offset/OffsetHigh, unused by AcceptEx) at submit and read back at completion.
+/// Never reused, unlike the overlapped's address. Lets us prove whether one
+/// AcceptEx submission produces two completions vs two submissions aliasing.
+pub var accept_gen = std.atomic.Value(u64).init(1);
+
 var dumped = std.atomic.Value(bool).init(false);
 
 pub fn dump() void {

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -49,6 +49,11 @@ const Event = struct {
     loop: usize = 0,
 };
 
+/// DEBUG (#530): a socket handle the test marks as "must not be closed mid-run"
+/// (the listening socket). net.close panics if it sees this handle closed, so the
+/// panic stack trace reveals the buggy close path.
+pub var protected: usize = 0;
+
 const N = 8192;
 var buf: [N]Event = undefined;
 var idx: std.atomic.Value(u64) = .init(0);

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -36,6 +36,8 @@ pub const Kind = enum(u8) {
     wait_join, // waitInternal: park on a future/awaitable (val=future)
     wcb, // Waiter.callback fired for a completion (val=completion, loop=0)
     mark_complete, // Awaitable.markComplete entry (ptr=awaitable, val=has_waiter)
+    sock_open, // net.socket created a handle (ptr=handle)
+    sock_close, // net.close closed a handle (ptr=handle)
 };
 
 const Event = struct {
@@ -55,7 +57,7 @@ var idx: std.atomic.Value(u64) = .init(0);
 /// event perturbs timing enough to change the bug's manifestation (Heisenbug).
 fn wanted(kind: Kind) bool {
     return switch (kind) {
-        .wait_io, .wait_join, .wcb, .signal, .mark_complete, .park, .park_prewoken, .sched_local, .sched_migrate, .sched_remote, .sched_token, .sched_main, .sched_finished => true,
+        .wait_io, .wait_join, .wcb, .signal, .mark_complete, .park, .park_prewoken, .sched_local, .sched_migrate, .sched_remote, .sched_token, .sched_main, .sched_finished, .sock_open, .sock_close => true,
         else => false,
     };
 }

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -19,6 +19,9 @@ pub const Kind = enum(u8) {
     cancel_enq, // cross-thread cancel enqueued to target loop
     group_dec, // groupCallback: remaining decrement (val = prev)
     group_finish, // groupCallback: group completed (prev==1)
+    timer_set, // setTimer: insert/reset (val = deadline)
+    timer_clear, // clearTimer (val = was_active)
+    timer_fire, // checkTimers: deadline passed, about to markCompleted (val = deadline)
 };
 
 const Event = struct {

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -54,6 +54,60 @@ const Event = struct {
 /// panic stack trace reveals the buggy close path.
 pub var protected: usize = 0;
 
+/// DEBUG (#530): open-socket tracker to catch a double-close / close-of-not-open
+/// (a stale close of a reused fd). Fixed open-addressing set under a mutex.
+var sock_lock = std.atomic.Value(bool).init(false);
+fn lockSock() void {
+    while (sock_lock.swap(true, .acquire)) {}
+}
+fn unlockSock() void {
+    sock_lock.store(false, .release);
+}
+const SET_N = 16384;
+var open_set: [SET_N]usize = @splat(0); // 0 = empty slot
+
+pub fn sockOpen(h: usize) void {
+    if (!enabled or h == 0) return;
+    lockSock();
+    defer unlockSock();
+    var i = h % SET_N;
+    var probes: usize = 0;
+    while (open_set[i] != 0) : (probes += 1) {
+        if (open_set[i] == h) return; // already present (shouldn't happen)
+        if (probes >= SET_N) return; // full; give up silently
+        i = (i + 1) % SET_N;
+    }
+    open_set[i] = h;
+}
+
+/// Returns true if `h` was open (and removes it); false = double-close.
+pub fn sockClose(h: usize) bool {
+    if (!enabled or h == 0) return true;
+    lockSock();
+    defer unlockSock();
+    var i = h % SET_N;
+    var probes: usize = 0;
+    while (open_set[i] != 0) : (probes += 1) {
+        if (open_set[i] == h) {
+            open_set[i] = 0;
+            // Re-cluster: rehash the following cluster so probe chains stay valid.
+            var j = (i + 1) % SET_N;
+            while (open_set[j] != 0) {
+                const v = open_set[j];
+                open_set[j] = 0;
+                var k = v % SET_N;
+                while (open_set[k] != 0) k = (k + 1) % SET_N;
+                open_set[k] = v;
+                j = (j + 1) % SET_N;
+            }
+            return true;
+        }
+        if (probes >= SET_N) break;
+        i = (i + 1) % SET_N;
+    }
+    return false; // not found = double-close / close of never-opened
+}
+
 const N = 8192;
 var buf: [N]Event = undefined;
 var idx: std.atomic.Value(u64) = .init(0);

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -1,0 +1,55 @@
+//! DEBUG (iocp-debug branch only): a tiny lock-free ring buffer for tracing the
+//! completion/group/cancel lifecycle, dumped by a watchdog when the #530 hang is
+//! detected. Volume-bounded (only the last N events survive), so it can sit in
+//! hot paths. Do not merge.
+
+const std = @import("std");
+const log = @import("common.zig").log;
+
+pub const enabled = true;
+
+pub const Kind = enum(u8) {
+    complete, // markCompletedFromBackend: backend reported an op done
+    mc_finish, // markCompleted: finished inline (in_queue was clear)
+    mc_defer, // markCompleted: deferred to cancel queue (in_queue set)
+    finish, // finishCompletion entry (the per-child decrement happens here)
+    cancel_local, // cancelLocal entry
+    cancel_fin, // cancelLocal defer: finished (completed was set)
+    cancel_nofin, // cancelLocal defer: did NOT finish (completed clear)
+    cancel_enq, // cross-thread cancel enqueued to target loop
+    group_dec, // groupCallback: remaining decrement (val = prev)
+    group_finish, // groupCallback: group completed (prev==1)
+};
+
+const Event = struct {
+    seq: u64 = 0,
+    kind: Kind = .complete,
+    op: u16 = 0,
+    ptr: usize = 0,
+    val: u64 = 0,
+    loop: usize = 0,
+};
+
+const N = 4096;
+var buf: [N]Event = undefined;
+var idx: std.atomic.Value(u64) = .init(0);
+
+pub inline fn rec(kind: Kind, op: u16, ptr: usize, val: u64, loop: usize) void {
+    if (!enabled) return;
+    const i = idx.fetchAdd(1, .monotonic);
+    buf[i % N] = .{ .seq = i, .kind = kind, .op = op, .ptr = ptr, .val = val, .loop = loop };
+}
+
+pub fn dump() void {
+    if (!enabled) return;
+    const total = idx.load(.monotonic);
+    const count = @min(total, @as(u64, N));
+    const start = total - count;
+    log.warn("=== TRACE DUMP: last {} of {} events ===", .{ count, total });
+    var s = start;
+    while (s < total) : (s += 1) {
+        const e = buf[s % N];
+        log.warn("T#{d} {s} op={d} c=0x{x} val={d} loop=0x{x}", .{ e.seq, @tagName(e.kind), e.op, e.ptr, e.val, e.loop });
+    }
+    log.warn("=== END TRACE DUMP ===", .{});
+}

--- a/src/debug_trace.zig
+++ b/src/debug_trace.zig
@@ -52,8 +52,18 @@ const N = 8192;
 var buf: [N]Event = undefined;
 var idx: std.atomic.Value(u64) = .init(0);
 
+/// Focus on the wake chain only — recording every completion/group/timer/cancel
+/// event perturbs timing enough to change the bug's manifestation (Heisenbug).
+fn wanted(kind: Kind) bool {
+    return switch (kind) {
+        .wait_io, .wait_join, .wcb, .signal, .mark_complete, .park, .park_prewoken, .sched_local, .sched_migrate, .sched_remote, .sched_token, .sched_main, .sched_finished => true,
+        else => false,
+    };
+}
+
 pub inline fn rec(kind: Kind, op: u16, ptr: usize, val: u64, loop: usize) void {
     if (!enabled) return;
+    if (!wanted(kind)) return;
     const i = idx.fetchAdd(1, .monotonic);
     buf[i % N] = .{ .seq = i, .kind = kind, .op = op, .ptr = ptr, .val = val, .loop = loop };
 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1759,11 +1759,11 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         0,
                         0,
                     );
-                    if (assoc != self.shared_state.iocp) {
-                        // DEBUG (#530): non-destructive — log and continue so we can
-                        // see whether result_private is garbage (duplicate completion)
-                        // or a valid socket that's already associated (inheritance).
-                        std.debug.print("POST-ASSOC FAIL h=0x{x} assoc=0x{x} err={s}\n", .{ @intFromPtr(data.result_private_do_not_touch), if (assoc) |a| @intFromPtr(a) else 0, @tagName(windows.GetLastError()) });
+                    if (assoc == null or assoc != self.shared_state.iocp) {
+                        net.close(data.result_private_do_not_touch);
+                        c.setError(error.Unexpected);
+                        state.markCompletedFromBackend(c);
+                        return;
                     }
 
                     c.setResult(.net_accept, data.result_private_do_not_touch);

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -716,17 +716,13 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     const accept_socket = try net.socket(@enumFromInt(family), .stream, .ip, data.flags);
     errdefer net.close(accept_socket);
 
-    // Associate the accept socket with IOCP
-    const iocp_result = windows.CreateIoCompletionPort(
-        @ptrCast(accept_socket),
-        self.shared_state.iocp,
-        0,
-        0,
-    ) orelse return error.Unexpected;
-
-    if (iocp_result != self.shared_state.iocp) {
-        return error.Unexpected;
-    }
+    // FIX (#530): do NOT associate the accept socket with the IOCP before AcceptEx.
+    // AcceptEx operates on both the listening and accept sockets; if both are bound
+    // to the same completion port, the single AcceptEx completion is delivered TWICE
+    // (once per association), and the second, stray completion is serviced against
+    // the reused accept op -> double-close UAF (the whole #530 cascade). Both libuv
+    // and Go's runtime associate the accepted socket only AFTER AcceptEx completes.
+    // We do the association in processCompletion (after SO_UPDATE_ACCEPT_CONTEXT).
 
     // Initialize OVERLAPPED
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);
@@ -1752,8 +1748,23 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         }
                     }
 
-                    // Note: Socket was already associated with IOCP in submitAccept()
-                    // No need to associate again here
+                    // FIX (#530): associate the accepted socket with the IOCP now,
+                    // AFTER AcceptEx has completed (not before — see submitAccept).
+                    // The socket inherits the listener's port association via
+                    // SO_UPDATE_ACCEPT_CONTEXT, so this often returns
+                    // ERROR_INVALID_PARAMETER (already associated), which is fine.
+                    const assoc = windows.CreateIoCompletionPort(
+                        @ptrCast(data.result_private_do_not_touch),
+                        self.shared_state.iocp,
+                        0,
+                        0,
+                    );
+                    if (assoc != self.shared_state.iocp and windows.GetLastError() != .INVALID_PARAMETER) {
+                        net.close(data.result_private_do_not_touch);
+                        c.setError(error.Unexpected);
+                        state.markCompletedFromBackend(c);
+                        return;
+                    }
 
                     c.setResult(.net_accept, data.result_private_do_not_touch);
                 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1759,11 +1759,11 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         0,
                         0,
                     );
-                    if (assoc == null or assoc != self.shared_state.iocp) {
-                        net.close(data.result_private_do_not_touch);
-                        c.setError(error.Unexpected);
-                        state.markCompletedFromBackend(c);
-                        return;
+                    if (assoc != self.shared_state.iocp) {
+                        // DEBUG (#530): non-destructive — log and continue so we can
+                        // see whether result_private is garbage (duplicate completion)
+                        // or a valid socket that's already associated (inheritance).
+                        std.debug.print("POST-ASSOC FAIL h=0x{x} assoc=0x{x} err={s}\n", .{ @intFromPtr(data.result_private_do_not_touch), if (assoc) |a| @intFromPtr(a) else 0, @tagName(windows.GetLastError()) });
                     }
 
                     c.setResult(.net_accept, data.result_private_do_not_touch);

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1747,24 +1747,8 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         }
                     }
 
-                    // FIX (#530): associate the accepted socket with the IOCP now
-                    // (AFTER AcceptEx has completed), not before. Doing it before
-                    // AcceptEx made the single accept completion be queued twice
-                    // (via the listen + accept associations) -> duplicate completion
-                    // -> double-close UAF. SO_UPDATE_ACCEPT_CONTEXT does not inherit
-                    // the port association, so the handler's I/O needs this.
-                    const assoc = windows.CreateIoCompletionPort(
-                        @ptrCast(data.result_private_do_not_touch),
-                        self.shared_state.iocp,
-                        0,
-                        0,
-                    );
-                    if (assoc == null or assoc != self.shared_state.iocp) {
-                        net.close(data.result_private_do_not_touch);
-                        c.setError(error.Unexpected);
-                        state.markCompletedFromBackend(c);
-                        return;
-                    }
+                    // Note: Socket was already associated with IOCP in submitAccept()
+                    // No need to associate again here
 
                     c.setResult(.net_accept, data.result_private_do_not_touch);
                 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -716,17 +716,12 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     const accept_socket = try net.socket(@enumFromInt(family), .stream, .ip, data.flags);
     errdefer net.close(accept_socket);
 
-    // Associate the accept socket with IOCP
-    const iocp_result = windows.CreateIoCompletionPort(
-        @ptrCast(accept_socket),
-        self.shared_state.iocp,
-        0,
-        0,
-    ) orelse return error.Unexpected;
-
-    if (iocp_result != self.shared_state.iocp) {
-        return error.Unexpected;
-    }
+    // FIX (#530): do NOT associate the accept socket with the IOCP here. AcceptEx
+    // touches both the listening socket and the accept socket; if both are
+    // associated with the same port, the single AcceptEx completion is queued
+    // TWICE (once per association), and the duplicate packet is serviced against
+    // the reused accept op -> double-close UAF. The accepted socket inherits the
+    // listener's IOCP association via SO_UPDATE_ACCEPT_CONTEXT after completion.
 
     // Initialize OVERLAPPED
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1628,6 +1628,10 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
     const c: *Completion = @fieldParentPtr("internal", completion_data);
 
     dbg.rec(.pc_entry, @intFromEnum(c.op), @intFromPtr(overlapped), @intFromPtr(c), 0);
+    // Per-packet result snapshot (reliable even if the OVERLAPPED struct was reused),
+    // plus the OVERLAPPED struct's own fields (may be stale/overwritten by reuse).
+    dbg.rec(.pc_detail, @intFromEnum(c.op), @intFromPtr(overlapped), entry.Internal, entry.dwNumberOfBytesTransferred);
+    dbg.rec(.pc_ovl, @intFromEnum(c.op), @intFromPtr(overlapped), overlapped.Internal, @intFromPtr(overlapped.hEvent orelse @as(windows.HANDLE, @ptrFromInt(0xdead))));
 
     // Process based on operation type
     switch (c.op) {

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1474,7 +1474,6 @@ fn submitProcessWait(self: *Self, state: *LoopState, data: *ProcessWait) !void {
 /// Cancel a completion - infallible.
 /// Note: target.canceled is already set by loop.add() or loop.cancel() before this is called.
 pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
-    _ = self;
     _ = state;
 
     switch (target.state) {
@@ -1557,8 +1556,38 @@ pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
 
             // Cancel the I/O operation
             const result = windows.CancelIoEx(handle, &target.internal.overlapped);
-            if (result == .FALSE) {
-                const err = windows.GetLastError();
+            // Capture the error immediately, before any log call (which issues a
+            // write syscall that would clobber GetLastError).
+            const cancel_err: ?windows.Win32Error = if (result == .FALSE) windows.GetLastError() else null;
+
+            // DEBUG (iocp-debug branch): data-op cancels happen only on a real
+            // io_timeout in the stress test (accept uses its own short timeout and
+            // is excluded), so each line here marks a stalled op. The CancelIoEx
+            // outcome is the key discriminator:
+            //   NOT_FOUND -> kernel already completed it; the completion packet is
+            //                (or was) in the port = a delivery/wake stall.
+            //   TRUE      -> op genuinely still pending in the kernel = no data /
+            //                kernel-level stall.
+            switch (target.op) {
+                .net_accept => {},
+                .net_recv, .net_send, .net_connect, .net_poll, .net_send_file, .net_recvfrom, .net_sendto, .net_recvmsg, .net_sendmsg => {
+                    const outcome = if (cancel_err) |e| switch (e) {
+                        .NOT_FOUND => "NOT_FOUND(already-completed)",
+                        else => "OTHER-ERR",
+                    } else "TRUE(pending)";
+                    log.warn("STALL cancel op={s} c=0x{x} hresult={s} cancel_state={} inflight={} active={}", .{
+                        @tagName(target.op),
+                        @intFromPtr(target),
+                        outcome,
+                        target.cancel_state.load(.acquire),
+                        self.shared_state.inflight_io.load(.monotonic),
+                        self.shared_state.active.load(.monotonic),
+                    });
+                },
+                else => {},
+            }
+
+            if (cancel_err) |err| {
                 // ERROR_NOT_FOUND means the operation already completed - that's fine
                 if (err != .NOT_FOUND) {
                     log.warn("CancelIoEx failed: {}", .{err});
@@ -1732,8 +1761,12 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
 
             if (result == windows.FALSE) {
                 const err = windows.WSAGetLastError();
+                if (c.cancel_state.load(.acquire).requested)
+                    log.warn("LATE complete op=net_recv c=0x{x} ERR={s}", .{ @intFromPtr(c), @tagName(err) });
                 c.setError(net.errnoToRecvError(err));
             } else {
+                if (c.cancel_state.load(.acquire).requested)
+                    log.warn("LATE complete op=net_recv c=0x{x} bytes={} (data arrived after cancel)", .{ @intFromPtr(c), bytes_transferred });
                 c.setResult(.net_recv, @intCast(bytes_transferred));
             }
 
@@ -1755,8 +1788,12 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
 
             if (result == windows.FALSE) {
                 const err = windows.WSAGetLastError();
+                if (c.cancel_state.load(.acquire).requested)
+                    log.warn("LATE complete op=net_send c=0x{x} ERR={s}", .{ @intFromPtr(c), @tagName(err) });
                 c.setError(net.errnoToSendError(err));
             } else {
+                if (c.cancel_state.load(.acquire).requested)
+                    log.warn("LATE complete op=net_send c=0x{x} bytes={} (sent after cancel)", .{ @intFromPtr(c), bytes_transferred });
                 c.setResult(.net_send, @intCast(bytes_transferred));
             }
 

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -716,13 +716,24 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     const accept_socket = try net.socket(@enumFromInt(family), .stream, .ip, data.flags);
     errdefer net.close(accept_socket);
 
-    // FIX (#530): do NOT associate the accept socket with the IOCP before AcceptEx.
-    // AcceptEx operates on both the listening and accept sockets; if both are bound
-    // to the same completion port, the single AcceptEx completion is delivered TWICE
-    // (once per association), and the second, stray completion is serviced against
-    // the reused accept op -> double-close UAF (the whole #530 cascade). Both libuv
-    // and Go's runtime associate the accepted socket only AFTER AcceptEx completes.
-    // We do the association in processCompletion (after SO_UPDATE_ACCEPT_CONTEXT).
+    // FIX (#530): publish the accept socket into the op BEFORE issuing AcceptEx.
+    // On the shared multi-threaded IOCP port, AcceptEx can complete and be dequeued
+    // by another executor thread the instant it is posted. If result_private were
+    // still unset at that point, processCompletion would read a garbage handle and
+    // close it (the double-close UAF). The AcceptEx syscall below is a full barrier,
+    // so writing the handle first guarantees the completion handler sees it.
+    data.result_private_do_not_touch = accept_socket;
+
+    // Associate the accept socket with IOCP.
+    const iocp_result = windows.CreateIoCompletionPort(
+        @ptrCast(accept_socket),
+        self.shared_state.iocp,
+        0,
+        0,
+    ) orelse return error.Unexpected;
+    if (iocp_result != self.shared_state.iocp) {
+        return error.Unexpected;
+    }
 
     // Initialize OVERLAPPED
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);
@@ -748,8 +759,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
         &data.c.internal.overlapped,
     );
 
-    // Store accept_socket so we can retrieve it later (needed for both success and error cases)
-    data.result_private_do_not_touch = accept_socket;
+    // (result_private_do_not_touch was published before AcceptEx above — see #530.)
     dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), accept_gen);
     dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.FALSE) 1 else 0, @intFromPtr(&data.c));
 
@@ -1755,24 +1765,7 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         }
                     }
 
-                    // FIX (#530): associate the accepted socket with the IOCP now,
-                    // AFTER AcceptEx has completed (not before — see submitAccept).
-                    // The socket inherits the listener's port association via
-                    // SO_UPDATE_ACCEPT_CONTEXT, so this often returns
-                    // ERROR_INVALID_PARAMETER (already associated), which is fine.
-                    const assoc = windows.CreateIoCompletionPort(
-                        @ptrCast(data.result_private_do_not_touch),
-                        self.shared_state.iocp,
-                        0,
-                        0,
-                    );
-                    if (assoc != self.shared_state.iocp and windows.GetLastError() != .INVALID_PARAMETER) {
-                        net.close(data.result_private_do_not_touch);
-                        c.setError(error.Unexpected);
-                        state.markCompletedFromBackend(c);
-                        return;
-                    }
-
+                    // Socket was already associated with IOCP in submitAccept().
                     c.setResult(.net_accept, data.result_private_do_not_touch);
                 }
             }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -716,12 +716,17 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     const accept_socket = try net.socket(@enumFromInt(family), .stream, .ip, data.flags);
     errdefer net.close(accept_socket);
 
-    // FIX (#530): do NOT associate the accept socket with the IOCP here. AcceptEx
-    // touches both the listening socket and the accept socket; if both are
-    // associated with the same port, the single AcceptEx completion is queued
-    // TWICE (once per association), and the duplicate packet is serviced against
-    // the reused accept op -> double-close UAF. The accepted socket inherits the
-    // listener's IOCP association via SO_UPDATE_ACCEPT_CONTEXT after completion.
+    // Associate the accept socket with IOCP
+    const iocp_result = windows.CreateIoCompletionPort(
+        @ptrCast(accept_socket),
+        self.shared_state.iocp,
+        0,
+        0,
+    ) orelse return error.Unexpected;
+
+    if (iocp_result != self.shared_state.iocp) {
+        return error.Unexpected;
+    }
 
     // Initialize OVERLAPPED
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -727,6 +727,12 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     // Initialize OVERLAPPED
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);
 
+    // DEBUG (#530): stamp a never-reused generation into Offset/OffsetHigh (unused
+    // by AcceptEx) so each completion can be traced back to its exact submission.
+    const accept_gen = dbg.accept_gen.fetchAdd(1, .monotonic);
+    data.c.internal.overlapped.DUMMYUNIONNAME.DUMMYSTRUCTNAME.Offset = @truncate(accept_gen);
+    data.c.internal.overlapped.DUMMYUNIONNAME.DUMMYSTRUCTNAME.OffsetHigh = @truncate(accept_gen >> 32);
+
     // Call AcceptEx
     var bytes_received: windows.DWORD = 0;
     const addr_size: windows.DWORD = NetAcceptData.addr_slot_size;
@@ -744,7 +750,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
 
     // Store accept_socket so we can retrieve it later (needed for both success and error cases)
     data.result_private_do_not_touch = accept_socket;
-    dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), @intFromPtr(state.loop));
+    dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), accept_gen);
     dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.FALSE) 1 else 0, @intFromPtr(&data.c));
 
     // When AcceptEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
@@ -1627,7 +1633,8 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
     // Per-packet result snapshot (reliable even if the OVERLAPPED struct was reused),
     // plus the OVERLAPPED struct's own fields (may be stale/overwritten by reuse).
     dbg.rec(.pc_detail, @intFromEnum(c.op), @intFromPtr(overlapped), entry.Internal, entry.dwNumberOfBytesTransferred);
-    dbg.rec(.pc_ovl, @intFromEnum(c.op), @intFromPtr(overlapped), overlapped.Internal, @intFromPtr(overlapped.hEvent orelse @as(windows.HANDLE, @ptrFromInt(0xdead))));
+    const pc_gen = (@as(u64, overlapped.DUMMYUNIONNAME.DUMMYSTRUCTNAME.OffsetHigh) << 32) | overlapped.DUMMYUNIONNAME.DUMMYSTRUCTNAME.Offset;
+    dbg.rec(.pc_ovl, @intFromEnum(c.op), @intFromPtr(overlapped), overlapped.Internal, pc_gen);
 
     // Process based on operation type
     switch (c.op) {

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -321,6 +321,7 @@ pub const NetShutdownError = error{
 const Self = @This();
 
 const log = @import("../../common.zig").log;
+const dbg = @import("../../debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 
 allocator: std.mem.Allocator,
 shared_state: *SharedState,
@@ -747,6 +748,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
 
     // Store accept_socket so we can retrieve it later (needed for both success and error cases)
     data.result_private_do_not_touch = accept_socket;
+    dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), @intFromPtr(&data.c));
 
     // When AcceptEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
     // the completion will be posted to the IOCP port.
@@ -1569,7 +1571,7 @@ pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
             //   TRUE      -> op genuinely still pending in the kernel = no data /
             //                kernel-level stall.
             switch (target.op) {
-                .net_accept => {},
+                .net_accept => dbg.rec(.acc_cancel, 0, @intFromPtr(&target.internal.overlapped), 0, @intFromPtr(target)),
                 .net_recv, .net_send, .net_connect, .net_poll, .net_send_file, .net_recvfrom, .net_sendto, .net_recvmsg, .net_sendmsg => {
                     const outcome = if (cancel_err) |e| switch (e) {
                         .NOT_FOUND => "NOT_FOUND(already-completed)",
@@ -1619,6 +1621,8 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
 
     // Use @fieldParentPtr again to get from CompletionData to Completion
     const c: *Completion = @fieldParentPtr("internal", completion_data);
+
+    dbg.rec(.pc_entry, @intFromEnum(c.op), @intFromPtr(overlapped), @intFromPtr(c), 0);
 
     // Process based on operation type
     switch (c.op) {

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1681,6 +1681,9 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
 
             if (result == windows.FALSE) {
                 const err = windows.WSAGetLastError();
+                // DEBUG (#530): log the listening + accept handles on accept error
+                // so a FileDescriptorNotASocket can be correlated to sock_close.
+                std.debug.print("ACCEPT FAIL listen_h=0x{x} accept_h=0x{x} err={s}\n", .{ @intFromPtr(data.handle), @intFromPtr(data.result_private_do_not_touch), @tagName(err) });
                 // Error occurred - close the accept socket
                 net.close(data.result_private_do_not_touch);
                 c.setError(net.errnoToAcceptError(err));

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -749,6 +749,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     // Store accept_socket so we can retrieve it later (needed for both success and error cases)
     data.result_private_do_not_touch = accept_socket;
     dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), @intFromPtr(&data.c));
+    dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.FALSE) 1 else 0, @intFromPtr(&data.c));
 
     // When AcceptEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
     // the completion will be posted to the IOCP port.
@@ -841,6 +842,7 @@ fn submitRecv(self: *Self, state: *LoopState, data: *NetRecv) !void {
     // When WSARecv succeeds (result == 0) OR returns WSA_IO_PENDING,
     // the completion will be posted to the IOCP port. We should NOT
     // complete it immediately here.
+    dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.SOCKET_ERROR) 1 else 0, @intFromPtr(&data.c));
     if (result == windows.SOCKET_ERROR) {
         const err = windows.WSAGetLastError();
         if (err != .IO_PENDING) {
@@ -878,6 +880,7 @@ fn submitSend(self: *Self, state: *LoopState, data: *NetSend) !void {
 
     // When WSASend succeeds (result == 0) OR returns WSA_IO_PENDING,
     // the completion will be posted to the IOCP port.
+    dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.SOCKET_ERROR) 1 else 0, @intFromPtr(&data.c));
     if (result == windows.SOCKET_ERROR) {
         const err = windows.WSAGetLastError();
         if (err != .IO_PENDING) {
@@ -1197,6 +1200,8 @@ fn submitConnect(self: *Self, state: *LoopState, data: *NetConnect) !void {
     );
 
     // When ConnectEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
+    dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.FALSE) 1 else 0, @intFromPtr(&data.c));
+
     // the completion will be posted to the IOCP port.
     if (result == windows.FALSE) {
         const err = windows.WSAGetLastError();

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -1747,8 +1747,24 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                         }
                     }
 
-                    // Note: Socket was already associated with IOCP in submitAccept()
-                    // No need to associate again here
+                    // FIX (#530): associate the accepted socket with the IOCP now
+                    // (AFTER AcceptEx has completed), not before. Doing it before
+                    // AcceptEx made the single accept completion be queued twice
+                    // (via the listen + accept associations) -> duplicate completion
+                    // -> double-close UAF. SO_UPDATE_ACCEPT_CONTEXT does not inherit
+                    // the port association, so the handler's I/O needs this.
+                    const assoc = windows.CreateIoCompletionPort(
+                        @ptrCast(data.result_private_do_not_touch),
+                        self.shared_state.iocp,
+                        0,
+                        0,
+                    );
+                    if (assoc == null or assoc != self.shared_state.iocp) {
+                        net.close(data.result_private_do_not_touch);
+                        c.setError(error.Unexpected);
+                        state.markCompletedFromBackend(c);
+                        return;
+                    }
 
                     c.setResult(.net_accept, data.result_private_do_not_touch);
                 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -744,7 +744,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
 
     // Store accept_socket so we can retrieve it later (needed for both success and error cases)
     data.result_private_do_not_touch = accept_socket;
-    dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), @intFromPtr(&data.c));
+    dbg.rec(.acc_submit, 0, @intFromPtr(&data.c.internal.overlapped), @intFromPtr(accept_socket), @intFromPtr(state.loop));
     dbg.rec(.io_submit, @intFromEnum(data.c.op), @intFromPtr(&data.c.internal.overlapped), if (result != windows.FALSE) 1 else 0, @intFromPtr(&data.c));
 
     // When AcceptEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
@@ -1623,7 +1623,7 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
     // Use @fieldParentPtr again to get from CompletionData to Completion
     const c: *Completion = @fieldParentPtr("internal", completion_data);
 
-    dbg.rec(.pc_entry, @intFromEnum(c.op), @intFromPtr(overlapped), @intFromPtr(c), 0);
+    dbg.rec(.pc_entry, @intFromEnum(c.op), @intFromPtr(overlapped), @intFromPtr(c), @intFromPtr(state.loop));
     // Per-packet result snapshot (reliable even if the OVERLAPPED struct was reused),
     // plus the OVERLAPPED struct's own fields (may be stale/overwritten by reuse).
     dbg.rec(.pc_detail, @intFromEnum(c.op), @intFromPtr(overlapped), entry.Internal, entry.dwNumberOfBytesTransferred);

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const dbg = @import("../debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 const posix = @import("../os/posix.zig");
 
 const Loop = @import("loop.zig").Loop;
@@ -445,7 +446,9 @@ pub const Group = struct {
         }
 
         const prev = self.remaining.fetchSub(1, .acq_rel);
+        dbg.rec(.group_dec, @intFromEnum(completion.op), @intFromPtr(self), prev, @intFromPtr(loop));
         if (prev == 1) {
+            dbg.rec(.group_finish, @intFromEnum(self.c.op), @intFromPtr(self), 0, @intFromPtr(loop));
             if (self.c.cancel_state.load(.acquire).requested) {
                 self.c.setError(error.Canceled);
             } else {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -441,7 +441,10 @@ pub const Loop = struct {
     loop_group: *LoopGroup,
     internal_loop_group: LoopGroup = .{},
 
-    max_wait: Duration = .fromSeconds(60),
+    // DEBUG (iocp-debug branch): 60s normally; forced to 50ms to bisect #530.
+    // If the deadlock is a lost wakeup, periodic re-polling recovers it and the
+    // test passes; if it's a true hang it still fails. Do not merge.
+    max_wait: Duration = .fromMilliseconds(50),
     /// Upper bound on the poll wait while a boot/real timer is pending on a
     /// backend without native wall-clock timers. The poll clock (`awake`)
     /// can't track suspend or wall-clock steps, so we re-evaluate boot/real

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -427,10 +427,12 @@ pub const LoopState = struct {
         }
         timer.c.state = .running;
         self.timers[idx].insert(timer);
+        dbg.rec(.timer_set, 1, @intFromPtr(timer), timer.deadline.value, @intFromPtr(self.loop));
     }
 
     pub fn clearTimer(self: *LoopState, timer: *Timer) void {
         const was_active = timer.c.state == .running;
+        dbg.rec(.timer_clear, 1, @intFromPtr(timer), @intFromBool(was_active), @intFromPtr(self.loop));
         if (was_active) {
             self.timers[clockIndex(timer.clock)].remove(timer);
         }
@@ -948,6 +950,7 @@ pub const Loop = struct {
                         }
                         break;
                     }
+                    dbg.rec(.timer_fire, 1, @intFromPtr(timer), timer.deadline.value, @intFromPtr(self));
                     timer.c.setResult(.timer, {});
                     self.state.clearTimer(timer);
                     batch[batch_count] = timer;

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -441,10 +441,7 @@ pub const Loop = struct {
     loop_group: *LoopGroup,
     internal_loop_group: LoopGroup = .{},
 
-    // DEBUG (iocp-debug branch): 60s normally; forced to 50ms to bisect #530.
-    // If the deadlock is a lost wakeup, periodic re-polling recovers it and the
-    // test passes; if it's a true hang it still fails. Do not merge.
-    max_wait: Duration = .fromMilliseconds(50),
+    max_wait: Duration = .fromSeconds(60),
     /// Upper bound on the poll wait while a boot/real timer is pending on a
     /// backend without native wall-clock timers. The poll clock (`awake`)
     /// can't track suspend or wall-clock steps, so we re-evaluate boot/real

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const dbg = @import("../debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 const Backend = @import("backend.zig").Backend;
 const BackendCapabilities = @import("completion.zig").BackendCapabilities;
 const Completion = @import("completion.zig").Completion;
@@ -323,6 +324,7 @@ pub const LoopState = struct {
     /// Called by backends when an I/O operation completes.
     /// Decrements inflight_io counter and marks the completion done.
     pub fn markCompletedFromBackend(self: *LoopState, completion: *Completion) void {
+        dbg.rec(.complete, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self.loop));
         self.decrInflight();
         self.markCompleted(completion);
     }
@@ -345,15 +347,20 @@ pub const LoopState = struct {
         // Only call finish if not in cancel queue
         // If in_queue, cancel queue processing will call finishCompletion
         if (!old.in_queue) {
+            dbg.rec(.mc_finish, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self.loop));
             if (self.loop.defer_callbacks) {
                 self.completions.push(completion);
             } else {
                 self.finishCompletion(completion);
             }
+        } else {
+            dbg.rec(.mc_defer, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self.loop));
         }
     }
 
     pub fn finishCompletion(self: *LoopState, completion: *Completion) void {
+        const grp_ptr: usize = if (completion.group.owner) |o| @intFromPtr(o) else @intFromPtr(completion);
+        dbg.rec(.finish, @intFromEnum(completion.op), @intFromPtr(completion), grp_ptr, @intFromPtr(self.loop));
         std.debug.assert(completion.state == .completed);
 
         completion.state = .dead;
@@ -592,6 +599,7 @@ pub const Loop = struct {
             // Same loop - cancel directly
             self.cancelLocal(completion);
         } else {
+            dbg.rec(.cancel_enq, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(target));
             // Push to target's cancel queue (lock-free Treiber stack)
             var head = target.cancel_queue.load(.acquire);
             while (true) {
@@ -607,6 +615,7 @@ pub const Loop = struct {
 
     /// Cancel a completion on the local loop (must be called from the loop's thread)
     fn cancelLocal(self: *Loop, completion: *Completion) void {
+        dbg.rec(.cancel_local, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self));
         defer {
             // Clear in_queue and call finishCompletion if completed
             var old = completion.cancel_state.load(.acquire);
@@ -616,7 +625,10 @@ pub const Loop = struct {
                 old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
             }
             if (old.completed) {
+                dbg.rec(.cancel_fin, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self));
                 self.state.finishCompletion(completion);
+            } else {
+                dbg.rec(.cancel_nofin, @intFromEnum(completion.op), @intFromPtr(completion), 0, @intFromPtr(self));
             }
         }
 

--- a/src/iocp_repro.zig
+++ b/src/iocp_repro.zig
@@ -64,6 +64,7 @@ const impl = struct {
     const State = struct {
         iocp: windows.HANDLE,
         completions: []std.atomic.Value(u32), // indexed by gen
+        global: std.atomic.Value(u32) = .init(0), // total completions (works even when overlapped reused)
         stop: std.atomic.Value(bool) = .init(false),
         assoc: Assoc,
     };
@@ -84,6 +85,7 @@ const impl = struct {
                 if (st.assoc == .after) {
                     _ = windows.CreateIoCompletionPort(toHandle(ctx.accept_sock), st.iocp, 0, 0);
                 }
+                _ = st.global.fetchAdd(1, .monotonic);
                 if (ctx.gen < st.completions.len) {
                     _ = st.completions[ctx.gen].fetchAdd(1, .monotonic);
                 }
@@ -93,7 +95,7 @@ const impl = struct {
 
     const Result = struct { accepts: u64, total: u64, max: u32, dup_gens: u64 };
 
-    fn runVariant(alloc: std.mem.Allocator, assoc: Assoc, n_accepts: u64, n_pollers: usize) !Result {
+    fn runVariant(alloc: std.mem.Allocator, assoc: Assoc, reuse: bool, n_accepts: u64, n_pollers: usize) !Result {
         const iocp = windows.CreateIoCompletionPort(windows.INVALID_HANDLE_VALUE, null, 0, 0) orelse return error.Unexpected;
         defer _ = windows.CloseHandle(iocp);
 
@@ -125,9 +127,15 @@ const impl = struct {
 
         const connect_addr = IpAddress.initIp4(.{ 127, 0, 0, 1 }, port);
 
+        // In reuse mode, a single AcceptCtx (and its OVERLAPPED) is recycled for
+        // every accept — exactly what zio's acceptor does. The accepted socket is
+        // closed after each completion before the slot is reused.
+        var shared_ctx: *AcceptCtx = undefined;
+        if (reuse) shared_ctx = try alloc.create(AcceptCtx);
+
         var gen: u64 = 1;
         while (gen <= n_accepts) : (gen += 1) {
-            const ctx = try alloc.create(AcceptCtx); // intentionally never freed during run
+            const ctx = if (reuse) shared_ctx else try alloc.create(AcceptCtx);
             ctx.* = .{ .gen = gen };
             ctx.accept_sock = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });
 
@@ -135,6 +143,7 @@ const impl = struct {
                 _ = windows.CreateIoCompletionPort(toHandle(ctx.accept_sock), iocp, 0, 0);
             }
 
+            const before = st.global.load(.monotonic);
             var bytes: windows.DWORD = 0;
             const r = acceptex(listener, ctx.accept_sock, &ctx.buf, 0, addr_slot, addr_slot, &bytes, &ctx.overlapped);
             if (r == windows.FALSE and windows.WSAGetLastError() != .IO_PENDING) return error.Unexpected;
@@ -143,12 +152,14 @@ const impl = struct {
             const client = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });
             try net.connect(client, &connect_addr.any, @sizeOf(windows.sockaddr.in));
 
-            // Wait for this generation's first completion (bounded).
+            // Wait for a completion to land (bounded). Use the global counter so it
+            // works whether the overlapped is unique or reused.
             var spins: u32 = 0;
-            while (st.completions[gen].load(.monotonic) == 0 and spins < 4000) : (spins += 1) {
+            while (st.global.load(.monotonic) == before and spins < 4000) : (spins += 1) {
                 Sleep(1);
             }
             net.close(client);
+            net.close(ctx.accept_sock);
             // Brief window for a possible duplicate completion to arrive.
             Sleep(2);
         }
@@ -158,15 +169,21 @@ const impl = struct {
         st.stop.store(true, .release);
         for (pollers) |t| t.join();
 
-        var total: u64 = 0;
+        const total: u64 = st.global.load(.monotonic);
         var max: u32 = 0;
         var dups: u64 = 0;
-        var g: u64 = 1;
-        while (g <= n_accepts) : (g += 1) {
-            const c = completions[g].load(.monotonic);
-            total += c;
-            if (c > max) max = c;
-            if (c > 1) dups += 1;
+        if (!reuse) {
+            var g: u64 = 1;
+            while (g <= n_accepts) : (g += 1) {
+                const c = completions[g].load(.monotonic);
+                if (c > max) max = c;
+                if (c > 1) dups += 1;
+            }
+        } else {
+            // Per-gen is meaningless when the overlapped is reused; a duplicate
+            // shows up as more completions than accepts.
+            max = if (total > n_accepts) 2 else 1;
+            dups = if (total > n_accepts) total - n_accepts else 0;
         }
         return .{ .accepts = n_accepts, .total = total, .max = max, .dup_gens = dups };
     }
@@ -193,15 +210,17 @@ const impl = struct {
         net.ensureWSAInitialized(); // the runtime normally does this; we run runtime-free
         const alloc = std.heap.page_allocator;
         const n: u64 = 1000;
-        const variants = [_]struct { name: []const u8, assoc: Assoc }{
-            .{ .name = "assoc_none  ", .assoc = .none },
-            .{ .name = "assoc_before", .assoc = .before },
-            .{ .name = "assoc_after ", .assoc = .after },
+        const variants = [_]struct { name: []const u8, assoc: Assoc, reuse: bool }{
+            .{ .name = "unique assoc_none  ", .assoc = .none, .reuse = false },
+            .{ .name = "unique assoc_before", .assoc = .before, .reuse = false },
+            .{ .name = "REUSE  assoc_none  ", .assoc = .none, .reuse = true },
+            .{ .name = "REUSE  assoc_before", .assoc = .before, .reuse = true },
+            .{ .name = "REUSE  assoc_after ", .assoc = .after, .reuse = true },
         };
         for (variants) |v| {
-            const res = try runVariant(alloc, v.assoc, n, 3);
+            const res = try runVariant(alloc, v.assoc, v.reuse, n, 3);
             std.debug.print(
-                "REPRO #530 variant={s} accepts={d} total_completions={d} max_per_gen={d} DUP_GENS={d}\n",
+                "REPRO #530 variant=[{s}] accepts={d} total_completions={d} max_per_gen={d} DUP={d}\n",
                 .{ v.name, res.accepts, res.total, res.max, res.dup_gens },
             );
         }

--- a/src/iocp_repro.zig
+++ b/src/iocp_repro.zig
@@ -190,6 +190,7 @@ const impl = struct {
     }
 
     fn run() !void {
+        net.ensureWSAInitialized(); // the runtime normally does this; we run runtime-free
         const alloc = std.heap.page_allocator;
         const n: u64 = 1000;
         const variants = [_]struct { name: []const u8, assoc: Assoc }{

--- a/src/iocp_repro.zig
+++ b/src/iocp_repro.zig
@@ -1,0 +1,208 @@
+//! DEBUG (iocp-debug branch only): standalone, runtime-free reproducer for
+//! lalinsky/zio#530 — does a single AcceptEx deliver two completion packets?
+//!
+//! Strips away ALL of zio's machinery (fibers, race-groups, timers, the loop):
+//! just raw Winsock + one shared IOCP port + N poller threads, doing serial
+//! accepts. Each accept uses a UNIQUE heap OVERLAPPED that is never freed during
+//! the run, so a generation stamped into it is reliable (no reuse race) and a
+//! stray second completion lands on valid memory and is counted, not a UAF.
+//!
+//! It toggles the one suspected variable — whether/when the accepted socket is
+//! associated with the completion port — and reports completions-per-generation
+//! for each variant. If any generation completes more than once, the duplicate
+//! is reproduced with that variable, zio-free. Do not merge.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+test "iocp repro: AcceptEx double-completion (#530)" {
+    // Comptime-pruned on non-Windows so the Windows-only code below is never
+    // analyzed for other targets / the user's linux `zig build test`.
+    if (builtin.os.tag == .windows) {
+        try impl.run();
+    } else {
+        return error.SkipZigTest;
+    }
+}
+
+const impl = struct {
+    const windows = @import("os/windows.zig");
+    const net = @import("os/net.zig");
+    const IpAddress = @import("net.zig").IpAddress;
+
+    const WSAID_ACCEPTEX = windows.GUID{
+        .Data1 = 0xb5367df1,
+        .Data2 = 0xcbac,
+        .Data3 = 0x11cf,
+        .Data4 = .{ 0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92 },
+    };
+
+    const LPFN_ACCEPTEX = *const fn (
+        sListenSocket: windows.SOCKET,
+        sAcceptSocket: windows.SOCKET,
+        lpOutputBuffer: *anyopaque,
+        dwReceiveDataLength: windows.DWORD,
+        dwLocalAddressLength: windows.DWORD,
+        dwRemoteAddressLength: windows.DWORD,
+        lpdwBytesReceived: *windows.DWORD,
+        lpOverlapped: *windows.OVERLAPPED,
+    ) callconv(.winapi) windows.BOOL;
+
+    extern "kernel32" fn Sleep(dwMilliseconds: windows.DWORD) callconv(.winapi) void;
+
+    const addr_slot = @sizeOf(windows.sockaddr.storage) + 16;
+
+    const AcceptCtx = struct {
+        overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED),
+        gen: u64 = 0,
+        accept_sock: windows.SOCKET = undefined,
+        buf: [addr_slot * 2]u8 = undefined,
+    };
+
+    const Assoc = enum { none, before, after };
+
+    const State = struct {
+        iocp: windows.HANDLE,
+        completions: []std.atomic.Value(u32), // indexed by gen
+        stop: std.atomic.Value(bool) = .init(false),
+        assoc: Assoc,
+    };
+
+    fn toHandle(s: windows.SOCKET) windows.HANDLE {
+        return @ptrCast(s);
+    }
+
+    fn poller(st: *State) void {
+        var entries: [16]windows.OVERLAPPED_ENTRY = undefined;
+        while (!st.stop.load(.acquire)) {
+            var removed: windows.ULONG = 0;
+            const ok = windows.GetQueuedCompletionStatusEx(st.iocp, &entries, entries.len, &removed, 50, windows.FALSE);
+            if (ok == windows.FALSE) continue; // timeout / no entries
+            for (entries[0..removed]) |e| {
+                const ovl = e.lpOverlapped orelse continue;
+                const ctx: *AcceptCtx = @alignCast(@fieldParentPtr("overlapped", ovl));
+                if (st.assoc == .after) {
+                    _ = windows.CreateIoCompletionPort(toHandle(ctx.accept_sock), st.iocp, 0, 0);
+                }
+                if (ctx.gen < st.completions.len) {
+                    _ = st.completions[ctx.gen].fetchAdd(1, .monotonic);
+                }
+            }
+        }
+    }
+
+    const Result = struct { accepts: u64, total: u64, max: u32, dup_gens: u64 };
+
+    fn runVariant(alloc: std.mem.Allocator, assoc: Assoc, n_accepts: u64, n_pollers: usize) !Result {
+        const iocp = windows.CreateIoCompletionPort(windows.INVALID_HANDLE_VALUE, null, 0, 0) orelse return error.Unexpected;
+        defer _ = windows.CloseHandle(iocp);
+
+        // Listening socket.
+        const listener = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });
+        defer net.close(listener);
+        var bind_addr = IpAddress.initIp4(.{ 127, 0, 0, 1 }, 0);
+        try net.bind(listener, &bind_addr.any, @sizeOf(windows.sockaddr.in));
+        try net.listen(listener, 128);
+        // Read back the assigned port.
+        var sa: windows.sockaddr = undefined;
+        var salen: i32 = @sizeOf(windows.sockaddr);
+        if (windows.getsockname(listener, &sa, &salen) != 0) return error.Unexpected;
+        const got = IpAddress.initPosix(@ptrCast(&sa), @intCast(salen));
+        const port = std.mem.bigToNative(u16, got.in.port);
+        _ = windows.CreateIoCompletionPort(toHandle(listener), iocp, 0, 0) orelse return error.Unexpected;
+
+        const acceptex = try loadAcceptEx(listener);
+
+        const completions = try alloc.alloc(std.atomic.Value(u32), n_accepts + 2);
+        defer alloc.free(completions);
+        for (completions) |*c| c.* = .init(0);
+
+        var st = State{ .iocp = iocp, .completions = completions, .assoc = assoc };
+
+        const pollers = try alloc.alloc(std.Thread, n_pollers);
+        defer alloc.free(pollers);
+        for (pollers) |*t| t.* = try std.Thread.spawn(.{}, poller, .{&st});
+
+        const connect_addr = IpAddress.initIp4(.{ 127, 0, 0, 1 }, port);
+
+        var gen: u64 = 1;
+        while (gen <= n_accepts) : (gen += 1) {
+            const ctx = try alloc.create(AcceptCtx); // intentionally never freed during run
+            ctx.* = .{ .gen = gen };
+            ctx.accept_sock = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });
+
+            if (assoc == .before) {
+                _ = windows.CreateIoCompletionPort(toHandle(ctx.accept_sock), iocp, 0, 0);
+            }
+
+            var bytes: windows.DWORD = 0;
+            const r = acceptex(listener, ctx.accept_sock, &ctx.buf, 0, addr_slot, addr_slot, &bytes, &ctx.overlapped);
+            if (r == windows.FALSE and windows.WSAGetLastError() != .IO_PENDING) return error.Unexpected;
+
+            // Trigger the accept by connecting a client.
+            const client = try net.socket(.ipv4, .stream, .ip, .{ .nonblocking = false });
+            try net.connect(client, &connect_addr.any, @sizeOf(windows.sockaddr.in));
+
+            // Wait for this generation's first completion (bounded).
+            var spins: u32 = 0;
+            while (st.completions[gen].load(.monotonic) == 0 and spins < 4000) : (spins += 1) {
+                Sleep(1);
+            }
+            net.close(client);
+            // Brief window for a possible duplicate completion to arrive.
+            Sleep(2);
+        }
+
+        // Let any stragglers land.
+        Sleep(400);
+        st.stop.store(true, .release);
+        for (pollers) |t| t.join();
+
+        var total: u64 = 0;
+        var max: u32 = 0;
+        var dups: u64 = 0;
+        var g: u64 = 1;
+        while (g <= n_accepts) : (g += 1) {
+            const c = completions[g].load(.monotonic);
+            total += c;
+            if (c > max) max = c;
+            if (c > 1) dups += 1;
+        }
+        return .{ .accepts = n_accepts, .total = total, .max = max, .dup_gens = dups };
+    }
+
+    fn loadAcceptEx(sock: windows.SOCKET) !LPFN_ACCEPTEX {
+        var func_ptr: LPFN_ACCEPTEX = undefined;
+        var bytes: windows.DWORD = 0;
+        const rc = windows.WSAIoctl(
+            sock,
+            windows.SIO_GET_EXTENSION_FUNCTION_POINTER,
+            @constCast(&WSAID_ACCEPTEX),
+            @sizeOf(windows.GUID),
+            @ptrCast(&func_ptr),
+            @sizeOf(LPFN_ACCEPTEX),
+            &bytes,
+            null,
+            null,
+        );
+        if (rc != 0) return error.Unexpected;
+        return func_ptr;
+    }
+
+    fn run() !void {
+        const alloc = std.heap.page_allocator;
+        const n: u64 = 1000;
+        const variants = [_]struct { name: []const u8, assoc: Assoc }{
+            .{ .name = "assoc_none  ", .assoc = .none },
+            .{ .name = "assoc_before", .assoc = .before },
+            .{ .name = "assoc_after ", .assoc = .after },
+        };
+        for (variants) |v| {
+            const res = try runVariant(alloc, v.assoc, n, 3);
+            std.debug.print(
+                "REPRO #530 variant={s} accepts={d} total_completions={d} max_per_gen={d} DUP_GENS={d}\n",
+                .{ v.name, res.accepts, res.total, res.max, res.dup_gens },
+            );
+        }
+    }
+};

--- a/src/net.zig
+++ b/src/net.zig
@@ -2441,19 +2441,17 @@ test "Stream.Reader/Writer.fromStd" {
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
     if (builtin.single_threaded) return error.SkipZigTest;
-    // IOCP intermittently loses a cross-loop completion under this workload
-    // (lalinsky/zio#530); skip until that latent IOCP bug is fixed so it does
-    // not flake CI. The bug being regression-tested here (the race-group
-    // use-after-free) is exercised by the epoll/kqueue and io_uring backends.
-    if (ev.backend == .iocp) return error.SkipZigTest;
+    // DEBUG (iocp-debug branch): IOCP is NOT skipped here — we WANT it to run so
+    // CI reproduces lalinsky/zio#530. Load is cranked up and io_timeout lowered
+    // so a stall surfaces quickly and the STALL/LATE warn lines fire. Do not merge.
 
     const H = struct {
         const executors = 3;
-        const waves = 5;
+        const waves = 40;
         const per_wave = 12;
         const total = 8 * 1024;
         const chunk = 2048;
-        const io_timeout = Timeout.fromMilliseconds(5_000);
+        const io_timeout = Timeout.fromMilliseconds(3_000);
 
         const Shared = struct {
             conns: std.atomic.Value(u32) = .init(0),

--- a/src/net.zig
+++ b/src/net.zig
@@ -2479,11 +2479,10 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                     _ = sh.errors.fetchAdd(1, .monotonic);
                     return;
                 };
-                // Spawning round-robins to another executor; joining wakes us
-                // from there, migrating this handler (and the socket's next op)
-                // to a different loop.
-                var h = runtime_mod.spawn(nudge, .{}) catch return;
-                h.join();
+                // DEBUG (iocp-debug branch): nudge spawn/join removed to bisect
+                // #530 — does the deadlock need the spawn/join migration driver?
+                // var h = runtime_mod.spawn(nudge, .{}) catch return;
+                // h.join();
             }
         }
 

--- a/src/net.zig
+++ b/src/net.zig
@@ -2441,7 +2441,6 @@ test "Stream.Reader/Writer.fromStd" {
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
     if (builtin.single_threaded) return error.SkipZigTest;
-    if (true) return error.SkipZigTest; // DEBUG (#530): skipped while running the standalone repro. Do not merge.
     // DEBUG (iocp-debug branch): IOCP is NOT skipped here — we WANT it to run so
     // CI reproduces lalinsky/zio#530. Load is cranked up and io_timeout lowered
     // so a stall surfaces quickly and the STALL/LATE warn lines fire. Do not merge.

--- a/src/net.zig
+++ b/src/net.zig
@@ -2451,10 +2451,7 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
         const per_wave = 12;
         const total = 8 * 1024;
         const chunk = 2048;
-        // DEBUG (iocp-debug branch): .none removes the race-group/timer entirely
-        // (plain waitForIo). If the deadlock vanishes, the bug is in the
-        // race-group timer path; if it persists, plain io-completion wake.
-        const io_timeout: Timeout = .none;
+        const io_timeout = Timeout.fromMilliseconds(3_000);
 
         const Shared = struct {
             conns: std.atomic.Value(u32) = .init(0),

--- a/src/net.zig
+++ b/src/net.zig
@@ -2605,7 +2605,10 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(H.executors) });
+    // DEBUG (iocp-debug branch): migration OFF to bisect #530. If the deadlock
+    // disappears, the bug is in scheduleTask's migrate-to-current branch; if it
+    // persists, it's the remote-wake/home-schedule path.
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(H.executors), .enable_task_migration = false });
     defer runtime.deinit();
 
     var sh: H.Shared = .{};

--- a/src/net.zig
+++ b/src/net.zig
@@ -2610,8 +2610,9 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                 _ = sh.errors.fetchAdd(1, .monotonic);
                 return;
             };
-            const stream = addr.connect(.{ .timeout = io_timeout }) catch {
+            const stream = addr.connect(.{ .timeout = io_timeout }) catch |e| {
                 _ = sh.errors.fetchAdd(1, .monotonic);
+                std.debug.print("CONNECT-ERR id={d} err={s}\n", .{ id, @errorName(e) });
                 return;
             };
             defer stream.close();

--- a/src/net.zig
+++ b/src/net.zig
@@ -2544,9 +2544,10 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
             while (sent < total) {
                 const this = @min(chunk, total - sent);
                 for (0..this) |i| buf[i] = pat(id, sent + i);
-                stream.writeAll(buf[0..this], io_timeout) catch {
-                    _ = sh.errors.fetchAdd(1, .monotonic);
-                    return;
+                stream.writeAll(buf[0..this], io_timeout) catch |e| {
+                    std.debug.print("WRITE-ERR id={d} sent={d} err={s}\n", .{ id, sent, @errorName(e) });
+                    @import("debug_trace.zig").dump();
+                    std.process.exit(8);
                 };
                 sent += this;
             }
@@ -2559,18 +2560,27 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                 const want = @min(chunk, total - got);
                 var off: usize = 0;
                 while (off < want) {
-                    const n = stream.read(buf[off..want], io_timeout) catch {
-                        _ = sh.errors.fetchAdd(1, .monotonic);
-                        return;
+                    const n = stream.read(buf[off..want], io_timeout) catch |e| {
+                        std.debug.print("READ-ERR id={d} got={d} off={d} err={s}\n", .{ id, got, off, @errorName(e) });
+                        @import("debug_trace.zig").dump();
+                        std.process.exit(8);
                     };
                     if (n == 0) {
-                        _ = sh.errors.fetchAdd(1, .monotonic); // premature EOF
-                        return;
+                        std.debug.print("PREMATURE-EOF id={d} got={d} off={d}\n", .{ id, got, off });
+                        @import("debug_trace.zig").dump();
+                        std.process.exit(8);
                     }
                     for (0..n) |k| {
-                        if (buf[off + k] != pat(id, got + off + k)) {
-                            _ = sh.errors.fetchAdd(1, .monotonic);
-                            return;
+                        const pos = got + off + k;
+                        const expected = pat(id, pos);
+                        const gotb = buf[off + k];
+                        if (gotb != expected) {
+                            // DEBUG (#530): which connection does the wrong byte
+                            // belong to? cand = (got-pos)*31^-1 mod 256; 31^-1=223.
+                            const cand: u8 = (gotb -% @as(u8, @truncate(pos))) *% 223;
+                            std.debug.print("MISMATCH id={d}(idmod={d}) pos={d} expected={d} got={d} cand_id_mod256={d} k={d}/n={d} buf=0x{x}\n", .{ id, @as(u8, @truncate(id)), pos, expected, gotb, cand, k, n, @intFromPtr(&buf) });
+                            @import("debug_trace.zig").dump();
+                            std.process.exit(8);
                         }
                     }
                     off += n;

--- a/src/net.zig
+++ b/src/net.zig
@@ -2529,10 +2529,14 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                 return;
             };
             defer srv.close();
+            // DEBUG (#530): protect the listening socket — net.close panics if
+            // anything closes it before we clear this at loop exit.
+            @import("debug_trace.zig").protected = @intFromPtr(srv.socket.handle);
             port_ch.send(srv.socket.address.ip.getPort()) catch return;
 
             var handlers: Group = .init;
             defer handlers.wait() catch {};
+            defer @import("debug_trace.zig").protected = 0; // legit close at teardown is fine
             while (!sh.done.load(.acquire)) {
                 const stream = srv.accept(.{ .timeout = Timeout.fromMilliseconds(50) }) catch |err| {
                     if (err == error.Timeout) continue; // re-check the done flag

--- a/src/net.zig
+++ b/src/net.zig
@@ -2466,6 +2466,29 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
 
         fn nudge() void {}
 
+        // DEBUG (iocp-debug branch): dump the trace ring if progress stalls,
+        // catching the #530 hang before the 3s timeout cascade mutates state.
+        fn watchdog(sh: *Shared) void {
+            var last: u32 = 0;
+            var stable: u32 = 0;
+            var dumped = false;
+            while (!sh.done.load(.acquire)) {
+                runtime_mod.sleep(.fromMilliseconds(300)) catch return;
+                const cur = sh.conns.load(.monotonic) + sh.verified.load(.monotonic) + sh.errors.load(.monotonic);
+                if (cur == last) {
+                    stable += 1;
+                } else {
+                    stable = 0;
+                    last = cur;
+                }
+                if (stable >= 5 and !dumped) { // ~1.5s with no progress
+                    @import("debug_trace.zig").dump();
+                    dumped = true;
+                    return;
+                }
+            }
+        }
+
         fn handler(stream: Stream, sh: *Shared) void {
             defer stream.close();
             var buf: [chunk]u8 = undefined;
@@ -2591,11 +2614,15 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
 
     var server_group: Group = .init;
     try server_group.spawn(H.server, .{ &port_ch, &sh });
+    // DEBUG (iocp-debug branch): watchdog dumps the trace ring on a stall.
+    var wd_group: Group = .init;
+    try wd_group.spawn(H.watchdog, .{&sh});
     // Signal the acceptor to stop *before* draining it, so an early return from
     // any `try` below can't leave it looping forever.
     defer {
         sh.done.store(true, .release);
         server_group.wait() catch {};
+        wd_group.wait() catch {};
     }
 
     const port = try port_ch.receive();

--- a/src/net.zig
+++ b/src/net.zig
@@ -2441,6 +2441,7 @@ test "Stream.Reader/Writer.fromStd" {
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
     if (builtin.single_threaded) return error.SkipZigTest;
+    if (true) return error.SkipZigTest; // DEBUG (#530): skipped while running the standalone repro. Do not merge.
     // DEBUG (iocp-debug branch): IOCP is NOT skipped here — we WANT it to run so
     // CI reproduces lalinsky/zio#530. Load is cranked up and io_timeout lowered
     // so a stall surfaces quickly and the STALL/LATE warn lines fire. Do not merge.

--- a/src/net.zig
+++ b/src/net.zig
@@ -2494,16 +2494,22 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
         fn handler(stream: Stream, sh: *Shared) void {
             defer stream.close();
             var buf: [chunk]u8 = undefined;
+            var rounds: usize = 0;
             while (true) {
-                const n = stream.read(&buf, io_timeout) catch {
+                const n = stream.read(&buf, io_timeout) catch |e| {
                     _ = sh.errors.fetchAdd(1, .monotonic);
-                    return;
+                    std.debug.print("HANDLER-READ-ERR rounds={d} err={s}\n", .{ rounds, @errorName(e) });
+                    @import("debug_trace.zig").dump();
+                    std.process.exit(8);
                 };
                 if (n == 0) return; // peer closed its send side
-                stream.writeAll(buf[0..n], io_timeout) catch {
+                stream.writeAll(buf[0..n], io_timeout) catch |e| {
                     _ = sh.errors.fetchAdd(1, .monotonic);
-                    return;
+                    std.debug.print("HANDLER-WRITE-ERR rounds={d} n={d} err={s}\n", .{ rounds, n, @errorName(e) });
+                    @import("debug_trace.zig").dump();
+                    std.process.exit(8);
                 };
+                rounds += 1;
                 // DEBUG (iocp-debug branch): nudge spawn/join removed to bisect
                 // #530 — does the deadlock need the spawn/join migration driver?
                 // var h = runtime_mod.spawn(nudge, .{}) catch return;
@@ -2530,10 +2536,14 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
             while (!sh.done.load(.acquire)) {
                 const stream = srv.accept(.{ .timeout = Timeout.fromMilliseconds(50) }) catch |err| {
                     if (err == error.Timeout) continue; // re-check the done flag
-                    break;
+                    std.debug.print("ACCEPT-ERR err={s}\n", .{@errorName(err)});
+                    @import("debug_trace.zig").dump();
+                    std.process.exit(8);
                 };
-                handlers.spawn(handler, .{ stream, sh }) catch {
-                    stream.close();
+                handlers.spawn(handler, .{ stream, sh }) catch |e| {
+                    std.debug.print("SPAWN-FAIL err={s}\n", .{@errorName(e)});
+                    @import("debug_trace.zig").dump();
+                    std.process.exit(8);
                 };
             }
         }

--- a/src/net.zig
+++ b/src/net.zig
@@ -2481,10 +2481,12 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                     stable = 0;
                     last = cur;
                 }
-                if (stable >= 5 and !dumped) { // ~1.5s with no progress
+                if (stable >= 20 and !dumped) { // ~6s no progress (> the 3s io_timeout)
+                    // If we get here, the 3s timeouts did NOT rescue the stall =>
+                    // a genuine permanent hang, not a timeout-rescued delivery delay.
                     @import("debug_trace.zig").dump();
                     dumped = true;
-                    std.process.exit(7); // fast-fail with the dump (no-timeout hang safety)
+                    std.process.exit(7);
                 }
             }
         }

--- a/src/net.zig
+++ b/src/net.zig
@@ -2451,7 +2451,10 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
         const per_wave = 12;
         const total = 8 * 1024;
         const chunk = 2048;
-        const io_timeout = Timeout.fromMilliseconds(3_000);
+        // DEBUG (iocp-debug branch): .none removes the race-group/timer entirely
+        // (plain waitForIo). If the deadlock vanishes, the bug is in the
+        // race-group timer path; if it persists, plain io-completion wake.
+        const io_timeout: Timeout = .none;
 
         const Shared = struct {
             conns: std.atomic.Value(u32) = .init(0),
@@ -2484,7 +2487,7 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                 if (stable >= 5 and !dumped) { // ~1.5s with no progress
                     @import("debug_trace.zig").dump();
                     dumped = true;
-                    return;
+                    std.process.exit(7); // fast-fail with the dump (no-timeout hang safety)
                 }
             }
         }
@@ -2605,10 +2608,7 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
         }
     };
 
-    // DEBUG (iocp-debug branch): migration OFF to bisect #530. If the deadlock
-    // disappears, the bug is in scheduleTask's migrate-to-current branch; if it
-    // persists, it's the remote-wake/home-schedule path.
-    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(H.executors), .enable_task_migration = false });
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(H.executors) });
     defer runtime.deinit();
 
     var sh: H.Shared = .{};

--- a/src/net.zig
+++ b/src/net.zig
@@ -2545,6 +2545,7 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
                 const this = @min(chunk, total - sent);
                 for (0..this) |i| buf[i] = pat(id, sent + i);
                 stream.writeAll(buf[0..this], io_timeout) catch |e| {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
                     std.debug.print("WRITE-ERR id={d} sent={d} err={s}\n", .{ id, sent, @errorName(e) });
                     @import("debug_trace.zig").dump();
                     std.process.exit(8);

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -153,6 +153,10 @@ pub fn poll(fds: []pollfd, timeout: i32) PollError!usize {
 pub fn close(fd: fd_t) void {
     switch (builtin.os.tag) {
         .windows => {
+            if (dbg.protected != 0 and @intFromPtr(fd) == dbg.protected) {
+                dbg.dump();
+                @panic("BUG #530: closing the protected listening socket mid-run");
+            }
             dbg.rec(.sock_close, 0, @intFromPtr(fd), 0, 0);
             _ = windows.closesocket(fd);
         },

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -7,6 +7,7 @@ const unexpectedError = @import("base.zig").unexpectedError;
 const thread = @import("thread.zig");
 
 const log = @import("../common.zig").log;
+const dbg = @import("../debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 
 // Windows addrinfo definitions
 const windows_addrinfo = if (builtin.os.tag == .windows) extern struct {
@@ -152,6 +153,7 @@ pub fn poll(fds: []pollfd, timeout: i32) PollError!usize {
 pub fn close(fd: fd_t) void {
     switch (builtin.os.tag) {
         .windows => {
+            dbg.rec(.sock_close, 0, @intFromPtr(fd), 0, 0);
             _ = windows.closesocket(fd);
         },
         else => {
@@ -328,6 +330,7 @@ pub fn socket(domain: Domain, socket_type: Type, protocol: Protocol, flags: Open
                 var mode: c_ulong = 1;
                 _ = windows.ioctlsocket(sock, windows.FIONBIO, &mode);
             }
+            dbg.rec(.sock_open, 0, @intFromPtr(sock), 0, 0);
             return sock;
         },
         else => {

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -158,6 +158,7 @@ pub fn close(fd: fd_t) void {
                 @panic("BUG #530: closing the protected listening socket mid-run");
             }
             if (!dbg.sockClose(@intFromPtr(fd))) {
+                std.debug.print("DOUBLE-CLOSE h=0x{x}\n", .{@intFromPtr(fd)});
                 dbg.dump();
                 @panic("BUG #530: double-close / close of never-opened socket");
             }

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -157,6 +157,10 @@ pub fn close(fd: fd_t) void {
                 dbg.dump();
                 @panic("BUG #530: closing the protected listening socket mid-run");
             }
+            if (!dbg.sockClose(@intFromPtr(fd))) {
+                dbg.dump();
+                @panic("BUG #530: double-close / close of never-opened socket");
+            }
             dbg.rec(.sock_close, 0, @intFromPtr(fd), 0, 0);
             _ = windows.closesocket(fd);
         },
@@ -335,6 +339,7 @@ pub fn socket(domain: Domain, socket_type: Type, protocol: Protocol, flags: Open
                 _ = windows.ioctlsocket(sock, windows.FIONBIO, &mode);
             }
             dbg.rec(.sock_open, 0, @intFromPtr(sock), 0, 0);
+            dbg.sockOpen(@intFromPtr(sock));
             return sock;
         },
         else => {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 
 const ev = @import("ev/root.zig");
+const dbg = @import("debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 const os = @import("os/root.zig");
 
 const meta = @import("meta.zig");
@@ -542,6 +543,7 @@ pub const Executor = struct {
         const home_exec = Executor.fromCoroutine(&task.coro);
 
         if (task == &home_exec.main_task) {
+            dbg.rec(.sched_main, 0, @intFromPtr(task), 0, @intFromPtr(&home_exec.loop));
             home_exec.loop.wake();
             return;
         }
@@ -549,6 +551,7 @@ pub const Executor = struct {
         if (getCurrentExecutorOrNull()) |current_exec| {
             if (current_exec == home_exec) {
                 // Schedule locally
+                dbg.rec(.sched_local, 0, @intFromPtr(task), 0, @intFromPtr(&current_exec.loop));
                 current_exec.scheduleTaskLocal(task);
                 return;
             }
@@ -559,6 +562,7 @@ pub const Executor = struct {
             // load (see https://github.com/lalinsky/zio/issues/460).
             if (old.tag != .new and current_exec.runtime == home_exec.runtime and home_exec.runtime.options.enable_task_migration) {
                 // Migrate to the current executor
+                dbg.rec(.sched_migrate, 0, @intFromPtr(task), 0, @intFromPtr(&current_exec.loop));
                 task.last_run_tick = 0;
                 current_exec.scheduleTaskLocal(task);
                 return;
@@ -566,6 +570,7 @@ pub const Executor = struct {
         }
 
         // Schedule on the home executor
+        dbg.rec(.sched_remote, 0, @intFromPtr(task), 0, @intFromPtr(&home_exec.loop));
         home_exec.scheduleTaskRemote(task);
     }
 
@@ -604,6 +609,7 @@ pub const Executor = struct {
                             old = actual;
                             continue;
                         }
+                        dbg.rec(.park_prewoken, 0, @intFromPtr(task), 0, @intFromPtr(&self.loop));
                         self.scheduleTaskLocal(task);
                         return;
                     }
@@ -613,6 +619,7 @@ pub const Executor = struct {
                         old = actual;
                         continue;
                     }
+                    dbg.rec(.park, 0, @intFromPtr(task), 0, @intFromPtr(&self.loop));
                     break; // Task is now .waiting
                 }
             },

--- a/src/select.zig
+++ b/src/select.zig
@@ -8,6 +8,7 @@ const getCurrentTask = @import("runtime.zig").getCurrentTask;
 const getCurrentTaskOrNull = @import("runtime.zig").getCurrentTaskOrNull;
 const yield = @import("runtime.zig").yield;
 const common = @import("common.zig");
+const dbg = @import("debug_trace.zig"); // DEBUG (iocp-debug branch): do not merge
 const Cancelable = common.Cancelable;
 const Waiter = common.Waiter;
 const NO_WINNER = common.NO_WINNER;
@@ -419,6 +420,8 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
         const result = if (has_context) fut.getResult(&context) else fut.getResult();
         return .{ .value = result };
     }
+
+    dbg.rec(.wait_join, 0, @intFromPtr(&waiter), 0, if (waiter.mode.direct.task) |t| @intFromPtr(t) else 0);
 
     // Clean up waiter on exit
     defer {

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -4,6 +4,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+// DEBUG (iocp-debug branch only): surface log.warn/info/debug in release test
+// builds so IOCP cross-loop tracing is visible in CI. Do not merge.
+pub const std_options: std.Options = .{ .log_level = .debug };
+
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
 pub const RuntimeOptions = runtime.RuntimeOptions;

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -101,4 +101,5 @@ test {
     _ = @import("io.zig");
     _ = @import("random.zig");
     _ = @import("task.zig");
+    _ = @import("iocp_repro.zig"); // DEBUG (#530): standalone AcceptEx repro. Do not merge.
 }

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -8,6 +8,15 @@ const builtin = @import("builtin");
 // builds so IOCP cross-loop tracing is visible in CI. Do not merge.
 pub const std_options: std.Options = .{ .log_level = .debug };
 
+// DEBUG (iocp-debug branch only): dump the trace ring on any panic / access
+// violation (Zig converts segfaults to panics in safe modes), so a crash that
+// happens before the watchdog's stall dump still yields the lead-up. Do not merge.
+pub const panic = std.debug.FullPanic(panicHandler);
+fn panicHandler(msg: []const u8, ret_addr: ?usize) noreturn {
+    @import("debug_trace.zig").dump();
+    std.debug.defaultPanic(msg, ret_addr);
+}
+
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
 pub const RuntimeOptions = runtime.RuntimeOptions;


### PR DESCRIPTION
Throwaway debug branch to reproduce and diagnose #530 in CI. Enables the cross-loop stress test on IOCP, cranks load, lowers io_timeout to 3s, and logs STALL (with CancelIoEx outcome) + LATE completions. Matrix trimmed to Windows/IOCP. Not for merge.