### PR TITLE
Remove the spin from the futex mutex

### DIFF
--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -702,18 +702,6 @@ const MutexFutex = struct {
     }
 
     fn lockSlow(self: *MutexFutex) void {
-        // First try spinning a bit
-        var spin: u32 = 0;
-        while (spin < 100) : (spin += 1) {
-            const state = self.state.load(.monotonic);
-            if (state == UNLOCKED) {
-                if (self.state.cmpxchgWeak(UNLOCKED, LOCKED, .acquire, .monotonic) == null) {
-                    return;
-                }
-            }
-            std.atomic.spinLoopHint();
-        }
-
         // Avoid doing an atomic swap below if we already know the state is contended.
         // An atomic swap unconditionally stores which marks the cache-line as modified unnecessarily.
         if (self.state.load(.monotonic) == LOCKED_WITH_WAITERS) {


### PR DESCRIPTION
While measuring the spin-before-park suggestion on #573, the same question applied here. Interleaved spin/no-spin runs of a contended counter (100k lock/unlock per thread), medians:

| threads | with spin | without |
|---|--:|--:|
| 2 | 11.6 ms | 7.7 ms |
| 4 | 24.3 ms | 14.2 ms |
| 8 | 68.6 ms | 28.4 ms |

The spin does what it's meant to (fewer parks), but the spinners keep the state word's cache line hot in the wrong caches, slowing the holder's unlock and the next acquire by more than the saved syscalls are worth. The penalty grows with thread count. At 2 threads the spin sometimes wins a run outright (min 3.5 ms vs 6.7 ms) but loses the median by 50% with far higher variance.

Same conclusion std.Thread.Mutex reached when it dropped spinning. Repro: `mutex_bench_native --os --workers=N` in zio-benchmarks.