### PR TITLE
ev: add per-job thread reservation to the pool

### DIFF
--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -540,6 +540,14 @@ pub const Work = struct {
     /// `ThreadPool.cancel` signals it to interrupt an in-progress syscall.
     cancel_token: ?*os.syscall_cancel.Token = null,
 
+    /// When set, the pool guarantees a worker will pick this job up: at submit it
+    /// reuses an idle worker if one is free, and only spawns a new worker (beyond
+    /// `max_threads` if needed) when idle workers can't cover every outstanding
+    /// reserved job. Used to honor std.Io's `concurrent` guarantee from a
+    /// saturated pool without deadlocking — a job queued behind blocked workers
+    /// that are themselves waiting on it. See issue #567.
+    reserve_thread: bool = false,
+
     /// Intrusive link + membership key for the loop's cancel-resend list
     /// (`Loop.cancel_resend`). A canceled-but-still-blocked worker is added here
     /// so `tick` re-sends `SIGURG` until it acknowledges. `resend_key` is the

--- a/src/ev/test/thread_pool.zig
+++ b/src/ev/test/thread_pool.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const ev = @import("../root.zig");
+const os_thread = @import("../../os/thread.zig");
+const ResetEvent = os_thread.ResetEvent;
 
 test "ev.ThreadPool: one task" {
     var thread_pool: ev.ThreadPool = undefined;
@@ -35,4 +38,164 @@ test "ev.ThreadPool: one task" {
 
     try std.testing.expectEqual(.dead, work.c.state);
     try std.testing.expectEqual(1, test_fn.called);
+}
+
+test "ev.ThreadPool: reserved work runs even when the pool is saturated" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    var thread_pool: ev.ThreadPool = undefined;
+    try thread_pool.init(std.testing.allocator, .{
+        .min_threads = 0,
+        .max_threads = 1,
+    });
+    defer thread_pool.deinit();
+    defer thread_pool.stop();
+
+    // A job that occupies the pool's single worker until the test releases it.
+    const Blocker = struct {
+        started: ResetEvent,
+        gate: ResetEvent,
+        pub fn main(work: *ev.Work) void {
+            const self: *@This() = @ptrCast(@alignCast(work.userdata));
+            self.started.set();
+            self.gate.wait();
+        }
+    };
+
+    // A job that records that it ran and signals completion. With max_threads == 1
+    // fully occupied, this can only make progress if reserve_thread grows the pool.
+    const Reserved = struct {
+        ran: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        done: ResetEvent,
+        pub fn main(work: *ev.Work) void {
+            const self: *@This() = @ptrCast(@alignCast(work.userdata));
+            self.ran.store(true, .release);
+            self.done.set();
+        }
+    };
+
+    var blocker: Blocker = .{ .started = .init(), .gate = .init() };
+    defer blocker.started.deinit();
+    defer blocker.gate.deinit();
+    var blocker_work = ev.Work.init(&Blocker.main, @ptrCast(&blocker));
+    thread_pool.submit(&blocker_work);
+
+    // Ensure the worker is inside the blocker (the pool is now saturated) before
+    // submitting the reserved job.
+    blocker.started.wait();
+
+    var reserved: Reserved = .{ .done = .init() };
+    defer reserved.done.deinit();
+    var reserved_work = ev.Work.init(&Reserved.main, @ptrCast(&reserved));
+    reserved_work.reserve_thread = true;
+    thread_pool.submit(&reserved_work);
+
+    // Without the reservation this would deadlock (queued behind the blocker);
+    // with it, a second worker is spawned to run it.
+    reserved.done.wait();
+    try std.testing.expect(reserved.ran.load(.acquire));
+
+    // Release the blocker so the pool can shut down cleanly.
+    blocker.gate.set();
+}
+
+test "ev.ThreadPool: reserved work reuses an idle worker instead of spawning" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    var thread_pool: ev.ThreadPool = undefined;
+    try thread_pool.init(std.testing.allocator, .{
+        .min_threads = 2,
+        .max_threads = 10,
+    });
+    defer thread_pool.deinit();
+    defer thread_pool.stop();
+
+    // Wait until both min-threads have parked, so there is idle capacity for the
+    // reservation to reuse.
+    var spins: usize = 0;
+    while (thread_pool.idle_threads.load(.monotonic) < 2) {
+        spins += 1;
+        if (spins > 100_000_000) return error.TimedOut;
+        os_thread.yield();
+    }
+    try std.testing.expectEqual(@as(usize, 2), thread_pool.running_threads.load(.monotonic));
+
+    // A reserved job that parks so we can observe the worker count while it runs.
+    const Job = struct {
+        started: ResetEvent,
+        gate: ResetEvent,
+        pub fn main(work: *ev.Work) void {
+            const self: *@This() = @ptrCast(@alignCast(work.userdata));
+            self.started.set();
+            self.gate.wait();
+        }
+    };
+
+    var job: Job = .{ .started = .init(), .gate = .init() };
+    defer job.started.deinit();
+    defer job.gate.deinit();
+    var work = ev.Work.init(&Job.main, @ptrCast(&job));
+    work.reserve_thread = true;
+    thread_pool.submit(&work);
+
+    // The reserved job runs on one of the two idle workers; because idle capacity
+    // already covers the reservation, no new thread is spawned.
+    job.started.wait();
+    try std.testing.expectEqual(@as(usize, 2), thread_pool.running_threads.load(.monotonic));
+
+    job.gate.set();
+}
+
+test "ev.ThreadPool: regular work still scales when reserved work occupies max_threads" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    var thread_pool: ev.ThreadPool = undefined;
+    try thread_pool.init(std.testing.allocator, .{
+        .min_threads = 0,
+        .max_threads = 1,
+        .scale_threshold = 1,
+    });
+    defer thread_pool.deinit();
+    defer thread_pool.stop();
+
+    // A reserved job occupies the pool's single regular-budget worker.
+    const Reserved = struct {
+        started: ResetEvent,
+        gate: ResetEvent,
+        pub fn main(work: *ev.Work) void {
+            const self: *@This() = @ptrCast(@alignCast(work.userdata));
+            self.started.set();
+            self.gate.wait();
+        }
+    };
+    var reserved: Reserved = .{ .started = .init(), .gate = .init() };
+    defer reserved.started.deinit();
+    defer reserved.gate.deinit();
+    var reserved_work = ev.Work.init(&Reserved.main, @ptrCast(&reserved));
+    reserved_work.reserve_thread = true;
+    thread_pool.submit(&reserved_work);
+    reserved.started.wait(); // now occupying the single max_threads slot
+
+    // Regular work must still run: max_threads is the budget for regular work and
+    // reserved work is additive, so the pool spawns a second worker for it. Without
+    // counting reserved-occupied workers separately, this would starve behind the
+    // blocked reserved job.
+    const Regular = struct {
+        ran: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        done: ResetEvent,
+        pub fn main(work: *ev.Work) void {
+            const self: *@This() = @ptrCast(@alignCast(work.userdata));
+            self.ran.store(true, .release);
+            self.done.set();
+        }
+    };
+    var regular: Regular = .{ .done = .init() };
+    defer regular.done.deinit();
+    var regular_work = ev.Work.init(&Regular.main, @ptrCast(&regular));
+    thread_pool.submit(&regular_work);
+
+    regular.done.wait();
+    try std.testing.expect(regular.ran.load(.acquire));
+
+    reserved.gate.set();
 }

