### PR TITLE
Add a next-up slot to the run queue (Go's runnext)

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -744,6 +744,23 @@ pub const Executor = struct {
         self.runtime.armSearcher();
     }
 
+    /// Schedule a task woken by the currently running task: it goes to the run
+    /// queue's next-up slot (Go's runnext) and runs here right after the
+    /// waker, keeping communicating tasks on one executor. The slot placement
+    /// itself is not announced — inviting a thief at that moment would just
+    /// scatter the pair, and a stalled slot can still be stolen (with backoff)
+    /// through the normal steal path. A previous occupant demoted to the ring
+    /// is ordinary queued work, though, and must be advertised.
+    fn scheduleTaskNext(self: *Executor, task: *AnyTask) void {
+        if (task == &self.main_task) return;
+
+        std.debug.assert(getCurrentExecutorOrNull() == self);
+
+        if (self.run_queue.pushNext(&task.awaitable.wait_node)) {
+            self.runtime.armSearcher();
+        }
+    }
+
     /// Schedule a task from another thread (or no executor context) onto its home
     /// executor, and wake that executor's loop. Goes to the home executor's
     /// `overflow` queue — the shared global one (migration on, any executor may
@@ -797,8 +814,13 @@ pub const Executor = struct {
 
         if (getCurrentExecutorOrNull()) |current_exec| {
             if (current_exec == home_exec) {
-                // Schedule locally
-                current_exec.scheduleTaskLocal(task);
+                // Schedule locally; a wake coming from the running task goes
+                // to the next-up slot so communicating tasks stay together.
+                if (old.tag != .new and current_exec.current_task != null) {
+                    current_exec.scheduleTaskNext(task);
+                } else {
+                    current_exec.scheduleTaskLocal(task);
+                }
                 return;
             }
             // Tasks spawned from an executor of this runtime are homed there and
@@ -807,8 +829,13 @@ pub const Executor = struct {
             // tasks may migrate to the current executor (cache locality with the
             // waker).
             if (zio_options.task_migration and old.tag != .new and current_exec.runtime == home_exec.runtime and home_exec.runtime.options.enable_task_migration) {
-                // Migrate to the current executor
-                current_exec.scheduleTaskLocal(task);
+                // Migrate to the current executor; a wake from the running
+                // task takes the next-up slot, like the local branch above.
+                if (current_exec.current_task != null) {
+                    current_exec.scheduleTaskNext(task);
+                } else {
+                    current_exec.scheduleTaskLocal(task);
+                }
                 return;
             }
         }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -339,6 +339,11 @@ pub const Executor = struct {
     // the hot path).
     tick_checkpoint_countdown: u32 = checkpoint_interval,
 
+    // Consecutive tasks taken from the next-up slot. At max_slot_streak the
+    // ring is serviced first, so a hot wake chain can't starve queued tasks
+    // (tokio's MAX_LIFO_POLLS_PER_TICK).
+    slot_streak: u8 = 0,
+
     // Deferred cleanup for the task that just yielded away from this executor.
     // Processed by the next coroutine to run (at landing sites: startFn, yield resume, run loop).
     pending_cleanup: TaskCleanup = .none,
@@ -714,6 +719,10 @@ pub const Executor = struct {
     ///
     /// Returns null if no tasks are available, or if the tick's quantum budget
     /// is spent (to ensure I/O responsiveness).
+    /// Consecutive next-up slot pops before the ring gets a turn (tokio's
+    /// MAX_LIFO_POLLS_PER_TICK).
+    const max_slot_streak = 3;
+
     fn getNextTask(self: *Executor) ?*AnyTask {
         // The budget approximates tick_target_ns of task time (see the field
         // docs): a re-readied task may run repeatedly within a tick, but once
@@ -723,9 +732,27 @@ pub const Executor = struct {
             return null;
         }
 
-        const node = self.run_queue.pop() orelse return null;
-        self.spendQuantum();
-        return AnyTask.fromWaitNode(node);
+        // The next-up slot wins over the ring, but not indefinitely: a pair of
+        // tasks waking each other re-fills the slot on every quantum, so after
+        // max_slot_streak consecutive slot pops the ring is serviced first.
+        if (self.slot_streak >= max_slot_streak) {
+            if (self.run_queue.popRing()) |node| {
+                self.slot_streak = 0;
+                self.spendQuantum();
+                return AnyTask.fromWaitNode(node);
+            }
+        }
+        if (self.run_queue.popNext()) |node| {
+            self.slot_streak +|= 1;
+            self.spendQuantum();
+            return AnyTask.fromWaitNode(node);
+        }
+        if (self.run_queue.popRing()) |node| {
+            self.slot_streak = 0;
+            self.spendQuantum();
+            return AnyTask.fromWaitNode(node);
+        }
+        return null;
     }
 
     /// Schedule a task on this executor's local run queue. MUST run on the owning

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -210,11 +210,20 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         /// Owner-only pop: the next-up slot first, then the ring head (Go's
         /// runqget). CAS because stealers race both the slot and the head.
         pub fn pop(self: *Self) ?*T {
-            // One CAS attempt on the slot: only a thief can zero it, so on
-            // failure it's simply gone — fall through to the ring.
+            return self.popNext() orelse self.popRing();
+        }
+
+        /// Owner-only pop of just the next-up slot. One CAS attempt: only a
+        /// thief can zero it, so on failure the slot is simply gone.
+        pub fn popNext(self: *Self) ?*T {
             if (self.loadNext()) |node| {
                 if (self.casNext(node)) return node;
             }
+            return null;
+        }
+
+        /// Owner-only pop of just the ring head.
+        pub fn popRing(self: *Self) ?*T {
             while (true) {
                 const h = self.loadHead();
                 const t = self.ownTail();

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -27,6 +27,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const SimpleQueue = @import("simple_queue.zig").SimpleQueue;
 const OsMutex = @import("../os/thread.zig").Mutex;
+const os_time = @import("../os/time.zig");
 
 /// Thread-safe FIFO overflow queue: a mutex-guarded intrusive list plus an atomic
 /// length so the drain fast-path can skip the lock when empty. `count` is mutated
@@ -102,6 +103,11 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         // a single-owner queue pays no atomic cost.
         head: u32 = 0,
         tail: u32 = 0,
+        // Next-up slot (Go's runnext): a task that should run ahead of the
+        // ring, typically one just woken by the running task. The owner
+        // installs and pops it; a thief may CAS it out (after a short backoff)
+        // when the ring is empty, so a stalled owner can't sit on it.
+        next: ?*T = null,
         /// Set once, at executor init, to the global or the executor-local queue.
         overflow: *OverflowQueue(T) = undefined,
 
@@ -124,6 +130,28 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         inline fn storeTail(self: *Self, v: u32) void {
             if (stealable) @atomicStore(u32, &self.tail, v, .release) else self.tail = v;
         }
+        inline fn loadNext(self: *const Self) ?*T {
+            return if (stealable) @atomicLoad(?*T, &self.next, .acquire) else self.next;
+        }
+        /// Owner-only: install a task in the next slot, returning the one it
+        /// displaced (if any).
+        inline fn swapNext(self: *Self, node: ?*T) ?*T {
+            if (!stealable) {
+                const prev = self.next;
+                self.next = node;
+                return prev;
+            }
+            return @atomicRmw(?*T, &self.next, .Xchg, node, .acq_rel);
+        }
+        /// Claim `expected` out of the next slot (owner pop or thief steal).
+        inline fn casNext(self: *Self, expected: *T) bool {
+            if (!stealable) {
+                self.next = null;
+                return true;
+            }
+            return @cmpxchgStrong(?*T, &self.next, expected, null, .acq_rel, .acquire) == null;
+        }
+
         /// Advance `head` from `expected` to `new`. Returns true on success. A plain
         /// store when not stealable (uncontended); a CAS against racing thieves
         /// otherwise. `weak` selects cmpxchgWeak (retry loops) vs Strong.
@@ -140,6 +168,15 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
 
         pub fn init(overflow: *OverflowQueue(T)) Self {
             return .{ .overflow = overflow };
+        }
+
+        /// Owner-only push into the next-up slot (Go's runqput with next=true).
+        /// A previous occupant is demoted to the ring tail; returns true when
+        /// that happened so the caller can announce the newly queued work.
+        pub fn pushNext(self: *Self, node: *T) bool {
+            const prev = self.swapNext(node) orelse return false;
+            self.push(prev);
+            return true;
         }
 
         /// Owner-only push (FIFO, to the tail). On a full ring, spills half the
@@ -170,8 +207,14 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
             return true;
         }
 
-        /// Owner-only pop (FIFO, from the head). CAS because stealers race the head.
+        /// Owner-only pop: the next-up slot first, then the ring head (Go's
+        /// runqget). CAS because stealers race both the slot and the head.
         pub fn pop(self: *Self) ?*T {
+            // One CAS attempt on the slot: only a thief can zero it, so on
+            // failure it's simply gone — fall through to the ring.
+            if (self.loadNext()) |node| {
+                if (self.casNext(node)) return node;
+            }
             while (true) {
                 const h = self.loadHead();
                 const t = self.ownTail();
@@ -218,7 +261,16 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
                 const vt = victim.loadTail(); // sync with victim's producer
                 var take = vt -% h;
                 take -= take / 2; // ceil half
-                if (take == 0) return null; // victim empty
+                if (take == 0) {
+                    // Empty ring: try the victim's next-up slot. Back off
+                    // first so a victim that just woke the task gets a chance
+                    // to run it itself, instead of us thrashing communicating
+                    // tasks between threads (Go's runqgrab).
+                    const node = victim.loadNext() orelse return null;
+                    os_time.sleep(.fromMicroseconds(3));
+                    if (victim.casNext(node)) return node;
+                    continue; // slot changed under us; re-examine the victim
+                }
                 if (take > capacity / 2) continue; // inconsistent h/t read; retry
                 if (take > dst_space) take = dst_space; // clamp to the thief's room
                 var i: u32 = 0;
@@ -255,15 +307,18 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
             if (got > 0) self.storeTail(tt);
         }
 
-        /// Number of tasks currently in the ring (used for maybeYield fairness).
+        /// Number of tasks currently queued, including the next-up slot.
         pub fn len(self: *const Self) u32 {
             const t = self.loadTail();
             const h = self.loadHead();
-            return t -% h;
+            return (t -% h) + @intFromBool(self.loadNext() != null);
         }
 
+        /// Owner-side emptiness check (ring and next-up slot). Callers are the
+        /// owning executor, which is the only mutator of `tail` and the only
+        /// installer of `next`, so no runqempty-style re-read is needed.
         pub fn isEmpty(self: *const Self) bool {
-            return self.loadHead() == self.loadTail();
+            return self.loadNext() == null and self.loadHead() == self.loadTail();
         }
     };
 }
@@ -285,6 +340,41 @@ const TestNode = struct {
 const TestQueue = LocalRunQueue(TestNode, true);
 const TestLocalQueue = LocalRunQueue(TestNode, false);
 const TestOverflow = OverflowQueue(TestNode);
+
+test "LocalRunQueue: next-up slot pops first, previous occupant demoted" {
+    var ov: TestOverflow = .{};
+    var q = TestQueue.init(&ov);
+
+    var a = TestNode{ .id = 1 };
+    var b = TestNode{ .id = 2 };
+    var c = TestNode{ .id = 3 };
+
+    q.push(&a);
+    try testing.expect(!q.pushNext(&b)); // empty slot: nothing demoted
+    try testing.expectEqual(2, q.len());
+    try testing.expect(q.pushNext(&c)); // demotes b to the ring tail
+
+    try testing.expectEqual(3, q.pop().?.id); // slot first
+    try testing.expectEqual(1, q.pop().?.id); // then ring FIFO
+    try testing.expectEqual(2, q.pop().?.id);
+    try testing.expect(q.pop() == null);
+    try testing.expect(q.isEmpty());
+}
+
+test "LocalRunQueue: steal takes the next-up slot when the ring is empty" {
+    var ov1: TestOverflow = .{};
+    var ov2: TestOverflow = .{};
+    var victim = TestQueue.init(&ov1);
+    var thief = TestQueue.init(&ov2);
+
+    var a = TestNode{ .id = 1 };
+    _ = victim.pushNext(&a);
+
+    const got = thief.steal(&victim) orelse return error.Unexpected;
+    try testing.expectEqual(1, got.id);
+    try testing.expect(victim.isEmpty());
+    try testing.expect(thief.isEmpty()); // handed back to run, not queued
+}
 
 test "LocalRunQueue: FIFO push and pop within capacity" {
     var ov: TestOverflow = .{};


### PR DESCRIPTION
Builds on #579. A task woken by the currently running task goes into a next-up slot on the run queue instead of the ring, and runs right after the waker on the same executor.

The motivation is communicating-task placement: a channel ping-pong pair on the multi-threaded runtime used to scatter across executors — the wake pushed the task to the ring and armed a searcher, which promptly stole it, so every message paid a cross-executor wake. The slot placement itself is deliberately not announced; a previous occupant demoted to the ring is ordinary queued work and is announced as usual. The slot is stealable exactly like Go's runnext: a thief that finds the ring empty backs off ~3us to give the owner a chance to run the task itself, then CASes the slot, so a stalled owner can't sit on a runnable task.

Fairness is the same story as Go's inheritTime: a slot chain shares the executor's tick budget (#579), so it gets cut off at the ~100us poll target like any other work, and demoted slot occupants land in the ring where stealing applies.

Wakes from scheduler context (I/O completions, timers) keep going to the ring: they're already local to the right executor and have no waker to pair with.

## Benchmarks

ReleaseFast, medians, same machine as #579.

| benchmark (native API, mt) | before | after | st reference |
|---|---|---|---|
| channel ping-pong | 12.9 ms | **9.2 ms** | 9.0 ms |
| worker pool 1 -> 1000, work=64 | ~2.0M items/s | ~1.8M items/s (noise) | 4.1M |
| worker pool 1000 -> 1 (fan-in) | ~2.5M items/s | ~2.4M items/s | 19M |
| tcp echo 1000 conns | ~225k msgs/s | ~220k msgs/s | 72k |
| tcp echo 1 conn | 41k msgs/s | 41k msgs/s | 55k |

The multi-threaded channel ping-pong now matches the single-threaded runtime — the pair settles on one executor and stays there, since ping-pong wakes never displace a slot occupant. Fan-out/fan-in patterns wake many tasks back to back, so each wake demotes the previous one to the ring with a normal announcement, and their behavior is unchanged.