### PR TITLE
Support select() and wait() on Group

### DIFF
--- a/src/group.zig
+++ b/src/group.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const log = @import("common.zig").log;
+const Waiter = @import("common.zig").Waiter;
 const meta = @import("meta.zig");
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
@@ -217,6 +218,52 @@ pub const Group = struct {
         // Clear the canceled flag for reuse
         group.getTasks().clearFlag();
     }
+
+    // Future protocol implementation for use with select() / wait().
+    //
+    // Waits until the group naturally drains to zero pending tasks. Unlike
+    // `wait()`, this does NOT close the group and does not participate in
+    // fail_fast — it purely observes the task counter reaching zero, so it can
+    // be raced against other futures without changing the group's behavior.
+    //
+    // Registration parks on the same futex address that `unregisterGroupTask`
+    // wakes when the counter hits zero, so no per-group waiter storage is needed.
+
+    pub const Result = void;
+
+    pub const WaitContext = Futex.FutexWaiter;
+
+    pub fn getResult(self: *Group, ctx: *WaitContext) void {
+        _ = self;
+        _ = ctx;
+    }
+
+    pub fn asyncWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {
+        const state_ptr = self.getState();
+
+        // Fast path: no pending tasks means the group is already "complete".
+        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) return false;
+
+        // Park on the completion futex address.
+        Futex.prepareWait(state_ptr, ctx, waiter);
+
+        // Double-check: the last task may have completed (and issued its wake)
+        // between the fast-path check and our registration above.
+        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) {
+            // We removed ourselves before any wake -> already complete.
+            if (Futex.cancelWait(ctx)) return false;
+            // A concurrent completion already dequeued us; the wake is in-flight.
+            return true;
+        }
+
+        return true;
+    }
+
+    pub fn asyncCancelWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {
+        _ = self;
+        _ = waiter;
+        return Futex.cancelWait(ctx);
+    }
 };
 
 /// Spawn a task in the group with raw context bytes and start function.
