### PR TITLE
loop: make checkTimers lock-free on ticks with no due-heap work

### DIFF
--- a/src/ev/heap.zig
+++ b/src/ev/heap.zig
@@ -49,28 +49,43 @@ pub fn Heap(
     return struct {
         const Self = @This();
 
-        root: ?*T = null,
+        /// Atomic so `isEmpty` can be read without the caller's lock. All
+        /// mutations still happen under that lock; the atomicity only exists to
+        /// make the pointer safe to *read* (never dereference) concurrently.
+        root: std.atomic.Value(?*T) = .init(null),
         context: Context,
 
         /// Insert a new element v into the heap. An element v can only
         /// be a member of a single heap at any given time. When compiled
         /// with runtime-safety, assertions will help verify this property.
         pub fn insert(self: *Self, v: *T) void {
-            self.root = if (self.root) |root| self.meld(v, root) else v;
+            const cur = self.root.load(.monotonic);
+            self.root.store(if (cur) |root| self.meld(v, root) else v, .release);
         }
 
         /// Look at the next minimum value but do not remove it.
         pub fn peek(self: *Self) ?*T {
-            return self.root;
+            return self.root.load(.monotonic);
+        }
+
+        /// Lock-free emptiness check. Unlike the other methods, this is safe to
+        /// call *without* the caller's lock: it only compares the root pointer to
+        /// null and never dereferences it, so a stale non-null read at worst
+        /// sends the caller into its locked path to re-check. A null read is
+        /// always real — root only becomes non-null via `insert` (owner thread,
+        /// which orders before that thread's own check) and a cross-thread
+        /// `remove` can only null it.
+        pub fn isEmpty(self: *Self) bool {
+            return self.root.load(.acquire) == null;
         }
 
         /// Delete the minimum value from the heap and return it.
         pub fn deleteMin(self: *Self) ?*T {
-            const root = self.root orelse return null;
-            self.root = if (root.heap.child) |child|
+            const root = self.root.load(.monotonic) orelse return null;
+            self.root.store(if (root.heap.child) |child|
                 self.combine_siblings(child)
             else
-                null;
+                null, .release);
 
             // Clear pointers with runtime safety so we can verify on
             // insert that values aren't incorrectly being set multiple times.
@@ -85,7 +100,7 @@ pub fn Heap(
             // element. If it is NOT the root element, v can't be in this
             // heap and we trigger an assertion failure.
             const prev = v.heap.prev orelse {
-                assert(self.root.? == v);
+                assert(self.root.load(.monotonic).? == v);
                 _ = self.deleteMin();
                 return;
             };
@@ -106,7 +121,8 @@ pub fn Heap(
             const child = v.heap.child orelse return;
             v.heap.child = null;
             const x = self.combine_siblings(child);
-            self.root = self.meld(x, self.root.?);
+            const cur = self.root.load(.monotonic).?;
+            self.root.store(self.meld(x, cur), .release);
         }
 
         /// Meld (union) two heaps together. This isn't a generalized

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -914,9 +914,10 @@ pub const Loop = struct {
 
         // Advance the scan once and refresh the awake snapshot; this also
         // invalidates the lazily-cached boot/real values for this scan.
-        self.state.lockTimers();
+        // `now`/`tick` are only ever touched by the owning executor thread
+        // (`updateNow` is called here and in `setTimer`, both owner-thread; the
+        // cross-thread `clearTimer` never reads them), so no timer lock is needed.
         self.state.updateNow();
-        self.state.unlockTimers();
 
         // Each wall-clock domain has its own heap, compared against `now` in
         // that clock. The earliest remaining across all domains becomes the
@@ -925,6 +926,12 @@ pub const Loop = struct {
         // (the re-read of `now(clock)` on the next scan corrects it).
         for (0..wall_clock_count) |idx| {
             const clock = indexClock(idx);
+
+            // Lock-free fast path: an empty heap has nothing to fire and no
+            // deadline to contribute, so skip the timer mutex entirely. A null
+            // read is always real (see Heap.isEmpty); a stale non-null just falls
+            // through to the locked drain below and re-checks.
+            if (self.state.timers[idx].isEmpty()) continue;
 
             // Process fired timers in batches to avoid holding the lock during
             // callbacks. This prevents deadlock when callbacks set/clear timers.


### PR DESCRIPTION
## What

Every `Loop.tick` calls `checkTimers`, which took the per-loop timer mutex several times per tick even when nothing was pending: once for `updateNow`, then once per wall-clock heap just to peek it. That mutex is contended cross-thread — timed-wait cancellation reaches into a loop's timer heap from another executor — so paying it on every idle tick is pure overhead on the scheduler hot path.

Two changes make a tick with no due-heap work fully lock-free:

1. **`Heap.root` becomes an atomic pointer** with a lock-free `isEmpty()` that only *reads* it and never dereferences. `checkTimers` skips a clock's locked drain when its heap is empty.
2. **`updateNow` no longer takes the timer lock.** It only touches `now`/`tick`, which are owner-thread state.

## Why it's safe

- `isEmpty()` compares the root pointer to null without dereferencing, so there's no lifetime hazard against a cross-thread `remove` freeing a stack `Timer`. A **null read is always real**: `root` only goes non-null via owner-thread `insert` (ordered before that thread's own `checkTimers`), and a cross-thread `remove` can only null it — so no false "empty". A stale non-null read just falls through to the existing locked path and re-checks. All heap *mutations* still happen under the timer lock; the atomic exists only to make the pointer safe to read concurrently.
- `updateNow`'s callers (`init`, `setTimer`, `checkTimers`) all run on the owning executor and are mutually exclusive, and `Loop.now()` already reads `now[0]` without the timer lock — so that lock never synchronized `now`/`tick` against its one lock-free reader in the first place. De-locking it changes nothing about that access pattern.

## Measurement

Two-task 100k-message queue ping-pong (empty timer heaps every tick), before vs after built side-by-side and run **interleaved** in one hyperfine invocation to cancel ambient drift:

| | speedup |
|---|---|
| `std.Io.Queue` | **1.09× (−8%)** |
| futex-based channel | **1.10× (−10%)** |

Benefits anything that ticks the loop while no timer is due — not just these benchmarks.

## Scope / follow-ups

This only skips the lock when a heap is **empty**. The **pending-but-not-due** case (heaps non-empty, earliest deadline in the future) still locks every tick; covering it needs a lock-free read of the *earliest deadline*, which means an atomic 64-bit key — not portable to 32-bit targets (riscv32 has no 64-bit atomics) without a seqlock or a comptime-gated fast path. Deferred until a timed-wait-heavy workload profiles as timer-bound.

## Testing

`./check.sh` — 507/507 unit tests pass, including repeated runs of the cross-thread/multi-executor, cancel, and timer suites to shake out races.