### PR TITLE
Route panic and scheduler I/O through the blocking path (#545)

### DIFF
--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Completion = @import("completion.zig").Completion;
+const Group = @import("completion.zig").Group;
 const PipeClose = @import("completion.zig").PipeClose;
 const NetClose = @import("completion.zig").NetClose;
 const NetShutdown = @import("completion.zig").NetShutdown;
@@ -117,13 +118,50 @@ pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
         // Device I/O control - blocking ioctl
         .device_io_control => handleDeviceIoControl(c),
 
+        // A gather group of individually-supported ops can be run sequentially.
+        .group => handleBlockingGroup(c, allocator),
+
         // Async operations require the event loop
-        .async,
-        .group,
-        => @panic("Async operations not supported in blocking mode (requires event loop)"),
+        .async => @panic("Async operations not supported in blocking mode (requires event loop)"),
 
         .mach_port => unreachable,
     }
+}
+
+/// Execute a group completion synchronously by running each child in turn.
+///
+/// Only gather groups whose children are all individually supported in blocking
+/// mode are handled. Today that means close batches (see `io.fileCloseImpl` /
+/// `io.netCloseImpl`), which the panic/crash path exercises when std's stack-trace
+/// symbolization opens and then closes the executable through `debug_io`. Anything
+/// else keeps the "requires event loop" panic. Children are validated before any is
+/// run so we never leave a group half-executed.
+fn handleBlockingGroup(c: *Completion, allocator: std.mem.Allocator) void {
+    const group: *Group = @alignCast(@fieldParentPtr("c", c));
+
+    // Race groups (used for timeouts) genuinely need the loop to arbitrate.
+    if (group.race.load(.acquire)) {
+        @panic("Race groups are not supported in blocking mode (requires event loop)");
+    }
+
+    // Validate every child is an op we can run inline before running any of them.
+    var node = group.head;
+    while (node) |n| : (node = n.next) {
+        const child: *Completion = @alignCast(@fieldParentPtr("group", n));
+        switch (child.op) {
+            .file_close, .net_close => {},
+            else => @panic("Group contains an operation not supported in blocking mode"),
+        }
+    }
+
+    // Run each child to completion; each sets its own result.
+    node = group.head;
+    while (node) |n| : (node = n.next) {
+        const child: *Completion = @alignCast(@fieldParentPtr("group", n));
+        executeBlocking(child, allocator);
+    }
+
+    c.setResult(.group, {});
 }
 
 /// Synchronous file-to-socket transfer for the no-runtime path. Drives the same

