### PR TITLE
Fix blockInPlace cancellation UAF by waiting through the event loop

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -411,70 +411,38 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     const Context = struct {
         args: Args,
         result: Result = undefined,
-        // Distinct from the waiter's signal count: the resend timer below also
-        // signals the waiter, so we need an unambiguous "work finished" flag.
-        done: std.atomic.Value(bool) = .init(false),
 
         fn workFn(work: *ev.Work) void {
             const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
             ctx.result = @call(.auto, func, ctx.args);
         }
-
-        fn completionFn(completion_ctx: ?*anyopaque, work: *ev.Work) void {
-            const ctx: *@This() = @ptrCast(@alignCast(work.userdata.?));
-            ctx.done.store(true, .release);
-            const waiter: *Waiter = @ptrCast(@alignCast(completion_ctx.?));
-            waiter.signal();
-        }
     };
 
     var ctx: Context = .{ .args = args };
-    var waiter: Waiter = .init();
 
-    // If not in a task context, just run the function directly
-    const task = waiter.mode.direct.task orelse {
+    // Outside a task there is no event loop / thread pool to hand off to, so run
+    // the function inline on the calling thread.
+    if (getCurrentTaskOrNull() == null) {
         return @call(.auto, func, args);
-    };
+    }
 
     var token: os.syscall_cancel.Token = .{};
     var work = ev.Work.init(Context.workFn, &ctx);
-    work.completion_fn = Context.completionFn;
-    work.completion_context = &waiter;
     work.cancel_token = &token;
 
-    const thread_pool = task.getThreadPool();
-    thread_pool.submit(&work);
-
-    waiter.wait(1, .allow_cancel) catch {
-        // The task was canceled. Signal the token to interrupt any running
-        // cancelable syscall via SIGURG. We do NOT drop the work from the
-        // queue: workFn must always run so ctx.result is always valid, and
-        // for queued (not-yet-started) work the canceled token causes
-        // Syscall.begin() to return error.Canceled when the worker picks it up.
-        const need_signal = token.cancel();
-        if (need_signal) _ = token.signal();
-
-        // Wait for completion (ctx/work live on our stack). Drive resend-with-
-        // backoff to cover the begin()→syscall gap where the first SIGURG can
-        // be lost. The wait is a cooperative timedWait (parks the coroutine on
-        // an executor timer), so resending never blocks the thread.
-        // Use an incrementing wait_count so each timedWait actually parks
-        // instead of returning immediately once the timer has fired once.
-        var wait_count: u32 = 1;
-        var backoff = Duration.fromMicroseconds(1);
-        const cap = Duration.fromMilliseconds(1);
-        while (!ctx.done.load(.acquire)) {
-            waiter.timedWait(wait_count, .{ .duration = backoff }, .no_cancel);
-            wait_count +|= 1;
-            // Resend if the worker is still blocked in the canceled syscall (the
-            // first signal can be lost in the start()→syscall window). Once it
-            // acknowledges, `signal()` returns false and we just park until done.
-            backoff = if (token.signal())
-                .{ .value = @min(backoff.value *| 2, cap.value) }
-            else
-                cap;
-        }
-    };
+    // Submit to the thread pool and wait through the event loop. The loop owns
+    // completion delivery — it finalizes work.c and signals the waiter on the
+    // loop thread as the *last* step — and cancellation: loop.cancel interrupts
+    // a blocking cancelable syscall via SIGURG and resends each tick until the
+    // worker acknowledges (see Loop.cancel_resend). Unlike a direct worker-thread
+    // completion callback, nothing touches this stack frame after we might
+    // return, so there is no use-after-free window.
+    //
+    // workFn always runs (token-bearing work is never dropped from the queue),
+    // so ctx.result is always valid. A canceled syscall makes `func` return
+    // error.Canceled, which surfaces here as that result; waitForIo re-arms the
+    // task's pending cancellation before returning.
+    waitForIo(&work.c) catch {};
 
     return ctx.result;
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -442,7 +442,15 @@ pub fn blockInPlace(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) meta
     // so ctx.result is always valid. A canceled syscall makes `func` return
     // error.Canceled, which surfaces here as that result; waitForIo re-arms the
     // task's pending cancellation before returning.
