### PR TITLE
Fix use-after-free in blockInPlace cancellation

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -411,8 +411,11 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     const Context = struct {
         args: Args,
         result: Result = undefined,
-        // Distinct from the waiter's signal count: the resend timer below also
-        // signals the waiter, so we need an unambiguous "work finished" flag.
+        // Set by completionFn (before it signals the waiter) to tell the cancel
+        // path's resend loop that the work has finished, so it stops resending.
+        // It is NOT a "safe to return" flag: completionFn still touches our stack
+        // frame in the trailing waiter.signal(), which the cancel path waits for
+        // separately. See the cancel handler below.
         done: std.atomic.Value(bool) = .init(false),
 
         fn workFn(work: *ev.Work) void {
@@ -454,26 +457,33 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
         const need_signal = token.cancel();
         if (need_signal) _ = token.signal();
 
-        // Wait for completion (ctx/work live on our stack). Drive resend-with-
-        // backoff to cover the begin()→syscall gap where the first SIGURG can
-        // be lost. The wait is a cooperative timedWait (parks the coroutine on
-        // an executor timer), so resending never blocks the thread.
-        // Use an incrementing wait_count so each timedWait actually parks
-        // instead of returning immediately once the timer has fired once.
-        var wait_count: u32 = 1;
+        // Wait for the worker to finish. ctx/work/waiter live on our stack, so
+        // we must not return until completionFn is completely done touching them
+        // — including its trailing waiter.signal(), which runs *after* it sets
+        // `done`. Observing `done` alone is therefore not safe: the pending
+        // signal() would then access this frame after we returned and freed it
+        // (a use-after-free that corrupts the waiter and crashes in signal()).
+        //
+        // So we split it: resend SIGURG with backoff until the work finishes
+        // (`done`), then do one clean wait for completionFn's trailing signal().
+        // The backoff sleeps park on a *separate* waiter, leaving our `waiter`
+        // to be signaled only by completionFn, so that final wait synchronizes
+        // exactly with the worker's last access to our frame.
         var backoff = Duration.fromMicroseconds(1);
         const cap = Duration.fromMilliseconds(1);
         while (!ctx.done.load(.acquire)) {
-            waiter.timedWait(wait_count, .{ .duration = backoff }, .no_cancel);
-            wait_count +|= 1;
-            // Resend if the worker is still blocked in the canceled syscall (the
-            // first signal can be lost in the start()→syscall window). Once it
-            // acknowledges, `signal()` returns false and we just park until done.
-            backoff = if (token.signal())
-                .{ .value = @min(backoff.value *| 2, cap.value) }
-            else
-                cap;
+            var sleeper: Waiter = .init();
+            sleeper.timedWait(1, .{ .duration = backoff }, .no_cancel);
+            // Resend while the worker is still blocked in the canceled syscall
+            // (the first signal can be lost in the start()→syscall window). Once
+            // it acknowledges, signal() is a no-op and we just park until done.
+            _ = token.signal();
+            backoff = .{ .value = @min(backoff.value *| 2, cap.value) };
         }
+
+        // `done` is set; wait for completionFn's trailing waiter.signal() (the
+        // worker's last touch of our stack frame) before returning.
+        waiter.wait(1, .no_cancel);
     };
 
     return ctx.result;


### PR DESCRIPTION
## Problem

The `common.test.blockInPlace: cancellation interrupts a blocking syscall on the worker` test segfaults on powerpc64le/epoll under QEMU in CI (reported crash: `cmpxchgStrong` at address `0x0`, under the `completion_fn` call in `thread_pool.runTasks`). It reproduces fairly regularly in CI.

## Root cause

`blockInPlace` keeps everything on its own stack — `ctx`, `waiter`, `token`, `work`. The invariant that keeps this safe is: the task must not return (and reclaim that stack) until the worker's `completionFn` has completely finished touching those objects.

The cancel handler broke that invariant. `completionFn` publishes `done` **before** its trailing `waiter.signal()`:

```zig
ctx.done.store(true, .release);   // (1)
waiter.signal();                  // (2) still reads our stack-allocated waiter
```

The cancel loop returned as soon as it observed `done`:

```zig
while (!ctx.done.load(.acquire)) { ... }
return ctx.result;   // frame reclaimed here
```

So the sequence was:

1. Worker sets `ctx.done = true`.
2. The canceled task (parked in the resend-backoff `timedWait`) is woken by the backoff timer, sees `done == true`, and returns from `blockInPlace` — **reclaiming its stack**.
3. Worker executes `waiter.signal()` against the now-freed `waiter`. The reused stack memory makes the tagged-union `mode` read as `.select`, which takes the `cmpxchgStrong` path (`common.zig`, `Waiter.signal`) on a garbage `winner` pointer → segfault at `0x0`.

The window between (1) and (2) is only a couple of instructions on the worker, so the crash requires the backoff timer to fire in exactly that gap. That is rare on fast native hardware but happens regularly under QEMU emulation and CI load. Nothing here is architecture-specific — it's a pure timing window.

The fast (non-canceled) path was never affected: it returns only after `signal()`, which is `completionFn`'s last action there.

## Fix

Keep resending `SIGURG` with backoff until the work finishes (`done`), but drive the backoff sleeps on a **separate** waiter, leaving `blockInPlace`'s `waiter` to be signaled only by `completionFn`. After the loop, do one final `waiter.wait(1, .no_cancel)` to synchronize with `completionFn`'s trailing `signal()` — the worker's last access to the stack frame — before returning.

`completionFn` and the fast path are unchanged.