--- a/src/ev/thread_pool.zig
+++ b/src/ev/thread_pool.zig
@@ -30,6 +30,22 @@ pub const ThreadPool = struct {
     running_threads: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     idle_threads: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
 
+    /// Reserved jobs (see `Work.reserve_thread`) currently sitting in the queue,
+    /// each still needing a worker to pick it up. Guarded by `queue_mutex`, so it
+    /// is consistent with `idle_threads` and the queue when the spawn decision is
+    /// made. A reservation spawns a worker only when there aren't enough idle
+    /// workers to cover every pending reserved job — otherwise a parked worker
+    /// takes it, no new thread needed.
+    reserved_pending: usize = 0,
+
+    /// Reserved jobs currently occupying a worker (picked up, not yet finished).
+    /// `max_threads` is the budget for *regular* work; reserved work is additive,
+    /// so the effective ceiling for spawning is `max_threads + reserved_running`.
+    /// Without this, reserved jobs would eat the regular budget and starve
+    /// regular work once they occupy all `max_threads` workers. Atomic because it
+    /// is decremented off the queue lock, on the running worker at completion.
+    reserved_running: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
     pub const Options = struct {
         min_threads: usize = 0,
         max_threads: ?usize = null,
@@ -68,15 +84,19 @@ pub const ThreadPool = struct {
         try self.workers.ensureTotalCapacity(allocator, max_threads);
 
         for (0..min_threads) |_| {
-            try self.spawnThread();
+            try self.spawnThread(false);
         }
     }
 
-    fn spawnThread(self: *ThreadPool) !void {
+    /// Spawn a worker thread. `forced` bypasses the `max_threads` cap, used for a
+    /// reservation that must add capacity beyond the configured maximum (the
+    /// extra worker is reaped back toward `min_threads` once idle, like any
+    /// other). Non-forced spawns (init, scale-up) respect the cap.
+    fn spawnThread(self: *ThreadPool, forced: bool) !void {
         self.workers_mutex.lock();
         defer self.workers_mutex.unlock();
 
-        if (self.workers.items.len >= self.max_threads) return;
+        if (!forced and self.workers.items.len >= self.max_threads + self.reserved_running.load(.monotonic)) return;
 
         _ = self.running_threads.fetchAdd(1, .monotonic);
         errdefer _ = self.running_threads.fetchSub(1, .monotonic);
@@ -86,7 +106,10 @@ pub const ThreadPool = struct {
 
         log.debug("Spawning thread {}", .{worker_id});
 
-        const worker = self.workers.addOneAssumeCapacity();
+        // Reservations can push the worker count past the init-time capacity, so
+        // this must allocate on demand rather than assume capacity.
+        const worker = try self.workers.addOne(self.allocator);
+        errdefer _ = self.workers.pop();
         worker.worker_id = worker_id;
         worker.thread = try std.Thread.spawn(.{}, run, .{ self, worker_id });
     }
@@ -136,6 +159,7 @@ pub const ThreadPool = struct {
             // completion_fn after shutdown and wake a loop being torn down.
             while (self.queue.pop()) |_| {}
             self.queue_size = 0;
+            self.reserved_pending = 0;
             self.queue_not_empty.broadcast();
         }
 
@@ -182,14 +206,43 @@ pub const ThreadPool = struct {
         self.queue.push(&work.c);
         self.queue_size += 1;
         const queued = self.queue_size;
+
+        // Decide, under queue_mutex, whether a reserved job needs a fresh worker.
+        // Both idle_threads and reserved_pending are only mutated while holding
+        // this lock, so the snapshot is race-free: a parked worker can't wake and
+        // claim work until we release the lock. Spawn only when the idle workers
+        // can't cover every pending reserved job; otherwise a parked worker takes
+        // it. This is the guarantee's headroom accounting — one spare (idle or
+        // freshly spawned) worker per outstanding reserved job.
+        var reservation_needs_spawn = false;
+        if (work.reserve_thread) {
+            self.reserved_pending += 1;
+            reservation_needs_spawn = self.idle_threads.load(.monotonic) < self.reserved_pending;
+        }
+
         self.queue_not_empty.signal();
         self.queue_mutex.unlock();
 
+        if (reservation_needs_spawn) {
+            // Forced: a reserved job may need capacity beyond max_threads. On
+            // failure the job stays queued (reserved_pending is dropped when a
+            // worker eventually picks it up) and runs once a worker frees up —
+            // the hard guarantee degrades, but nothing is lost.
+            self.spawnThread(true) catch |err| {
+                log.err("Failed to spawn reserved thread: {}", .{err});
+            };
+            return;
+        }
+
         const running = self.running_threads.load(.monotonic);
         const idle = self.idle_threads.load(.monotonic);
-        const should_spawn = running < self.min_threads or (idle == 0 and queued >= running * self.scale_threshold and running < self.max_threads);
+        // Ceiling is max_threads + reserved_running: reserved work is additive to
+        // the regular budget, so regular work can still scale to max_threads even
+        // when reserved jobs occupy workers.
+        const ceiling = self.max_threads + self.reserved_running.load(.monotonic);
+        const should_spawn = running < self.min_threads or (idle == 0 and queued >= running * self.scale_threshold and running < ceiling);
         if (should_spawn) {
-            self.spawnThread() catch |err| {
+            self.spawnThread(false) catch |err| {
                 log.err("Failed to spawn thread: {}", .{err});
             };
         }
@@ -219,6 +272,9 @@ pub const ThreadPool = struct {
         const removed = self.queue.remove(&work.c);
         if (removed) {
             self.queue_size -= 1;
+            // A reserved job leaving the queue without being picked up no longer
+            // needs a worker; drop its pending count under the same lock.
+            if (work.reserve_thread) self.reserved_pending -= 1;
         }
         self.queue_mutex.unlock();
 
@@ -260,10 +316,20 @@ pub const ThreadPool = struct {
             };
             self.queue_size -= 1;
 
+            const work = c.cast(Work);
+            // Snapshot before running: the completion callback below may free
+            // `work`, so we can't read `reserve_thread` off it afterwards.
+            const is_reserved = work.reserve_thread;
+            if (is_reserved) {
+                // This worker now owns the reserved job: drop its pending count
+                // (no longer queued) and count it as occupying a worker, which
+                // lifts the regular ceiling by one. Both under the queue lock.
+                self.reserved_pending -= 1;
+                _ = self.reserved_running.fetchAdd(1, .monotonic);
+            }
+
             self.queue_mutex.unlock();
             defer self.queue_mutex.lock();
-
-            const work = c.cast(Work);
 
             // Try to claim the work by transitioning from pending to running
             if (work.state.cmpxchgStrong(.pending, .running, .acq_rel, .acquire)) |state| {
@@ -278,6 +344,10 @@ pub const ThreadPool = struct {
                 work.c.setResult(.work, {});
                 work.state.store(.completed, .release);
             }
+
+            // Reserved job no longer occupies a worker; drop the ceiling before
+            // the completion callback, which may free `work`.
+            if (is_reserved) _ = self.reserved_running.fetchSub(1, .monotonic);
 
             // Notify via completion callback
             if (work.completion_fn) |completion_fn| {


### PR DESCRIPTION
## What

Adds `Work.reserve_thread`: when set, the thread pool guarantees a worker will pick the job up, even from a saturated pool.

Groundwork for the blocking `std.Io` implementation (#567). **No current caller sets the flag, so behavior is unchanged for existing code.**

## Why

`std.Io`'s `concurrent` is a hard "must run concurrently" guarantee — unlike `async`, it may not run inline. On a fixed-size pool it deadlocks: a job spawned from a pool worker that then `await`s it pins its thread; if every worker is likewise blocked at `max_threads`, the awaited job never gets a thread.

## How — two counters, each with a distinct job

**`reserved_pending`** (guarded by `queue_mutex`) — reserved jobs still sitting in the queue. **The spawn decision is made under `queue_mutex`**, where `idle_threads`, the queue, and this count form a race-free snapshot: a parked worker can't wake and claim work until the lock is released.
- Reuses a parked worker when idle capacity already covers every pending reserved job (`idle_threads >= reserved_pending`); only spawns otherwise. So an idle-rich pool doesn't needlessly spawn, and concurrent reservations can't both bank on the same idle worker (the second sees `pending > idle` and spawns).
- When it must spawn, `spawnThread(forced=true)` may exceed `max_threads`.

**`reserved_running`** (atomic) — reserved jobs currently occupying a worker. `max_threads` is the budget for **regular** work; reserved work is **additive**, so the effective spawn ceiling is `max_threads + reserved_running` (used by both the scale heuristic and `spawnThread`). Without this, reserved jobs would eat the regular budget and starve regular work once they occupy all `max_threads` workers — so e.g. with `max=100` fully reserved, regular work can still scale to 100 more.

Extra workers (reserved or scaled) are reaped back toward `min_threads` once idle, like any other. `spawnThread` uses `addOne` instead of `addOneAssumeCapacity` (a reservation can exceed the init-time capacity), with an `errdefer pop` that also closes a latent leak if `Thread.spawn` failed.

## Behavior summary

| Pool state | reserve a job |
|---|---|
| 10 idle workers (`max=100`) | **reuse an idle worker, no spawn** |
| saturated (`idle=0`) | spawn (may exceed `max_threads`) |
| all `max_threads` reserved, then regular work arrives | regular work **still spawns** up to `max_threads` more (ceiling `max + reserved_running`) |

## Tests

- Saturated pool (`max=1` occupied): a `reserve_thread` job still runs (would deadlock without it).
- Idle-rich pool (`min=2`): a `reserve_thread` job reuses an idle worker — `running_threads` unchanged, asserts no spawn.
- Reserved job occupies `max=1`: regular work still scales to a second worker (would starve without the additive budget).

All 546 tests pass (1 pre-existing skip), `zig fmt` clean.