### PR TITLE
fix(io_uring): fall back to the thread pool for file_set_size on pre-6.9 kernels

### DIFF
--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -88,7 +88,11 @@ pub const capabilities: BackendCapabilities = .{
     .file_create = true,
     .file_close = true,
     .file_sync = true,
-    .file_set_size = true,
+    // Runtime-dispatched, not statically native: the native IORING_OP_FTRUNCATE
+    // needs Linux >= 6.9. `false` makes the completion carry a DelegatedWork so
+    // the thread-pool path is available; the Loop upgrades to the native SQE at
+    // runtime when `fileSetSizeSupported()` (probed once) says the kernel has it.
+    .file_set_size = false,
     .dir_create_dir = true,
     .dir_rename = true,
     .dir_rename_preserve = true,
@@ -102,9 +106,20 @@ pub const capabilities: BackendCapabilities = .{
     .native_wall_timers = true,
 };
 
+// Tri-state for the once-probed IORING_OP_FTRUNCATE support. `unknown` is treated
+// as `no` at the dispatch site, so a missed/failed probe is always safe (the
+// thread-pool fallback works on every kernel) — never a rejected SQE.
+const ftruncate_unknown: u8 = 0;
+const ftruncate_yes: u8 = 1;
+const ftruncate_no: u8 = 2;
+
 pub const SharedState = struct {
     master_fd: std.atomic.Value(c_int) = .init(-1),
     refcount: std.atomic.Value(usize) = .init(0),
+    /// Whether the running kernel supports IORING_OP_FTRUNCATE (Linux >= 6.9),
+    /// probed exactly once when the master ring is created (see `init`). Read by
+    /// `fileSetSizeSupported()`.
+    ftruncate_support: std.atomic.Value(u8) = .init(ftruncate_unknown),
 };
 
 pub const NetRecvData = struct {
@@ -214,6 +229,12 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
             break :blk try ringFromMasterFd(master_fd, flags, queue_size);
         } else {
             var ring = try linux.IoUring.init(queue_size, flags);
+            // Probe FTRUNCATE support once, on this fresh ring, and publish the
+            // verdict BEFORE master_fd. Any executor that later attaches sees a
+            // non-negative master_fd (seq_cst) and is thus guaranteed to observe
+            // the stored verdict. Racing creators store the same kernel-global
+            // value, so a redundant store by a CAS loser is harmless.
+            probeAndStoreFtruncate(&ring, shared_state);
             const old_fd = shared_state.master_fd.cmpxchgStrong(-1, ring.fd, .seq_cst, .seq_cst);
             if (old_fd != null) {
                 ring.deinit();
@@ -242,6 +263,25 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
     // never deaf to wake() — the SQE rides the first enter2, covering the first
     // poll and startup. wake() just writes the eventfd.
     _ = self.armWaker();
+}
+
+/// Probe (once, via IORING_REGISTER_PROBE) whether the kernel knows the
+/// IORING_OP_FTRUNCATE opcode (added in Linux 6.9) and record it in `SharedState`.
+/// A failed probe records "no", so file_set_size takes the always-correct
+/// thread-pool fallback rather than risk a rejected SQE.
+fn probeAndStoreFtruncate(ring: *linux.IoUring, shared_state: *SharedState) void {
+    const supported = blk: {
+        const probe = ring.get_probe() catch break :blk false;
+        break :blk probe.is_supported(.FTRUNCATE);
+    };
+    shared_state.ftruncate_support.store(if (supported) ftruncate_yes else ftruncate_no, .seq_cst);
+}
+
+/// Runtime capability query used by the Loop: may file_set_size use the native
+/// IORING_OP_FTRUNCATE SQE, or must it fall back to the thread pool? Probed once
+/// at ring creation; see `SharedState.ftruncate_support`.
+pub fn fileSetSizeSupported(self: *Self) bool {
+    return self.shared_state.ftruncate_support.load(.seq_cst) == ftruncate_yes;
 }
 
 fn ringFromMasterFd(master_fd: i32, flags: u32, queue_size: u16) !linux.IoUring {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -958,6 +958,23 @@ pub const Loop = struct {
                     else => {},
                 }
 
+                // Ops a backend can handle natively only on some kernels (probed at
+                // runtime): if the backend advertises a runtime query and it says
+                // yes, use the native SQE path; otherwise fall through to the
+                // capability-based routing below (which sends it to the thread pool).
+                switch (completion.op) {
+                    .file_set_size => {
+                        if (comptime @hasDecl(Backend, "fileSetSizeSupported")) {
+                            if (self.backend.fileSetSizeSupported()) {
+                                self.state.incrInflight();
+                                self.backend.submit(&self.state, completion);
+                                return;
+                            }
+                        }
+                    },
+                    else => {},
+                }
+
                 // Regular backend operation
                 // Route file/dir ops to thread pool for backends without native support
                 switch (completion.op) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -774,6 +774,17 @@ pub const Loop = struct {
                                 return;
                             }
                         }
+                        // file_set_size may have been submitted natively (the
+                        // FTRUNCATE SQE) when the runtime probe found kernel
+                        // support, so it must be canceled on the backend, not the
+                        // thread pool. The probe verdict is stable for the process,
+                        // so re-querying here agrees with the submission decision.
+                        if (comptime op == .file_set_size and @hasDecl(Backend, "fileSetSizeSupported")) {
+                            if (self.backend.fileSetSizeSupported()) {
+                                self.backend.cancel(&self.state, completion);
+                                return;
+                            }
+                        }
                         const thread_pool = self.thread_pool orelse unreachable;
                         const op_data = completion.cast(op.toType());
                         thread_pool.cancel(&op_data.internal.work);


### PR DESCRIPTION
## Problem

`file_set_size` (`File.setSize` / `setLength`) uses **`IORING_OP_FTRUNCATE`**, which the kernel only added in **Linux 6.9**. On an older kernel io_uring rejects the SQE with `-EINVAL`, which surfaces as `error.Unexpected` and breaks set-size entirely. On a 6.8 host this fails two tests:

- `fs.test.File: size and setSize`
- `io.test.io: file length/sync/setLength`

Isolated three ways:
- **Backend**: fails on io_uring, passes `11/11` on `-Dbackend=epoll` (which routes set-size through a synchronous `ftruncate()` on the thread pool).
- **Direct probe** on the 6.8 host: a bare io_uring `FTRUNCATE` SQE returns `-22` (`EINVAL`) while `STATX` returns `0`.
- **Source**: the only version-gated async op in the set-size path is `.FTRUNCATE`.

## Fix

Probe once, fall back to the thread pool when unsupported, use the native SQE when supported:

1. **`capabilities.file_set_size = false`** — the `FileSetSize` completion now carries a `DelegatedWork`, so the thread-pool `ftruncate()` path is available and is the safe default on every kernel.
2. **Probe once** via `IORING_REGISTER_PROBE` when the master ring is created (same one-time handoff as the WQ-attach `master_fd`), storing the verdict in `SharedState`. The verdict is published before `master_fd`, so any executor that later attaches observes it. A `REGISTER_PROBE` is unambiguous — unlike inferring support from `-EINVAL`, since `ftruncate()` itself returns `EINVAL` for bad arguments.
3. **Runtime upgrade in the `Loop`** — for `file_set_size`, if the backend advertises `fileSetSizeSupported()` and the probe said yes, use the native `FTRUNCATE` SQE; otherwise fall through to the thread pool. This mirrors the existing `pollable` runtime dispatch for streaming file ops. Generic backends (kqueue/poll) lack the decl and are unaffected. An unknown/failed probe is treated as unsupported, so an SQE the kernel would reject is never emitted.

**Net:** native io_uring `FTRUNCATE` on kernels ≥ 6.9, transparent thread-pool fallback on older kernels.

## Verification

- io_uring suite on a **6.8** host: **525/525** (was 523/525 — the two failures above are gone; no regressions).
- Coverage of both paths: local 6.8 exercises the fallback; CI runners (kernel ≥ 6.9) exercise the native `FTRUNCATE` SQE.
- epoll backend still compiles and is unchanged (no `fileSetSizeSupported` decl → no runtime dispatch).
