### PR TITLE
feat: work stealing and improved idling

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1172,21 +1172,19 @@ pub const Runtime = struct {
     fn armSearcher(self: *Runtime) void {
         if (!(zio_options.task_migration and self.options.enable_task_migration) or !self.executors_stealable.load(.acquire) or (self.searchers.load(.monotonic) != 0)) return;
         if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
-        const idle_mask = self.idle_mask.load(.acquire);
 
-        if (idle_mask == 0) {
-            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
-            return;
+        var candidates = self.idle_mask.load(.acquire);
+        while (candidates != 0) {
+            const id: ExecutorId = @intCast(@ctz(candidates));
+            const bit = @as(usize, 1) << id;
+            const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
+            if (previous_mask & bit != 0) {
+                self.executors.items[id].loop.wake();
+                return;
+            }
+            candidates &= ~bit;
         }
-        const id: ExecutorId = @intCast(@ctz(idle_mask));
-        const bit = @as(usize, 1) << id;
-        const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
-
-        if (previous_mask & bit == 0) {
-            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
-            return;
-        }
-        self.executors.items[id].loop.wake();
+        _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
     }
 
     // Convenience methods that operate on the current coroutine context

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -38,7 +38,7 @@ const select = @import("select.zig");
 const Waiter = @import("common.zig").Waiter;
 const random_mod = @import("random.zig");
 
-const U5U6 = switch (@sizeOf(usize)) {
+const ExecutorId = switch (@sizeOf(usize)) {
     4 => u5,
     8 => u6,
     else => @compileError("Unsupported architecture"),
@@ -289,13 +289,9 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
 
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
-    pub const max_executors = switch (@sizeOf(usize)) {
-        4 => 32,
-        8 => 64,
-        else => @compileError("Unsupported architecture"),
-    };
+    pub const max_executors = std.math.maxInt(ExecutorId) + 1;
 
-    id: U5U6,
+    id: ExecutorId,
     loop: ev.Loop,
 
     /// Per-executor random state (non-secure CSPRNG; later the secure-path fd/handle).
@@ -370,7 +366,7 @@ pub const Executor = struct {
         return @alignCast(@fieldParentPtr("main_task", main_task));
     }
 
-    pub fn init(self: *Executor, runtime: *Runtime, id: U5U6) !void {
+    pub fn init(self: *Executor, runtime: *Runtime, id: ExecutorId) !void {
         self.* = .{
             .id = id,
             .loop = undefined,
@@ -1014,7 +1010,7 @@ pub const Runtime = struct {
                 const worker = self.workers.addOneAssumeCapacity();
                 errdefer _ = self.workers.pop();
                 worker.* = .{};
-                worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(U5U6, @intCast(i + worker_id_start)) });
+                worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(ExecutorId, @intCast(i + worker_id_start)) });
             }
 
             for (self.workers.items, 0..) |*worker, i| {
@@ -1150,7 +1146,7 @@ pub const Runtime = struct {
 
     /// Worker thread entry point. Initializes executor and runs until stopped.
     /// Signals worker.ready after initialization (success or failure).
-    fn runWorker(self: *Runtime, worker: *Worker, id: U5U6) void {
+    fn runWorker(self: *Runtime, worker: *Worker, id: ExecutorId) void {
         worker.executor.init(self, id) catch |e| {
             worker.err = e;
             worker.ready.set();
@@ -1183,7 +1179,7 @@ pub const Runtime = struct {
             _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
             return;
         }
-        const id: U5U6 = @intCast(@ctz(idle_mask));
+        const id: ExecutorId = @intCast(@ctz(idle_mask));
         const bit = @as(usize, 1) << id;
         const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
 
@@ -1596,11 +1592,11 @@ test "runtime: local ring overflow spills and drains with task migration disable
     try std.testing.expectEqual(@as(u32, H.n_tasks), counter.load(.monotonic));
 }
 
-test "runtime: multi-threaded execution with 64 executors" {
-    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(64) });
+test "runtime: multi-threaded execution with max executors" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(Executor.max_executors) });
     defer runtime.deinit();
 
-    try std.testing.expectEqual(64, runtime.executors.items.len);
+    try std.testing.expectEqual(Executor.max_executors, runtime.executors.items.len);
 }
 
 test "Runtime: multi-threaded with task migration" {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -595,7 +595,7 @@ pub const Executor = struct {
     }
 
     fn stealWork(self: *Executor) bool {
-        if (!zio_options.task_migration) return false;
+        if (!zio_options.task_migration or !self.runtime.executors_stealable) return false;
         const executors = self.runtime.executors.items;
         if (executors.len <= 1) return false;
 
@@ -933,6 +933,7 @@ pub const Runtime = struct {
     options: RuntimeOptions,
 
     executors: std.ArrayList(*Executor) = .empty,
+    executors_stealable: bool = false,
     // Shared global run queue (used when task migration is on): external
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
@@ -1021,6 +1022,7 @@ pub const Runtime = struct {
                 }
                 self.executors.appendAssumeCapacity(&worker.executor);
             }
+            self.executors_stealable = true;
         }
     }
 
@@ -1040,6 +1042,7 @@ pub const Runtime = struct {
             worker.thread.join();
         }
         self.workers.deinit(self.allocator);
+        self.executors_stealable = false;
     }
 
     pub fn deinit(self: *Runtime) void {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -602,7 +602,12 @@ pub const Executor = struct {
             const victim_idle = self.runtime.idle_mask.load(.acquire) & victim_bit != 0;
             if (victim_idle) continue;
 
-            if (self.run_queue.steal(&victim.run_queue)) |node| {
+            if (self.run_queue.steal(&victim.run_queue, struct {
+                fn reset(node: *WaitNode) void {
+                    const task = AnyTask.fromWaitNode(node);
+                    task.last_run_tick = 0;
+                }
+            }.reset)) |node| {
                 self.run_queue.push(node);
                 self.runtime.armSearcher();
                 return true;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -284,7 +284,11 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
 
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
-    pub const max_executors = 64;
+    pub const max_executors = switch (@sizeOf(usize)) {
+        4 => 32,
+        8 => 64,
+        else => @compileError("Unsupported architecture"),
+    };
 
     id: u6,
     loop: ev.Loop,
@@ -520,25 +524,18 @@ pub const Executor = struct {
     }
 
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
-        const my_bit = @as(u64, 1) << self.id;
-        self.runtime.idle_mask_mutex.lock();
-        self.runtime.idle_mask |= my_bit;
-        self.runtime.idle_mask_mutex.unlock();
+        const my_bit = @as(usize, 1) << self.id;
+        _ = self.runtime.idle_mask.fetchOr(my_bit, .acq_rel);
 
         if (self.checkAboutForWork(check_ready)) {
-            self.runtime.idle_mask_mutex.lock();
-            self.runtime.idle_mask &= ~my_bit;
-            self.runtime.idle_mask_mutex.unlock();
+            _ = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
             try self.loop.run(.no_wait);
             return;
         }
 
         try self.loop.run(.once);
 
-        self.runtime.idle_mask_mutex.lock();
-        const was_already_clear = self.runtime.idle_mask & my_bit == 0;
-        self.runtime.idle_mask &= ~my_bit;
-        self.runtime.idle_mask_mutex.unlock();
+        const was_already_clear = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel) & my_bit == 0;
 
         if (was_already_clear) {
             if (self.main_task.state.load(.acquire).tag == .ready or !self.run_queue.isEmpty()) {
@@ -605,10 +602,8 @@ pub const Executor = struct {
             const victim = executors[(self.id + i) % executors.len];
             if (victim == self) continue;
 
-            const victim_bit = @as(u64, 1) << victim.id;
-            self.runtime.idle_mask_mutex.lock();
-            const victim_idle = self.runtime.idle_mask & victim_bit != 0;
-            self.runtime.idle_mask_mutex.unlock();
+            const victim_bit = @as(usize, 1) << victim.id;
+            const victim_idle = self.runtime.idle_mask.load(.acquire) & victim_bit != 0;
             if (victim_idle) continue;
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
@@ -941,9 +936,7 @@ pub const Runtime = struct {
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
     global_overflow: OverflowQueue(WaitNode) = .{},
-    idle_mask: u64 = 0,
-    // TODO: replace with atomic scoped based on architecture
-    idle_mask_mutex: OsMutex = .init(),
+    idle_mask: std.atomic.Value(usize) = .init(0),
     searchers: std.atomic.Value(u32) = .init(0),
     loop_group: ev.LoopGroup = .{},
     main_executor: Executor,
@@ -1179,15 +1172,20 @@ pub const Runtime = struct {
 
     fn armSearcher(self: *Runtime) void {
         if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
-        self.idle_mask_mutex.lock();
-        defer self.idle_mask_mutex.unlock();
-        if (self.idle_mask == 0) {
+        const idle_mask = self.idle_mask.load(.acquire);
+
+        if (idle_mask == 0) {
             _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
             return;
         }
-        const id: u6 = @intCast(@ctz(self.idle_mask));
-        const bit = @as(u64, 1) << id;
-        self.idle_mask &= ~bit;
+        const id: u6 = @intCast(@ctz(idle_mask));
+        const bit = @as(usize, 1) << id;
+        const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
+
+        if (previous_mask & bit == 0) {
+            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            return;
+        }
         self.executors.items[id].loop.wake();
     }
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -505,42 +505,122 @@ pub const Executor = struct {
                 @panic("event loop stopped while the main task was yielding");
             }
 
-            // Run event loop - non-blocking if there's local work, otherwise wait
-            // for I/O. Overflow-queue work needn't be checked here: any cross-thread
-            // push to the overflow queue also wakes this executor's loop, so .once
-            // returns promptly and the next iteration drains it.
-            const main_ready = check_ready and self.main_task.state.load(.acquire).tag == .ready;
-            // Overflow work counts too: if the ring is empty but the overflow queue
-            // still holds tasks (e.g. a local ring spill, which doesn't wake the
-            // loop), don't block — return promptly and refill from it below.
-            const has_work = main_ready or !self.run_queue.isEmpty() or !self.run_queue.overflow.isEmpty();
-            try self.loop.run(if (has_work) .no_wait else .once);
+            if (self.checkAboutForWork(check_ready)) try self.loop.run(.no_wait) else try self.parkAndSearch(check_ready);
 
             // Reset task counter and update tick time after event loop tick
             self.tick_task_count = 0;
             self.current_tick +%= 1;
             self.last_tick_time = self.loop.now();
 
-            // Pull a fair batch from the overflow queue (global when migration is
-            // on, this executor's own when off) back into the ring.
-            const pending = self.run_queue.overflow.len();
-            if (pending != 0) {
-                // With migration on the overflow is the shared global queue, so
-                // take only a fair ~1/n_exec slice to avoid monopolizing it. With
-                // migration off it is this executor's own private queue and we are
-                // its sole drainer, so take as much as fits (refill caps it).
-                const batch = if (self.runtime.options.enable_task_migration)
-                    pending / @max(self.runtime.executors.items.len, 1) + 1
-                else
-                    pending;
-                self.run_queue.refill(batch);
-            }
-
             // Check again after I/O
             if (check_ready and self.main_task.state.load(.acquire).tag == .ready) {
                 return;
             }
         }
+    }
+
+    fn parkAndSearch(self: *Executor, check_ready: bool) !void {
+        const my_bit = @as(u64, 1) << self.id;
+        self.runtime.idle_mask_mutex.lock();
+        self.runtime.idle_mask |= my_bit;
+        self.runtime.idle_mask_mutex.unlock();
+
+        if (self.checkAboutForWork(check_ready)) {
+            self.runtime.idle_mask_mutex.lock();
+            self.runtime.idle_mask &= ~my_bit;
+            self.runtime.idle_mask_mutex.unlock();
+            try self.loop.run(.no_wait);
+            return;
+        }
+
+        try self.loop.run(.once);
+
+        self.runtime.idle_mask_mutex.lock();
+        const was_already_clear = self.runtime.idle_mask & my_bit == 0;
+        self.runtime.idle_mask &= ~my_bit;
+        self.runtime.idle_mask_mutex.unlock();
+
+        if (was_already_clear) {
+            if (self.main_task.state.load(.acquire).tag == .ready or !self.run_queue.isEmpty()) {
+                _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+                return;
+            }
+
+            const pending = self.run_queue.overflow.len();
+            if (pending != 0) {
+                self.run_queue.refill(@min(pending, 64));
+                if (!self.run_queue.isEmpty()) {
+                    _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+                    if (!self.run_queue.overflow.isEmpty()) self.runtime.armSearcher();
+                    return;
+                }
+            }
+
+            _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            if (self.stealWork()) return;
+
+            // Release the token before the final recheck. A concurrent
+            // pusher that sees searchers == 0 can arm a fresh search instead of
+            // being blocked behind a token we're about to give up anyway.
+            _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            if (self.checkAboutForWork(true)) self.runtime.armSearcher();
+        }
+    }
+
+    fn checkAboutForWork(self: *Executor, check_ready: bool) bool {
+        // Run event loop - non-blocking if there's local work, otherwise wait
+        // for I/O. Overflow-queue work needn't be checked here: any cross-thread
+        // push to the overflow queue also wakes this executor's loop, so .once
+        // returns promptly and the next iteration drains it.
+        const main_ready = check_ready and self.main_task.state.load(.acquire).tag == .ready;
+        // Overflow work counts too: if the ring is empty but the overflow queue
+        // still holds tasks (e.g. a local ring spill, which doesn't wake the
+        // loop), don't block — return promptly and refill from it below.
+        var has_work = main_ready or !self.run_queue.isEmpty();
+        // Pull a fair batch from the overflow queue (global when migration is
+        // on, this executor's own when off) back into the ring.
+        const pending = self.run_queue.overflow.len();
+        if (pending != 0 and !has_work) {
+            // With migration on the overflow is the shared global queue, so
+            // take only a fair ~1/n_exec slice to avoid monopolizing it. With
+            // migration off it is this executor's own private queue and we are
+            // its sole drainer, so take as much as fits (refill caps it).
+            const batch = if (self.runtime.options.enable_task_migration)
+                pending / @max(self.runtime.executors.items.len, 1) + 1
+            else
+                pending;
+            self.run_queue.refill(batch);
+            has_work = !self.run_queue.isEmpty();
+        }
+        if (!has_work) has_work = self.stealWork();
+        return has_work;
+    }
+
+    fn stealWork(self: *Executor) bool {
+        if (!zio_options.task_migration) return false;
+        const executors = self.runtime.executors.items;
+        if (executors.len <= 1) return false;
+
+        for (0..executors.len) |i| {
+            const victim = executors[(self.id + i) % executors.len];
+            if (victim == self) continue;
+
+            const victim_bit = @as(u64, 1) << victim.id;
+            self.runtime.idle_mask_mutex.lock();
+            const victim_idle = self.runtime.idle_mask & victim_bit != 0;
+            self.runtime.idle_mask_mutex.unlock();
+            if (victim_idle) continue;
+
+            if (self.run_queue.steal(&victim.run_queue)) |node| {
+                const task = AnyTask.fromWaitNode(node);
+                task.last_run_tick = 0;
+                self.run_queue.push(node);
+                self.runtime.armSearcher();
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// Get the next task to run from the ready queue.
@@ -861,6 +941,10 @@ pub const Runtime = struct {
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
     global_overflow: OverflowQueue(WaitNode) = .{},
+    idle_mask: u64 = 0,
+    // TODO: replace with atomic scoped based on architecture
+    idle_mask_mutex: OsMutex = .init(),
+    searchers: std.atomic.Value(u32) = .init(0),
     loop_group: ev.LoopGroup = .{},
     main_executor: Executor,
     next_executor_index: std.atomic.Value(usize) = .init(0),
@@ -1091,6 +1175,26 @@ pub const Runtime = struct {
             };
             break;
         }
+    }
+
+    fn armSearcher(self: *Runtime) void {
+        if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
+        self.idle_mask_mutex.lock();
+        defer self.idle_mask_mutex.unlock();
+        if (self.idle_mask == 0) {
+            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            return;
+        }
+        const id: u6 = @intCast(@ctz(self.idle_mask));
+        const bit = @as(u64, 1) << id;
+        const previous_mask = self.idle_mask;
+        self.idle_mask &= ~bit;
+
+        if (previous_mask & bit == 0) {
+            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            return;
+        }
+        self.executors.items[id].loop.wake();
     }
 
     // Convenience methods that operate on the current coroutine context

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -527,26 +527,26 @@ pub const Executor = struct {
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
         const my_bit = @as(usize, 1) << self.id;
         _ = self.runtime.idle_mask.fetchOr(my_bit, .acq_rel);
+        errdefer _ = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 
-        if (self.checkAboutForWork(check_ready)) {
-            _ = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
-            try self.loop.run(.no_wait);
-            return;
-        }
+        const found_work = self.checkAboutForWork(check_ready);
+        try self.loop.run(if (found_work) .no_wait else .once);
 
-        try self.loop.run(.once);
+        const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 
-        const was_already_clear = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel) & my_bit == 0;
-
-        if (was_already_clear) {
-            if (self.main_task.state.load(.acquire).tag == .ready or !self.run_queue.isEmpty()) {
+        if (previous_bit & my_bit == 0) {
+            if (found_work or (check_ready and self.main_task.state.load(.acquire).tag == .ready) or !self.run_queue.isEmpty()) {
                 _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
                 return;
             }
 
             const pending = self.run_queue.overflow.len();
             if (pending != 0) {
-                self.run_queue.refill(@min(pending, 64));
+                const batch = if (self.runtime.options.enable_task_migration)
+                    pending / @max(self.runtime.executors.items.len, 1) + 1
+                else
+                    pending;
+                self.run_queue.refill(batch);
                 if (!self.run_queue.isEmpty()) {
                     _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
                     if (!self.run_queue.overflow.isEmpty()) self.runtime.armSearcher();
@@ -554,22 +554,16 @@ pub const Executor = struct {
                 }
             }
 
-            _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
-            if (self.stealWork()) return;
-
             // Release the token before the final recheck. A concurrent
             // pusher that sees searchers == 0 can arm a fresh search instead of
             // being blocked behind a token we're about to give up anyway.
             _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            if (self.stealWork()) return;
             if (self.checkAboutForWork(true)) self.runtime.armSearcher();
         }
     }
 
     fn checkAboutForWork(self: *Executor, check_ready: bool) bool {
-        // Run event loop - non-blocking if there's local work, otherwise wait
-        // for I/O. Overflow-queue work needn't be checked here: any cross-thread
-        // push to the overflow queue also wakes this executor's loop, so .once
-        // returns promptly and the next iteration drains it.
         const main_ready = check_ready and self.main_task.state.load(.acquire).tag == .ready;
         // Overflow work counts too: if the ring is empty but the overflow queue
         // still holds tasks (e.g. a local ring spill, which doesn't wake the
@@ -595,12 +589,13 @@ pub const Executor = struct {
     }
 
     fn stealWork(self: *Executor) bool {
-        if (!zio_options.task_migration or !self.runtime.executors_stealable) return false;
+        if (!(zio_options.task_migration and self.runtime.options.enable_task_migration) or !self.runtime.executors_stealable.load(.acquire)) return false;
         const executors = self.runtime.executors.items;
         if (executors.len <= 1) return false;
 
+        const start = self.random_state.csprng.random().int(usize) % executors.len;
         for (0..executors.len) |i| {
-            const victim = executors[(self.id + i) % executors.len];
+            const victim = executors[(start + i) % executors.len];
             if (victim == self) continue;
 
             const victim_bit = @as(usize, 1) << victim.id;
@@ -608,8 +603,6 @@ pub const Executor = struct {
             if (victim_idle) continue;
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
-                const task = AnyTask.fromWaitNode(node);
-                task.last_run_tick = 0;
                 self.run_queue.push(node);
                 self.runtime.armSearcher();
                 return true;
@@ -663,6 +656,7 @@ pub const Executor = struct {
         std.debug.assert(getCurrentExecutorOrNull() == self);
 
         self.run_queue.push(&task.awaitable.wait_node);
+        self.runtime.armSearcher();
     }
 
     /// Schedule a task from another thread (or no executor context) onto its home
@@ -674,6 +668,7 @@ pub const Executor = struct {
 
         self.run_queue.overflow.push(&task.awaitable.wait_node);
         self.loop.wake();
+        self.runtime.armSearcher();
     }
 
     /// Schedule a task for execution.
@@ -933,7 +928,7 @@ pub const Runtime = struct {
     options: RuntimeOptions,
 
     executors: std.ArrayList(*Executor) = .empty,
-    executors_stealable: bool = false,
+    executors_stealable: std.atomic.Value(bool) = .init(false),
     // Shared global run queue (used when task migration is on): external
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
@@ -1005,7 +1000,7 @@ pub const Runtime = struct {
         errdefer self.shutdownWorkers();
 
         if (!builtin.single_threaded) {
-            const worker_id_start: u6 = if (options.enable_main_executor) 1 else 0;
+            const worker_id_start: ExecutorId = if (options.enable_main_executor) 1 else 0;
             for (0..num_workers) |i| {
                 log.debug("Spawning worker thread {}", .{i + worker_id_start});
                 const worker = self.workers.addOneAssumeCapacity();
@@ -1022,7 +1017,7 @@ pub const Runtime = struct {
                 }
                 self.executors.appendAssumeCapacity(&worker.executor);
             }
-            self.executors_stealable = true;
+            self.executors_stealable.store(true, .release);
         }
     }
 
@@ -1042,7 +1037,7 @@ pub const Runtime = struct {
             worker.thread.join();
         }
         self.workers.deinit(self.allocator);
-        self.executors_stealable = false;
+        self.executors_stealable.store(false, .release);
     }
 
     pub fn deinit(self: *Runtime) void {
@@ -1175,6 +1170,7 @@ pub const Runtime = struct {
     }
 
     fn armSearcher(self: *Runtime) void {
+        if (!(zio_options.task_migration and self.options.enable_task_migration) or !self.executors_stealable.load(.acquire) or (self.searchers.load(.monotonic) != 0)) return;
         if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
         const idle_mask = self.idle_mask.load(.acquire);
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1187,13 +1187,7 @@ pub const Runtime = struct {
         }
         const id: u6 = @intCast(@ctz(self.idle_mask));
         const bit = @as(u64, 1) << id;
-        const previous_mask = self.idle_mask;
         self.idle_mask &= ~bit;
-
-        if (previous_mask & bit == 0) {
-            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
-            return;
-        }
         self.executors.items[id].loop.wake();
     }
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -38,6 +38,11 @@ const select = @import("select.zig");
 const Waiter = @import("common.zig").Waiter;
 const random_mod = @import("random.zig");
 
+const U5U6 = switch (@sizeOf(usize)) {
+    4 => u5,
+    8 => u6,
+    else => @compileError("Unsupported architecture"),
+};
 const mod = @This();
 
 /// Number of executor threads to run (including main).
@@ -290,7 +295,7 @@ pub const Executor = struct {
         else => @compileError("Unsupported architecture"),
     };
 
-    id: u6,
+    id: U5U6,
     loop: ev.Loop,
 
     /// Per-executor random state (non-secure CSPRNG; later the secure-path fd/handle).
@@ -365,7 +370,7 @@ pub const Executor = struct {
         return @alignCast(@fieldParentPtr("main_task", main_task));
     }
 
-    pub fn init(self: *Executor, runtime: *Runtime, id: u6) !void {
+    pub fn init(self: *Executor, runtime: *Runtime, id: U5U6) !void {
         self.* = .{
             .id = id,
             .loop = undefined,
@@ -1009,7 +1014,7 @@ pub const Runtime = struct {
                 const worker = self.workers.addOneAssumeCapacity();
                 errdefer _ = self.workers.pop();
                 worker.* = .{};
-                worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(u6, @intCast(i + worker_id_start)) });
+                worker.thread = try std.Thread.spawn(.{}, runWorker, .{ self, worker, @as(U5U6, @intCast(i + worker_id_start)) });
             }
 
             for (self.workers.items, 0..) |*worker, i| {
@@ -1145,7 +1150,7 @@ pub const Runtime = struct {
 
     /// Worker thread entry point. Initializes executor and runs until stopped.
     /// Signals worker.ready after initialization (success or failure).
-    fn runWorker(self: *Runtime, worker: *Worker, id: u6) void {
+    fn runWorker(self: *Runtime, worker: *Worker, id: U5U6) void {
         worker.executor.init(self, id) catch |e| {
             worker.err = e;
             worker.ready.set();
@@ -1178,7 +1183,7 @@ pub const Runtime = struct {
             _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
             return;
         }
-        const id: u6 = @intCast(@ctz(idle_mask));
+        const id: U5U6 = @intCast(@ctz(idle_mask));
         const bit = @as(usize, 1) << id;
         const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -527,7 +527,12 @@ pub const Executor = struct {
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
         const my_bit = @as(usize, 1) << self.id;
         _ = self.runtime.idle_mask.fetchOr(my_bit, .acq_rel);
-        errdefer _ = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
+        errdefer {
+            const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
+            if (previous_bit & my_bit == 0) {
+                _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            }
+        }
 
         const found_work = self.checkAboutForWork(check_ready);
         try self.loop.run(if (found_work) .no_wait else .once);
@@ -559,7 +564,7 @@ pub const Executor = struct {
             // being blocked behind a token we're about to give up anyway.
             _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
             if (self.stealWork()) return;
-            if (self.checkAboutForWork(true)) self.runtime.armSearcher();
+            if (self.checkAboutForWork(check_ready)) self.runtime.armSearcher();
         }
     }
 
@@ -1028,6 +1033,7 @@ pub const Runtime = struct {
 
     /// Stop worker executors and join threads. Used by deinit() and init() error path.
     fn shutdownWorkers(self: *Runtime) void {
+        self.executors_stealable.store(false, .release);
         // Wait for all workers to finish initialization, then stop their event loops.
         // Workers that failed to initialize (err != null) don't have valid executors.
         for (self.workers.items) |*worker| {
@@ -1042,7 +1048,6 @@ pub const Runtime = struct {
             worker.thread.join();
         }
         self.workers.deinit(self.allocator);
-        self.executors_stealable.store(false, .release);
     }
 
     pub fn deinit(self: *Runtime) void {
@@ -1176,6 +1181,8 @@ pub const Runtime = struct {
 
     fn armSearcher(self: *Runtime) void {
         if (!(zio_options.task_migration and self.options.enable_task_migration) or !self.executors_stealable.load(.acquire) or (self.searchers.load(.monotonic) != 0)) return;
+        if (self.idle_mask.load(.monotonic) == 0) return;
+        if (self.searchers.load(.monotonic) != 0) return;
         if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
 
         var candidates = self.idle_mask.load(.acquire);

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -207,7 +207,7 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         ///
         /// Only available on a stealable queue: with task migration compiled out no
         /// thief exists, so calling this is a programming error and won't compile.
-        pub fn steal(self: *Self, victim: *Self) ?*T {
+        pub fn steal(self: *Self, victim: *Self, comptime callbackFn: fn (*T) void) ?*T {
             if (!stealable) @compileError("steal() is unavailable: this queue was built without task migration / work stealing");
             const dst_tail = self.ownTail(); // the thief owns its own tail
             const dst_space = capacity - (dst_tail -% self.loadHead());
@@ -229,6 +229,9 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
                 if (victim.casHead(h, h +% take, false)) break take;
                 // Lost the race (an owner pop or another thief); retry the grab.
             };
+
+            var i: u32 = 0;
+            while (i < stolen) : (i += 1) callbackFn(self.buffer[(dst_tail +% i) & mask]);
 
             // Hand back the last stolen task; publish the rest into the thief's ring.
             const rest = stolen - 1;
@@ -427,7 +430,9 @@ test "LocalRunQueue: steal takes half into the thief and returns one" {
 
     // victim holds 0,1,2,3 (head=0). Steal ceil(4/2)=2 (ids 0,1): returns the last
     // stolen (id 1), keeps id 0 in the thief; victim left with 2,3.
-    const got = thief.steal(&victim) orelse return error.Unexpected;
+    const got = thief.steal(&victim, struct {
+        fn reset(_: *TestNode) void {}
+    }.reset) orelse return error.Unexpected;
     try testing.expectEqual(1, got.id);
     try testing.expectEqual(1, thief.len());
     try testing.expectEqual(2, victim.len());
@@ -451,7 +456,9 @@ test "LocalRunQueue: steal with an odd count takes the ceil half" {
     }
     // 7 tasks -> steal 7 - 7/2 = 4 (ids 0..3), return id 3, thief keeps 0,1,2;
     // victim left with 4,5,6.
-    const got = thief.steal(&victim) orelse return error.Unexpected;
+    const got = thief.steal(&victim, struct {
+        fn reset(_: *TestNode) void {}
+    }.reset) orelse return error.Unexpected;
     try testing.expectEqual(3, got.id);
     try testing.expectEqual(3, thief.len());
     try testing.expectEqual(3, victim.len());
@@ -462,7 +469,9 @@ test "LocalRunQueue: steal from an empty victim returns null" {
     var ov2: TestOverflow = .{};
     var victim = TestQueue.init(&ov1);
     var thief = TestQueue.init(&ov2);
-    try testing.expect(thief.steal(&victim) == null);
+    try testing.expect(thief.steal(&victim, struct {
+        fn reset(_: *TestNode) void {}
+    }.reset) == null);
 }
 
 test "LocalRunQueue: index cycling past capacity stays correct" {
@@ -510,7 +519,9 @@ test "LocalRunQueue: concurrent push/pop and steal loses or duplicates no task" 
     const stealer = try std.Thread.spawn(.{}, struct {
         fn run(c: *Ctx) void {
             while (!c.stop.load(.acquire) or !c.owner.isEmpty()) {
-                if (c.thief.steal(c.owner)) |n| c.mark(n);
+                if (c.thief.steal(c.owner, struct {
+                    fn reset(_: *TestNode) void {}
+                }.reset)) |n| c.mark(n);
                 while (c.thief.pop()) |n| c.mark(n);
             }
             while (c.thief.pop()) |n| c.mark(n);
@@ -587,7 +598,9 @@ test "LocalRunQueue: multiple concurrent stealers lose or duplicate no task" {
     const Thief = struct {
         fn run(c: *Ctx, thief: *TestQueue) void {
             while (!c.stop.load(.acquire) or !c.owner.isEmpty()) {
-                if (thief.steal(c.owner)) |n| c.mark(n);
+                if (thief.steal(c.owner, struct {
+                    fn reset(_: *TestNode) void {}
+                }.reset)) |n| c.mark(n);
                 while (thief.pop()) |n| c.mark(n);
             }
             while (thief.pop()) |n| c.mark(n);


### PR DESCRIPTION
adds work stealing and advanced idle state handling. closes: #460. earlier attempt: #541

## Goal

Idle executors find and run work sitting in other executors' local queues, without losing a task, without a stuck wakeup, and without more than one executor "searching" at a time under normal load.

## Structures

+ **`idle_mask: atomic usize`**: bit `i` set <=> executor `i` is currently parked with no known work.
+ **`searchers: atomic u32`**: 0 or 1. Caps concurrent active searches to one at a time; the thread holding it is responsible for eventually releasing it.

## Steady state (busy executor, every tick)

`checkAboutForWork`, cheapest first strategy:
1. Main task ready? / local ring non-empty?.
2. Overflow non-empty? refill a batch into the ring, recheck.
3. Still nothing? `stealWork()`: scan other executors (skip any with its `idle_mask` bit set), try `run_queue.steal(victim)`. First success wins.

If none of these find anything, the executor goes idle.

## Going idle

`parkAndSearch`
1. **Publish intent**: set own `idle_mask` bit.
2. **Recheck**: we're trying to make sure nothing lands in-between. If work is found now, clear the bit and return.
3. Otherwise block in `loop.run(.once)`.
4. On return, clear own bit and inspect the *previous* value:
   + **Bit was already clear** means some other thread cleared it for us before we did which is a wake signal. We inherited search duty: check ready -> refill overflow -> `stealWork()` -> give up. Every branch that finds nothing forwards, one and only one call releases `searchers` back to 0.
   + **Bit was still set** means we cleared it ourselves; we just woke for unrelated I/O, not because anyone was signaling us. No search obligation.

## Waking someone (called after any push, and after a successful steal)

`armSearcher`
1. CAS `searchers` 0 -> 1. If this fails then someone's already searching, we're done here.
2. Read `idle_mask`. If it's empty, no one to wake, release the token immediately.
3. Pick the lowest set bit, clear it via `fetchAnd` (this clear *is* the token handoff), check the previous value:
   + If the previous bit was already cleared (target was self-cleared concurrently) it means we lost the race, release the token.
   + Otherwise, `wake()` that executor's loop.

**Token handoff**: searcher token is never passed by a separate message — it's implied by *which thread's clear of a given idle-mask bit "wins."* If `armSearcher` clears it, that executor inherits the search obligation on wake. If the executor clears its own bit first (step 4 above), no one ever gets to claim it and there was nothing to hand off. This is why every code path that finds a bit already clear must immediately release `searchers`.

## Two liveness rules

+ **Re-arm on leftover work**: any time a search step (refill, steal) finds work but leaves more visible behind it (steal's victim not empty, overflow not drained), we call `armSearcher()` again before returning not to risk any leftover work having no one looking for it until the next unrelated wake.
+ **Release before final recheck**: when a search is about to give up entirely, release `searchers` *before* the last check, not after so a concurrent pusher racing that exact moment can arm a fresh search instead of finding the token falsely held by a thread that's about to abandon it anyway.

## Other Changes

+ `max_executors` and executor ids (`ExecutorId`) were made architecture scoped to follow u32 on 32-bit arch and u64 on 64-bit arch, with their corresponding bit shifting values (u5 for 32-bit, u6 for 64-bit)
