### PR TITLE
fix(iocp): keep overlapped I/O out-params alive until completion

### DIFF
--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -182,6 +182,16 @@ pub const capabilities: BackendCapabilities = .{
 // Backend-specific data stored in Completion.internal
 pub const CompletionData = struct {
     overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED),
+    // Out-params for the overlapped call must live as long as the OVERLAPPED they
+    // accompany: when an operation completes asynchronously the kernel may write
+    // the transferred byte count (and, for a receive, the result flags) at
+    // completion time — long after the submit function has returned. A stack
+    // local would be a dangling write. The authoritative byte count is read from
+    // WSAGetOverlappedResult at completion; `bytes` here is only backing storage
+    // for the required out-param pointer. `flags` doubles as the in/out lpFlags
+    // for WSARecv/WSARecvFrom (which cannot be NULL).
+    bytes: windows.DWORD = 0,
+    flags: windows.DWORD = 0,
 };
 
 // Backend-specific data stored in ProcessWait.internal
@@ -740,7 +750,6 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
     data.c.internal.overlapped = std.mem.zeroes(windows.OVERLAPPED);
 
     // Call AcceptEx
-    var bytes_received: windows.DWORD = 0;
     const addr_size: windows.DWORD = NetAcceptData.addr_slot_size;
 
     const result = exts.acceptex(
@@ -750,7 +759,7 @@ fn submitAccept(self: *Self, state: *LoopState, data: *NetAccept) !void {
         0, // dwReceiveDataLength - we don't want any data, just connection
         addr_size, // local address length
         addr_size, // remote address length
-        &bytes_received,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
     );
 
@@ -784,8 +793,7 @@ fn submitPoll(self: *Self, state: *LoopState, data: *NetPoll) !void {
     var dummy: u8 = 0;
     var zero_buf = windows.WSABUF{ .len = 0, .buf = @ptrCast(&dummy) };
 
-    var bytes_transferred: windows.DWORD = 0;
-    var flags: windows.DWORD = 0;
+    data.c.internal.flags = 0;
 
     // Choose WSARecv or WSASend based on which event is requested
     const result = switch (data.event) {
@@ -793,8 +801,8 @@ fn submitPoll(self: *Self, state: *LoopState, data: *NetPoll) !void {
             data.handle,
             @ptrCast(&zero_buf),
             1,
-            &bytes_transferred,
-            &flags,
+            &data.c.internal.bytes,
+            &data.c.internal.flags,
             &data.c.internal.overlapped,
             null,
         ),
@@ -802,8 +810,8 @@ fn submitPoll(self: *Self, state: *LoopState, data: *NetPoll) !void {
             data.handle,
             @ptrCast(&zero_buf),
             1,
-            &bytes_transferred,
-            flags,
+            &data.c.internal.bytes,
+            data.c.internal.flags,
             &data.c.internal.overlapped,
             null,
         ),
@@ -831,15 +839,14 @@ fn submitRecv(self: *Self, state: *LoopState, data: *NetRecv) !void {
     // iovecs are already WSABUF on Windows
     const wsabufs = data.buffers.iovecs;
 
-    var bytes_received: windows.DWORD = 0;
-    var flags: windows.DWORD = recvFlagsToMsg(data.flags);
+    data.c.internal.flags = recvFlagsToMsg(data.flags);
 
     const result = windows.WSARecv(
         data.handle,
         wsabufs.ptr,
         @intCast(wsabufs.len),
-        &bytes_received,
-        &flags,
+        &data.c.internal.bytes,
+        &data.c.internal.flags,
         &data.c.internal.overlapped,
         null, // No completion routine
     );
@@ -869,14 +876,13 @@ fn submitSend(self: *Self, state: *LoopState, data: *NetSend) !void {
     // iovecs are already WSABUF on Windows (need to cast away const)
     const wsabufs = data.buffer.iovecs;
 
-    var bytes_sent: windows.DWORD = 0;
     const flags: windows.DWORD = sendFlagsToMsg(data.flags);
 
     const result = windows.WSASend(
         data.handle,
         @constCast(wsabufs.ptr),
         @intCast(wsabufs.len),
-        &bytes_sent,
+        &data.c.internal.bytes,
         flags,
         &data.c.internal.overlapped,
         null, // No completion routine
@@ -906,15 +912,14 @@ fn submitRecvFrom(self: *Self, state: *LoopState, data: *NetRecvFrom) !void {
     // iovecs are already WSABUF on Windows
     const wsabufs = data.buffer.iovecs;
 
-    var bytes_received: windows.DWORD = 0;
-    var flags: windows.DWORD = recvFlagsToMsg(data.flags);
+    data.c.internal.flags = recvFlagsToMsg(data.flags);
 
     const result = windows.WSARecvFrom(
         data.handle,
         wsabufs.ptr,
         @intCast(wsabufs.len),
-        &bytes_received,
-        &flags,
+        &data.c.internal.bytes,
+        &data.c.internal.flags,
         if (data.addr) |addr| @ptrCast(addr) else null,
         if (data.addr_len) |len| len else null,
         &data.c.internal.overlapped,
@@ -945,14 +950,13 @@ fn submitSendTo(self: *Self, state: *LoopState, data: *NetSendTo) !void {
     // iovecs are already WSABUF on Windows (need to cast away const)
     const wsabufs = data.buffer.iovecs;
 
-    var bytes_sent: windows.DWORD = 0;
     const flags: windows.DWORD = sendFlagsToMsg(data.flags);
 
     const result = windows.WSASendTo(
         data.handle,
         @constCast(wsabufs.ptr),
         @intCast(wsabufs.len),
-        &bytes_sent,
+        &data.c.internal.bytes,
         flags,
         @ptrCast(data.addr),
         @intCast(data.addr_len),
@@ -1005,12 +1009,10 @@ fn submitRecvMsg(self: *Self, state: *LoopState, data: *NetRecvMsg) !void {
         .dwFlags = recvFlagsToMsg(data.flags),
     };
 
-    var bytes_received: windows.DWORD = 0;
-
     const result = exts.wsarecvmsg(
         data.handle,
         &data.internal.msg,
-        &bytes_received,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
         null, // No completion routine
     );
@@ -1057,13 +1059,11 @@ fn submitSendMsg(self: *Self, state: *LoopState, data: *NetSendMsg) !void {
     // Load WSASendMsg extension function
     const exts = self.shared_state.exts;
 
-    var bytes_sent: windows.DWORD = 0;
-
     const result = exts.wsasendmsg(
         data.handle,
         &data.internal.msg,
         sendFlagsToMsg(data.flags),
-        &bytes_sent,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
         null, // No completion routine
     );
@@ -1228,13 +1228,12 @@ fn submitFileRead(self: *Self, state: *LoopState, data: *FileRead) !void {
     // ReadFile only supports a single buffer, so we read into the first iovec
     // TODO: Handle multiple iovecs with multiple ReadFile calls
     const buffer = data.buffer.iovecs[0];
-    var bytes_read: windows.DWORD = 0;
 
     const result = windows.ReadFile(
         data.handle,
         buffer.buf,
         @intCast(buffer.len),
-        &bytes_read,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
     );
 
@@ -1270,13 +1269,12 @@ fn submitFileWrite(self: *Self, state: *LoopState, data: *FileWrite) !void {
     // WriteFile only supports a single buffer, so we write from the first iovec
     // TODO: Handle multiple iovecs with multiple WriteFile calls
     const buffer = data.buffer.iovecs[0];
-    var bytes_written: windows.DWORD = 0;
 
     const result = windows.WriteFile(
         data.handle,
         buffer.buf,
         @intCast(buffer.len),
-        &bytes_written,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
     );
 
@@ -1352,13 +1350,12 @@ fn submitFileReadStreaming(self: *Self, state: *LoopState, data: *FileReadStream
     // ReadFile only supports a single buffer, so we read into the first iovec
     // TODO: Handle multiple iovecs with multiple ReadFile calls
     const buffer = data.buffer.iovecs[0];
-    var bytes_read: windows.DWORD = 0;
 
     const result = windows.ReadFile(
         data.handle,
         buffer.buf,
         @intCast(buffer.len),
-        &bytes_read,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
     );
 
@@ -1399,13 +1396,12 @@ fn submitFileWriteStreaming(self: *Self, state: *LoopState, data: *FileWriteStre
     // WriteFile only supports a single buffer, so we write from the first iovec
     // TODO: Handle multiple iovecs with multiple WriteFile calls
     const buffer = data.buffer.iovecs[0];
-    var bytes_written: windows.DWORD = 0;
 
     const result = windows.WriteFile(
         data.handle,
         buffer.buf,
         @intCast(buffer.len),
-        &bytes_written,
+        &data.c.internal.bytes,
         &data.c.internal.overlapped,
     );
 


### PR DESCRIPTION
## Problem

Every IOCP submit path handed the kernel a pointer to a **stack-local** out-param — the transferred byte count (`lpNumberOfBytes*`), plus `lpFlags` for receives — alongside a persistent `OVERLAPPED`.

For an operation that completes **asynchronously** (`WSA_IO_PENDING` / `ERROR_IO_PENDING`), the kernel writes those out-params **at completion time**, which is *after* the submit function has already returned and its stack frame is gone. The write then lands in a dead stack frame and can corrupt whatever now occupies that slot. This is the same class of async-lifetime bug that produced the `pending_cleanup` corruption, just via a different mechanism (kernel-side write into freed stack rather than a dropped register clobber).

## Fix

Give the out-params the same lifetime as the `OVERLAPPED` they accompany by moving their storage into `CompletionData` (which already owns the `OVERLAPPED`):

```zig
pub const CompletionData = struct {
    overlapped: windows.OVERLAPPED = ...,
    bytes: windows.DWORD = 0,   // backing for the required lpNumberOfBytes* out-param
    flags: windows.DWORD = 0,   // also the in/out lpFlags for WSARecv/WSARecvFrom
};
```

- The **authoritative** byte count is still read from `WSAGetOverlappedResult` at completion — `bytes` here is only valid backing for the required out-param pointer.
- `flags` doubles as the in/out `lpFlags` for `WSARecv`/`WSARecvFrom`, which cannot be `NULL`.

Covered submit paths: accept, poll, recv, send, recvfrom, sendto, recvmsg, sendmsg, file read/write, and streaming file read/write.

The completion-path locals (the `bytes_transferred`/`flags` passed to `WSAGetOverlappedResult` *after* the op has finished) are correct as-is and left unchanged.

Left as documented-correct and unchanged: `ConnectEx`'s `lpdwBytesSent` is already `NULL` (no send buffer), and `AcceptEx`'s `lpdwBytesReceived` (non-nullable) now points into `CompletionData` too.

## Verification

Cross-compiles on every Windows target: x86_64 (Debug + ReleaseSafe) and aarch64 (ReleaseSafe). No other backend is affected — `CompletionData` is IOCP-only.
