### PR TITLE
fix(ev): use-after-free finishing a group member's completion (#561)

### DIFF
--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -398,12 +398,24 @@ pub const LoopState = struct {
         completion.state = .dead;
         self.decrActive();
 
-        // Notify group/queue owner if this completion belongs to one
-        if (completion.group.owner_callback) |cb| {
+        // Both callbacks below can free `completion`, so whichever may free it must
+        // run LAST, with nothing touching `completion` afterward. Cache the owner
+        // callback now, before `call` — for a standalone completion `call` wakes a
+        // waiter that may free `completion`, so we must not read it afterward.
+        const owner_callback = completion.group.owner_callback;
+
+        // The completion's own callback runs first: for a group member it reports
+        // the member's own result while the member is still alive; for a standalone
+        // completion (no owner) it is the last thing we do.
+        completion.call(self.loop);
+
+        // Then notify the group/queue owner. This can drive the group to completion
+        // and free the frame this member lives on (e.g. the last `.gather` member
+        // completing the group, whose callback frees the member), so it must run
+        // last — `completion` may be dangling after this returns.
+        if (owner_callback) |cb| {
             cb(self.loop, completion);
         }
-
-        completion.call(self.loop);
     }
 
     pub fn markRunning(self: *LoopState, completion: *Completion) void {

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -125,6 +125,45 @@ test "group: callback invoked when all complete" {
     try std.testing.expect(ctx.group_callback_order > ctx.timer2_callback_order);
 }
 
+test "group: gather member freed by the group callback is not used-after-free (#561)" {
+    // Regression for #561. finishCompletion used to run a member's own `call`
+    // AFTER notifying the group owner. The last `.gather` member completing drives
+    // the group to completion and runs the group's user callback, which in real
+    // code frees the frame the member's completion lives on — then the trailing
+    // `call` dereferenced the freed member (GP fault on the poisoned callback ptr).
+    // Inline callbacks (defer_callbacks=false) make the free happen mid-finish.
+    var loop: Loop = undefined;
+    try loop.init(.{ .defer_callbacks = false });
+    defer loop.deinit();
+
+    const Ctx = struct {
+        member: *Timer,
+        completed: bool = false,
+
+        fn onGroup(_: *Loop, c: *Completion) void {
+            const self: *@This() = @ptrCast(@alignCast(c.userdata.?));
+            self.completed = true;
+            // Simulate the member's frame being reclaimed/reused the instant the
+            // group completes. Pre-fix, finishCompletion touches this right after,
+            // and the 0xAA callback pointer faults.
+            @memset(std.mem.asBytes(self.member), 0xAA);
+        }
+    };
+
+    var member: Timer = .init(.{ .duration = .fromMilliseconds(1) });
+    var ctx: Ctx = .{ .member = &member };
+
+    var group: Group = .init(.gather);
+    group.c.userdata = &ctx;
+    group.c.callback = Ctx.onGroup;
+    group.add(&member.c);
+    loop.add(&group.c);
+
+    try loop.run(.until_done);
+
+    try std.testing.expect(ctx.completed);
+}
+
 test "group: cancel cancels all children" {
     var loop: Loop = undefined;
     try loop.init(.{});


### PR DESCRIPTION
Fixes #561.

## Problem

A use-after-free in `LoopState.finishCompletion`: the scheduler dereferences a group member's completion after it has been freed, faulting on a poisoned (`0xAA…`) callback pointer. Reported under stress with the epoll backend; it's backend-agnostic (all completion paths funnel through `finishCompletion`).

## Root cause

`finishCompletion` ran the group/queue **owner** callback before the completion's **own** callback:

```zig
if (completion.group.owner_callback) |cb| cb(self.loop, completion); // may free the member (group case)
completion.call(self.loop);                                          // ← touches the freed member
```

The subtlety: **both** callbacks can free the completion, so whichever runs *last* is the hazard — and which one frees it depends on the case:

- **Standalone completion** — freed by its *own* callback (which wakes a waiter that frees it), so `call` must run last. This is why the code was written this way.
- **Group member** — freed by the *owner* callback: the last `.gather` member drives the group to completion, and the group's user callback frees the frame the member's completion lives on. So for a member, the owner callback must run last.

The old order (owner first, own callback last) is correct for standalone completions but wrong for group members — the trailing `completion.call` dereferenced the already-freed member.

The minimal repro is a `.gather` group with one timer member, `defer_callbacks = false`, whose group callback poisons the member (simulating the frame being reclaimed) — exactly the LLM-generated example in the issue.

## Fix

Cache the owner callback up front, run the completion's own `call` first (while it is still alive), then notify the owner last. Nothing touches the completion after the call that may free it, in either case.

## Verification

- New regression test `group: gather member freed by the group callback is not used-after-free (#561)` — **GP-faults / aborts pre-fix, passes post-fix** (verified by reverting the fix).
- Full suite: `epoll` **525/525**; `io_uring` 523/525 (only the two pre-existing FTRUNCATE `setSize` failures on the 6.8 test host, addressed separately in #559 — unrelated).
- The existing "group: callback invoked when all complete" ordering test still passes: the change only reorders a member's own `call` vs the group's *internal* owner callback, not vs the user's group callback.
