### PR TITLE
fs: use getdents(2) on NetBSD for directory iteration

### DIFF
--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -413,6 +413,12 @@ pub const DirEntryIterator = struct {
             // Skip . and ..
             if (self.isDotOrDotDot(entry)) continue;
 
+            // On NetBSD/OpenBSD a zero fileno marks an invalid or deleted entry
+            // still present in the directory block; skip it (matches std).
+            if (builtin.os.tag == .netbsd or builtin.os.tag == .openbsd) {
+                if (self.extractInode(entry) == 0) continue;
+            }
+
             const name = self.extractName(entry) orelse {
                 // On Windows, null means no buffer space - backtrack and stop
                 if (builtin.os.tag == .windows) {
@@ -2841,7 +2847,12 @@ fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
                 var basep: i64 = 0;
                 break :blk @as(usize, @bitCast(std.c.__getdirentries64(handle, buffer.ptr, buffer.len, &basep)));
             },
-            .freebsd, .netbsd, .openbsd, .dragonfly => blk: {
+            // NetBSD's getdirentries(2) is a legacy compat interface that returns
+            // the old dirent layout (32-bit d_fileno), which does not match the
+            // modern std.c.dirent we parse with. getdents(2) (__getdents30) returns
+            // the modern layout, matching std's own directory iteration.
+            .netbsd => posix.system.getdents(handle, buffer.ptr, buffer.len),
+            .freebsd, .openbsd, .dragonfly => blk: {
                 var basep: c_long = 0;
                 break :blk posix.system.getdirentries(handle, buffer.ptr, buffer.len, &basep);
             },


### PR DESCRIPTION
## Problem

`Dir.iterate()` panics on NetBSD:

```
fs.test.Dir: iterate
thread 293 panic: index out of bounds: index 36995, len 512
```

The iterator advances `self.index` by a garbage `reclen` — a struct-layout mismatch, not a logic bug.

## Root cause

`dirRead` fills the buffer with `getdirentries(2)` for all BSDs. On NetBSD, `getdirentries(2)` is a **legacy compat interface** that returns the *old* dirent layout (32-bit `d_fileno`), but the iterator parses entries as the modern `std.c.dirent`:

```zig
.netbsd => extern struct {
    fileno: ino_t,   // u64 -> offset 0
    reclen: u16,     //     -> offset 8
    ...
```

So `reclen` is read from offset 8 of an old-format record (where the name bytes sit) → bogus length → the index walks past the 512-byte buffer. FreeBSD doesn't hit this because its `getdirentries` already returns the modern layout.

## Fix

Use `getdents(2)` (`__getdents30`) on NetBSD, which returns the modern layout matching `std.c.dirent`. This mirrors std's own `dirReadBsd`, which uses `getdents` for all BSDs. FreeBSD/OpenBSD/DragonFly keep `getdirentries` (already matching there).

Also skip entries with `fileno == 0` on NetBSD/OpenBSD (invalid/deleted entries still present in the block), matching std.

## Testing

- Cross-compiles clean for `x86_64-netbsd` (`./check.sh --target x86_64-netbsd --no-exec`).
- Opening as **draft** to run the NetBSD job in CI, since there's no local NetBSD runner.

Unrelated to any in-flight work; branched from `main`.