### PR TITLE
Futex: skip timer path and redundant bucket-lock for untimed waits

### DIFF
--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -137,6 +137,12 @@ pub fn timedWait(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable ||
 
 /// Like `timedWait`, but the timeout is measured against `clock`.
 pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
+    // No deadline: delegate to the untimed `wait`. This skips the timer setup
+    // and, more importantly, the unconditional post-wake `removeFromBucket`
+    // below (a second bucket-mutex acquisition per wait) that can never observe
+    // a timeout when there is none. `wake()` dequeues us instead.
+    if (timeout == .none) return wait(ptr, expect);
+
     // Fast path: check if value already changed
     if (@atomicLoad(u32, ptr, .acquire) != expect) {
         return;


### PR DESCRIPTION
## What

`Futex.timedWaitClock` always ran `removeFromBucket` after a wake to decide the timeout-vs-wake winner (a second bucket-mutex acquisition), and drove the timed waiter path — even when the caller passed no deadline (`.none`).

For an untimed wait there is no timer, so that post-wake `removeFromBucket` can *never* observe a timeout. It's pure waste on the hottest blocking path: every untimed wait took the bucket mutex twice (push + removeFromBucket) instead of once.

This short-circuits `.none` to the existing untimed `wait()`, which parks without a timer and lets `wake()` dequeue the waiter — one bucket-mutex acquisition instead of two.

```zig
pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
    if (timeout == .none) return wait(ptr, expect);
    ...
}
```

## Why it matters broadly

Every `std.Io` synchronization primitive on zio issues untimed `io.futexWait` calls (`Mutex.lock` under contention, `Condition.wait`, `Queue`, `Semaphore`), and they all flow through `Futex.timedWaitClock` via the io vtable. So this one line benefits the whole `std.Io` sync layer, not just direct `Futex` users.

## Measurement

A two-task 100k-message queue ping-pong, normalized against a native-`Channel` run as an ambient-load control (native parks via `Waiter` directly and does not hit `Futex.timedWaitClock`):

| | before | after |
|---|---|---|
| `std.Io.Queue` (relative to control) | 1.61× | 1.47× (**−8%**) |
| futex-based channel (relative to control) | 1.40× | 1.29× (**−8%**) |

## Testing

`./check.sh` — 507/507 unit tests pass. No behavioral change for timed waits; `.none` waits keep identical semantics (cancelable, spurious-wake-safe), just without the timer setup and the extra bucket-mutex round-trip.