### PR TITLE
Adaptive time-based tick budget for the scheduler

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -782,9 +782,11 @@ pub const Executor = struct {
                 current_exec.scheduleTaskLocal(task);
                 return;
             }
-            // New tasks always go to their round-robin assigned home executor to
-            // distribute load across executors. Only already-running tasks may
-            // migrate to the current executor (for cache locality with the waker).
+            // Tasks spawned from an executor of this runtime are homed there and
+            // take the local branch above; this remote path serves foreign-thread
+            // spawns and round-robin homes (migration off). Only already-running
+            // tasks may migrate to the current executor (cache locality with the
+            // waker).
             if (zio_options.task_migration and old.tag != .new and current_exec.runtime == home_exec.runtime and home_exec.runtime.options.enable_task_migration) {
                 // Migrate to the current executor
                 current_exec.scheduleTaskLocal(task);

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -503,6 +503,15 @@ pub const Executor = struct {
     }
 
     pub fn maybeYield(self: *Executor, comptime mode: AnyTask.YieldMode, comptime cancel_mode: YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
+        // Cancellation is observed even on the fast path, so a CPU-bound loop
+        // that only calls maybeYield() reacts to cancel promptly, like yield().
+        if (cancel_mode == .allow_cancel) {
+            const task = getCurrentTask();
+            task.checkCancel() catch |err| {
+                task.state.store(.{ .tag = .ready }, .release);
+                return err;
+            };
+        }
         // Pure time-slice check: each call spends a quantum of the tick budget,
         // and only when the slice is used up does a real yield happen (letting
         // other tasks run and I/O get polled). Within the slice this returns
@@ -573,7 +582,11 @@ pub const Executor = struct {
             // Retune the tick budget from this batch. Skipped when we may have
             // slept in parkAndSearch — sleep time would poison the estimate.
             const tick_now = Timestamp.now(.monotonic);
-            if (has_work and self.tick_task_count > 0 and self.tick_started_at.value != 0) {
+            // Skip the retune on the fresh-drain entry pass: tick_task_count
+            // still holds quanta spent before run() was entered, while
+            // tick_started_at was just reset, so the pair would yield a bogus
+            // near-zero estimate and inflate the budget.
+            if (has_work and self.tick_task_count > 0 and self.tick_started_at.value != 0 and !need_fresh_drain) {
                 const elapsed: f64 = @floatFromInt(tick_now.toNanoseconds() -| self.tick_started_at.toNanoseconds());
                 const n: f64 = @floatFromInt(self.tick_task_count);
                 // One EWMA step per quantum, applied per batch (tokio's scheme).
@@ -668,7 +681,7 @@ pub const Executor = struct {
     }
 
     fn stealWork(self: *Executor) bool {
-        if (!(zio_options.task_migration and self.runtime.options.enable_task_migration) or !self.runtime.executors_stealable.load(.acquire)) return false;
+        if (!self.runtime.stealingActive()) return false;
         const executors = self.runtime.executors.items;
         if (executors.len <= 1) return false;
 
@@ -693,8 +706,8 @@ pub const Executor = struct {
 
     /// Get the next task to run from the ready queue.
     ///
-    /// Returns null if no tasks are available, or if EVENT_INTERVAL tasks have
-    /// been run since the last event loop tick (to ensure I/O responsiveness).
+    /// Returns null if no tasks are available, or if the tick's quantum budget
+    /// is spent (to ensure I/O responsiveness).
     fn getNextTask(self: *Executor) ?*AnyTask {
         // The budget approximates tick_target_ns of task time (see the field
         // docs): a re-readied task may run repeatedly within a tick, but once
@@ -1259,7 +1272,7 @@ pub const Runtime = struct {
     }
 
     fn armSearcher(self: *Runtime) void {
-        if (!(zio_options.task_migration and self.options.enable_task_migration) or !self.executors_stealable.load(.acquire) or (self.idle_mask.load(.monotonic) == 0) or (self.searchers.load(.monotonic) != 0)) return;
+        if (!self.stealingActive() or (self.idle_mask.load(.monotonic) == 0) or (self.searchers.load(.monotonic) != 0)) return;
         if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
 
         var candidates = self.idle_mask.load(.acquire);
@@ -1526,7 +1539,7 @@ test "runtime: maybeYield without an executor is a no-op" {
     try maybeYield();
 }
 
-test "runtime: maybeYield yields once the ready queue crosses the fairness threshold" {
+test "runtime: maybeYield yields once the tick budget is spent" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
@@ -1553,8 +1566,8 @@ test "runtime: maybeYield yields once the ready queue crosses the fairness thres
         try group.spawn(waiterTask, .{ &event, &counter });
     }
 
-    // Every task is now parked in event.wait(), so waking them all at once fills
-    // the ready queue past the fairness threshold.
+    // Every task is now parked in event.wait(); wake them all at once so the
+    // main loop's maybeYield() has ready work to hand control to.
     event.set();
 
     var iterations: usize = 0;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -310,18 +310,30 @@ pub const Executor = struct {
     // this stays empty.
     overflow: OverflowQueue(WaitNode) = .{},
 
-    // Tracks tasks run since last event loop tick.
-    // After EVENT_INTERVAL tasks, getNextTask() returns null to force I/O processing.
-    tick_task_count: u8 = 0,
+    // Scheduling quanta (task runs, yield fast-paths, maybeYield checks) spent
+    // since the last event loop tick. Once it reaches tick_task_budget the
+    // executor forces an I/O poll.
+    tick_task_count: u32 = 0,
 
-    // Monotonically increasing tick counter, bumped after each event loop tick.
-    // With task.last_run_tick it stops a task that re-readies itself from running
-    // again in the same tick, forcing an I/O poll first (responsiveness). Starts
-    // at 1 so new tasks (last_run_tick == 0) run immediately.
-    current_tick: u32 = 1,
+    // How many quanta fit in tick_target_ns, re-estimated after each tick from
+    // task_ns_ewma. Counting against this approximates a time-based poll
+    // interval without reading the clock on the hot path.
+    tick_task_budget: u32 = initial_tick_budget,
 
-    // Timestamp of last event loop tick, used for time-based yield decisions.
-    last_tick_time: Timestamp = .zero,
+    // EWMA of nanoseconds per quantum, measured across each tick's batch.
+    task_ns_ewma: f64 = @as(f64, tick_target_ns) / initial_tick_budget,
+
+    // When the current tick's batch started running tasks.
+    tick_started_at: Timestamp = .zero,
+
+    // Set by the periodic checkpoint when the batch has already run past
+    // tick_target_ns (the budget was a misprediction); forces a poll like an
+    // exhausted budget, while tick_task_count stays truthful for the EWMA.
+    tick_expired: bool = false,
+
+    // Quanta left until the next clock checkpoint (cheaper than a modulo on
+    // the hot path).
+    tick_checkpoint_countdown: u32 = checkpoint_interval,
 
     // Deferred cleanup for the task that just yielded away from this executor.
     // Processed by the next coroutine to run (at landing sites: startFn, yield resume, run loop).
@@ -457,11 +469,46 @@ pub const Executor = struct {
 
     pub const YieldCancelMode = enum { allow_cancel, no_cancel };
 
-    /// Yield to other tasks only if many are waiting, to balance fairness vs. context-switch overhead.
-    const yield_ready_threshold = 13;
+    /// Aim to poll I/O roughly this often while running tasks back-to-back.
+    const tick_target_ns = 100_000;
+    /// Budget until the first measurement (Go's scheduler / tokio's event_interval).
+    const initial_tick_budget = 61;
+    /// Budget clamp: at least 2 to make progress between polls, capped so a
+    /// mis-measured EWMA can't defer polling indefinitely.
+    pub const max_tick_budget = 8192;
+    /// Weight of one quantum in the EWMA (tokio's value).
+    const task_ns_ewma_alpha = 0.1;
+    /// Quanta between clock checkpoints: a hard time backstop for budget
+    /// mispredictions. Prime (like Go's 61) to avoid resonating with periodic
+    /// workloads; also tokio's max tasks per global-queue interval.
+    const checkpoint_interval = 127;
+
+    /// True while the current tick may keep spending quanta without polling.
+    inline fn tickBudgetLeft(self: *const Executor) bool {
+        return self.tick_task_count < self.tick_task_budget and !self.tick_expired;
+    }
+
+    /// Account one scheduling quantum. Every checkpoint_interval quanta the
+    /// clock is read to catch budget mispredictions: if the batch has already
+    /// overrun tick_target_ns, the tick is expired so every budget check fails
+    /// until the next poll resets it.
+    fn spendQuantum(self: *Executor) void {
+        self.tick_task_count += 1;
+        self.tick_checkpoint_countdown -= 1;
+        if (self.tick_checkpoint_countdown == 0) {
+            self.tick_checkpoint_countdown = checkpoint_interval;
+            const elapsed = Timestamp.now(.monotonic).toNanoseconds() -| self.tick_started_at.toNanoseconds();
+            if (elapsed >= tick_target_ns) self.tick_expired = true;
+        }
+    }
 
     pub fn maybeYield(self: *Executor, comptime mode: AnyTask.YieldMode, comptime cancel_mode: YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
-        if (self.run_queue.len() >= yield_ready_threshold) {
+        // Pure time-slice check: each call spends a quantum of the tick budget,
+        // and only when the slice is used up does a real yield happen (letting
+        // other tasks run and I/O get polled). Within the slice this returns
+        // immediately without looking at the queues.
+        self.spendQuantum();
+        if (!self.tickBudgetLeft()) {
             return getCurrentTask().yield(mode, cancel_mode);
         }
     }
@@ -492,6 +539,16 @@ pub const Executor = struct {
         // Process deferred cleanup (e.g. main task's park/reschedule)
         self.processCleanup();
 
+        // When entered with the tick budget already spent (e.g. the main task
+        // yielded because its slice ran out), ready tasks must get one
+        // fresh-budget batch after the next poll before control can return to
+        // the main task — otherwise they'd starve behind the exhausted budget.
+        var need_fresh_drain = !self.tickBudgetLeft();
+
+        // Start the batch window here: time spent in the main task between
+        // run() calls must not count toward the per-quantum estimate.
+        self.tick_started_at = Timestamp.now(.monotonic);
+
         while (true) {
             // Process ready coroutines
             while (self.getNextTask()) |next_task| {
@@ -510,12 +567,29 @@ pub const Executor = struct {
                 @panic("event loop stopped while the main task was yielding");
             }
 
-            if (self.checkAboutForWork(check_ready, true)) try self.loop.run(.no_wait) else try self.parkAndSearch(check_ready);
+            const has_work = self.checkAboutForWork(check_ready, true);
+            if (has_work) try self.loop.run(.no_wait) else try self.parkAndSearch(check_ready);
 
-            // Reset task counter and update tick time after event loop tick
+            // Retune the tick budget from this batch. Skipped when we may have
+            // slept in parkAndSearch — sleep time would poison the estimate.
+            const tick_now = Timestamp.now(.monotonic);
+            if (has_work and self.tick_task_count > 0 and self.tick_started_at.value != 0) {
+                const elapsed: f64 = @floatFromInt(tick_now.toNanoseconds() -| self.tick_started_at.toNanoseconds());
+                const n: f64 = @floatFromInt(self.tick_task_count);
+                // One EWMA step per quantum, applied per batch (tokio's scheme).
+                const alpha = 1.0 - std.math.pow(f64, 1.0 - task_ns_ewma_alpha, n);
+                self.task_ns_ewma = alpha * (elapsed / n) + (1.0 - alpha) * self.task_ns_ewma;
+                self.tick_task_budget = @intFromFloat(std.math.clamp(tick_target_ns / self.task_ns_ewma, 2.0, max_tick_budget));
+            }
+            self.tick_started_at = tick_now;
             self.tick_task_count = 0;
-            self.current_tick +%= 1;
-            self.last_tick_time = self.loop.now();
+            self.tick_expired = false;
+            self.tick_checkpoint_countdown = checkpoint_interval;
+
+            if (need_fresh_drain) {
+                need_fresh_drain = false;
+                continue;
+            }
 
             // Check again after I/O
             if (check_ready and self.main_task.state.load(.acquire).tag == .ready) {
@@ -607,12 +681,7 @@ pub const Executor = struct {
             const victim_idle = self.runtime.idle_mask.load(.acquire) & victim_bit != 0;
             if (victim_idle) continue;
 
-            if (self.run_queue.steal(&victim.run_queue, struct {
-                fn reset(node: *WaitNode) void {
-                    const task = AnyTask.fromWaitNode(node);
-                    task.last_run_tick = 0;
-                }
-            }.reset)) |node| {
+            if (self.run_queue.steal(&victim.run_queue)) |node| {
                 self.run_queue.push(node);
                 self.runtime.armSearcher();
                 return true;
@@ -627,30 +696,17 @@ pub const Executor = struct {
     /// Returns null if no tasks are available, or if EVENT_INTERVAL tasks have
     /// been run since the last event loop tick (to ensure I/O responsiveness).
     fn getNextTask(self: *Executor) ?*AnyTask {
-        // Maximum tasks to run before forcing an event loop tick (from Go's scheduler)
-        const EVENT_INTERVAL = 61;
-
-        // Force event loop tick after running EVENT_INTERVAL tasks
-        if (self.tick_task_count >= EVENT_INTERVAL) {
+        // The budget approximates tick_target_ns of task time (see the field
+        // docs): a re-readied task may run repeatedly within a tick, but once
+        // the budget is spent the executor polls I/O, so a self-looping task
+        // can't starve timers or I/O.
+        if (!self.tickBudgetLeft()) {
             return null;
         }
 
-        // Peek the head (via popIf) and only take it if it hasn't already run this
-        // tick. FIFO already keeps a re-queued task from jumping the line; this
-        // guard additionally forces an I/O poll before re-running a task that
-        // re-readied itself, so a self-looping task stays I/O-responsive. A task
-        // that isn't runnable is left in place and we return null (poll first).
-        const node = self.run_queue.popIf(self, isRunnableThisTick) orelse return null;
-        const task = AnyTask.fromWaitNode(node);
-        task.last_run_tick = self.current_tick;
-        self.tick_task_count += 1;
-        return task;
-    }
-
-    /// Head-runnable predicate for getNextTask's peek: a task may run unless it has
-    /// already run in the current tick.
-    fn isRunnableThisTick(self: *Executor, node: *WaitNode) bool {
-        return AnyTask.fromWaitNode(node).last_run_tick != self.current_tick;
+        const node = self.run_queue.pop() orelse return null;
+        self.spendQuantum();
+        return AnyTask.fromWaitNode(node);
     }
 
     /// Schedule a task on this executor's local run queue. MUST run on the owning
@@ -731,7 +787,6 @@ pub const Executor = struct {
             // migrate to the current executor (for cache locality with the waker).
             if (zio_options.task_migration and old.tag != .new and current_exec.runtime == home_exec.runtime and home_exec.runtime.options.enable_task_migration) {
                 // Migrate to the current executor
-                task.last_run_tick = 0;
                 current_exec.scheduleTaskLocal(task);
                 return;
             }
@@ -866,6 +921,23 @@ pub fn yield() Cancelable!void {
         os.thread.yield();
         return;
     };
+    const exec = getCurrentExecutor();
+    // Fast path: no other task is ready and there is tick budget left, so
+    // there is nothing to switch to and no poll due yet — spend a quantum and
+    // keep running. Budget exhaustion falls through to the real yield, which
+    // reaches the run loop and polls I/O, keeping timers and I/O bounded. The
+    // main task is not in the run queue, so its readiness is checked directly.
+    if (exec.tickBudgetLeft() and
+        exec.run_queue.isEmpty() and exec.run_queue.overflow.isEmpty() and
+        exec.main_task.state.load(.acquire).tag != .ready)
+    {
+        task.checkCancel() catch |err| {
+            task.state.store(.{ .tag = .ready }, .release);
+            return err;
+        };
+        exec.spendQuantum();
+        return;
+    }
     return task.yield(.reschedule, .allow_cancel);
 }
 
@@ -1025,7 +1097,9 @@ pub const Runtime = struct {
                 }
                 self.executors.appendAssumeCapacity(&worker.executor);
             }
-            self.executors_stealable.store(true, .release);
+            // With no workers there is nobody to steal from or to; leaving this
+            // false lets single-executor runtimes skip the steal machinery.
+            if (num_workers > 0) self.executors_stealable.store(true, .release);
         }
     }
 
@@ -1175,6 +1249,11 @@ pub const Runtime = struct {
             };
             break;
         }
+    }
+
+    /// Whether other executors can currently steal from this runtime's queues.
+    pub fn stealingActive(self: *Runtime) bool {
+        return zio_options.task_migration and self.options.enable_task_migration and self.executors_stealable.load(.acquire);
     }
 
     fn armSearcher(self: *Runtime) void {
@@ -1461,10 +1540,9 @@ test "runtime: maybeYield yields once the ready queue crosses the fairness thres
         }
     }.call;
 
-    // Spawn more waiters than Executor.yield_ready_threshold so that, once they're
-    // all woken at once, ready_count is high enough for maybeYield() to actually
-    // reschedule instead of no-op.
-    const task_count = Executor.yield_ready_threshold + 5;
+    // maybeYield() only does a real yield once the tick budget is spent, so the
+    // main loop below must be allowed at least one full budget of iterations.
+    const task_count = 18;
 
     var group: Group = .init;
     defer group.cancel();
@@ -1479,7 +1557,7 @@ test "runtime: maybeYield yields once the ready queue crosses the fairness thres
 
     var iterations: usize = 0;
     while (counter < task_count) : (iterations += 1) {
-        if (iterations >= 100) {
+        if (iterations >= Executor.max_tick_budget * 2) {
             std.debug.print("maybeYield not working: counter={}, iterations={}\n", .{ counter, iterations });
             return error.TestExpectedEqual;
         }

--- a/src/task.zig
+++ b/src/task.zig
@@ -186,10 +186,6 @@ pub const AnyTask = struct {
     canceled_status: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
     // Tracks which tick this task last ran on (per-executor).
-    // Used to prevent running the same task more than once per event loop tick.
-    // Reset to 0 when stolen, allowing immediate execution on the thief.
-    last_run_tick: u32 = 0,
-
     // Closure for the task
     closure: Closure,
 
@@ -669,6 +665,9 @@ pub fn TaskLocal(comptime T: type) type {
 
 const getNextExecutor = @import("runtime.zig").getNextExecutor;
 
+/// Ready-queue length past which a spawning task yields to let new tasks start.
+const spawn_yield_threshold = 13;
+
 /// Register a task with the runtime and schedule it for execution.
 /// Increments its reference count, adds the task to the runtime's task list,
 /// and schedules it on its executor.
@@ -685,7 +684,13 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
 
     if (runtime.getCurrentExecutorOrNull()) |current_executor| {
         if (current_executor.runtime == task.runtime) {
-            current_executor.maybeYield(.reschedule, .no_cancel);
+            // Backpressure for spawn loops: once the ready queue grows past the
+            // threshold, yield so new tasks start running instead of piling up
+            // (distinct from maybeYield's time-slice check). Only needed when
+            // no other executor can steal the backlog.
+            if (!task.runtime.stealingActive() and current_executor.run_queue.len() >= spawn_yield_threshold) {
+                runtime.getCurrentTask().yield(.reschedule, .no_cancel);
+            }
         }
     }
 }

--- a/src/task.zig
+++ b/src/task.zig
@@ -723,7 +723,18 @@ pub fn spawnTask(
     start: Closure.Start,
     group: ?*Group,
 ) !*AnyTask {
-    const executor = try getNextExecutor(rt);
+    // With work stealing active, spawn onto the current executor: the task goes
+    // to the local ring (no global-queue push, no wake syscall) and stealing
+    // redistributes if load piles up. Round-robin is only needed to spread load
+    // when nobody can steal, or when spawning from outside the runtime.
+    const executor = blk: {
+        if (rt.stealingActive()) {
+            if (runtime.getCurrentExecutorOrNull()) |cur| {
+                if (cur.runtime == rt) break :blk cur;
+            }
+        }
+        break :blk try getNextExecutor(rt);
+    };
 
     const task = try AnyTask.create(
         executor,

--- a/src/task.zig
+++ b/src/task.zig
@@ -185,7 +185,6 @@ pub const AnyTask = struct {
     // Cancellation status - tracks user cancel, timeout, pending errors, and shield count
     canceled_status: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
-    // Tracks which tick this task last ran on (per-executor).
     // Closure for the task
     closure: Closure,
 
@@ -688,8 +687,10 @@ pub fn registerTask(rt: *Runtime, task: *AnyTask) error{RuntimeShutdown}!void {
             // threshold, yield so new tasks start running instead of piling up
             // (distinct from maybeYield's time-slice check). Only needed when
             // no other executor can steal the backlog.
-            if (!task.runtime.stealingActive() and current_executor.run_queue.len() >= spawn_yield_threshold) {
-                runtime.getCurrentTask().yield(.reschedule, .no_cancel);
+            if (!rt.stealingActive() and current_executor.run_queue.len() >= spawn_yield_threshold) {
+                if (current_executor.current_task) |spawner| {
+                    spawner.yield(.reschedule, .no_cancel);
+                }
             }
         }
     }

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -207,7 +207,7 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         ///
         /// Only available on a stealable queue: with task migration compiled out no
         /// thief exists, so calling this is a programming error and won't compile.
-        pub fn steal(self: *Self, victim: *Self, comptime callbackFn: fn (*T) void) ?*T {
+        pub fn steal(self: *Self, victim: *Self) ?*T {
             if (!stealable) @compileError("steal() is unavailable: this queue was built without task migration / work stealing");
             const dst_tail = self.ownTail(); // the thief owns its own tail
             const dst_space = capacity - (dst_tail -% self.loadHead());
@@ -229,9 +229,6 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
                 if (victim.casHead(h, h +% take, false)) break take;
                 // Lost the race (an owner pop or another thief); retry the grab.
             };
-
-            var i: u32 = 0;
-            while (i < stolen) : (i += 1) callbackFn(self.buffer[(dst_tail +% i) & mask]);
 
             // Hand back the last stolen task; publish the rest into the thief's ring.
             const rest = stolen - 1;
@@ -430,9 +427,7 @@ test "LocalRunQueue: steal takes half into the thief and returns one" {
 
     // victim holds 0,1,2,3 (head=0). Steal ceil(4/2)=2 (ids 0,1): returns the last
     // stolen (id 1), keeps id 0 in the thief; victim left with 2,3.
-    const got = thief.steal(&victim, struct {
-        fn reset(_: *TestNode) void {}
-    }.reset) orelse return error.Unexpected;
+    const got = thief.steal(&victim) orelse return error.Unexpected;
     try testing.expectEqual(1, got.id);
     try testing.expectEqual(1, thief.len());
     try testing.expectEqual(2, victim.len());
@@ -456,9 +451,7 @@ test "LocalRunQueue: steal with an odd count takes the ceil half" {
     }
     // 7 tasks -> steal 7 - 7/2 = 4 (ids 0..3), return id 3, thief keeps 0,1,2;
     // victim left with 4,5,6.
-    const got = thief.steal(&victim, struct {
-        fn reset(_: *TestNode) void {}
-    }.reset) orelse return error.Unexpected;
+    const got = thief.steal(&victim) orelse return error.Unexpected;
     try testing.expectEqual(3, got.id);
     try testing.expectEqual(3, thief.len());
     try testing.expectEqual(3, victim.len());
@@ -469,9 +462,7 @@ test "LocalRunQueue: steal from an empty victim returns null" {
     var ov2: TestOverflow = .{};
     var victim = TestQueue.init(&ov1);
     var thief = TestQueue.init(&ov2);
-    try testing.expect(thief.steal(&victim, struct {
-        fn reset(_: *TestNode) void {}
-    }.reset) == null);
+    try testing.expect(thief.steal(&victim) == null);
 }
 
 test "LocalRunQueue: index cycling past capacity stays correct" {
@@ -519,9 +510,7 @@ test "LocalRunQueue: concurrent push/pop and steal loses or duplicates no task" 
     const stealer = try std.Thread.spawn(.{}, struct {
         fn run(c: *Ctx) void {
             while (!c.stop.load(.acquire) or !c.owner.isEmpty()) {
-                if (c.thief.steal(c.owner, struct {
-                    fn reset(_: *TestNode) void {}
-                }.reset)) |n| c.mark(n);
+                if (c.thief.steal(c.owner)) |n| c.mark(n);
                 while (c.thief.pop()) |n| c.mark(n);
             }
             while (c.thief.pop()) |n| c.mark(n);
@@ -598,9 +587,7 @@ test "LocalRunQueue: multiple concurrent stealers lose or duplicate no task" {
     const Thief = struct {
         fn run(c: *Ctx, thief: *TestQueue) void {
             while (!c.stop.load(.acquire) or !c.owner.isEmpty()) {
-                if (thief.steal(c.owner, struct {
-                    fn reset(_: *TestNode) void {}
-                }.reset)) |n| c.mark(n);
+                if (thief.steal(c.owner)) |n| c.mark(n);
                 while (thief.pop()) |n| c.mark(n);
             }
             while (thief.pop()) |n| c.mark(n);


### PR DESCRIPTION
The executor used to force an event loop poll after a fixed 61 task runs, and additionally refused to run the same task twice within one tick. That second rule turned out to be expensive: in wake-heavy workloads (channel ping-pong, fan-in) it injected a poll every ~2 messages.

This replaces both with a time-calibrated budget, similar in spirit to how tokio tunes its global queue interval:

- Elapsed time is measured once per tick (across the batch between polls), never on the hot path. An EWMA of ns-per-quantum sizes the next batch to ~100us of task time, clamped to [2, 8192] quanta.
- A checkpoint every 127 quanta reads the clock and expires the tick early if the estimate was wrong, so a misprediction can't defer polling for long (worst case ~100us + 127 quanta instead of 8192 quanta).
- `yield()` returns without a context switch when nothing else can run (run queue and overflow empty, main task not ready) and budget remains. A lone yielding task pays ~5ns instead of two context switches and a poll.
- `maybeYield()` becomes a pure time-slice check: spend a quantum, real yield only when the slice is used up.
- Spawn loops yield on queue pressure only when stealing is inactive; with workers available, they drain the backlog themselves.
- Fixes `executors_stealable` being set with zero workers, which made single-executor runtimes take the steal-check paths for nothing.
- Removes `last_run_tick`, `current_tick`, `last_tick_time` and the steal callback, which only served the old guard.

## Benchmarks

zio-benchmarks, ReleaseFast, medians of 4-5 interleaved runs, 100k messages. "before" is main with the old guard. Go / tokio / photon / asio binaries are the existing counterparts from zio-benchmarks (photon built from source, WorkPool with one vcpu per core; the single-threaded photon column is WorkPool(1), its intended shared-nothing configuration).

### Single-threaded

| benchmark | zio before | zio after | photon (1 vcpu) |
|---|---|---|---|
| channel ping-pong | 12.3 ms | **9.7 ms** | 19.1 ms |
| channel fan-in (1000 producers) | 5.9 ms | **4.7 ms** | 72.7 ms |
| yield, 2 tasks | 55 ns/yield | **21 ns/yield** | 40 ns/yield |
| yield, solo task | 55 ns/yield | **5.5 ns/yield** | — |
| spawn 100k no-op tasks | 212 ns/spawn | 224 ns/spawn | ~28,000 ns/spawn |

### Multi-threaded

| benchmark | zio before | zio after | Go | tokio | photon (n vcpus) |
|---|---|---|---|---|---|
| channel ping-pong | 16.3 ms | **~13 ms** | 20.4 ms | 33.2 ms | ~1100 ms |
| channel fan-in (1000 producers) | ~41 ms | **~25 ms** (noisy, 10-45) | 13.7 ms | 53.0 ms | ~555 ms |

Fan-in multi-threaded remains the one benchmark where Go is ahead; it is also by far the noisiest (a lock-serialized workload at the mercy of wake placement). Everything else improves, and the poll-injection overhead that used to dominate yield-heavy paths is effectively gone.