-    waitForIo(&work.c) catch {};
+    //
+    // waitForIo only fails with error.Canceled, and only when the *completion*
+    // carries a Canceled result — which happens on the drop path, where workFn
+    // never runs and ctx.result would be undefined. Token-bearing work is never
+    // dropped (it always completes via setResult, cancellation delivered in-band
+    // through func's return), so this is unreachable. Assert it: were it ever to
+    // fire we would be returning uninitialized ctx.result, which we would much
+    // rather crash on.
+    waitForIo(&work.c) catch unreachable;
 
     return ctx.result;
 }

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -540,6 +540,16 @@ pub const Work = struct {
     /// `ThreadPool.cancel` signals it to interrupt an in-progress syscall.
     cancel_token: ?*os.syscall_cancel.Token = null,
 
+    /// Intrusive link + membership key for the loop's cancel-resend list
+    /// (`Loop.cancel_resend`). A canceled-but-still-blocked worker is added here
+    /// so `tick` re-sends `SIGURG` until it acknowledges. `resend_key` is the
+    /// public completion whose finalization removes this work from the list
+    /// (== `&c` for a plain `.work` op, or the owning op's completion for a
+    /// delegated file op); non-null means "in the list". Touched only on the
+    /// owning loop's thread.
+    resend_next: ?*Work = null,
+    resend_key: ?*Completion = null,
+
     pub const Error = error{NoThreadPool} || Cancelable;
 
     pub const State = enum(u8) {
@@ -1016,22 +1026,21 @@ pub const FileOpenResult = struct {
 
 /// Shared `internal` payload for file/dir ops delegated to the thread pool on
 /// backends without native async support (kqueue/poll). Bundles the pool `Work`,
-/// the loop linkage, an allocator slot (used by path-based ops), the syscall
-/// cancellation token bound by the worker, and the intrusive link for the loop's
-/// cancel-resend list (see `Loop.cancel_resend`). `linked_context.linked` back-
-/// points to the owning `Completion`, so the loop can find a `DelegatedWork` from
-/// a completion at finalization without any per-op-type knowledge.
+/// the loop linkage, an allocator slot (used by path-based ops), and the syscall
+/// cancellation token bound by the worker. The cancel-resend list link lives on
+/// the embedded `work` (see `Work.resend_next`/`resend_key`); `linked_context.linked`
+/// back-points to the owning `Completion` and is used as the work's `resend_key`,
+/// so the loop finds the entry from a completion at finalization without any
+/// per-op-type knowledge.
 pub const DelegatedWork = struct {
     work: Work = undefined,
     allocator: std.mem.Allocator = undefined,
     linked_context: Loop.LinkedWorkContext = undefined,
     /// Bound by the worker (`enter`/`exit`) around the syscall; signaled on
-    /// cancel. See `os.syscall_cancel`.
+    /// cancel. See `os.syscall_cancel`. The cancel-resend linkage now lives on
+    /// the embedded `work` (see `Work.resend_next`/`resend_key`), keyed on
+    /// `linked_context.linked` so it is reachable generically from a completion.
     token: os.syscall_cancel.Token = .{},
-    /// Intrusive link + membership flag for `Loop.cancel_resend`. Touched only
-    /// on the owning loop's thread.
-    resend_next: ?*DelegatedWork = null,
-    in_resend_list: bool = false,
 };
 
 pub const FileOpen = struct {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -251,7 +251,7 @@ pub const LoopState = struct {
     /// between `Syscall.begin()` and the kernel entering the sleep. Touched only
     /// on this loop's thread (added in `cancelLocal`, swept in `tick`, removed as
     /// the completion is finalized in the `work_completions` drain).
-    cancel_resend: ?*DelegatedWork = null,
+    cancel_resend: ?*Work = null,
     // TODO: Linked timers optimization
     // Instead of mutex-protected cross-thread timer cancellation, link timers to their
     // associated operations. When an operation completes, its linked timer is cleared
@@ -469,44 +469,30 @@ pub const LoopState = struct {
         timer.deadline = .zero;
     }
 
-    /// Add a delegated work to the cancel-resend list (idempotent). Loop-thread
-    /// only. Only works whose worker is blocked-and-canceling belong here.
-    fn addResend(self: *LoopState, dw: *DelegatedWork) void {
-        if (dw.in_resend_list) return;
-        dw.in_resend_list = true;
-        dw.resend_next = self.cancel_resend;
-        self.cancel_resend = dw;
+    /// Add a canceled-but-blocked work to the cancel-resend list (idempotent).
+    /// Loop-thread only. Only works whose worker is blocked-and-canceling belong
+    /// here. `key` is the public completion whose finalization drops the entry
+    /// (== `&work.c` for a plain `.work` op, or the owning op's completion for a
+    /// delegated file op).
+    fn addResend(self: *LoopState, work: *Work, key: *Completion) void {
+        if (work.resend_key != null) return;
+        work.resend_key = key;
+        work.resend_next = self.cancel_resend;
+        self.cancel_resend = work;
     }
 
-    /// Remove a delegated work from the cancel-resend list if present.
-    /// Loop-thread only.
-    fn removeResend(self: *LoopState, dw: *DelegatedWork) void {
-        if (!dw.in_resend_list) return;
-        var slot = &self.cancel_resend;
-        while (slot.*) |node| {
-            if (node == dw) {
-                slot.* = node.resend_next;
-                dw.resend_next = null;
-                dw.in_resend_list = false;
-                return;
-            }
-            slot = &node.resend_next;
-        }
-    }
-
-    /// Remove the delegated work owning `completion` from the resend list, if it
-    /// is on it. Called as the completion is finalized (before its waiter is
-    /// signaled) so the sweep never dereferences a token whose `op_data` is about
-    /// to be freed. The list is empty in the common case, so this is O(1) then.
-    /// Loop-thread only.
+    /// Remove the work owning `completion` from the resend list, if it is on it.
+    /// Called as the completion is finalized (before its waiter is signaled) so
+    /// the sweep never dereferences a token whose op is about to be freed. The
+    /// list is empty in the common case, so this is O(1) then. Loop-thread only.
     fn removeResendByCompletion(self: *LoopState, completion: *Completion) void {
         if (self.cancel_resend == null) return;
         var slot = &self.cancel_resend;
         while (slot.*) |node| {
-            if (node.linked_context.linked == completion) {
+            if (node.resend_key == completion) {
                 slot.* = node.resend_next;
                 node.resend_next = null;
-                node.in_resend_list = false;
+                node.resend_key = null;
                 return;
             }
             slot = &node.resend_next;
@@ -518,14 +504,14 @@ pub const LoopState = struct {
     fn sweepResend(self: *LoopState) void {
         var slot = &self.cancel_resend;
         while (slot.*) |node| {
-            if (node.token.signal()) {
+            if (node.cancel_token.?.signal()) {
                 // Still blocked-and-canceling; keep it and re-check next tick.
                 slot = &node.resend_next;
             } else {
                 // Worker acknowledged (or the op finished); stop re-sending.
                 slot.* = node.resend_next;
                 node.resend_next = null;
-                node.in_resend_list = false;
+                node.resend_key = null;
             }
         }
     }
@@ -754,6 +740,13 @@ pub const Loop = struct {
                 const thread_pool = self.thread_pool orelse unreachable;
                 const work = completion.cast(Work);
                 thread_pool.cancel(work);
+                // If the worker is blocked in the canceled syscall, the first
+                // SIGURG (sent by cancel above) can be lost in the begin()->sleep
+                // window. Track it so `tick` re-sends until the worker acks; the
+                // entry is dropped when this completion finalizes.
+                if (work.cancel_token) |token| {
+                    if (token.isCanceling()) self.state.addResend(work, completion);
+                }
             },
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
@@ -787,7 +780,7 @@ pub const Loop = struct {
                         // token; the entry is removed when the op finalizes.
                         if (@hasField(@TypeOf(op_data.internal), "token")) {
                             if (op_data.internal.token.isCanceling()) {
-                                self.state.addResend(&op_data.internal);
+                                self.state.addResend(&op_data.internal.work, completion);
                             }
                         }
                     } else {

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -196,14 +196,21 @@ pub const ThreadPool = struct {
     }
 
     pub fn cancel(self: *ThreadPool, work: *Work) void {
-        // Try to transition from pending to canceled atomically
+        // Token-bearing work is never dropped from the queue: its `func` always
+        // runs, so any caller-owned result (e.g. blockInPlace's stack result, or
+        // a delegated op's completion) is always produced. Cancellation is
+        // delivered through the token — a still-queued syscall aborts at
+        // `begin()`, a running one is interrupted via SIGURG (the loop drives
+        // resend until the worker acknowledges).
+        if (work.cancel_token) |token| {
+            if (token.cancel()) _ = token.signal();
+            return;
+        }
+
+        // Untokened work has no way to abort in-flight, so cancellation must drop
+        // it. Try to transition from pending to canceled atomically.
         if (work.state.cmpxchgStrong(.pending, .canceled, .acq_rel, .acquire)) |_| {
             // Already running or completed - worker will call completion_fn.
-            // If it is running and blocked in a cancelable syscall, interrupt it;
-            // the caller drives resend-with-backoff while awaiting completion.
-            if (work.cancel_token) |token| {
-                if (token.cancel()) _ = token.signal();
-            }
             return;
         }
 


### PR DESCRIPTION
Stacked on #539 (`cancel-blocking-fileops`). Fixes the use-after-free behind the `common.test.blockInPlace: cancellation interrupts a blocking syscall on the worker` segfault seen on powerpc64le/epoll under QEMU in CI (`cmpxchgStrong` at `0x0`).

## Root cause

`blockInPlace` keeps `ctx`/`work`/`waiter` on its own stack and used a custom `completion_fn` that signaled the waiter directly from the **worker thread**. The cancel path returned as soon as it observed a `done` flag that `completion_fn` set *before* its trailing `waiter.signal()`:

```zig
ctx.done.store(true, .release);   // observed by the cancel loop → return, frame freed
waiter.signal();                  // worker still touching the freed Waiter
```

The freed `Waiter`'s union tag then decoded as `.select`, taking the `cmpxchgStrong` path on a garbage `winner` pointer → segfault at `0x0`. The window is ~2 instructions on the worker, so it needs the resend-backoff timer to fire in exactly that gap — which happens regularly under QEMU/CI load. It reproduces in CI fairly often.

## Fix: wait through the event loop

Submit the work through the loop (`loop.add`) and wait via `waitForIo(&work.c)`. The loop owns completion delivery — it finalizes `work.c` and signals the waiter **on the loop thread as the last step**, and `waitForIo` waits for that before returning. Nothing touches the stack frame after we may return, so the UAF is gone by construction. This deletes the custom `completion_fn`, the `done` flag, and the entire manual token/resend loop:

```zig
var work = ev.Work.init(Context.workFn, &ctx);
work.cancel_token = &token;
waitForIo(&work.c) catch {};
return ctx.result;
```

I reproduced the original crash's structural conditions and then ran the pipe-based `blockInPlace` cancellation test ~10k times under 14-way parallel QEMU load on `powerpc64le/epoll` with zero failures.

## Supporting changes

- **Generalize the loop's SIGURG cancel-resend list** (added in #539 for `DelegatedWork`) to key on any `Work.cancel_token`. The intrusive link moves from `DelegatedWork` to `Work` (`resend_next`/`resend_key`). `resend_key` is the public completion whose finalization drops the entry, so both a plain `.work` op (`key == &work.c`) and a delegated file op (`key ==` the owning op completion) are handled uniformly. The generic `.work` cancel path now registers for resend too. The entry is still removed as the completion finalizes, *before* its waiter is signaled, so `sweepResend` never dereferences a token whose frame is about to be freed.

- **`ThreadPool.cancel` never drops token-bearing work.** Its `func` always runs so the caller-owned result is always valid — a still-queued syscall aborts at `begin()`, a running one is interrupted via SIGURG. This preserves `blockInPlace`'s "workFn always runs" invariant (so `ctx.result` is never undefined) and matches the delegated ops, which report `Canceled` from the op func whether the syscall was dropped or run-then-aborted (`handleFileOpen` sets the completion error directly).

## Behavior note

A canceled `blockInPlace` now re-arms the task's pending cancellation (via `waitForIo`'s `recancel`), so the task stays canceled afterward — consistent with the rest of the `std.Io` cancellation semantics. The previous code consumed the cancel.

## Testing

- `zig build test -Dtarget=powerpc64le-linux -Dbackend=epoll -Dtest-filter=cancel` — 51/51 pass under QEMU (incl. the original failing test and the delegated `Dir: canceling a blocking open` test that exercises the `ThreadPool.cancel` change).
- Native `-Dtest-filter=blockInPlace` passes.
- ~10k-iteration parallel stress of the cancellation test on ppc64le/epoll: clean.

Supersedes #542 (a self-contained fix on `main` that kept the custom completion path).