### PR TITLE
Fix thread pool shutdown order

### DIFF
--- a/src/ev/test/cancel.zig
+++ b/src/ev/test/cancel.zig
@@ -330,6 +330,9 @@ test "cancel: work after completion is no-op" {
     var loop: Loop = undefined;
     try loop.init(.{ .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const TestFn = struct {
         called: bool = false,
@@ -365,11 +368,15 @@ test "cancel: work before run" {
         .max_threads = 1,
     });
     defer thread_pool.deinit();
-    defer blocker_event.set(); // Ensure thread unblocks before deinit
 
     var loop: Loop = undefined;
     try loop.init(.{ .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Teardown order (defers run LIFO): unblock the worker, then join the pool's
+    // threads while the loop is still alive (completion callbacks wake the loop),
+    // then deinit the loop, then free the pool.
+    defer thread_pool.stop();
+    defer blocker_event.set();
 
     const BlockingFn = struct {
         started: *os.ResetEvent,
@@ -429,11 +436,15 @@ test "cancel: work double cancel is idempotent" {
         .max_threads = 1,
     });
     defer thread_pool.deinit();
-    defer blocker_event.set(); // Ensure thread unblocks before deinit
 
     var loop: Loop = undefined;
     try loop.init(.{ .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Teardown order (defers run LIFO): unblock the worker, then join the pool's
+    // threads while the loop is still alive (completion callbacks wake the loop),
+    // then deinit the loop, then free the pool.
+    defer thread_pool.stop();
+    defer blocker_event.set();
 
     const BlockingFn = struct {
         started: *os.ResetEvent,

--- a/src/ev/test/fs.zig
+++ b/src/ev/test/fs.zig
@@ -11,6 +11,9 @@ test "File: open/close" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 
@@ -87,6 +90,9 @@ test "File: rename/delete" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 
@@ -167,6 +173,9 @@ test "File: read EOF" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 
@@ -224,6 +233,9 @@ test "File: size" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 
@@ -294,6 +306,9 @@ test "File: stat" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 
@@ -352,6 +367,9 @@ test "File: stat_path" {
     var loop: ev.Loop = undefined;
     try loop.init(.{ .allocator = std.testing.allocator, .thread_pool = &thread_pool });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const cwd = os.fs.cwd();
 

--- a/src/ev/test/thread_pool.zig
+++ b/src/ev/test/thread_pool.zig
@@ -14,6 +14,9 @@ test "ev.ThreadPool: one task" {
         .thread_pool = &thread_pool,
     });
     defer loop.deinit();
+    // Join the pool's threads before the loop is torn down: completion
+    // callbacks wake the loop, so the loop must outlive the pool's threads.
+    defer thread_pool.stop();
 
     const TestFn = struct {
         called: usize = 0,

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -124,6 +124,11 @@ pub const ThreadPool = struct {
             defer self.queue_mutex.unlock();
             if (self.shutdown) return; // already stopped, threads already joined
             self.shutdown = true;
+            // Drop any queued (not-yet-started) work so it can't be removed and
+            // completed later (e.g. by cancel()), which would invoke its
+            // completion_fn after shutdown and wake a loop being torn down.
+            while (self.queue.pop()) |_| {}
+            self.queue_size = 0;
             self.queue_not_empty.broadcast();
         }
 

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -107,10 +107,28 @@ pub const ThreadPool = struct {
     }
 
     pub fn deinit(self: *ThreadPool) void {
+        // stop() has already joined all worker threads (it is idempotent, so
+        // calling it again here is safe if the caller did not stop() first).
         self.stop();
+        self.workers.deinit(self.allocator);
+    }
 
-        // Join all threads - they will remove themselves from the list
-        // We need to keep joining until all workers are gone
+    /// Stop the pool: drop any queued work, refuse new submissions, and join all
+    /// worker threads. After this returns, no worker thread exists, so no
+    /// completion callback can run anymore (callbacks wake the owning event
+    /// loop, so the loop must outlive the pool's threads). The pool object stays
+    /// valid until deinit(); submit() called after stop() drops the work.
+    pub fn stop(self: *ThreadPool) void {
+        {
+            self.queue_mutex.lock();
+            defer self.queue_mutex.unlock();
+            if (self.shutdown) return; // already stopped, threads already joined
+            self.shutdown = true;
+            self.queue_not_empty.broadcast();
+        }
+
+        // Join all threads - they will remove themselves from the list.
+        // We need to keep joining until all workers are gone.
         while (true) {
             self.workers_mutex.lock();
             const thread = if (self.workers.items.len > 0) self.workers.items[0].thread else null;
@@ -122,15 +140,6 @@ pub const ThreadPool = struct {
                 break;
             }
         }
-
-        self.workers.deinit(self.allocator);
-    }
-
-    pub fn stop(self: *ThreadPool) void {
-        self.queue_mutex.lock();
-        defer self.queue_mutex.unlock();
-        self.shutdown = true;
-        self.queue_not_empty.broadcast();
     }
 
     pub fn submit(self: *ThreadPool, work: *Work) void {
@@ -150,6 +159,12 @@ pub const ThreadPool = struct {
         }
 
         self.queue_mutex.lock();
+        if (self.shutdown) {
+            // Pool is shutting down: drop the work without running it or
+            // signaling completion. The owning loop may already be tearing down.
+            self.queue_mutex.unlock();
+            return;
+        }
         self.queue.push(&work.c);
         self.queue_size += 1;
         const queued = self.queue_size;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -843,14 +843,22 @@ pub const Runtime = struct {
         // Set shutting_down flag to prevent new spawns
         self.shutting_down.store(true, .release);
 
-        // Stop worker executors and join threads
-        self.shutdownWorkers();
-
-        // Shutdown thread pool
+        // Stop and join the thread pool first, while all executor loops are
+        // still alive. Thread-pool completion callbacks wake the owning loop
+        // (writing its eventfd), so the pool's worker threads must be fully
+        // joined before any loop is torn down. stop() leaves the pool object
+        // valid (in shutdown mode), so any late submissions from executors being
+        // shut down are safely dropped.
         self.thread_pool.stop();
+
+        // Stop worker executors and join threads (deinits their loops)
+        self.shutdownWorkers();
 
         // All tasks should be complete before deinit
         std.debug.assert(self.task_count.load(.acquire) == 0);
+
+        // Clean up ThreadPool (worker threads already joined by stop()).
+        self.thread_pool.deinit();
 
         // Worker executors clean themselves up via defer in runWorker.
         // We only need to deinit the main executor here (if it was created).
@@ -859,9 +867,6 @@ pub const Runtime = struct {
         }
 
         self.executors.deinit(allocator);
-
-        // Clean up ThreadPool after executors
-        self.thread_pool.deinit();
 
         // Clean up stack pool
         self.stack_pool.deinit();


### PR DESCRIPTION
Fixes #524.

## Problem

Thread-pool completion callbacks reach back into the event loop and write its eventfd. In `loopLinkedWorkComplete` the worker thread first publishes the result (`work_completions.push`) and *then* calls `loop.wake()` → `backend.wake()` → `eventfd_write`. These are two separate steps, so the worker can be preempted between them. Meanwhile the loop observes the published completion, finishes, and gets torn down — and the worker's trailing `wake()` then writes to a closed eventfd:

```
thread panic: eventfd_write: write failed: .BADF
  src/os/eventfd.zig:120  in eventfd_write
  src/ev/thread_pool.zig:241  in runTasks
```

The violated invariant is that **the loop must outlive the thread pool's threads.** The old `ThreadPool.stop()` only *signalled* shutdown; only `deinit()` *joined* the threads. So nothing guaranteed the pool was quiescent before a loop was closed — neither in the failing test nor in `Runtime.deinit` (which closed loops at `shutdownWorkers()`/`main_executor.deinit()` while the pool wasn't joined until later).

## Fix

- **`ThreadPool.stop()`** now performs the full hard stop: set shutdown, drop queued work, refuse new submissions, and **join all worker threads** (idempotent). After it returns, no worker thread exists, so no completion callback can fire. The pool object stays valid until `deinit()`.
- **`submit()`** drops work when shutdown is set (also prevents a post-stop `spawnThread`), so executors still tearing down can safely call into it.
- **`ThreadPool.deinit()`** is now just `stop()` + free the workers list.
- **`Runtime.deinit()`** reordered to: stop+join the pool (all loops still alive) → shut down executors → deinit pool → deinit executors.
- **Tests** reordered so the pool is `stop()`-ed (joined) before `loop.deinit()`; the blocker-based cancel tests unblock the worker before the join so it can't deadlock.

## Behavior note

`submit()` after `stop()` now silently drops the work without firing its completion. This is intentional for shutdown ("all tasks are dropped"); in practice nothing submits post-stop since all tasks are already complete.

## Testing

- Full native unit suite passes (io_uring and `-Dbackend=epoll`).
- `cancel: work before run` (the reported failure) and the cancel/fs/ThreadPool groups pass under `aarch64-linux` qemu with epoll. (io_uring is unavailable under qemu; the original CI failure was on the epoll path.)