### PR TITLE
iocp: fix accept double-close UAF (#530)

### DIFF
--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -715,6 +715,15 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     const accept_socket = try net.socket(@enumFromInt(family), .stream, .ip, data.flags);
     errdefer net.close(accept_socket);
 
+    // Publish the accepted socket into the op BEFORE issuing AcceptEx (#530). The
+    // IOCP port is shared across all executors, so AcceptEx can complete and be
+    // dequeued by another thread the instant it is posted. If result_private were
+    // still unset at that point, processCompletion would read an uninitialized
+    // handle and close it — a double-close use-after-free. The AcceptEx call below
+    // is a syscall (a full barrier), so writing the handle first guarantees the
+    // completion handler — on any thread — observes a valid value.
+    data.result_private_do_not_touch = accept_socket;
+
     // Associate the accept socket with IOCP
     const iocp_result = windows.CreateIoCompletionPort(
         @ptrCast(accept_socket),
@@ -745,8 +754,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
         &data.c.internal.overlapped,
     );
 
-    // Store accept_socket so we can retrieve it later (needed for both success and error cases)
-    data.result_private_do_not_touch = accept_socket;
+    // (result_private_do_not_touch was published before AcceptEx above — see #530.)
 
     // When AcceptEx succeeds (result == TRUE) OR returns WSA_IO_PENDING,
     // the completion will be posted to the IOCP port.

--- a/src/net.zig
+++ b/src/net.zig
@@ -2441,11 +2441,6 @@ test "Stream.Reader/Writer.fromStd" {
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
     if (builtin.single_threaded) return error.SkipZigTest;
-    // IOCP intermittently loses a cross-loop completion under this workload
-    // (lalinsky/zio#530); skip until that latent IOCP bug is fixed so it does
-    // not flake CI. The bug being regression-tested here (the race-group
-    // use-after-free) is exercised by the epoll/kqueue and io_uring backends.
-    if (ev.backend == .iocp) return error.SkipZigTest;
 
     const H = struct {
         const executors = 3;


### PR DESCRIPTION
## Summary

Fixes #530 — the intermittent IOCP failure surfaced by the *multi-executor: cross-loop socket stress* test.

`submitAccept` stored the freshly-created accept socket into `result_private_do_not_touch` **after** calling `AcceptEx`. The IOCP port is shared across all executor threads, so `AcceptEx` can complete and be dequeued by **another** thread the instant it is posted — before the submitting thread runs that store. `processCompletion` then read an **uninitialized handle** and closed it: a double-close use-after-free that corrupted unrelated sockets and produced the flaky failures (hangs, `ConnectionReset`, `FileDescriptorNotASocket`, data mismatches — symptoms varied with timing).

The fix publishes the handle **before** the `AcceptEx` syscall (a full barrier), so the completion handler on any thread is guaranteed to observe a valid value. The race window is only a few instructions, which is why it was rare and required the shared, multi-threaded port to hit.

## Why this is the root cause

A standalone, runtime-free reproducer (raw IOCP, multi-threaded pollers) was used to isolate it:

| configuration | result |
|---|---|
| unique overlapped, any accept-socket association | exactly 1 completion per accept ✓ |
| **reused** overlapped (zio's pattern), any association | exactly 1 completion per accept ✓ |

The kernel never double-posts `AcceptEx`; the bug was purely the post-`AcceptEx` store racing a cross-thread completion. The reproducer stays clean precisely because it sets all op metadata *before* `AcceptEx` — which is exactly what this patch makes `submitAccept` do.

`connect`/`recv`/`send` were audited and do not share this pattern (they read results from the completion entry and zero the overlapped before the syscall), so accept was the only affected path.

## Validation

Re-enabled the cross-loop socket stress test on IOCP (removing the #531 skip) and ran it under a cranked-up load (480 conns/iteration) on `windows-latest`, both debug and release: 15× clean, and ~33× clean before the harness hit ephemeral-port exhaustion (unrelated `AddressInUse`). No double-close / UAF in ~15k accepts.