@@ -421,4 +468,128 @@ test "Group: failed task does not close group" {
     try group.wait();
 
     try std.testing.expectEqual(n / 2, T.counter);
+}
+
+test "Group: select on group completion - group wins" {
+    const select = @import("select.zig").select;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const quick = struct {
+        fn call() void {
+            sleep(.fromMilliseconds(10)) catch {};
+        }
+    }.call;
+
+    const slow = struct {
+        fn call() i32 {
+            sleep(.fromMilliseconds(1000)) catch {};
+            return 42;
+        }
+    }.call;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(quick, .{});
+    try group.spawn(quick, .{});
+
+    var slow_handle = try rt.spawn(slow, .{});
+    defer slow_handle.cancel();
+
+    // The group's quick tasks drain long before the slow handle completes.
+    const result = try select(.{ .group = &group, .slow = &slow_handle });
+    switch (result) {
+        .group => {},
+        .slow => return error.TestUnexpectedResult,
+    }
+
+    // select() must not have closed the group: it is still usable.
+    try group.spawn(quick, .{});
+    try group.wait();
+}
+
+test "Group: select on group completion - other future wins" {
+    const select = @import("select.zig").select;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const slow = struct {
+        fn call() void {
+            sleep(.fromMilliseconds(1000)) catch {};
+        }
+    }.call;
+
+    const quick = struct {
+        fn call() i32 {
+            sleep(.fromMilliseconds(10)) catch {};
+            return 7;
+        }
+    }.call;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(slow, .{});
+
+    var quick_handle = try rt.spawn(quick, .{});
+    defer quick_handle.cancel();
+
+    const result = try select(.{ .group = &group, .quick = &quick_handle });
+    switch (result) {
+        .group => return error.TestUnexpectedResult,
+        .quick => |v| try std.testing.expectEqual(7, v),
+    }
+}
+
+test "Group: select on already-drained group - fast path" {
+    const select = @import("select.zig").select;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const slow = struct {
+        fn call() i32 {
+            sleep(.fromMilliseconds(1000)) catch {};
+            return 3;
+        }
+    }.call;
+
+    // Empty group: counter is already zero, so select must pick it immediately.
+    var group: Group = .init;
+    defer group.cancel();
+
+    var slow_handle = try rt.spawn(slow, .{});
+    defer slow_handle.cancel();
+
+    const result = try select(.{ .group = &group, .slow = &slow_handle });
+    try std.testing.expectEqual(std.meta.Tag(@TypeOf(result)).group, std.meta.activeTag(result));
+}
+
+test "Group: wait() future protocol drains without closing" {
+    const waitFuture = @import("select.zig").wait;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const quick = struct {
+        fn call() void {
+            sleep(.fromMilliseconds(10)) catch {};
+        }
+    }.call;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(quick, .{});
+    try group.spawn(quick, .{});
+
+    // Single-future wait() over the group completes when tasks drain.
+    _ = try waitFuture(&group);
+
+    // Not closed: can spawn again and drain a second time.
+    try group.spawn(quick, .{});
+    _ = try waitFuture(&group);
 }

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -78,8 +78,9 @@ pub fn wait(ptr: *const u32, expect: u32) Cancelable!void {
     const bucket = getBucket(address);
 
     // Use a stack-allocated waiter
+    var waiter = Waiter.init();
     var futex_waiter = FutexWaiter{
-        .waiter = Waiter.init(),
+        .waiter = &waiter,
         .address = address,
     };
 
@@ -117,14 +118,19 @@ pub fn waitUncancelable(ptr: *const u32, expect: u32) void {
     wait(ptr, expect) catch unreachable;
 }
 
-/// Stack-allocated waiter for futex operations.
-const FutexWaiter = struct {
+/// Stack-allocated waiter node for the global futex buckets.
+///
+/// `waiter` references an externally-owned `Waiter`: the blocking `wait()` /
+/// `timedWait()` paths point it at a local direct waiter, while the non-blocking
+/// `prepareWait()` path used by select() points it at a caller-owned select
+/// waiter. All fields default so the node can serve as a select `WaitContext`.
+pub const FutexWaiter = struct {
     // Linked list fields for SimpleQueue
     next: ?*FutexWaiter = null,
     prev: ?*FutexWaiter = null,
     in_list: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_safety) false else {},
-    waiter: Waiter,
-    address: usize,
+    waiter: *Waiter = undefined,
+    address: usize = 0,
 
     /// Pad to cache line to prevent false sharing.
     _: void align(std.atomic.cache_line) = {},
@@ -152,8 +158,9 @@ pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clo
     const bucket = getBucket(address);
 
     // Use a stack-allocated waiter with its own WaitNode
+    var waiter = Waiter.init();
     var futex_waiter = FutexWaiter{
-        .waiter = Waiter.init(),
+        .waiter = &waiter,
         .address = address,
     };
 
@@ -236,6 +243,32 @@ pub fn wake(ptr: *const u32, max_waiters: u32) void {
         local_stack = waiter.next;
         waiter.waiter.signal();
     }
+}
+
+/// Register `node` in the bucket for `ptr` so a later `wake(ptr)` signals `waiter`.
+///
+/// Non-blocking counterpart of `wait()`, used by the select() future protocol.
+/// The caller owns `node` and must keep it alive (and not move it) until either
+/// `cancelWait(node)` is called or the wake fires. Unlike `wait()`, this performs
+/// no value check: the caller is responsible for checking its own completion
+/// predicate before and after registering (to close the lost-wakeup race).
+pub fn prepareWait(ptr: *const u32, node: *FutexWaiter, waiter: *Waiter) void {
+    const address = @intFromPtr(ptr);
+    node.* = .{ .waiter = waiter, .address = address };
+
+    const bucket = getBucket(address);
+    bucket.mutex.lock();
+    bucket.waiters.push(node);
+    bucket.mutex.unlock();
+}
+
+/// Cancel a `prepareWait()` registration.
+///
+/// Returns true if `node` was still queued (it will not be woken), or false if a
+/// concurrent `wake()` already dequeued it (a signal to `node`'s waiter is
+/// in-flight and the caller must wait for it before reusing the waiter).
+pub fn cancelWait(node: *FutexWaiter) bool {
+    return removeFromBucket(getBucket(node.address), node);
 }
 
 test "Futex: basic wait/wake" {


### PR DESCRIPTION
## What

Adds the `select()` future protocol to `Group`, so a group's completion (all tasks drained to zero) can be raced against other futures:

```zig
var group: zio.Group = .init;
try group.spawn(worker, .{});
// ...
const result = try zio.select(.{ .group = &group, .recv = channel.asyncReceive() });
switch (result) {
    .group => {},   // all group tasks finished
    .recv  => |v| ...,
}
```

Single-future `wait(&group)` works too.

## Why this approach

`Group`'s storage is pinned to `std.Io.Group`'s two words (`token` + `state`) via the `fromStd` pointer cast, so there is no room to add a waiter queue. Instead of splitting the type or stealing bits, the waiter **parks on the same futex address that `unregisterGroupTask` already wakes** when the task counter hits zero.

This means:
- **No new storage on `Group`** — layout stays identical to `std.Io.Group`, `fromStd` is unchanged.
- **No lifetime hazard** — parking lives in the global futex bucket, and `Futex.wake` only hashes the address (never dereferences the group) and is already stack-safe. The group can be freed the instant completion fires.
- **No single-consumer restriction** — a `Group.wait()`er and a `select` waiter can coexist on the same address; the wake fans out to both.

## Changes

- **`Futex`**: `FutexWaiter` now references an externally-owned `Waiter` (was embedded), and a non-blocking `prepareWait()`/`cancelWait()` pair is added — the async counterpart of `wait()`, used by the select protocol. The caller owns the predicate check.
- **`Group`**: implements `Result` / `WaitContext` / `getResult` / `asyncWait` / `asyncCancelWait`. `asyncWait` checks the counter, parks, then re-checks to close the lost-wakeup race.

## Semantics

Unlike `Group.wait()`, observing a group via `select()` / `wait()` does **not** close it and does **not** participate in `fail_fast` — it purely waits for the task counter to reach zero, leaving the group reusable afterward.

> Note for a future `fail_fast` early-wake (the `TODO`s in `group.zig`): select rides the completion futex, so an early wake while `counter > 0` would make select report completion prematurely. Not an issue today since no such wake exists.

## Tests

Added to `group.zig`: group-wins, other-future-wins, already-drained fast path, and single-future `wait(&group)` — all asserting the group remains usable after being observed. Full suite: 525/525 pass.