### PR TITLE
blocking_task: make cancellation actually interrupt the worker

### DIFF
--- a/src/blocking_task.zig
+++ b/src/blocking_task.zig
@@ -6,6 +6,8 @@ const Allocator = std.mem.Allocator;
 const ev = @import("ev/root.zig");
 
 const Runtime = @import("runtime.zig").Runtime;
+const getCurrentExecutorOrNull = @import("runtime.zig").getCurrentExecutorOrNull;
+const syscall_cancel = @import("os/root.zig").syscall_cancel;
 const Awaitable = @import("awaitable.zig").Awaitable;
 const Closure = @import("task.zig").Closure;
 const finishTask = @import("task.zig").finishTask;
@@ -21,7 +23,13 @@ pub const AnyBlockingTask = struct {
     runtime: *Runtime,
     closure: Closure,
 
-    // Simple cancellation flag for blocking tasks
+    /// Bound by the pool worker around the task's function (via
+    /// `work.cancel_token`), so a `SIGURG` from `cancel()` can interrupt a
+    /// cancelable blocking syscall or `Waiter` park inside it.
+    token: syscall_cancel.Token = .{},
+
+    // Guards cancel(): only the first caller arms cancellation and takes the
+    // keep-alive ref.
     user_canceled: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     pub inline fn fromAwaitable(awaitable: *Awaitable) *AnyBlockingTask {
@@ -42,11 +50,36 @@ pub const AnyBlockingTask = struct {
         return result_ptr.*;
     }
 
-    /// Cancel this blocking task by setting canceled flag and canceling the thread pool work.
+    /// Request cancellation of this blocking task.
+    ///
+    /// Cancels the pool work (first `SIGURG`) and, if the worker is blocked in a
+    /// cancelable syscall, arms the current loop's resend so `tick` re-sends
+    /// until the worker acknowledges. A keep-alive ref is taken so the work (and
+    /// its token) cannot be freed while it may sit on the loop's resend list; it
+    /// is released via `onResendRelease` when the entry is dropped (or right away
+    /// when no resend is armed).
     pub fn cancel(self: *AnyBlockingTask) void {
-        self.user_canceled.store(true, .release);
-        // TODO: Actually cancel the task via thread pool
-        // self.runtime.thread_pool.cancel(&self.work);
+        // Only the first caller arms cancellation and takes the ref.
+        if (self.user_canceled.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) return;
+
+        self.awaitable.ref_count.incr();
+        self.work.resend_release = onResendRelease;
+
+        if (getCurrentExecutorOrNull()) |exec| {
+            exec.loop.cancelWork(&self.work);
+        } else {
+            // Not on a loop thread, so there is no ticking loop here to drive the
+            // SIGURG resend: best-effort single signal, then drop the ref.
+            self.runtime.thread_pool.cancel(&self.work);
+            onResendRelease(&self.work);
+        }
+    }
+
+    /// Drop the keep-alive ref taken by `cancel()`. Runs on the loop thread when
+    /// the resend entry is dropped (or inline when no resend was armed).
+    fn onResendRelease(work: *ev.Work) void {
+        const self: *AnyBlockingTask = @fieldParentPtr("work", work);
+        self.awaitable.release();
     }
 
     pub inline fn getRuntime(self: *AnyBlockingTask) *Runtime {
@@ -92,6 +125,10 @@ pub const AnyBlockingTask = struct {
         self.work.completion_fn = threadPoolCompletion;
         self.work.completion_context = self;
 
+        // Bind the cancel token so the worker enters/exits it around the task's
+        // function, making cancelable syscalls (and Waiter parks) interruptible.
+        self.work.cancel_token = &self.token;
+
         // Copy context data into the allocation
         const context_dest = self.closure.getContextSlice(AnyBlockingTask, self);
         @memcpy(context_dest, context);
@@ -104,8 +141,10 @@ pub const AnyBlockingTask = struct {
 fn workFunc(work: *ev.Work) void {
     const task: *AnyBlockingTask = @ptrCast(@alignCast(work.userdata.?));
 
-    // Execute the user's blocking function
-    // ev handles cancellation - if canceled, this won't be called
+    // Execute the user's blocking function. Token-bearing work always runs; a
+    // cancellation is delivered by SIGURG interrupting a cancelable syscall (or
+    // Waiter park) inside the function, which surfaces as error.Canceled in the
+    // function's own result.
     task.closure.call(AnyBlockingTask, task);
 }
 
@@ -113,10 +152,10 @@ fn workFunc(work: *ev.Work) void {
 // All operations here must be thread-safe as this runs on a foreign thread.
 fn threadPoolCompletion(ctx: ?*anyopaque, work: *ev.Work) void {
     const task: *AnyBlockingTask = @ptrCast(@alignCast(ctx));
-
-    // TODO: Handle error case (work.c.err) when task was canceled
     _ = work;
 
+    // Cancellation, if any, was already delivered in-band as the function's
+    // error.Canceled result; nothing extra to do here beyond finishing.
     finishTask(task.runtime, &task.awaitable);
 }
 

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -638,6 +638,13 @@ pub const Work = struct {
     resend_next: ?*Work = null,
     resend_key: ?*Completion = null,
 
+    /// Optional hook fired when this work leaves the cancel-resend list (the
+    /// worker acknowledged the cancel). Used by pool-direct work that is not a
+    /// loop-managed completion — e.g. a blocking task — to drop the reference it
+    /// held to keep the work alive across the resend window. Called once, on the
+    /// loop thread, after the entry is unlinked. Null for loop-managed work.
+    resend_release: ?*const fn (work: *Work) void = null,
+
     pub const Error = error{NoThreadPool} || Cancelable;
 
     pub const State = enum(u8) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -470,6 +470,12 @@ pub const LoopState = struct {
                 slot.* = node.resend_next;
                 node.resend_next = null;
                 node.resend_key = null;
+                // Fire the release hook (drops the blocking task's keep-alive
+                // ref) now that the entry is unlinked. Cleared so it runs once.
+                if (node.resend_release) |release| {
+                    node.resend_release = null;
+                    release(node);
+                }
             }
         }
     }
@@ -793,15 +799,34 @@ pub const Loop = struct {
     fn cancelLinkedWork(self: *Loop, completion: *Completion, linked_work: *DelegatedWork) void {
         const thread_pool = self.thread_pool orelse unreachable;
         thread_pool.cancel(&linked_work.work);
-        // A worker can enter its blocking syscall just after the first SIGURG.
-        // Keep re-sending until it acknowledges or the completion finalizes.
         if (linked_work.token.isCanceling()) {
             self.state.addResend(&linked_work.work, completion);
         }
     }
 
-    /// Run the loop until every completion it owns has finished (or the loop
-    /// is stopped).
+    /// Cancel a thread-pool `work` that was submitted directly to the pool (not
+    /// through this loop), e.g. a blocking task. Loop-thread only.
+    pub fn cancelWork(self: *Loop, work: *Work) void {
+        const thread_pool = self.thread_pool orelse {
+            if (work.resend_release) |release| {
+                work.resend_release = null;
+                release(work);
+            }
+            return;
+        };
+        thread_pool.cancel(work);
+        if (work.cancel_token) |token| {
+            if (token.isCanceling()) {
+                self.state.addResend(work, &work.c);
+                return;
+            }
+        }
+        if (work.resend_release) |release| {
+            work.resend_release = null;
+            release(work);
+        }
+    }
+
     pub fn run(self: *Loop) !void {
         std.debug.assert(self.state.initialized);
         while (!self.done()) {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1958,6 +1958,51 @@ test "runtime: spawnBlocking smoke test" {
     try std.testing.expectEqual(42, result);
 }
 
+test "runtime: spawnBlocking cancel interrupts a blocking syscall on the worker" {
+    if (!os.syscall_cancel.enabled) return error.SkipZigTest;
+
+    const runtime = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer runtime.deinit();
+
+    // The blocking function parks in a cancelable read on an empty pipe. When the
+    // task is canceled, SIGURG (first signal + loop-driven resend) must interrupt
+    // the read and surface as error.Canceled.
+    const worker = struct {
+        fn cancelableRead(fd: std.c.fd_t, ready: *std.atomic.Value(bool)) error{ Canceled, Unexpected }!void {
+            const sc = try os.syscall_cancel.Syscall.begin();
+            defer sc.finish();
+            ready.store(true, .release);
+            var buf: [1]u8 = undefined;
+            while (true) {
+                const rc = std.c.read(fd, &buf, buf.len);
+                if (rc >= 0) return error.Unexpected;
+                switch (std.posix.errno(rc)) {
+                    .INTR => {
+                        try sc.checkCancel();
+                        continue;
+                    },
+                    else => return error.Unexpected,
+                }
+            }
+        }
+    };
+
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(0, std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    var ready = std.atomic.Value(bool).init(false);
+    var handle = try runtime.spawnBlocking(worker.cancelableRead, .{ fds[0], &ready });
+
+    // Wait until the worker is inside the cancelable read (the pool has bound the
+    // task's token), then cancel the blocking task directly.
+    while (!ready.load(.acquire)) try runtime.sleep(.fromMicroseconds(100));
+
+    handle.cancel(); // requests cancellation and waits for completion
+    try std.testing.expectError(error.Canceled, handle.getResult());
+}
+
 test "Runtime: implicit run" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();


### PR DESCRIPTION
## What

Wires `AnyBlockingTask.cancel()` (previously a stale flag + TODO) to the SIGURG cancellation machinery, so canceling a blocking task actually interrupts its worker at any cancelable point inside the task's function.

## Why

Groundwork for the blocking `std.Io` direction (issue #567): a canceled blocking task must actually stop. Until now `cancel()` did nothing.

## Design

Launch stays **pool-direct** — `spawnBlocking` remains callable from any thread; only cancellation touches a loop.

- **`AnyBlockingTask.token`** — embedded, bound by the pool worker via `work.cancel_token`, so a cancelable syscall inside the function is SIGURG-interruptible.
- **`cancel()`** — guards double-cancel, cancels the pool work (first SIGURG), and on the canceling coroutine's **current loop** arms the loop's resend if the worker is blocked. It takes a **keep-alive ref** so the work (and its token) can't be freed while it may sit on the resend list — this replaces the "resend entry removed before the work frees" guarantee that pool-direct work doesn't have (it doesn't finalize through the loop).
- **`Work.resend_release`** — a small per-`Work` hook fired by `sweepResend` when it unlinks the entry on ack (or inline when no resend was armed). It drops the keep-alive ref, **on the loop thread, after the entry is unlinked** → no UAF, and `ev` stays ignorant of task refcounts.
- **`Loop.cancelWork(work)`** — exposes the arm-and-resend step for pool-direct work.
- Off a loop thread (foreign caller), `cancel()` falls back to a best-effort single SIGURG with no resend.

## Test

A blocking task parks in a cancelable read on an empty pipe; canceling its handle interrupts the read via first-signal + loop-driven resend and surfaces `error.Canceled` — would hang without the fix. Stable across repeated runs.

All tests pass, `zig fmt` clean.

## Scope

Cancelable **syscalls** inside a task are interrupted by this PR. Making a `Waiter` park (sleep/await/futex) inside a task cancelable additionally needs a cancelable Waiter-park change, tracked separately. Also: the resend is armed on the canceling coroutine's current loop, so cancel from any **executor thread** gets full resend; cancel from a **foreign (non-executor) thread** falls back to best-effort single SIGURG.