### PR TITLE
I/O load shedding: rebalance sticky I/O across executors

### DIFF
--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -227,6 +227,8 @@ pub const LoopState = struct {
 
     active: usize = 0,
     /// I/O operations submitted to backend awaiting completion
+    // Plain counter mutated only by the owner thread, but read cross-thread
+    // by the scheduler's load shedding, hence the atomic accessors below.
     inflight_io: usize = 0,
 
     wake_requested: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
@@ -280,12 +282,13 @@ pub const LoopState = struct {
 
     /// Increment the inflight I/O counter. On multi-threaded backends
     /// (IOCP) this routes to a shared atomic; on single-threaded backends
-    /// it's a simple local increment.
+    /// only the owner thread mutates, but other executors read the count for
+    /// load shedding, so the access is a monotonic atomic either way.
     pub fn incrInflight(self: *LoopState) void {
         if (comptime Backend.capabilities.is_multi_threaded) {
             _ = self.loop.loop_group.shared.inflight_io.fetchAdd(1, .monotonic);
         } else {
-            self.inflight_io += 1;
+            @atomicStore(usize, &self.inflight_io, self.inflight_io + 1, .monotonic);
         }
     }
 
@@ -294,16 +297,16 @@ pub const LoopState = struct {
         if (comptime Backend.capabilities.is_multi_threaded) {
             _ = self.loop.loop_group.shared.inflight_io.fetchSub(1, .monotonic);
         } else {
-            self.inflight_io -= 1;
+            @atomicStore(usize, &self.inflight_io, self.inflight_io - 1, .monotonic);
         }
     }
 
-    /// Read the inflight I/O counter.
+    /// Read the inflight I/O counter (any thread).
     pub fn loadInflight(self: *const LoopState) usize {
         if (comptime Backend.capabilities.is_multi_threaded) {
             return @intCast(self.loop.loop_group.shared.inflight_io.load(.monotonic));
         } else {
-            return self.inflight_io;
+            return @atomicLoad(usize, &self.inflight_io, .monotonic);
         }
     }
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -734,7 +734,7 @@ pub const Executor = struct {
             if (victim_idle) continue;
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
-                self.run_queue.push(node);
+                _ = self.run_queue.push(node);
                 self.runtime.armSearcher();
                 return true;
             }
@@ -788,8 +788,16 @@ pub const Executor = struct {
             return;
         }
 
-        self.run_queue.push(&task.awaitable.wait_node);
-        self.runtime.armSearcher();
+        // A first task pushed onto an empty ring from scheduler context (an
+        // I/O completion wake) needs no searcher: this executor is inside its
+        // run loop and pops it right after completion processing — no thief
+        // can beat that, an announcement can only drag the task (and its I/O
+        // home) to another executor for nothing. Wakes from a running task
+        // still announce, since the waker may keep the executor busy.
+        const was_empty = self.run_queue.push(&task.awaitable.wait_node);
+        if (!was_empty or self.current_task != null) {
+            self.runtime.armSearcher();
+        }
     }
 
     /// Schedule a task from another thread (or no executor context) onto its home

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -339,6 +339,11 @@ pub const Executor = struct {
     // the hot path).
     tick_checkpoint_countdown: u32 = checkpoint_interval,
 
+    // How many wakes to shed to the global queue this tick, set by
+    // recomputeShedQuota() when this executor's I/O load is above the runtime
+    // average (see scheduleTaskLocal).
+    shed_quota: u32 = 0,
+
     // Deferred cleanup for the task that just yielded away from this executor.
     // Processed by the next coroutine to run (at landing sites: startFn, yield resume, run loop).
     pending_cleanup: TaskCleanup = .none,
@@ -604,6 +609,7 @@ pub const Executor = struct {
             self.tick_task_count = 0;
             self.tick_expired = false;
             self.tick_checkpoint_countdown = checkpoint_interval;
+            self.recomputeShedQuota();
 
             if (need_fresh_drain) {
                 need_fresh_drain = false;
@@ -614,6 +620,33 @@ pub const Executor = struct {
             if (check_ready and self.main_task.state.load(.acquire).tag == .ready) {
                 return;
             }
+        }
+    }
+
+    /// Maximum wakes shed to the global queue per tick; rebalancing a few
+    /// connections per ~100us converges quickly without turning the global
+    /// queue into the primary scheduling path.
+    const max_shed_per_tick = 4;
+
+    /// Once per tick, compare this executor's I/O-resident load (in-flight
+    /// ops == tasks parked on this ring) against the runtime average; the
+    /// excess becomes this tick's shed quota (see scheduleTaskLocal). Purely
+    /// decentralized: every executor reads the per-loop counters and makes
+    /// its own call.
+    fn recomputeShedQuota(self: *Executor) void {
+        self.shed_quota = 0;
+        if (!self.runtime.stealingActive()) return;
+
+        const executors = self.runtime.executors.items;
+        const mine = self.loop.state.loadInflight();
+        if (mine < 2) return; // nothing worth shedding
+        var total: usize = 0;
+        for (executors) |e| total += e.loop.state.loadInflight();
+        const avg = total / executors.len;
+        // The +1 keeps neighbors one apart from trading the same task back
+        // and forth forever.
+        if (mine > avg + 1) {
+            self.shed_quota = @intCast(@min(mine - avg, max_shed_per_tick));
         }
     }
 
@@ -740,13 +773,16 @@ pub const Executor = struct {
 
         std.debug.assert(getCurrentExecutorOrNull() == self);
 
-        // Spill to the global queue when this executor is already backlogged
-        // and someone is idle. Tasks woken by I/O completions otherwise pile up
-        // forever on the executor that owns their ring: the steal window
-        // between wake and local pop is sub-microsecond, so an idle executor
-        // never catches them. One spill rebalances a connection permanently —
-        // its next ops are submitted wherever it runs.
-        if (!self.run_queue.isEmpty() and self.runtime.stealingActive() and self.runtime.idle_mask.load(.monotonic) != 0) {
+        // Load shedding: I/O is sticky (a task's ops live on the ring of the
+        // executor it runs on — by preference on io_uring, by force on epoll
+        // and kqueue), so work stealing alone cannot rebalance I/O-bound
+        // tasks: their wakes are always local and the wake-to-pop window is
+        // too small for a thief. An executor that measured itself above the
+        // runtime's average I/O load at the last tick sheds the excess by
+        // routing that many wakes to the global queue; less loaded executors
+        // pull from it, and a shed task's I/O re-homes wherever it runs next.
+        if (self.shed_quota > 0) {
+            self.shed_quota -= 1;
             self.run_queue.overflow.push(&task.awaitable.wait_node);
             self.runtime.armSearcher();
             return;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -740,6 +740,18 @@ pub const Executor = struct {
 
         std.debug.assert(getCurrentExecutorOrNull() == self);
 
+        // Spill to the global queue when this executor is already backlogged
+        // and someone is idle. Tasks woken by I/O completions otherwise pile up
+        // forever on the executor that owns their ring: the steal window
+        // between wake and local pop is sub-microsecond, so an idle executor
+        // never catches them. One spill rebalances a connection permanently —
+        // its next ops are submitted wherever it runs.
+        if (!self.run_queue.isEmpty() and self.runtime.stealingActive() and self.runtime.idle_mask.load(.monotonic) != 0) {
+            self.run_queue.overflow.push(&task.awaitable.wait_node);
+            self.runtime.armSearcher();
+            return;
+        }
+
         self.run_queue.push(&task.awaitable.wait_node);
         self.runtime.armSearcher();
     }

--- a/src/task.zig
+++ b/src/task.zig
@@ -724,18 +724,11 @@ pub fn spawnTask(
     start: Closure.Start,
     group: ?*Group,
 ) !*AnyTask {
-    // With work stealing active, spawn onto the current executor: the task goes
-    // to the local ring (no global-queue push, no wake syscall) and stealing
-    // redistributes if load piles up. Round-robin is only needed to spread load
-    // when nobody can steal, or when spawning from outside the runtime.
-    const executor = blk: {
-        if (rt.stealingActive()) {
-            if (runtime.getCurrentExecutorOrNull()) |cur| {
-                if (cur.runtime == rt) break :blk cur;
-            }
-        }
-        break :blk try getNextExecutor(rt);
-    };
+    // New tasks are homed round-robin and scheduled through the global queue
+    // with a wake of the home executor. Initial spread matters: on epoll and
+    // kqueue backends a socket is pinned to the loop that registers it, so a
+    // task's first executor decides where its I/O lives.
+    const executor = try getNextExecutor(rt);
 
     const task = try AnyTask.create(
         executor,

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -144,16 +144,17 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
 
         /// Owner-only push (FIFO, to the tail). On a full ring, spills half the
         /// ring plus this node to the overflow queue (Go's runqput/runqputslow).
-        pub fn push(self: *Self, node: *T) void {
+        /// Returns true when the ring was empty before the push.
+        pub fn push(self: *Self, node: *T) bool {
             while (true) {
                 const h = self.loadHead(); // synchronize with consumers
                 const t = self.ownTail(); // owner is the sole producer
                 if (t -% h < capacity) {
                     self.buffer[t & mask] = node;
                     self.storeTail(t +% 1); // publish the slot
-                    return;
+                    return t == h;
                 }
-                if (self.pushOverflow(node, h, t)) return;
+                if (self.pushOverflow(node, h, t)) return false;
                 // Ring was full but a steal freed space; retry.
             }
         }
@@ -293,7 +294,7 @@ test "LocalRunQueue: FIFO push and pop within capacity" {
     var nodes: [10]TestNode = undefined;
     for (&nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        q.push(n);
+        _ = q.push(n);
     }
     try testing.expect(ov.isEmpty());
     try testing.expectEqual(10, q.len());
@@ -315,7 +316,7 @@ test "LocalRunQueue: fills to capacity without overflow" {
     defer testing.allocator.free(nodes);
     for (nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        q.push(n);
+        _ = q.push(n);
     }
     try testing.expect(ov.isEmpty()); // exactly full, nothing spilled
     try testing.expectEqual(cap, q.len());
@@ -335,7 +336,7 @@ test "LocalRunQueue: overflow spills to the overflow queue and everything drains
     defer testing.allocator.free(nodes);
     for (nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        q.push(n);
+        _ = q.push(n);
     }
     try testing.expect(!ov.isEmpty()); // spilled
 
@@ -375,7 +376,7 @@ test "LocalRunQueue: popIf leaves a non-runnable head in place" {
     var nodes: [3]TestNode = undefined;
     for (&nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        q.push(n);
+        _ = q.push(n);
     }
     // Head is id 0; reject it -> popIf returns null and leaves it in place.
     try testing.expect(q.popIf(RejectCtx{ .reject_id = 0 }, notRejected) == null);
@@ -397,7 +398,7 @@ test "LocalRunQueue: non-stealable variant pushes, pops, and overflows" {
     defer testing.allocator.free(nodes);
     for (nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        q.push(n);
+        _ = q.push(n);
     }
     try testing.expect(!ov.isEmpty()); // spilled to overflow
 
@@ -422,7 +423,7 @@ test "LocalRunQueue: steal takes half into the thief and returns one" {
     var nodes: [4]TestNode = undefined;
     for (&nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        victim.push(n);
+        _ = victim.push(n);
     }
 
     // victim holds 0,1,2,3 (head=0). Steal ceil(4/2)=2 (ids 0,1): returns the last
@@ -447,7 +448,7 @@ test "LocalRunQueue: steal with an odd count takes the ceil half" {
     var nodes: [7]TestNode = undefined;
     for (&nodes, 0..) |*n, i| {
         n.* = .{ .id = i };
-        victim.push(n);
+        _ = victim.push(n);
     }
     // 7 tasks -> steal 7 - 7/2 = 4 (ids 0..3), return id 3, thief keeps 0,1,2;
     // victim left with 4,5,6.
@@ -471,7 +472,7 @@ test "LocalRunQueue: index cycling past capacity stays correct" {
     var node: TestNode = .{ .id = 7 };
     // Cycle head/tail well past capacity to exercise the & mask indexing.
     for (0..10_000) |_| {
-        q.push(&node);
+        _ = q.push(&node);
         const n = q.pop() orelse return error.Unexpected;
         try testing.expectEqual(7, n.id);
     }
@@ -520,7 +521,7 @@ test "LocalRunQueue: concurrent push/pop and steal loses or duplicates no task" 
     var i: usize = 0;
     var buf: [64]*TestNode = undefined;
     while (i < N) : (i += 1) {
-        owner.push(&nodes[i]);
+        _ = owner.push(&nodes[i]);
         if (i % 64 == 0) {
             if (owner.pop()) |n| ctx.mark(n);
         }
@@ -600,7 +601,7 @@ test "LocalRunQueue: multiple concurrent stealers lose or duplicate no task" {
     }
 
     var i: usize = 0;
-    while (i < N) : (i += 1) owner.push(&nodes[i]);
+    while (i < N) : (i += 1) _ = owner.push(&nodes[i]);
     ctx.stop.store(true, .release);
     for (&threads) |*th| th.join();
 


### PR DESCRIPTION
Found while building the driver-based TCP benchmarks (separate C load generator, driver and server pinned to disjoint cores, so the runtime under test is only ever the server side).

I/O is sticky: a task's ops live on the ring of the executor it runs on — by preference on io_uring, by force on epoll/kqueue. Work stealing cannot rebalance I/O-bound tasks, because their wakes are always local and the wake-to-pop window is sub-microsecond: an idle executor gets searcher-woken tens of thousands of times a second and never catches anything. A multi-threaded TCP server ended up doing all of its work on one core (second executor at 0.0% CPU), byte-for-byte identical to single-threaded on the streaming benchmark.

Go avoids this problem structurally — one shared netpoller means readiness is global and balance is free (at the price of a central funnel, which is why zio beats go on 1000-connection echo). With per-executor rings we need an explicit balancer:

- **Round-robin homes for new tasks** (reverts spawn-onto-current-executor): initial spread is the only placement decision that exists on epoll/kqueue backends, and spawning everything onto the acceptor's executor concentrated whole servers onto one core.
- **Decentralized load shedding**: once per tick (~100us) each executor compares its in-flight I/O count (== tasks parked on its ring) against the runtime average; if above, it sheds the excess by routing up to 4 wakes to the global queue. Less loaded executors pull from it, and a shed task's I/O re-homes wherever it runs next, so one shed rebalances a connection permanently. No central coordinator, no idle-mask races; the cap keeps the global queue a rebalancing channel rather than a scheduling path.

## Benchmarks

Driver/server split, i7-6700 (2 driver cores, 2 server cores), 8 connections, 64KB chunks, ReleaseFast:

| server workload | before | after | go | tokio |
|---|---|---|---|---|
| stream write, 8 conns | 3.5 GB/s | **7.3 GB/s** | 7.1 | 7.4 |
| stream write, 1 conn | 2.7 GB/s | **3.3 GB/s** | 3.8 | 3.6 |
| stream read, 8 conns | 5.0 GB/s | **7.7 GB/s** | 7.5 | 7.7 |
| echo 1000 conns | 146k msgs/s | **166k msgs/s** | 108k | 150k |
| echo 1 conn 4KB | 25.1k msgs/s | 25.7k msgs/s | 23.4k | 24.7k |

In-process benchmarks (channel ping-pong, worker pool fan-out/fan-in, spawn) unchanged within noise — non-I/O workloads keep inflight counts below the shedding threshold, so the balancer never engages there.


Follow-up commit: the first wake pushed onto an empty ring from scheduler context no longer arms a searcher — the executor is in its run loop and pops it immediately, so the announcement only caused an idle executor to occasionally win the race and drag the connection to another ring. That fixed single-connection streaming on mt (2.7 -> 3.3 GB/s, now matching st) and, as a bonus, removed enough wakeup churn to lift 1000-connection echo from 147k to 166k msgs/s.