### PR TITLE
Cancelable delegated file ops on kqueue/poll backends

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -507,18 +507,19 @@ test "blockInPlace: cancellation interrupts a blocking syscall on the worker" {
     const worker = struct {
         fn cancelableRead(fd: std.c.fd_t, ready: *std.atomic.Value(bool)) error{ Canceled, Unexpected }!void {
             const sc = try os.syscall_cancel.Syscall.begin();
+            defer sc.finish();
             // Signal that we are inside the cancelable region, just before read().
             ready.store(true, .release);
             var buf: [1]u8 = undefined;
             while (true) {
                 const rc = std.c.read(fd, &buf, buf.len);
-                if (rc >= 0) return sc.fail(error.Unexpected);
+                if (rc >= 0) return error.Unexpected;
                 switch (std.posix.errno(rc)) {
                     .INTR => {
                         try sc.checkCancel();
                         continue;
                     },
-                    else => return sc.fail(error.Unexpected),
+                    else => return error.Unexpected,
                 }
             }
         }

--- a/src/common.zig
+++ b/src/common.zig
@@ -411,70 +411,38 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     const Context = struct {
         args: Args,
         result: Result = undefined,
-        // Distinct from the waiter's signal count: the resend timer below also
-        // signals the waiter, so we need an unambiguous "work finished" flag.
-        done: std.atomic.Value(bool) = .init(false),
 
         fn workFn(work: *ev.Work) void {
             const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
             ctx.result = @call(.auto, func, ctx.args);
         }
-
-        fn completionFn(completion_ctx: ?*anyopaque, work: *ev.Work) void {
-            const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
-            ctx.done.store(true, .release);
-            const waiter: *Waiter = @ptrCast(@alignCast(completion_ctx.?));
-            waiter.signal();
-        }
     };
 
     var ctx: Context = .{ .args = args };
-    var waiter: Waiter = .init();
 
-    // If not in a task context, just run the function directly
-    const task = waiter.mode.direct.task orelse {
+    // Outside a task there is no event loop / thread pool to hand off to, so run
+    // the function inline on the calling thread.
+    if (getCurrentTaskOrNull() == null) {
         return @call(.auto, func, args);
-    };
+    }
 
     var token: os.syscall_cancel.Token = .{};
     var work = ev.Work.init(Context.workFn, &ctx);
-    work.completion_fn = Context.completionFn;
-    work.completion_context = &waiter;
     work.cancel_token = &token;
 
-    const thread_pool = task.getThreadPool();
-    thread_pool.submit(&work);
-
-    waiter.wait(1, .allow_cancel) catch {
-        // The task was canceled. Signal the token to interrupt any running
-        // cancelable syscall via SIGURG. We do NOT drop the work from the
-        // queue: workFn must always run so ctx.result is always valid, and
-        // for queued (not-yet-started) work the canceled token causes
-        // Syscall.begin() to return error.Canceled when the worker picks it up.
-        const need_signal = token.cancel();
-        if (need_signal) _ = token.signal();
-
-        // Wait for completion (ctx/work live on our stack). Drive resend-with-
-        // backoff to cover the begin()→syscall gap where the first SIGURG can
-        // be lost. The wait is a cooperative timedWait (parks the coroutine on
-        // an executor timer), so resending never blocks the thread.
-        // Use an incrementing wait_count so each timedWait actually parks
-        // instead of returning immediately once the timer has fired once.
-        var wait_count: u32 = 1;
-        var backoff = Duration.fromMicroseconds(1);
-        const cap = Duration.fromMilliseconds(1);
-        while (!ctx.done.load(.acquire)) {
-            waiter.timedWait(wait_count, .{ .duration = backoff }, .no_cancel);
-            wait_count +|= 1;
-            // Resend if the worker is still blocked in the canceled syscall (the
-            // first signal can be lost in the start()→syscall window). Once it
-            // acknowledges, `signal()` returns false and we just park until done.
-            backoff = if (token.signal())
-                .{ .value = @min(backoff.value *| 2, cap.value) }
-            else
-                cap;
-        }
-    };
+    // Submit to the thread pool and wait through the event loop. The loop owns
+    // completion delivery — it finalizes work.c and signals the waiter on the
+    // loop thread as the *last* step — and cancellation: loop.cancel interrupts
+    // a blocking cancelable syscall via SIGURG and resends each tick until the
+    // worker acknowledges (see Loop.cancel_resend). Unlike a direct worker-thread
+    // completion callback, nothing touches this stack frame after we might
+    // return, so there is no use-after-free window.
+    //
+    // workFn always runs (token-bearing work is never dropped from the queue),
+    // so ctx.result is always valid. A canceled syscall makes `func` return
+    // error.Canceled, which surfaces here as that result; waitForIo re-arms the
+    // task's pending cancellation before returning.
+    waitForIo(&work.c) catch {};
 
     return ctx.result;
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -442,7 +442,15 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     // so ctx.result is always valid. A canceled syscall makes `func` return
     // error.Canceled, which surfaces here as that result; waitForIo re-arms the
     // task's pending cancellation before returning.
-    waitForIo(&work.c) catch {};
+    //
+    // waitForIo only fails with error.Canceled, and only when the *completion*
+    // carries a Canceled result — which happens on the drop path, where workFn
+    // never runs and ctx.result would be undefined. Token-bearing work is never
+    // dropped (it always completes via setResult, cancellation delivered in-band
+    // through func's return), so this is unreachable. Assert it: were it ever to
+    // fire we would be returning uninitialized ctx.result, which we would much
+    // rather crash on.
+    waitForIo(&work.c) catch unreachable;
 
     return ctx.result;
 }

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -540,6 +540,16 @@ pub const Work = struct {
     /// `ThreadPool.cancel` signals it to interrupt an in-progress syscall.
     cancel_token: ?*os.syscall_cancel.Token = null,
 
+    /// Intrusive link + membership key for the loop's cancel-resend list
+    /// (`Loop.cancel_resend`). A canceled-but-still-blocked worker is added here
+    /// so `tick` re-sends `SIGURG` until it acknowledges. `resend_key` is the
+    /// public completion whose finalization removes this work from the list
+    /// (== `&c` for a plain `.work` op, or the owning op's completion for a
+    /// delegated file op); non-null means "in the list". Touched only on the
+    /// owning loop's thread.
+    resend_next: ?*Work = null,
+    resend_key: ?*Completion = null,
+
     pub const Error = error{NoThreadPool} || Cancelable;
 
     pub const State = enum(u8) {
@@ -1016,22 +1026,21 @@ pub const FileOpenResult = struct {
 
 /// Shared `internal` payload for file/dir ops delegated to the thread pool on
 /// backends without native async support (kqueue/poll). Bundles the pool `Work`,
-/// the loop linkage, an allocator slot (used by path-based ops), the syscall
-/// cancellation token bound by the worker, and the intrusive link for the loop's
-/// cancel-resend list (see `Loop.cancel_resend`). `linked_context.linked` back-
-/// points to the owning `Completion`, so the loop can find a `DelegatedWork` from
-/// a completion at finalization without any per-op-type knowledge.
+/// the loop linkage, an allocator slot (used by path-based ops), and the syscall
+/// cancellation token bound by the worker. The cancel-resend list link lives on
+/// the embedded `work` (see `Work.resend_next`/`resend_key`); `linked_context.linked`
+/// back-points to the owning `Completion` and is used as the work's `resend_key`,
+/// so the loop finds the entry from a completion at finalization without any
+/// per-op-type knowledge.
 pub const DelegatedWork = struct {
     work: Work = undefined,
     allocator: std.mem.Allocator = undefined,
     linked_context: Loop.LinkedWorkContext = undefined,
     /// Bound by the worker (`enter`/`exit`) around the syscall; signaled on
-    /// cancel. See `os.syscall_cancel`.
+    /// cancel. See `os.syscall_cancel`. The cancel-resend linkage now lives on
+    /// the embedded `work` (see `Work.resend_next`/`resend_key`), keyed on
+    /// `linked_context.linked` so it is reachable generically from a completion.
     token: os.syscall_cancel.Token = .{},
-    /// Intrusive link + membership flag for `Loop.cancel_resend`. Touched only
-    /// on the owning loop's thread.
-    resend_next: ?*DelegatedWork = null,
-    in_resend_list: bool = false,
 };
 
 pub const FileOpen = struct {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -1014,12 +1014,32 @@ pub const FileOpenResult = struct {
     pollable: bool = false,
 };
 
+/// Shared `internal` payload for file/dir ops delegated to the thread pool on
+/// backends without native async support (kqueue/poll). Bundles the pool `Work`,
+/// the loop linkage, an allocator slot (used by path-based ops), the syscall
+/// cancellation token bound by the worker, and the intrusive link for the loop's
+/// cancel-resend list (see `Loop.cancel_resend`). `linked_context.linked` back-
+/// points to the owning `Completion`, so the loop can find a `DelegatedWork` from
+/// a completion at finalization without any per-op-type knowledge.
+pub const DelegatedWork = struct {
+    work: Work = undefined,
+    allocator: std.mem.Allocator = undefined,
+    linked_context: Loop.LinkedWorkContext = undefined,
+    /// Bound by the worker (`enter`/`exit`) around the syscall; signaled on
+    /// cancel. See `os.syscall_cancel`.
+    token: os.syscall_cancel.Token = .{},
+    /// Intrusive link + membership flag for `Loop.cancel_resend`. Touched only
+    /// on the owning loop's thread.
+    resend_next: ?*DelegatedWork = null,
+    in_resend_list: bool = false,
+};
+
 pub const FileOpen = struct {
     c: Completion,
     result_private_do_not_touch: FileOpenResult = undefined,
     internal: switch (Backend.capabilities.file_open) {
         true => if (@hasDecl(Backend, "FileOpenData")) Backend.FileOpenData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1046,7 +1066,7 @@ pub const FileCreate = struct {
     result_private_do_not_touch: FileOpenResult = undefined,
     internal: switch (Backend.capabilities.file_create) {
         true => if (@hasDecl(Backend, "FileCreateData")) Backend.FileCreateData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1073,7 +1093,7 @@ pub const FileClose = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_close) {
         true => if (@hasDecl(Backend, "FileCloseData")) Backend.FileCloseData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
 
@@ -1096,7 +1116,7 @@ pub const FileRead = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.file_read) {
         true => if (@hasDecl(Backend, "FileReadData")) Backend.FileReadData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     buffer: ReadBuf,
@@ -1123,7 +1143,7 @@ pub const FileWrite = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.file_write) {
         true => if (@hasDecl(Backend, "FileWriteData")) Backend.FileWriteData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     buffer: WriteBuf,
@@ -1150,7 +1170,7 @@ pub const FileReadStreaming = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.file_read_streaming) {
         true => if (@hasDecl(Backend, "FileReadStreamingData")) Backend.FileReadStreamingData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     buffer: ReadBuf,
@@ -1180,7 +1200,7 @@ pub const FileWriteStreaming = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.file_write_streaming) {
         true => if (@hasDecl(Backend, "FileWriteStreamingData")) Backend.FileWriteStreamingData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     buffer: WriteBuf,
@@ -1210,7 +1230,7 @@ pub const FileSync = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_sync) {
         true => if (@hasDecl(Backend, "FileSyncData")) Backend.FileSyncData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     flags: fs.FileSyncFlags,
@@ -1235,7 +1255,7 @@ pub const FileSetSize = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_set_size) {
         true => if (@hasDecl(Backend, "FileSetSizeData")) Backend.FileSetSizeData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     length: u64,
@@ -1260,7 +1280,7 @@ pub const FileSetPermissions = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_set_permissions) {
         true => if (@hasDecl(Backend, "FileSetPermissionsData")) Backend.FileSetPermissionsData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     mode: fs.mode_t,
@@ -1285,7 +1305,7 @@ pub const FileSetOwner = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_set_owner) {
         true => if (@hasDecl(Backend, "FileSetOwnerData")) Backend.FileSetOwnerData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     uid: ?fs.uid_t,
@@ -1312,7 +1332,7 @@ pub const FileSetTimestamps = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_set_timestamps) {
         true => if (@hasDecl(Backend, "FileSetTimestampsData")) Backend.FileSetTimestampsData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     timestamps: fs.FileTimestamps,
@@ -1337,7 +1357,7 @@ pub const DirSetPermissions = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_set_permissions) {
         true => if (@hasDecl(Backend, "DirSetPermissionsData")) Backend.DirSetPermissionsData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     mode: fs.mode_t,
@@ -1362,7 +1382,7 @@ pub const DirSetOwner = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_set_owner) {
         true => if (@hasDecl(Backend, "DirSetOwnerData")) Backend.DirSetOwnerData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     uid: ?fs.uid_t,
@@ -1389,7 +1409,7 @@ pub const DirSetFilePermissions = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_set_file_permissions) {
         true => if (@hasDecl(Backend, "DirSetFilePermissionsData")) Backend.DirSetFilePermissionsData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1418,7 +1438,7 @@ pub const DirSetFileOwner = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_set_file_owner) {
         true => if (@hasDecl(Backend, "DirSetFileOwnerData")) Backend.DirSetFileOwnerData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1449,7 +1469,7 @@ pub const DirSetFileTimestamps = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_set_file_timestamps) {
         true => if (@hasDecl(Backend, "DirSetFileTimestampsData")) Backend.DirSetFileTimestampsData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1478,7 +1498,7 @@ pub const DirSymLink = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_sym_link) {
         true => if (@hasDecl(Backend, "DirSymLinkData")) Backend.DirSymLinkData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     target: []const u8,
@@ -1507,7 +1527,7 @@ pub const DirReadLink = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.dir_read_link) {
         true => if (@hasDecl(Backend, "DirReadLinkData")) Backend.DirReadLinkData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1534,7 +1554,7 @@ pub const DirHardLink = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_hard_link) {
         true => if (@hasDecl(Backend, "DirHardLinkData")) Backend.DirHardLinkData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     old_dir: fs.fd_t,
     old_path: []const u8,
@@ -1565,7 +1585,7 @@ pub const DirAccess = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_access) {
         true => if (@hasDecl(Backend, "DirAccessData")) Backend.DirAccessData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1592,7 +1612,7 @@ pub const DirRealPath = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.dir_real_path) {
         true => if (@hasDecl(Backend, "DirRealPathData")) Backend.DirRealPathData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     fd: fs.fd_t,
     buffer: []u8,
@@ -1617,7 +1637,7 @@ pub const DirRealPathFile = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.dir_real_path_file) {
         true => if (@hasDecl(Backend, "DirRealPathFileData")) Backend.DirRealPathFileData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1644,7 +1664,7 @@ pub const FileRealPath = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.file_real_path) {
         true => if (@hasDecl(Backend, "FileRealPathData")) Backend.FileRealPathData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     fd: fs.fd_t,
     buffer: []u8,
@@ -1669,7 +1689,7 @@ pub const FileHardLink = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.file_hard_link) {
         true => if (@hasDecl(Backend, "FileHardLinkData")) Backend.FileHardLinkData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     fd: fs.fd_t,
     new_dir: fs.fd_t,
@@ -1698,7 +1718,7 @@ pub const DirCreateDir = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_create_dir) {
         true => if (@hasDecl(Backend, "DirCreateDirData")) Backend.DirCreateDirData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1725,7 +1745,7 @@ pub const DirRename = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_rename) {
         true => if (@hasDecl(Backend, "DirRenameData")) Backend.DirRenameData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     old_dir: fs.fd_t,
     old_path: []const u8,
@@ -1754,7 +1774,7 @@ pub const DirRenamePreserve = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_rename_preserve) {
         true => if (@hasDecl(Backend, "DirRenamePreserveData")) Backend.DirRenamePreserveData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     old_dir: fs.fd_t,
     old_path: []const u8,
@@ -1783,7 +1803,7 @@ pub const DirDeleteFile = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_delete_file) {
         true => if (@hasDecl(Backend, "DirDeleteFileData")) Backend.DirDeleteFileData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1808,7 +1828,7 @@ pub const DirDeleteDir = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_delete_dir) {
         true => if (@hasDecl(Backend, "DirDeleteDirData")) Backend.DirDeleteDirData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1833,7 +1853,7 @@ pub const FileSize = struct {
     result_private_do_not_touch: u64 = undefined,
     internal: switch (Backend.capabilities.file_size) {
         true => if (@hasDecl(Backend, "FileSizeData")) Backend.FileSizeData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
 
@@ -1856,7 +1876,7 @@ pub const FileStat = struct {
     result_private_do_not_touch: fs.FileStatInfo = undefined,
     internal: switch (Backend.capabilities.file_stat) {
         true => if (@hasDecl(Backend, "FileStatData")) Backend.FileStatData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     path: ?[]const u8,
@@ -1886,7 +1906,7 @@ pub const DirOpen = struct {
     result_private_do_not_touch: fs.fd_t = undefined,
     internal: switch (Backend.capabilities.dir_open) {
         true => if (@hasDecl(Backend, "DirOpenData")) Backend.DirOpenData else struct {},
-        false => struct { work: Work = undefined, allocator: std.mem.Allocator = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     dir: fs.fd_t,
     path: []const u8,
@@ -1913,7 +1933,7 @@ pub const DirClose = struct {
     result_private_do_not_touch: void = {},
     internal: switch (Backend.capabilities.dir_close) {
         true => if (@hasDecl(Backend, "DirCloseData")) Backend.DirCloseData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
 
@@ -1936,7 +1956,7 @@ pub const DirRead = struct {
     result_private_do_not_touch: usize = undefined,
     internal: switch (Backend.capabilities.dir_read) {
         true => if (@hasDecl(Backend, "DirReadData")) Backend.DirReadData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
     handle: fs.fd_t,
     buffer: []u8,
@@ -2123,7 +2143,7 @@ pub const ProcessWait = struct {
     handle: ProcessHandle,
     internal: switch (Backend.capabilities.process_wait) {
         true => if (@hasDecl(Backend, "ProcessWaitData")) Backend.ProcessWaitData else struct {},
-        false => struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined },
+        false => DelegatedWork,
     } = .{},
 
     pub const ProcessHandle = switch (builtin.os.tag) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -13,6 +13,7 @@ const Clock = @import("../time.zig").Clock;
 const Queue = @import("queue.zig").Queue;
 const Heap = @import("heap.zig").Heap;
 const Work = @import("completion.zig").Work;
+const DelegatedWork = @import("completion.zig").DelegatedWork;
 const FileRead = @import("completion.zig").FileRead;
 const NetSend = @import("completion.zig").NetSend;
 const NetSendFile = @import("completion.zig").NetSendFile;
@@ -148,6 +149,11 @@ const TimerHeap = Heap(Timer, void, timerDeadlineLess);
 /// 0..wall_clock_count contiguously, so the enum value is the heap index.
 const wall_clock_count = 3;
 
+/// How often `tick` re-sends `SIGURG` to a worker still blocked in a canceled
+/// syscall (see `LoopState.cancel_resend`). One signal almost always suffices;
+/// this bounds how long a lost first signal delays the interruption.
+const resend_interval: Duration = .fromMilliseconds(1);
+
 fn clockIndex(clock: Clock) usize {
     // Where the platform has no distinct suspend-inclusive clock, `.boot` and
     // `.awake` are the same clock, so boot timers share the awake heap (index 0)
@@ -238,6 +244,14 @@ pub const LoopState = struct {
         .{ .context = {} },
         .{ .context = {} },
     },
+
+    /// Intrusive list of thread-pool-delegated works whose cancellation has been
+    /// requested but whose worker is still blocked in the canceled syscall. Each
+    /// `tick` re-sends `SIGURG` to cover a first signal lost in the tiny window
+    /// between `Syscall.begin()` and the kernel entering the sleep. Touched only
+    /// on this loop's thread (added in `cancelLocal`, swept in `tick`, removed as
+    /// the completion is finalized in the `work_completions` drain).
+    cancel_resend: ?*DelegatedWork = null,
     // TODO: Linked timers optimization
     // Instead of mutex-protected cross-thread timer cancellation, link timers to their
     // associated operations. When an operation completes, its linked timer is cleared
@@ -453,6 +467,67 @@ pub const LoopState = struct {
             self.timers[clockIndex(timer.clock)].remove(timer);
         }
         timer.deadline = .zero;
+    }
+
+    /// Add a delegated work to the cancel-resend list (idempotent). Loop-thread
+    /// only. Only works whose worker is blocked-and-canceling belong here.
+    fn addResend(self: *LoopState, dw: *DelegatedWork) void {
+        if (dw.in_resend_list) return;
+        dw.in_resend_list = true;
+        dw.resend_next = self.cancel_resend;
+        self.cancel_resend = dw;
+    }
+
+    /// Remove a delegated work from the cancel-resend list if present.
+    /// Loop-thread only.
+    fn removeResend(self: *LoopState, dw: *DelegatedWork) void {
+        if (!dw.in_resend_list) return;
+        var slot = &self.cancel_resend;
+        while (slot.*) |node| {
+            if (node == dw) {
+                slot.* = node.resend_next;
+                dw.resend_next = null;
+                dw.in_resend_list = false;
+                return;
+            }
+            slot = &node.resend_next;
+        }
+    }
+
+    /// Remove the delegated work owning `completion` from the resend list, if it
+    /// is on it. Called as the completion is finalized (before its waiter is
+    /// signaled) so the sweep never dereferences a token whose `op_data` is about
+    /// to be freed. The list is empty in the common case, so this is O(1) then.
+    /// Loop-thread only.
+    fn removeResendByCompletion(self: *LoopState, completion: *Completion) void {
+        if (self.cancel_resend == null) return;
+        var slot = &self.cancel_resend;
+        while (slot.*) |node| {
+            if (node.linked_context.linked == completion) {
+                slot.* = node.resend_next;
+                node.resend_next = null;
+                node.in_resend_list = false;
+                return;
+            }
+            slot = &node.resend_next;
+        }
+    }
+
+    /// Re-send `SIGURG` to every still-blocked canceling worker, dropping any
+    /// that have acknowledged. Called once per `tick`. Loop-thread only.
+    fn sweepResend(self: *LoopState) void {
+        var slot = &self.cancel_resend;
+        while (slot.*) |node| {
+            if (node.token.signal()) {
+                // Still blocked-and-canceling; keep it and re-check next tick.
+                slot = &node.resend_next;
+            } else {
+                // Worker acknowledged (or the op finished); stop re-sending.
+                slot.* = node.resend_next;
+                node.resend_next = null;
+                node.in_resend_list = false;
+            }
+        }
     }
 };
 
@@ -705,6 +780,16 @@ pub const Loop = struct {
                         const thread_pool = self.thread_pool orelse unreachable;
                         const op_data = completion.cast(op.toType());
                         thread_pool.cancel(&op_data.internal.work);
+                        // If the worker is blocked in the canceled syscall, the
+                        // first SIGURG (sent by cancel above) can be lost in the
+                        // begin()->sleep window. Track it so `tick` re-sends until
+                        // the worker acknowledges. Only DelegatedWork ops have a
+                        // token; the entry is removed when the op finalizes.
+                        if (@hasField(@TypeOf(op_data.internal), "token")) {
+                            if (op_data.internal.token.isCanceling()) {
+                                self.state.addResend(&op_data.internal);
+                            }
+                        }
                     } else {
                         self.backend.cancel(&self.state, completion);
                     }
@@ -1065,6 +1150,10 @@ pub const Loop = struct {
     pub fn processCompletions(self: *Loop) void {
         var work_completions = self.state.work_completions.popAll();
         while (work_completions.pop()) |completion| {
+            // Drop from the cancel-resend list before finalizing: markCompleted
+            // wakes the waiter, whose coroutine may then free the op (and its
+            // token). Removing here keeps the sweep from touching freed memory.
+            self.state.removeResendByCompletion(completion);
             self.state.markCompleted(completion);
         }
 
@@ -1160,6 +1249,12 @@ pub const Loop = struct {
                 op_data.internal.work = Work.init(op_func, null);
                 op_data.internal.work.completion_fn = loopLinkedWorkComplete;
                 op_data.internal.work.completion_context = @ptrCast(&op_data.internal.linked_context);
+                // Ops whose internal is a DelegatedWork carry a cancellation
+                // token: bind it to the work so the worker enters/exits it and
+                // the blocking syscall becomes SIGURG-cancelable.
+                if (@hasField(@TypeOf(op_data.internal), "token")) {
+                    op_data.internal.work.cancel_token = &op_data.internal.token;
+                }
                 tp.submit(&op_data.internal.work);
             },
             else => unreachable,
@@ -1310,6 +1405,9 @@ pub const Loop = struct {
 
         const timer_result = self.checkTimers();
 
+        // Re-send SIGURG to any worker still blocked in a canceled syscall.
+        self.state.sweepResend();
+
         var timeout: Duration = .zero;
         if (wait) {
             // Don't block if we have completions waiting to be processed or timers fired
@@ -1321,6 +1419,11 @@ pub const Loop = struct {
             } else {
                 // No timers, wait for blocking I/O
                 timeout = self.max_wait;
+            }
+            // While cancellations are pending, keep waking to re-send SIGURG so a
+            // lost first signal is retried promptly rather than at max_wait.
+            if (self.state.cancel_resend != null and timeout.value > resend_interval.value) {
+                timeout = resend_interval;
             }
         }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -251,7 +251,7 @@ pub const LoopState = struct {
     /// between `Syscall.begin()` and the kernel entering the sleep. Touched only
     /// on this loop's thread (added in `cancelLocal`, swept in `tick`, removed as
     /// the completion is finalized in the `work_completions` drain).
-    cancel_resend: ?*DelegatedWork = null,
+    cancel_resend: ?*Work = null,
     // TODO: Linked timers optimization
     // Instead of mutex-protected cross-thread timer cancellation, link timers to their
     // associated operations. When an operation completes, its linked timer is cleared
@@ -469,44 +469,30 @@ pub const LoopState = struct {
         timer.deadline = .zero;
     }
 
-    /// Add a delegated work to the cancel-resend list (idempotent). Loop-thread
-    /// only. Only works whose worker is blocked-and-canceling belong here.
-    fn addResend(self: *LoopState, dw: *DelegatedWork) void {
-        if (dw.in_resend_list) return;
-        dw.in_resend_list = true;
-        dw.resend_next = self.cancel_resend;
-        self.cancel_resend = dw;
+    /// Add a canceled-but-blocked work to the cancel-resend list (idempotent).
+    /// Loop-thread only. Only works whose worker is blocked-and-canceling belong
+    /// here. `key` is the public completion whose finalization drops the entry
+    /// (== `&work.c` for a plain `.work` op, or the owning op's completion for a
+    /// delegated file op).
+    fn addResend(self: *LoopState, work: *Work, key: *Completion) void {
+        if (work.resend_key != null) return;
+        work.resend_key = key;
+        work.resend_next = self.cancel_resend;
+        self.cancel_resend = work;
     }
 
-    /// Remove a delegated work from the cancel-resend list if present.
-    /// Loop-thread only.
-    fn removeResend(self: *LoopState, dw: *DelegatedWork) void {
-        if (!dw.in_resend_list) return;
-        var slot = &self.cancel_resend;
-        while (slot.*) |node| {
-            if (node == dw) {
-                slot.* = node.resend_next;
-                dw.resend_next = null;
-                dw.in_resend_list = false;
-                return;
-            }
-            slot = &node.resend_next;
-        }
-    }
-
-    /// Remove the delegated work owning `completion` from the resend list, if it
-    /// is on it. Called as the completion is finalized (before its waiter is
-    /// signaled) so the sweep never dereferences a token whose `op_data` is about
-    /// to be freed. The list is empty in the common case, so this is O(1) then.
-    /// Loop-thread only.
+    /// Remove the work owning `completion` from the resend list, if it is on it.
+    /// Called as the completion is finalized (before its waiter is signaled) so
+    /// the sweep never dereferences a token whose op is about to be freed. The
+    /// list is empty in the common case, so this is O(1) then. Loop-thread only.
     fn removeResendByCompletion(self: *LoopState, completion: *Completion) void {
         if (self.cancel_resend == null) return;
         var slot = &self.cancel_resend;
         while (slot.*) |node| {
-            if (node.linked_context.linked == completion) {
+            if (node.resend_key == completion) {
                 slot.* = node.resend_next;
                 node.resend_next = null;
-                node.in_resend_list = false;
+                node.resend_key = null;
                 return;
             }
             slot = &node.resend_next;
@@ -518,14 +504,14 @@ pub const LoopState = struct {
     fn sweepResend(self: *LoopState) void {
         var slot = &self.cancel_resend;
         while (slot.*) |node| {
-            if (node.token.signal()) {
+            if (node.cancel_token.?.signal()) {
                 // Still blocked-and-canceling; keep it and re-check next tick.
                 slot = &node.resend_next;
             } else {
                 // Worker acknowledged (or the op finished); stop re-sending.
                 slot.* = node.resend_next;
                 node.resend_next = null;
-                node.in_resend_list = false;
+                node.resend_key = null;
             }
         }
     }
@@ -754,6 +740,13 @@ pub const Loop = struct {
                 const thread_pool = self.thread_pool orelse unreachable;
                 const work = completion.cast(Work);
                 thread_pool.cancel(work);
+                // If the worker is blocked in the canceled syscall, the first
+                // SIGURG (sent by cancel above) can be lost in the begin()->sleep
+                // window. Track it so `tick` re-sends until the worker acks; the
+                // entry is dropped when this completion finalizes.
+                if (work.cancel_token) |token| {
+                    if (token.isCanceling()) self.state.addResend(work, completion);
+                }
             },
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
@@ -787,7 +780,7 @@ pub const Loop = struct {
                         // token; the entry is removed when the op finalizes.
                         if (@hasField(@TypeOf(op_data.internal), "token")) {
                             if (op_data.internal.token.isCanceling()) {
-                                self.state.addResend(&op_data.internal);
+                                self.state.addResend(&op_data.internal.work, completion);
                             }
                         }
                     } else {

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -196,14 +196,21 @@ pub const ThreadPool = struct {
     }
 
     pub fn cancel(self: *ThreadPool, work: *Work) void {
-        // Try to transition from pending to canceled atomically
+        // Token-bearing work is never dropped from the queue: its `func` always
+        // runs, so any caller-owned result (e.g. blockInPlace's stack result, or
+        // a delegated op's completion) is always produced. Cancellation is
+        // delivered through the token — a still-queued syscall aborts at
+        // `begin()`, a running one is interrupted via SIGURG (the loop drives
+        // resend until the worker acknowledges).
+        if (work.cancel_token) |token| {
+            if (token.cancel()) _ = token.signal();
+            return;
+        }
+
+        // Untokened work has no way to abort in-flight, so cancellation must drop
+        // it. Try to transition from pending to canceled atomically.
         if (work.state.cmpxchgStrong(.pending, .canceled, .acq_rel, .acquire)) |_| {
             // Already running or completed - worker will call completion_fn.
-            // If it is running and blocked in a cancelable syscall, interrupt it;
-            // the caller drives resend-with-backoff while awaiting completion.
-            if (work.cancel_token) |token| {
-                if (token.cancel()) _ = token.signal();
-            }
             return;
         }
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1272,3 +1272,48 @@ test "Dir: resolve_beneath blocks parent escape" {
         else => return err,
     }
 }
+
+extern "c" fn mkfifo(path: [*:0]const u8, mode: std.c.mode_t) c_int;
+
+test "Dir: canceling a blocking open interrupts the worker" {
+    // Only exercises the thread-pool-delegated path (kqueue/poll and friends);
+    // backends that open natively (io_uring) cancel via the backend instead, and
+    // the SIGURG mechanism is POSIX-only.
+    if (ev.Backend.capabilities.file_open) return;
+    if (!os.syscall_cancel.enabled) return;
+
+    // A FIFO opened O_RDONLY with no writer blocks in the worker's openat(). On
+    // POSIX the open is unconditionally blocking (O_NONBLOCK is applied only
+    // *after* open, in probePollable), so this reliably parks a worker we can
+    // then interrupt.
+    const path = "zig-cache-zio-open-cancel.fifo";
+    _ = std.c.unlink(path);
+    try std.testing.expectEqual(0, mkfifo(path, 0o600));
+    defer _ = std.c.unlink(path);
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const worker = struct {
+        fn call(p: []const u8, result: *(Dir.OpenFileError!void)) void {
+            if (openFile(p)) |file| {
+                file.close();
+                result.* = {};
+            } else |err| {
+                result.* = err;
+            }
+        }
+    };
+
+    var result: Dir.OpenFileError!void = {};
+    var handle = try rt.spawn(worker.call, .{ path, &result });
+
+    // Let the worker reach the blocking open, then cancel. The loop re-sends
+    // SIGURG each tick until the worker acknowledges (covering a lost first
+    // signal), so the open returns error.Canceled.
+    try rt.sleep(.fromMilliseconds(50));
+    handle.cancel();
+    handle.join();
+
+    try std.testing.expectError(error.Canceled, result);
+}

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -693,13 +693,11 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
     // turns the blocking open into EINTR and `checkCancel` reports `Canceled`.
     // Off a cancelable worker the token is null and every call here is a no-op.
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             // EINTR is either the cancellation SIGURG (checkCancel -> Canceled) or
             // a spurious/foreign wake, in which case we retry the open.
             .INTR => {
@@ -708,10 +706,10 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
             },
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return sc.fail(error.AccessDenied);
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return sc.fail(error.AccessDenied);
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
                 }
-                return sc.fail(errnoToFileOpenError(err, flags));
+                return errnoToFileOpenError(err, flags);
             },
         }
     }
@@ -918,23 +916,21 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
     }
 
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, flags.mode);
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return sc.fail(error.AccessDenied);
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return sc.fail(error.AccessDenied);
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
                 }
-                return sc.fail(errnoToFileOpenError(err, flags));
+                return errnoToFileOpenError(err, flags);
             },
         }
     }
@@ -1074,18 +1070,16 @@ pub fn preadv(fd: fd_t, buffers: []iovec, offset: u64) FileReadError!usize {
     }
 
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.preadv(fd, buffers.ptr, @intCast(buffers.len), @intCast(offset));
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
-            else => |err| return sc.fail(errnoToFileReadError(err)),
+            else => |err| return errnoToFileReadError(err),
         }
     }
 }
@@ -1120,18 +1114,16 @@ pub fn pwritev(fd: fd_t, buffers: []const iovec_const, offset: u64) FileWriteErr
     }
 
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.pwritev(fd, buffers.ptr, @intCast(buffers.len), @intCast(offset));
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
-            else => |err| return sc.fail(errnoToFileWriteError(err)),
+            else => |err| return errnoToFileWriteError(err),
         }
     }
 }
@@ -1203,18 +1195,16 @@ pub fn readv(fd: fd_t, buffers: []iovec) FileReadError!usize {
     }
 
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.readv(fd, buffers.ptr, @intCast(buffers.len));
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
-            else => |err| return sc.fail(errnoToFileReadError(err)),
+            else => |err| return errnoToFileReadError(err),
         }
     }
 }
@@ -1278,18 +1268,16 @@ pub fn writev(fd: fd_t, buffers: []const iovec_const) FileWriteError!usize {
     }
 
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.writev(fd, buffers.ptr, @intCast(buffers.len));
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return @intCast(rc);
-            },
+            .SUCCESS => return @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
-            else => |err| return sc.fail(errnoToFileWriteError(err)),
+            else => |err| return errnoToFileWriteError(err),
         }
     }
 }
@@ -2771,6 +2759,7 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
 
     // Call getdents64 (Linux) or getdirentries (BSD)
     const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = switch (builtin.os.tag) {
             .linux => std.os.linux.getdents64(handle, buffer.ptr, buffer.len),
@@ -2786,23 +2775,17 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
         };
 
         switch (posix.errno(rc)) {
-            .SUCCESS => {
-                sc.finish();
-                return if (builtin.os.tag == .linux) rc else @intCast(rc);
-            },
+            .SUCCESS => return if (builtin.os.tag == .linux) rc else @intCast(rc),
             .INTR => {
                 try sc.checkCancel();
                 continue;
             },
-            .BADF, .FAULT, .NOTDIR => return sc.fail(error.Unexpected),
-            .NOENT => {
-                sc.finish();
-                return 0; // Directory deleted during iteration
-            },
-            .ACCES => return sc.fail(error.AccessDenied),
-            .PERM => return sc.fail(error.PermissionDenied),
-            .NOMEM => return sc.fail(error.SystemResources),
-            else => |err| return sc.fail(unexpectedError(err)),
+            .BADF, .FAULT, .NOTDIR => return error.Unexpected,
+            .NOENT => return 0, // Directory deleted during iteration
+            .ACCES => return error.AccessDenied,
+            .PERM => return error.PermissionDenied,
+            .NOMEM => return error.SystemResources,
+            else => |err| return unexpectedError(err),
         }
     }
 }

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -2651,6 +2651,7 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
     }
 
     // Call getdents64 (Linux) or getdirentries (BSD)
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = switch (builtin.os.tag) {
             .linux => std.os.linux.getdents64(handle, buffer.ptr, buffer.len),
@@ -2666,14 +2667,23 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
         };
 
         switch (posix.errno(rc)) {
-            .SUCCESS => return if (builtin.os.tag == .linux) rc else @intCast(rc),
-            .INTR => continue,
-            .BADF, .FAULT, .NOTDIR => return error.Unexpected,
-            .NOENT => return 0, // Directory deleted during iteration
-            .ACCES => return error.AccessDenied,
-            .PERM => return error.PermissionDenied,
-            .NOMEM => return error.SystemResources,
-            else => |err| return unexpectedError(err),
+            .SUCCESS => {
+                sc.finish();
+                return if (builtin.os.tag == .linux) rc else @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            .BADF, .FAULT, .NOTDIR => return sc.fail(error.Unexpected),
+            .NOENT => {
+                sc.finish();
+                return 0; // Directory deleted during iteration
+            },
+            .ACCES => return sc.fail(error.AccessDenied),
+            .PERM => return sc.fail(error.PermissionDenied),
+            .NOMEM => return sc.fail(error.SystemResources),
+            else => |err| return sc.fail(unexpectedError(err)),
         }
     }
 }

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -6,6 +6,7 @@ const w = @import("windows.zig");
 const options = @import("zio_options");
 
 const unexpectedError = @import("base.zig").unexpectedError;
+const syscall_cancel = @import("syscall_cancel.zig");
 
 // Cached probe result: once we see ENOSYS from openat2, skip future attempts.
 var openat2_nosys: std.atomic.Value(bool) = .init(false);
@@ -687,17 +688,30 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
+    // Cancelable region: when this runs on a thread-pool worker bound to a
+    // cancellation token (delegated file ops on kqueue/poll backends), a SIGURG
+    // turns the blocking open into EINTR and `checkCancel` reports `Canceled`.
+    // Off a cancelable worker the token is null and every call here is a no-op.
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            // EINTR is either the cancellation SIGURG (checkCancel -> Canceled) or
+            // a spurious/foreign wake, in which case we retry the open.
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return sc.fail(error.AccessDenied);
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return sc.fail(error.AccessDenied);
                 }
-                return errnoToFileOpenError(err, flags);
+                return sc.fail(errnoToFileOpenError(err, flags));
             },
         }
     }
