### PR TITLE
blocking_task: fix reference count leak in registerBlockingTask

### DIFF
--- a/src/blocking_task.zig
+++ b/src/blocking_task.zig
@@ -129,7 +129,13 @@ fn registerBlockingTask(rt: *Runtime, task: *AnyBlockingTask) error{RuntimeShutd
         return error.RuntimeShutdown;
     }
 
-    task.awaitable.ref_count.incr();
+    // Do NOT increment ref_count here. Unlike registerTask (task.zig), this would
+    // add a third reference that is never released: the init ref (=1) is dropped by
+    // finishTask via threadPoolCompletion, and the caller (JoinHandle) ref is added
+    // in spawnBlockingTask before submit and dropped by join()/cancel()/detach().
+    // The extra incr orphans one reference and leaks the blocking-task allocation.
+    // It is masked for pool-sized tasks (pool.deinit frees the backing buffer) and
+    // only observable for tasks larger than pool_item_size (direct allocator path).
     _ = rt.task_count.fetchAdd(1, .acq_rel);
     rt.thread_pool.submit(&task.work);
 }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1070,6 +1070,27 @@ test "Runtime: sleep from main" {
     try std.testing.expect(start.durationTo(end).toMilliseconds() >= 10);
 }
 
+test "runtime: spawnBlocking does not leak with a large result" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer runtime.deinit();
+
+    // Regression test for a blocking-task refcount leak. A large result forces
+    // TaskPool.alloc down the direct allocator path (size > pool_item_size), so
+    // the leaked allocation is reported by testing.allocator. With a small (e.g.
+    // i32) result the task is pool-allocated and the leak is masked by
+    // pool.deinit freeing the pool's backing buffer -- which is why the existing
+    // smoke test did not catch it.
+    const blockingWork = struct {
+        fn call(x: u8) [4000]u8 {
+            return [_]u8{x} ** 4000;
+        }
+    }.call;
+
+    var handle = try runtime.spawnBlocking(blockingWork, .{@as(u8, 7)});
+    const result = handle.join();
+    try std.testing.expectEqual(@as(u8, 7), result[0]);
+}
+
 test "runtime: basic sleep" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();


### PR DESCRIPTION
## Problem

`spawnBlocking` leaks the blocking-task allocation. `registerBlockingTask` increments `awaitable.ref_count`, but the equivalent `registerTask` (regular tasks) does not. That extra reference is never released:

- the init ref (=1 from `RefCounter.init`) is dropped by `finishTask` via `threadPoolCompletion`;
- the caller / `JoinHandle` ref (added in `spawnBlockingTask` before submit) is dropped by `join()` / `cancel()` / `detach()`;
- the extra `incr()` in `registerBlockingTask` has no matching release, so `AnyBlockingTask.destroy()` is never called.

## Why it wasn't caught

The leak is masked for pool-sized tasks: `Runtime.deinit` → `TaskPool.deinit` frees the pool's backing buffer regardless of whether individual tasks were destroyed. It only becomes observable for tasks whose allocation exceeds `pool_item_size` and take the direct `rt.allocator.alignedAlloc` path. The existing `spawnBlocking` smoke test returns an `i32`, so its task is pool-allocated and the leak stays hidden.

## Fix

Drop the extra `ref_count.incr()` in `registerBlockingTask` so it mirrors `registerTask`.

## Test

Adds `runtime: spawnBlocking does not leak with a large result` (returns `[4000]u8` to force the direct-allocator path). On `main` it reports `1 test leaked`; with the fix it passes. Full suite: 502/502 tests pass.