### PR TITLE
runtime: expose a top-level maybeYield()

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -681,6 +681,15 @@ pub fn yield() Cancelable!void {
     return task.yield(.reschedule, .allow_cancel);
 }
 
+/// Cooperatively yield, but only if enough other tasks are waiting (a cheap
+/// fairness check for long CPU-bound loops that would otherwise hog the
+/// executor). Returns error.Canceled if the task was canceled. No-op if called
+/// from a thread without an executor.
+pub fn maybeYield() Cancelable!void {
+    const exec = getCurrentExecutorOrNull() orelse return;
+    return exec.maybeYield(.reschedule, .allow_cancel);
+}
+
 /// Spawn a task on the current runtime.
 /// Panics if called outside of a task context.
 pub fn spawn(func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) !JoinHandle(meta.ReturnType(func)) {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1214,6 +1214,63 @@ test "runtime: yield from main allows tasks to run" {
     try std.testing.expectEqual(10, counter);
 }
 
+test "runtime: yield without an executor is a no-op" {
+    // No Runtime has been initialized on this thread, so there's no current
+    // executor. yield() should just fall back to an OS thread yield and return.
+    try yield();
+}
+
+test "runtime: maybeYield without an executor is a no-op" {
+    // Same as above, but for the fairness-checked variant.
+    try maybeYield();
+}
+
+test "runtime: maybeYield yields once the ready queue crosses the fairness threshold" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const ResetEvent = @import("sync/ResetEvent.zig");
+
+    var event: ResetEvent = .init;
+    var counter: usize = 0;
+
+    const waiterTask = struct {
+        fn call(reset_event: *ResetEvent, counter_ptr: *usize) !void {
+            try reset_event.wait();
+            counter_ptr.* += 1;
+        }
+    }.call;
+
+    // Spawn more waiters than Executor.yield_ready_threshold so that, once they're
+    // all woken at once, ready_count is high enough for maybeYield() to actually
+    // reschedule instead of no-op.
+    const task_count = Executor.yield_ready_threshold + 5;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    for (0..task_count) |_| {
+        try group.spawn(waiterTask, .{ &event, &counter });
+    }
+
+    // Every task is now parked in event.wait(), so waking them all at once fills
+    // the ready queue past the fairness threshold.
+    event.set();
+
+    var iterations: usize = 0;
+    while (counter < task_count) : (iterations += 1) {
+        if (iterations >= 100) {
+            std.debug.print("maybeYield not working: counter={}, iterations={}\n", .{ counter, iterations });
+            return error.TestExpectedEqual;
+        }
+        try maybeYield();
+    }
+
+    try std.testing.expectEqual(task_count, counter);
+    try group.wait();
+    try std.testing.expect(!group.hasFailed());
+}
+
 test "runtime: sleep from main allows tasks to run" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -13,6 +13,7 @@ pub const JoinHandle = runtime.JoinHandle;
 pub const spawn = runtime.spawn;
 pub const spawnBlocking = runtime.spawnBlocking;
 pub const yield = runtime.yield;
+pub const maybeYield = runtime.maybeYield;
 pub const sleep = runtime.sleep;
 pub const now = runtime.now;
 


### PR DESCRIPTION
## What

Adds a top-level `zio.maybeYield()`.

## Why

`Executor.maybeYield` already exists — it yields only when enough tasks are waiting (`ready_count >= yield_ready_threshold`), so it's a cheap fairness check rather than an unconditional context switch. But it's a method on the internal `Executor` and wasn't reachable from user code.

Long CPU-bound loops on the executor (segment merges, decoders, big scans) would otherwise starve other coroutines until they finish. Sprinkling `zio.yield()` works but forces a context switch every time; `maybeYield()` only switches when there's actually contention.

## How

Mirrors `zio.yield()`: fetches the current executor via `getCurrentExecutorOrNull()`, no-ops off-executor, and delegates to `Executor.maybeYield(.reschedule, .allow_cancel)`, returning `Cancelable!void`.

```zig
while (moreWork()) {
    doChunk();
    try zio.maybeYield();
}
```