@@ -898,17 +912,24 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, flags.mode);
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| {
                 if (flags.resolve_beneath) {
-                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
-                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return error.AccessDenied;
+                    if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return sc.fail(error.AccessDenied);
+                    if (builtin.os.tag.isDarwin() and @intFromEnum(err) == 107) return sc.fail(error.AccessDenied);
                 }
-                return errnoToFileOpenError(err, flags);
+                return sc.fail(errnoToFileOpenError(err, flags));
             },
         }
     }
@@ -1047,12 +1068,19 @@ pub fn preadv(fd: fd_t, buffers: []iovec, offset: u64) FileReadError!usize {
         return total_read;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.preadv(fd, buffers.ptr, @intCast(buffers.len), @intCast(offset));
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
-            else => |err| return errnoToFileReadError(err),
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return sc.fail(errnoToFileReadError(err)),
         }
     }
 }
@@ -1086,12 +1114,19 @@ pub fn pwritev(fd: fd_t, buffers: []const iovec_const, offset: u64) FileWriteErr
         return total_written;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.pwritev(fd, buffers.ptr, @intCast(buffers.len), @intCast(offset));
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
-            else => |err| return errnoToFileWriteError(err),
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return sc.fail(errnoToFileWriteError(err)),
         }
     }
 }
@@ -1157,12 +1192,19 @@ pub fn readv(fd: fd_t, buffers: []iovec) FileReadError!usize {
         return total_read;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.readv(fd, buffers.ptr, @intCast(buffers.len));
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
-            else => |err| return errnoToFileReadError(err),
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return sc.fail(errnoToFileReadError(err)),
         }
     }
 }