--- a/src/io.zig
+++ b/src/io.zig
@@ -267,6 +267,8 @@ fn globalIo() Io {
 
 fn crashHandlerImpl(_: ?*anyopaque) void {
     coro.crashHandler();
+    // Route any panic-message I/O through the blocking path, never the event loop.
+    runtime_mod.markCrashed();
 }
 
 fn asyncImpl(

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -284,10 +284,14 @@ pub const Executor = struct {
     // Periodic timer for evicting idle stacks from the shared stack pool.
     stack_pool_eviction_timer: ev.Timer = ev.Timer.init(.{ .duration = .fromSeconds(60) }),
 
-    // The task currently executing on this executor.
+    // The task currently executing on this executor, or null when we are running
+    // scheduler code (the run loop, a context switch, a completion callback) rather
+    // than a task body. A null value routes any I/O performed here through the
+    // blocking path in waitForIo instead of re-entering the event loop, which would
+    // otherwise recurse into Loop.add (see issue #545).
     // Updated before every context switch into a task and after every switch back.
     // Used by getCurrentTaskOrNull() instead of the TLS current_context chain.
-    current_task: *AnyTask,
+    current_task: ?*AnyTask,
 
     // Executor dedicated to this thread. Written once on init, never updated.
     pub threadlocal var current_DO_NOT_ACCESS_DIRECTLY: ?*Executor = null;
@@ -406,6 +410,16 @@ pub const Executor = struct {
     pub fn run(self: *Executor, mode: RunMode) !void {
         const check_ready = mode != .until_stopped;
 
+        // The run loop is scheduler code, not a task: clear current_task so any I/O
+        // it performs (a completion callback, std.log, a debug_io write) takes the
+        // blocking path rather than recursing into the event loop. Restored to the
+        // main task on return, since control goes back to the main task's user code
+        // (or, for worker executors, to shutdown). This defer does not run on the
+        // crash path: markCrashed()'s callers are noreturn and a panic does not
+        // unwind through defers, so the null marker it sets survives until abort().
+        self.current_task = null;
+        defer self.current_task = &self.main_task;
+
         // Process deferred cleanup (e.g. main task's park/reschedule)
         self.processCleanup();
 
@@ -415,7 +429,7 @@ pub const Executor = struct {
                 @atomicStore(*Context, &next_task.coro.parent_context_ptr, &self.main_task.coro.context, .release);
                 self.current_task = next_task;
                 next_task.coro.step();
-                self.current_task = &self.main_task;
+                self.current_task = null;
                 self.processCleanup();
             }
 
@@ -631,12 +645,16 @@ pub const Executor = struct {
     /// Yield the current coroutine to the next ready task or back to the run loop.
     /// Sets current_task for the target and performs the context switch.
     pub fn switchOut(self: *Executor, coro: *Coroutine) void {
+        // Picking the next task and switching is scheduler code: clear current_task
+        // so I/O performed here doesn't re-enter the event loop. On the direct-switch
+        // path it is set to the target task just before the switch; on the fall-back
+        // path it stays null and the run loop keeps it null until it steps a task.
+        self.current_task = null;
         if (self.getNextTask()) |next_task| {
             @atomicStore(*Context, &next_task.coro.parent_context_ptr, &self.main_task.coro.context, .release);
             self.current_task = next_task;
             coro.yieldTo(&next_task.coro);
         } else {
-            self.current_task = &self.main_task;
             coro.yield();
         }
     }
@@ -667,6 +685,18 @@ pub fn getCurrentTask() *AnyTask {
 pub fn getCurrentTaskOrNull() ?*AnyTask {
     const exec = getCurrentExecutorOrNull() orelse return null;
     return exec.current_task;
+}
+
+/// Called from the panic/crash handler. Marks this thread as not running a task so
+/// that any I/O performed while unwinding — in particular writing the panic message
+/// through debug_io — takes the blocking path in waitForIo instead of re-entering
+/// the event loop (which would recurse into Loop.add and abort with no message).
+/// The marker is never restored: markCrashed()'s callers (defaultPanic,
+/// defaultHandleSegfault) are noreturn and a panic does not unwind through defers,
+/// so no scheduler code runs again on this thread before abort(). See issue #545.
+pub fn markCrashed() void {
+    const exec = getCurrentExecutorOrNull() orelse return;
+    exec.current_task = null;
 }
 
 /// Cooperatively yield control to allow other tasks to run.


### PR DESCRIPTION
Fixes #545.

## Problem

When a panic unwinds while a task is inside `Loop.add` (or any in-flight I/O op) and the app sets `std_options_debug_io = zio.debug_io`, writing the panic message goes back through zio's async I/O:

```
defaultPanic -> lockStderr -> drain -> fileWriteStreamingImpl -> waitForIo -> Loop.add
```

`Loop.add`'s `in_add` guard is still set (its clearing `defer` never ran — we're unwinding, not returning), so it panics `"recursive call to Loop.add()"`, which reports itself the same way → infinite recursion → `abort()` with **no panic message**. The original panic is completely masked.

The same trap applies to any `std.log` / `std.debug.print` emitted from scheduler code (e.g. a completion callback, or `yield()` internals).

## Fix

`waitForIo` already falls back to a synchronous, in-thread syscall (`executeBlocking`) whenever there is no current task. This makes that condition true exactly where the loop must not be re-entered:

- `current_task` becomes `?*AnyTask` and is cleared while the executor is running scheduler code — the run loop between steps, and `switchOut` while it picks the next task / switches. It is set back to a task before every switch into a task body, and restored to `main_task` when the run loop returns.
- The crash handler (`crashHandlerImpl`) clears `current_task` so panic-message I/O always takes the blocking path, even when unwinding from *inside* `Loop.add`. This is sticky — once crashing, we never touch the loop again.

Forcing the blocking path surfaced a latent gap: std's stack-trace symbolization opens, reads and then **closes** the executable through `debug_io`, and both `fileCloseImpl` and `netCloseImpl` batch closes into a gather `Group`, which `executeBlocking` used to `@panic` on. `executeBlocking` now runs a gather group's children sequentially, after validating each child is an op it can run inline (`file_close` / `net_close`); other ops keep the clear "requires event loop" panic.

## Verification

- All unit tests pass (`./check.sh`), all examples build (`zig build examples`).
- Manual repro: a task that panics with `std_options_debug_io = zio.debug_io` set. Before this change the blocking path also broke on the grouped close (recursive panic during symbolization); with the full fix it prints the complete panic message **and** symbolized stack trace via the blocking path, then aborts normally — and because all panic-time I/O now bypasses the loop, the same holds when the panic unwinds from inside `Loop.add`.