@@ -1220,12 +1262,19 @@ pub fn writev(fd: fd_t, buffers: []const iovec_const) FileWriteError!usize {
         return total_written;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
     while (true) {
         const rc = posix.system.writev(fd, buffers.ptr, @intCast(buffers.len));
         switch (posix.errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .INTR => continue,
-            else => |err| return errnoToFileWriteError(err),
+            .SUCCESS => {
+                sc.finish();
+                return @intCast(rc);
+            },
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return sc.fail(errnoToFileWriteError(err)),
         }
     }
 }

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -657,6 +657,14 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    // Cancelable region covering both the openat2 (resolve_beneath) path and the
+    // plain openat loop below: on a thread-pool worker bound to a cancellation
+    // token (delegated file ops on kqueue/poll backends), a SIGURG turns the
+    // blocking open into EINTR and `checkCancel` reports `Canceled`. Off a
+    // cancelable worker the token is null and every call here is a no-op.
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+
     if (builtin.os.tag == .linux and flags.resolve_beneath) {
         if (!openat2_nosys.load(.monotonic)) {
             const how: posix.sys.open_how = .{
@@ -668,7 +676,11 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
                 const rc = posix.sys.openat2(dir, path_z.ptr, &how);
                 switch (posix.errno(rc)) {
                     .SUCCESS => return @intCast(rc),
-                    .INTR, .AGAIN => continue,
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
                         if (options.resolve_beneath_mode == .strict) return error.Unsupported;
@@ -688,12 +700,6 @@ pub fn openat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags: 
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
-    // Cancelable region: when this runs on a thread-pool worker bound to a
-    // cancellation token (delegated file ops on kqueue/poll backends), a SIGURG
-    // turns the blocking open into EINTR and `checkCancel` reports `Canceled`.
-    // Off a cancelable worker the token is null and every call here is a no-op.
-    const sc = try syscall_cancel.Syscall.begin();
-    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
@@ -768,6 +774,11 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    // Cancelable region covering both the openat2 (resolve_beneath) path and the
+    // plain openat loop below (see the note in `openat`).
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+
     if (builtin.os.tag == .linux and flags.resolve_beneath) {
         if (!openat2_nosys.load(.monotonic)) {
             const how: posix.sys.open_how = .{
@@ -779,7 +790,11 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
                 const rc = posix.sys.openat2(dir, path_z.ptr, &how);
                 switch (posix.errno(rc)) {
                     .SUCCESS => return @intCast(rc),
-                    .INTR, .AGAIN => continue,
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
                         if (options.resolve_beneath_mode == .strict) return error.Unsupported;
@@ -799,8 +814,6 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
-    const sc = try syscall_cancel.Syscall.begin();
-    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
@@ -884,6 +897,11 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    // Cancelable region covering both the openat2 (resolve_beneath) path and the
+    // plain openat loop below (see the note in `openat`).
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+
     if (builtin.os.tag == .linux and flags.resolve_beneath) {
         if (!openat2_nosys.load(.monotonic)) {
             const how: posix.sys.open_how = .{
@@ -895,7 +913,11 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
                 const rc = posix.sys.openat2(dir, path_z.ptr, &how);
                 switch (posix.errno(rc)) {
                     .SUCCESS => return @intCast(rc),
-                    .INTR, .AGAIN => continue,
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    .AGAIN => continue,
                     .NOSYS => {
                         openat2_nosys.store(true, .monotonic);
                         if (options.resolve_beneath_mode == .strict) return error.Unsupported;
@@ -915,8 +937,6 @@ pub fn createat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
-    const sc = try syscall_cancel.Syscall.begin();
-    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, flags.mode);
         switch (posix.errno(rc)) {

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -801,11 +801,16 @@ pub fn dirOpen(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
         std.log.warn("resolve_beneath is not supported on {s}, path escapes will not be detected", .{@tagName(builtin.os.tag)});
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.openat(dir, path_z.ptr, open_flags, @as(mode_t, 0));
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| {
                 if (flags.resolve_beneath) {
                     if (@hasField(@TypeOf(err), "NOTCAPABLE") and err == .NOTCAPABLE) return error.AccessDenied;
@@ -1152,11 +1157,16 @@ pub fn read(fd: fd_t, buffer: []u8) FileReadError!usize {
         return bytes_read;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.read(fd, buffer.ptr, buffer.len);
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileReadError(err),
         }
     }
@@ -1226,11 +1236,16 @@ pub fn write(fd: fd_t, buffer: []const u8) FileWriteError!usize {
         return bytes_written;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.write(fd, buffer.ptr, buffer.len);
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileWriteError(err),
         }
     }
@@ -1292,6 +1307,8 @@ pub fn fileSync(fd: fd_t, flags: FileSyncFlags) FileSyncError!void {
         return;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = if (flags.only_data)
             posix.system.fdatasync(fd)
@@ -1300,7 +1317,10 @@ pub fn fileSync(fd: fd_t, flags: FileSyncFlags) FileSyncError!void {
 
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSyncError(err),
         }
     }
@@ -1339,11 +1359,16 @@ pub fn renameat(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u
     const new_path_z = allocator.dupeSentinel(u8, new_path, 0) catch return error.SystemResources;
     defer allocator.free(new_path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.renameat(old_dir, old_path_z.ptr, new_dir, new_path_z.ptr);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToDirRenameError(err),
         }
     }
@@ -1451,11 +1476,16 @@ pub fn dirDeleteFile(allocator: std.mem.Allocator, dir: fd_t, path: []const u8) 
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.unlinkat(dir, path_z.ptr, 0);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             .PERM => {
                 // macOS and BSDs return EPERM (not EISDIR) when unlinkat is
                 // called on a directory without AT_REMOVEDIR.  Check with
@@ -1506,11 +1536,16 @@ pub fn dirDeleteDir(allocator: std.mem.Allocator, dir: fd_t, path: []const u8) D
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.unlinkat(dir, path_z.ptr, posix.AT.REMOVEDIR);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToDirDeleteDirError(err),
         }
     }
@@ -1539,11 +1574,16 @@ pub fn mkdirat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, mode: 
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.mkdirat(dir, path_z.ptr, mode);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToDirCreateDirError(err),
         }
     }
@@ -1794,6 +1834,8 @@ pub fn fileSize(fd: fd_t) FileSizeError!u64 {
         return @intCast(file_size);
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     if (builtin.os.tag == .linux) {
         const linux = std.os.linux;
         var statx_buf: linux.Statx = undefined;
@@ -1801,7 +1843,10 @@ pub fn fileSize(fd: fd_t) FileSizeError!u64 {
             const rc = linux.statx(fd, "", linux.AT.EMPTY_PATH, linux.STATX{ .SIZE = true }, &statx_buf);
             switch (posix.errno(rc)) {
                 .SUCCESS => return statx_buf.size,
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToFileSizeError(err),
             }
         }
@@ -1812,7 +1857,10 @@ pub fn fileSize(fd: fd_t) FileSizeError!u64 {
         const rc = posix.system.fstat(fd, &stat_buf);
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(stat_buf.size),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSizeError(err),
         }
     }
@@ -1865,6 +1913,8 @@ pub fn fstat(fd: fd_t) FileStatError!FileStatInfo {
         };
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     if (builtin.os.tag == .linux) {
         const linux = std.os.linux;
         const mask = linux.STATX{ .TYPE = true, .MODE = true, .INO = true, .NLINK = true, .SIZE = true, .ATIME = true, .MTIME = true, .CTIME = true };
@@ -1873,7 +1923,10 @@ pub fn fstat(fd: fd_t) FileStatError!FileStatInfo {
             const rc = linux.statx(fd, "", linux.AT.EMPTY_PATH, mask, &statx_buf);
             switch (posix.errno(rc)) {
                 .SUCCESS => return statxToFileStat(statx_buf),
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToFileStatError(err),
             }
         }
@@ -1884,7 +1937,10 @@ pub fn fstat(fd: fd_t) FileStatError!FileStatInfo {
         const rc = posix.system.fstat(fd, &stat_buf);
         switch (posix.errno(rc)) {
             .SUCCESS => return statToFileStat(stat_buf),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileStatError(err),
         }
     }
@@ -1928,6 +1984,8 @@ pub fn fstatat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
 
     const at_flags: u32 = if (flags.follow_symlinks) 0 else posix.AT.SYMLINK_NOFOLLOW;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     if (builtin.os.tag == .linux) {
         const linux = std.os.linux;
         const mask = linux.STATX{ .TYPE = true, .MODE = true, .INO = true, .NLINK = true, .SIZE = true, .ATIME = true, .MTIME = true, .CTIME = true };
@@ -1936,7 +1994,10 @@ pub fn fstatat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
             const rc = linux.statx(dir, path_z.ptr, at_flags, mask, &statx_buf);
             switch (posix.errno(rc)) {
                 .SUCCESS => return statxToFileStat(statx_buf),
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToFileStatError(err),
             }
         }
@@ -1947,7 +2008,10 @@ pub fn fstatat(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flags:
         const rc = posix.system.fstatat(dir, path_z.ptr, &stat_buf, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return statToFileStat(stat_buf),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileStatError(err),
         }
     }
@@ -2071,11 +2135,16 @@ pub fn fileSetSize(fd: fd_t, length: u64) FileSetSizeError!void {
         return;
     }
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.ftruncate(fd, @intCast(length));
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetSizeError(err),
         }
     }
@@ -2102,11 +2171,16 @@ pub fn fileSetPermissions(fd: fd_t, mode: mode_t) FileSetPermissionsError!void {
     // Windows doesn't have POSIX-style permissions
     if (builtin.os.tag == .windows) return;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.fchmod(fd, mode);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetPermissionsError(err),
         }
     }
@@ -2132,11 +2206,16 @@ pub fn fileSetOwner(fd: fd_t, uid: ?uid_t, gid: ?gid_t) FileSetOwnerError!void {
     const uid_arg: uid_t = uid orelse @bitCast(@as(i32, -1));
     const gid_arg: gid_t = gid orelse @bitCast(@as(i32, -1));
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.fchown(fd, uid_arg, gid_arg);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetOwnerError(err),
         }
     }
@@ -2195,11 +2274,16 @@ pub fn fileSetTimestamps(fd: fd_t, timestamps: FileTimestamps) FileSetTimestamps
             .{ .sec = 0, .nsec = UTIME_OMIT },
     };
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.futimens(fd, &times);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetTimestampsError(err),
         }
     }
@@ -2232,11 +2316,16 @@ pub fn dirSetFilePermissions(allocator: std.mem.Allocator, dir: fd_t, path: []co
     // Note: AT_SYMLINK_NOFOLLOW for fchmodat requires Linux 6.6+ (fchmodat2)
     const at_flags: u32 = if (flags.follow_symlinks) 0 else posix.AT.SYMLINK_NOFOLLOW;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.fchmodat(dir, path_z.ptr, mode, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetPermissionsError(err),
         }
     }
@@ -2256,11 +2345,16 @@ pub fn dirSetFileOwner(allocator: std.mem.Allocator, dir: fd_t, path: []const u8
 
     const at_flags: u32 = if (!flags.follow_symlinks) posix.AT.SYMLINK_NOFOLLOW else 0;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.fchownat(dir, path_z.ptr, uid_arg, gid_arg, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetOwnerError(err),
         }
     }
@@ -2292,11 +2386,16 @@ pub fn dirSetFileTimestamps(allocator: std.mem.Allocator, dir: fd_t, path: []con
 
     const at_flags: u32 = if (!flags.follow_symlinks) posix.AT.SYMLINK_NOFOLLOW else 0;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.utimensat(dir, path_z.ptr, &times, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToFileSetTimestampsError(err),
         }
     }
@@ -2337,11 +2436,16 @@ pub fn dirSymLink(allocator: std.mem.Allocator, dir: fd_t, target: []const u8, l
     const link_path_z = allocator.dupeSentinel(u8, link_path, 0) catch return error.SystemResources;
     defer allocator.free(link_path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.symlinkat(target_z.ptr, dir, link_path_z.ptr);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToSymLinkError(err),
         }
     }
@@ -2389,11 +2493,16 @@ pub fn dirReadLink(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, bu
     const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
     defer allocator.free(path_z);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.system.readlinkat(dir, path_z.ptr, buffer.ptr, buffer.len);
         switch (posix.errno(rc)) {
             .SUCCESS => return @intCast(rc),
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToReadLinkError(err),
         }
     }
@@ -2451,11 +2560,16 @@ pub fn dirHardLink(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []cons
 
     const at_flags: u32 = if (flags.follow_symlinks) posix.AT.SYMLINK_FOLLOW else 0;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.linkat(old_dir, old_path_z.ptr, new_dir, new_path_z.ptr, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToHardLinkError(err),
         }
     }
@@ -2578,11 +2692,16 @@ pub fn dirAccess(allocator: std.mem.Allocator, dir: fd_t, path: []const u8, flag
 
     const at_flags: u32 = if (flags.follow_symlinks) 0 else posix.AT.SYMLINK_NOFOLLOW;
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     while (true) {
         const rc = posix.faccessat(dir, path_z.ptr, mode, at_flags);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => continue,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
             else => |err| return errnoToDirAccessError(err),
         }
     }
@@ -2759,6 +2878,8 @@ pub fn dirRealPath(fd: fd_t, buffer: []u8) DirRealPathError!usize {
     } else fd;
     defer if (fd == posix.AT.FDCWD) posix.close(actual_fd);
 
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
     if (builtin.os.tag == .linux) {
         // Use /proc/self/fd/{fd} with readlink
         var proc_path_buf: [32:0]u8 = undefined;
@@ -2768,7 +2889,10 @@ pub fn dirRealPath(fd: fd_t, buffer: []u8) DirRealPathError!usize {
             const rc = posix.system.readlink(proc_path, buffer.ptr, buffer.len);
             switch (posix.errno(rc)) {
                 .SUCCESS => return @intCast(rc),
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToDirRealPathError(err),
             }
         }
@@ -2786,7 +2910,10 @@ pub fn dirRealPath(fd: fd_t, buffer: []u8) DirRealPathError!usize {
                     @memcpy(buffer[0..n], sufficient_buffer[0..n]);
                     return n;
                 },
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToDirRealPathError(err),
             }
         }
@@ -2805,7 +2932,10 @@ pub fn dirRealPath(fd: fd_t, buffer: []u8) DirRealPathError!usize {
                     @memcpy(buffer[0..n], kf.path[0..n]);
                     return n;
                 },
-                .INTR => continue,
+                .INTR => {
+                    try sc.checkCancel();
+                    continue;
+                },
                 else => |err| return errnoToDirRealPathError(err),
             }
         }

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -335,19 +335,15 @@ pub fn getrandom(buffer: []u8) (GetRandomError || syscall_cancel.Cancelable)!voi
             var i: usize = 0;
             while (i < buffer.len) {
                 const sc = try syscall_cancel.Syscall.begin();
+                // `defer` closes the region at the end of each iteration
+                // (blocked→idle, or blocked_canceling→canceled). On EINTR we just
+                // retry; if the token was canceled, the next begin() surfaces it.
+                defer sc.finish();
                 const rc = system.getrandom(buffer[i..].ptr, buffer.len - i, 0);
                 switch (errno(rc)) {
-                    .SUCCESS => {
-                        sc.finish();
-                        i += rc;
-                    },
-                    // EINTR: finish the region (blocked→idle or blocked_canceling→canceled)
-                    // and retry. If the token was canceled, the next begin() surfaces it.
-                    .INTR => {
-                        sc.finish();
-                        continue;
-                    },
-                    else => return sc.fail(error.EntropyUnavailable),
+                    .SUCCESS => i += rc,
+                    .INTR => continue,
+                    else => return error.EntropyUnavailable,
                 }
             }
         },

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -191,6 +191,10 @@ pub const Syscall = struct {
     /// Close the syscall region on success or any non-`EINTR` error:
     /// `blocked → idle`, or `blocked_canceling → canceled` (cancel still pending,
     /// surfaces at the next `start()`).
+    ///
+    /// Idempotent: closing an already-closed region (`idle`/`canceled`) is a
+    /// no-op, so `finish()` is safe as a `defer` even when `checkCancel()` has
+    /// already finalized the region on the `Canceled` path.
     pub fn finish(self: Syscall) void {
         const tok = self.token orelse return;
         var s = tok.state.load(.monotonic);
@@ -198,7 +202,7 @@ pub const Syscall = struct {
             const next: State = switch (s) {
                 .blocked => .idle,
                 .blocked_canceling => .canceled,
-                .idle, .canceled => unreachable,
+                .idle, .canceled => return,
             };
             if (tok.state.cmpxchgWeak(s, next, .acq_rel, .monotonic)) |actual| {
                 s = actual;

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -127,6 +127,15 @@ pub const Token = struct {
         _ = std.c.pthread_kill(handle, sig);
         return true;
     }
+
+    /// True while the worker is blocked in the canceled syscall and has not yet
+    /// acknowledged the cancellation — i.e. the `SIGURG` may still need
+    /// re-sending. Used to decide whether a work belongs on the loop's
+    /// cancel-resend list.
+    pub fn isCanceling(self: *Token) bool {
+        if (!enabled) return false;
+        return self.state.load(.acquire) == .blocked_canceling;
+    }
 };
 
 /// A scoped, cancelable syscall region. Obtained by `begin()`, closed by

--- a/src/os/syscall_cancel.zig
+++ b/src/os/syscall_cancel.zig
@@ -139,9 +139,10 @@ pub const Token = struct {
 };
 
 /// A scoped, cancelable syscall region. Obtained by `begin()`, closed by
-/// `finish()` (or `fail()`); on `EINTR` call `checkCancel()` to decide between
-/// retry and `error.Canceled`. A `null` token means "not on a cancelable worker"
-/// — every method is then a no-op and the syscall runs uncancelably.
+/// `finish()` (idempotent, so it pairs with `defer`); on `EINTR` call
+/// `checkCancel()` to decide between retry and `error.Canceled`. A `null` token
+/// means "not on a cancelable worker" — every method is then a no-op and the
+/// syscall runs uncancelably.
 pub const Syscall = struct {
     token: ?*Token,
 
@@ -210,12 +211,6 @@ pub const Syscall = struct {
             }
             return;
         }
-    }
-
-    /// `finish()` then return `err` — convenience for non-`EINTR` error exits.
-    pub fn fail(self: Syscall, err: anytype) @TypeOf(err) {
-        self.finish();
-        return err;
     }
 };
 
@@ -306,18 +301,19 @@ test "syscall_cancel: signal interrupts a blocking read" {
 
             self.result = blk: {
                 const sc = Syscall.begin() catch |e| break :blk e;
+                defer sc.finish();
                 // Signal that we are inside the cancelable region, just before read().
                 self.ready.store(true, .release);
                 var buf: [1]u8 = undefined;
                 while (true) {
                     const rc = std.c.read(self.read_fd, &buf, buf.len);
-                    if (rc >= 0) break :blk sc.fail(error.UnexpectedData);
+                    if (rc >= 0) break :blk error.UnexpectedData;
                     switch (std.posix.errno(rc)) {
                         .INTR => {
                             sc.checkCancel() catch |e| break :blk e;
                             continue;
                         },
-                        else => |e| break :blk sc.fail(std.posix.unexpectedErrno(e)),
+                        else => |e| break :blk std.posix.unexpectedErrno(e),
                     }
                 }
             };


### PR DESCRIPTION
Stacked on #514 (`cancel-blocking`). Extends the SIGURG syscall-cancellation mechanism from that PR to the file/dir operations that fall back to the thread pool on backends without native async file I/O (kqueue, poll, ...).

A task blocked in `open()`/`stat()`/`unlink()`/... on a hung mount, or `read()`/`write()` on a stalled network filesystem, can now be canceled instead of waiting the syscall out.

## Mechanism

- **`DelegatedWork` shared struct** — used as the `internal` payload of every delegated file/dir op. Bundles the pool `Work`, loop linkage, allocator slot, the cancellation `Token`, and an intrusive link for the loop's resend list. `linked_context.linked` back-points to the owning `Completion`, so the loop reaches a `DelegatedWork` from a completion generically — **nothing is added to the hot `Completion` struct**.

- **Bracketed fs wrappers** — the delegated syscall wrappers are wrapped in a `Syscall.begin()` / `defer finish()` / `checkCancel()`-on-EINTR region. The worker binds the token around `work.func`, so a SIGURG turns the blocking syscall into `EINTR → error.Canceled`. Off a cancelable worker the token is null and the brackets are no-ops (verified: all normal file I/O still passes). Now covered: `openat`, `createat`, `preadv`, `pwritev`, `readv`, `writev`, `getdents`/`dirRead`, `dirOpen`, `read`, `write`, `fileSync`, `renameat`, `dirDeleteFile`/`Dir`, `mkdirat`, `fileSize`, `fstat`, `fstatat`, `fileSetSize`/`Permissions`/`Owner`/`Timestamps`, `dirSetFilePermissions`/`Owner`/`Timestamps`, `dirSymLink`, `dirReadLink`, `dirHardLink`, `dirAccess`, `dirRealPath` (~30 wrappers).

- **Loop-driven resend** — `cancelLocal` sends the first signal and, if the worker is blocked-and-canceling, adds the work to `Loop.cancel_resend`. Each `tick` re-sends SIGURG to cover a first signal lost in the `begin()→sleep` window, dropping entries once the worker acknowledges. This is **not** driven by the canceling coroutine — `loop.cancel` runs on the loop thread too (e.g. `groupCallback` canceling race-group siblings), so resend had to be non-blocking and loop-owned. The entry is removed as the completion is finalized in the `work_completions` drain, before its waiter is signaled, so the sweep never dereferences a token whose op is being freed. All list access is on the owning loop's thread; no lock.

- **`Syscall` API simplified** — `finish()` is now idempotent, so every call site uses one idiom (`const sc = try begin(); defer sc.finish();` with plain returns) instead of an explicit success-`finish()` + a per-error-arm `fail()`. `Syscall.fail` is removed; `getrandom` and the two cancel tests were converted along with the wrappers. The surface is now `begin` / `checkCancel` / `finish` (+ `checkCanceled` for the getaddrinfo-style pre-check).

## The nesting constraint

`begin()` forbids nesting (a bracketed wrapper must not call another bracketed wrapper while its region is open — that would hit `unreachable`, a *runtime* panic, not a compile error). Every internal cross-call was audited; the transformed wrappers are all leaves. Three functions that call other now-cancelable wrappers — `dirRealPathFile`, `fileHardLink`, `renameatPreserve` — are deliberately left unbracketed (their constituent syscalls are still cancelable via the wrappers they call); making them cancelable needs block-scoped regions, a follow-up.

## Testing

- New `fs` test: canceling a blocking FIFO open (writerless `O_RDONLY` blocks in the worker's `openat`, since POSIX opens are unconditionally blocking) on the poll backend → `error.Canceled`. Passes; stress-clean (dozens of runs), no hangs.
- Full suite green on poll (509) and io_uring (510); base cancel tests (`syscall_cancel`, `blockInPlace`, `random`) pass; cross-compiles clean on macOS/kqueue, FreeBSD/kqueue, and Windows.

## Scope / notes

- `read`/`write` bracketing uses the identical path but has no CI-testable interrupt: pool reads only ever get **seekable regular files** (pipes route to the backend poll path; positional reads on pipes are `ESPIPE`), and regular-file I/O blocks in `TASK_UNINTERRUPTIBLE` locally. So their cancellation bites only on network filesystems. The FIFO-open test validates the shared machinery end-to-end; the metadata/path ops that block only on hung mounts are likewise validated by the shared mechanism, not a dedicated interrupt test.
- Not bracketed: `ioctlPosix`/`process_wait` (not cancelable file ops), and the three nesting functions above (`dirRealPathFile`/`fileHardLink`/`renameatPreserve`), which need block-scoped regions. All delegated ops carry the token via `DelegatedWork`, so each remaining wrapper is a one-spot follow-up.

