### PR TITLE
Per-completion flags: defer_callback and rearm

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -276,6 +276,9 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
 
     // Async path: Submit to the event loop and wait for completion
     task.getExecutor().loop.add(c);
+    // Inline completions never park; charge the coop budget so they still
+    // hit a yield point.
+    const completed_inline = waiter.mode.direct.notify.state.load(.acquire) != 0;
     waiter.wait(1, .allow_cancel) catch |err| switch (err) {
         error.Canceled => {
             // On cancellation, cancel the I/O and wait for completion
@@ -293,6 +296,9 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
             return;
         },
     };
+    if (completed_inline) {
+        task.getExecutor().maybeYield(.reschedule, .no_cancel);
+    }
 }
 
 /// Runs an I/O operation to completion without allowing cancellation.
@@ -320,7 +326,11 @@ pub fn waitForIoUncancelable(c: *ev.Completion) void {
 
     // Async path: Submit to the event loop and wait for completion (no cancel)
     task.getExecutor().loop.add(c);
+    const completed_inline = waiter.mode.direct.notify.state.load(.acquire) != 0;
     waiter.wait(1, .no_cancel);
+    if (completed_inline) {
+        task.getExecutor().maybeYield(.reschedule, .no_cancel);
+    }
 }
 
 /// Runs an I/O operation to completion with a timeout.

--- a/src/common.zig
+++ b/src/common.zig
@@ -260,7 +260,7 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     c.callback = Waiter.callback;
     // The callback only wakes the parked task — nothing that needs the
     // deferred-finish safety net, and the hot path skips the queue round trip.
-    c.flags.defer_callback = false;
+    c.flags = .{ .defer_callback = false }; // single-shot wait: no rearm either
 
     defer if (std.debug.runtime_safety) {
         c.callback = null;
@@ -310,7 +310,7 @@ pub fn waitForIoUncancelable(c: *ev.Completion) void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
     c.callback = Waiter.callback;
-    c.flags.defer_callback = false;
+    c.flags = .{ .defer_callback = false };
 
     defer if (std.debug.runtime_safety) {
         c.callback = null;

--- a/src/common.zig
+++ b/src/common.zig
@@ -258,6 +258,9 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
     c.callback = Waiter.callback;
+    // The callback only wakes the parked task — nothing that needs the
+    // deferred-finish safety net, and the hot path skips the queue round trip.
+    c.flags.defer_callback = false;
 
     defer if (std.debug.runtime_safety) {
         c.callback = null;
@@ -301,6 +304,7 @@ pub fn waitForIoUncancelable(c: *ev.Completion) void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
     c.callback = Waiter.callback;
+    c.flags.defer_callback = false;
 
     defer if (std.debug.runtime_safety) {
         c.callback = null;

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -267,19 +267,15 @@ pub const Op = enum {
 
 pub const Completion = struct {
     pub const Flags = packed struct(u8) {
-        /// Finish this completion through the loop's completions queue instead
-        /// of synchronously from whatever context completed it. Callbacks run
-        /// at the end of the tick, never nested inside backend processing or
-        /// another callback — the safe default: a deferred callback may freely
-        /// chain further operations. Opt out only for callbacks that just
-        /// record a result or wake a waiter, where the queue round trip is
-        /// wasted (waitForIo does).
+        /// Finish through the completions queue instead of synchronously from
+        /// whatever context completed the op; a deferred callback may freely
+        /// chain further operations. Opt out only when the callback just
+        /// records a result or wakes a waiter (waitForIo does).
         defer_callback: bool = true,
         /// Re-add the completion after its callback returns (persistent
-        /// handles: recurring timers, notification handles). Implies the
-        /// deferred finish above — a re-add from a synchronous finish could
-        /// recurse when the handle completes immediately (e.g. an Async that
-        /// was notified again). The callback must not free the completion.
+        /// handles). Implies the deferred finish: a synchronous re-add can
+        /// recurse when the handle completes immediately. The callback must
+        /// not free the completion.
         rearm: bool = false,
         _reserved: u6 = 0,
     };

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -426,6 +426,7 @@ pub const Group = struct {
         std.debug.assert(c.state == .new);
         std.debug.assert(self.c.state == .new); // Group must not be submitted yet
         std.debug.assert(c.group.owner == null);
+        std.debug.assert(!c.flags.rearm); // groups are single-shot
         c.group.next = self.head;
         c.group.owner = self;
         c.group.owner_callback = &groupCallback;

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -266,8 +266,28 @@ pub const Op = enum {
 };
 
 pub const Completion = struct {
+    pub const Flags = packed struct(u8) {
+        /// Finish this completion through the loop's completions queue instead
+        /// of synchronously from whatever context completed it. Callbacks run
+        /// at the end of the tick, never nested inside backend processing or
+        /// another callback — the safe default: a deferred callback may freely
+        /// chain further operations. Opt out only for callbacks that just
+        /// record a result or wake a waiter, where the queue round trip is
+        /// wasted (waitForIo does).
+        defer_callback: bool = true,
+        /// Re-add the completion after its callback returns (persistent
+        /// handles: recurring timers, notification handles). Implies the
+        /// deferred finish above — a re-add from a synchronous finish could
+        /// recurse when the handle completes immediately (e.g. an Async that
+        /// was notified again). The callback must not free the completion.
+        rearm: bool = false,
+        _reserved: u6 = 0,
+    };
+
     op: Op,
     state: State = .new,
+
+    flags: Flags = .{},
 
     userdata: ?*anyopaque = null,
     callback: ?*const CallbackFn = null,

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -349,7 +349,9 @@ pub const Completion = struct {
         c.state = .new;
         c.has_result = false;
         c.err = null;
-        c.loop = null;
+        // `loop` is kept: Async.notify() reads it cross-thread, and a null
+        // window during a rearm re-add loses the wake. A stale pointer only
+        // causes a spurious wake, and add() overwrites it.
         c.cancel_state.store(.{}, .release);
         c.cancel_next = null;
         c.group.next = null;
@@ -528,8 +530,8 @@ pub const Async = struct {
         const was_pending = self.pending.swap(1, .release);
         if (was_pending == 0) {
             // Only notify loop if transitioning from not-pending to pending
-            // If loop is not set (not actively waiting), this is a no-op
-            if (self.c.loop) |loop| {
+            // If loop is not set (never added), this is a no-op
+            if (@atomicLoad(?*Loop, &self.c.loop, .acquire)) |loop| {
                 loop.wakeAsync();
             }
         }

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -842,7 +842,7 @@ pub const Loop = struct {
         std.debug.assert(completion.state == .new);
 
         // Set the loop reference for cross-thread cancellation
-        completion.loop = self;
+        @atomicStore(?*Loop, &completion.loop, self, .release);
 
         if (completion.cancel_state.load(.acquire).requested) {
             // Directly mark it as canceled

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -384,11 +384,19 @@ pub const LoopState = struct {
         // Only call finish if not in cancel queue
         // If in_queue, cancel queue processing will call finishCompletion
         if (!old.in_queue) {
-            if (self.loop.defer_callbacks) {
-                self.completions.push(completion);
-            } else {
-                self.finishCompletion(completion);
-            }
+            self.dispatchCompletion(completion);
+        }
+    }
+
+    /// Finish a completed completion now, or queue it for processCompletions
+    /// when it opted into deferred finishing (rearm implies deferral: a
+    /// re-add from a synchronous finish could recurse when the handle
+    /// completes immediately).
+    pub fn dispatchCompletion(self: *LoopState, completion: *Completion) void {
+        if (completion.flags.defer_callback or completion.flags.rearm) {
+            self.completions.push(completion);
+        } else {
+            self.finishCompletion(completion);
         }
     }
 
@@ -402,12 +410,22 @@ pub const LoopState = struct {
         // run LAST, with nothing touching `completion` afterward. Cache the owner
         // callback now, before `call` — for a standalone completion `call` wakes a
         // waiter that may free `completion`, so we must not read it afterward.
+        // (Rearm handles are exempt from the freeing contract by definition.)
         const owner_callback = completion.group.owner_callback;
+        const rearm = completion.flags.rearm;
 
         // The completion's own callback runs first: for a group member it reports
         // the member's own result while the member is still alive; for a standalone
         // completion (no owner) it is the last thing we do.
         completion.call(self.loop);
+
+        // Re-add persistent handles once their own callback has run. This runs
+        // from processCompletions (rearm implies deferred finish), never nested
+        // inside Loop.add, so an immediately-completing handle just loops back
+        // through the completions queue.
+        if (rearm) {
+            self.loop.add(completion);
+        }
 
         // Then notify the group/queue owner. This can drive the group to completion
         // and free the frame this member lives on (e.g. the last `.gather` member
@@ -546,7 +564,6 @@ pub const Loop = struct {
     /// deadlines at least this often; this bounds how late such a timer can
     /// fire after a suspend/step. Unused once a backend arms them natively.
     wall_clock_cap: Duration = .fromSeconds(10),
-    defer_callbacks: bool = true,
 
     /// Cross-thread cancel queue (lock-free MPSC)
     cancel_queue: std.atomic.Value(?*Completion) = std.atomic.Value(?*Completion).init(null),
@@ -560,7 +577,6 @@ pub const Loop = struct {
         thread_pool: ?*ThreadPool = null,
         loop_group: ?*LoopGroup = null,
         queue_size: u16 = default_queue_size,
-        defer_callbacks: bool = true,
     };
 
     pub fn init(self: *Loop, options: Options) !void {
@@ -570,7 +586,6 @@ pub const Loop = struct {
             .allocator = options.allocator,
             .thread_pool = options.thread_pool,
             .loop_group = undefined,
-            .defer_callbacks = options.defer_callbacks,
         };
 
         if (options.loop_group) |group| {
@@ -718,7 +733,7 @@ pub const Loop = struct {
                 old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
             }
             if (old.completed) {
-                self.state.finishCompletion(completion);
+                self.state.dispatchCompletion(completion);
             }
         }
 
@@ -1194,7 +1209,16 @@ pub const Loop = struct {
             self.state.markCompleted(completion);
         }
 
-        while (self.state.completions.pop()) |completion| {
+        // Snapshot: drain only what was queued at entry. A rearm completion
+        // can re-complete itself from its own callback (a re-armed Async that
+        // was already notified again), and chasing those in the same loop
+        // would let a sustained notify stream pin us here. Deferrals created
+        // during this drain land on the fresh queue and run next tick, which
+        // stays non-blocking: a non-empty completions queue forces a zero
+        // poll timeout.
+        var snapshot = self.state.completions;
+        self.state.completions = .{};
+        while (snapshot.pop()) |completion| {
             self.state.finishCompletion(completion);
         }
     }

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -412,7 +412,7 @@ pub const LoopState = struct {
         // waiter that may free `completion`, so we must not read it afterward.
         // (Rearm handles are exempt from the freeing contract by definition.)
         const owner_callback = completion.group.owner_callback;
-        const rearm = completion.flags.rearm;
+        const was_rearm = completion.flags.rearm;
 
         // The completion's own callback runs first: for a group member it reports
         // the member's own result while the member is still alive; for a standalone
@@ -422,8 +422,10 @@ pub const LoopState = struct {
         // Re-add persistent handles once their own callback has run. This runs
         // from processCompletions (rearm implies deferred finish), never nested
         // inside Loop.add, so an immediately-completing handle just loops back
-        // through the completions queue.
-        if (rearm) {
+        // through the completions queue. The flag is re-read so a callback can
+        // stop its own handle by clearing it — guarded by the cached value,
+        // since only rearm completions are guaranteed still alive here.
+        if (was_rearm and completion.flags.rearm) {
             self.loop.add(completion);
         }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -341,31 +341,6 @@ pub const LoopState = struct {
         self.markCompleted(completion);
     }
 
-    /// Like markCompletedFromBackend, but always finishes via the deferred
-    /// completion queue instead of possibly running the callback inline. Used by
-    /// backends that complete an op synchronously inside `submit` (e.g. an
-    /// optimistic socket syscall that succeeds): finishing inline there would
-    /// re-enter the submit/add path of whatever driver issued the op.
-    pub fn markCompletedDeferredFromBackend(self: *LoopState, completion: *Completion) void {
-        self.decrInflight();
-
-        std.debug.assert(completion.state == .running);
-        std.debug.assert(completion.has_result);
-
-        var old = completion.cancel_state.load(.acquire);
-        while (true) {
-            var new = old;
-            new.completed = true;
-            old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
-        }
-        completion.state = .completed;
-
-        // If in_queue, cancel queue processing will call finishCompletion.
-        if (!old.in_queue) {
-            self.completions.push(completion);
-        }
-    }
-
     pub fn markCompleted(self: *LoopState, completion: *Completion) void {
         std.debug.assert(completion.state == .running);
         std.debug.assert(completion.has_result);
@@ -388,10 +363,8 @@ pub const LoopState = struct {
         }
     }
 
-    /// Finish a completed completion now, or queue it for processCompletions
-    /// when it opted into deferred finishing (rearm implies deferral: a
-    /// re-add from a synchronous finish could recurse when the handle
-    /// completes immediately).
+    /// Finish now, or queue for processCompletions when the completion uses
+    /// deferred finishing (rearm implies it).
     pub fn dispatchCompletion(self: *LoopState, completion: *Completion) void {
         if (completion.flags.defer_callback or completion.flags.rearm) {
             self.completions.push(completion);
@@ -419,12 +392,9 @@ pub const LoopState = struct {
         // completion (no owner) it is the last thing we do.
         completion.call(self.loop);
 
-        // Re-add persistent handles once their own callback has run. This runs
-        // from processCompletions (rearm implies deferred finish), never nested
-        // inside Loop.add, so an immediately-completing handle just loops back
-        // through the completions queue. The flag is re-read so a callback can
-        // stop its own handle by clearing it — guarded by the cached value,
-        // since only rearm completions are guaranteed still alive here.
+        // Re-add persistent handles. Re-reading the flag lets a callback stop
+        // its own handle; the cached value guards it, since only rearm
+        // completions are guaranteed still alive here.
         if (was_rearm and completion.flags.rearm) {
             self.loop.add(completion);
         }
@@ -1211,13 +1181,10 @@ pub const Loop = struct {
             self.state.markCompleted(completion);
         }
 
-        // Snapshot: drain only what was queued at entry. A rearm completion
-        // can re-complete itself from its own callback (a re-armed Async that
-        // was already notified again), and chasing those in the same loop
-        // would let a sustained notify stream pin us here. Deferrals created
-        // during this drain land on the fresh queue and run next tick, which
-        // stays non-blocking: a non-empty completions queue forces a zero
-        // poll timeout.
+        // Drain only what was queued at entry: a rearm completion can
+        // re-complete itself from its own callback, and chasing those here
+        // would let a notify storm pin the loop. The rest runs next tick
+        // (non-blocking; pending completions force a zero poll timeout).
         var snapshot = self.state.completions;
         self.state.completions = .{};
         while (snapshot.pop()) |completion| {

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -217,7 +217,7 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
         shard.mutex.unlock();
         log.err("sock registration table OOM", .{});
         completion.setError(error.Unexpected);
-        state.markCompletedDeferredFromBackend(completion);
+        state.markCompletedFromBackend(completion);
         return .failed;
     };
     if (!gop.found_existing) gop.value_ptr.* = .{};
@@ -241,7 +241,7 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
             if (created and entry.isEmpty()) _ = shard.map.remove(@as(u32, @bitCast(fd)));
             shard.mutex.unlock();
             completion.setError(error.Unexpected);
-            state.markCompletedDeferredFromBackend(completion);
+            state.markCompletedFromBackend(completion);
             return .failed;
         }
         owner.* = self_opaque;
@@ -299,13 +299,7 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
     shard.mutex.unlock();
 
     while (to_finish.pop()) |c| {
-        // Sends can be re-entered by the NetSendFile fallback (it re-submits a
-        // NetSend from inside its own send callback), so they must finish via the
-        // deferred queue rather than inline — same rule as submitIo.
-        switch (c.op) {
-            .net_send, .net_sendto, .net_sendmsg => state.markCompletedDeferredFromBackend(c),
-            else => state.markCompletedFromBackend(c),
-        }
+        state.markCompletedFromBackend(c);
     }
 }
 
@@ -352,16 +346,9 @@ pub fn submitIo(self: anytype, state: anytype, c: *Completion) void {
     while (true) {
         switch (Backend.checkCompletion(c, &probe)) {
             .completed => {
-                // Sends can be re-entered by the NetSendFile fallback (it
-                // re-submits a NetSend from inside its own send callback), so they
-                // must finish via the deferred queue. Reads/accepts cannot
-                // re-enter submit, so finishing them inline lets the consumer
-                // resume immediately - which keeps the producer/consumer in step
-                // and avoids an extra epoll_wait + EAGAIN per round trip.
-                switch (c.op) {
-                    .net_send, .net_sendto, .net_sendmsg => state.markCompletedDeferredFromBackend(c),
-                    else => state.markCompletedFromBackend(c),
-                }
+                // Inline finish (flags permitting) lets a bulk sender batch
+                // until WouldBlock instead of paying a poll per chunk (#525).
+                state.markCompletedFromBackend(c);
                 return;
             },
             .requeue => switch (park(self, state, fd, c)) {
@@ -377,13 +364,13 @@ pub fn submitConnect(self: anytype, state: anytype, c: *Completion) void {
     const data = c.cast(NetConnect);
     if (net.connect(data.handle, data.addr, data.addr_len)) |_| {
         c.setResult(.net_connect, {});
-        state.markCompletedDeferredFromBackend(c);
+        state.markCompletedFromBackend(c);
         return;
     } else |err| switch (err) {
         error.WouldBlock, error.ConnectionPending => {},
         else => {
             c.setError(err);
-            state.markCompletedDeferredFromBackend(c);
+            state.markCompletedFromBackend(c);
             return;
         },
     }
@@ -394,7 +381,7 @@ pub fn submitConnect(self: anytype, state: anytype, c: *Completion) void {
             if (net.getSockError(data.handle)) |se| {
                 if (se == 0) c.setResult(.net_connect, {}) else c.setError(net.errnoToConnectError(@enumFromInt(se)));
             } else |_| c.setError(error.Unexpected);
-            state.markCompletedDeferredFromBackend(c);
+            state.markCompletedFromBackend(c);
         },
     }
 }
@@ -413,7 +400,7 @@ pub fn submitPoll(self: anytype, state: anytype, c: *Completion) void {
         const ready = std.posix.poll(&pfd, 0) catch 0;
         if (ready > 0 and (pfd[0].revents & (want | std.posix.POLL.ERR | std.posix.POLL.HUP)) != 0) {
             c.setResult(.net_poll, {});
-            state.markCompletedDeferredFromBackend(c);
+            state.markCompletedFromBackend(c);
             return;
         }
         switch (park(self, state, data.handle, c)) {

--- a/src/ev/test/async_stress.zig
+++ b/src/ev/test/async_stress.zig
@@ -85,13 +85,18 @@ test "Async: cross-thread notify storm with rearm never strands work" {
     loop.add(&work.c);
 
     var threads: [num_producers]std.Thread = undefined;
+    var spawned: usize = 0;
+    errdefer for (threads[0..spawned]) |t| t.join();
     for (&threads) |*t| {
         t.* = try std.Thread.spawn(.{}, producer, .{ &shared, &work, per_producer });
+        spawned += 1;
     }
 
-    try loop.run(.until_done);
-
+    // Join before propagating a loop error: the producers publish into
+    // stack-local state that must not be unwound under them.
+    const run_result = loop.run(.until_done);
     for (threads) |t| t.join();
+    try run_result;
 
     // The callback that saw the final count may have left a raced remainder;
     // one more explicit drain settles it.
@@ -125,6 +130,7 @@ test "Async: notify racing the rearm re-add is never lost" {
 
     const Ctx = struct {
         seen: std.atomic.Value(usize) = .init(0),
+        abort: std.atomic.Value(bool) = .init(false),
         stop: *Async,
 
         fn cb(l: *Loop, c: *Completion) void {
@@ -154,6 +160,7 @@ test "Async: notify racing the rearm re-add is never lost" {
                 while (true) {
                     const seen = c.seen.load(.acquire);
                     if (seen > last or seen >= rounds) break;
+                    if (c.abort.load(.acquire)) return; // loop died; stop spinning
                     std.atomic.spinLoopHint();
                 }
                 last = c.seen.load(.acquire);
@@ -161,8 +168,12 @@ test "Async: notify racing the rearm re-add is never lost" {
         }
     }.run, .{ &work, &ctx });
 
-    try loop.run(.until_done);
+    // On a loop error the producer would spin forever waiting for progress;
+    // signal it before joining, and only then propagate.
+    const run_result = loop.run(.until_done);
+    ctx.abort.store(true, .release);
     t.join();
+    try run_result;
 
     try std.testing.expect(ctx.seen.load(.acquire) >= rounds);
 }

--- a/src/ev/test/async_stress.zig
+++ b/src/ev/test/async_stress.zig
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Stress tests for the Async notify/drain protocol under cross-thread fire.
+//!
+//! The contract under test: notifications are edge-triggered and coalescing —
+//! after any notify(), the callback runs at least once, and a callback that
+//! drains its guarded state to empty never strands work, no matter how
+//! notify() interleaves with the rearm re-add (which can complete the handle
+//! immediately when a notification already landed).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Loop = @import("../loop.zig").Loop;
+const completion = @import("../completion.zig");
+const Async = completion.Async;
+const Completion = completion.Completion;
+const OsMutex = @import("../../os/thread.zig").Mutex;
+
+const Shared = struct {
+    queue_mutex: OsMutex = .init(),
+    queue_items: usize = 0,
+    consumed: usize = 0,
+    produced_total: usize,
+    stop: *Async,
+
+    fn drainCallback(loop: *Loop, c: *Completion) void {
+        _ = loop;
+        const async_handle: *Async = c.cast(Async);
+        const self: *Shared = @ptrCast(@alignCast(async_handle.c.userdata.?));
+
+        // Drain everything present; the edge-triggered contract makes
+        // anything left behind here a stranding bug.
+        self.queue_mutex.lock();
+        const got = self.queue_items;
+        self.queue_items = 0;
+        self.queue_mutex.unlock();
+        self.consumed += got;
+
+        if (self.consumed >= self.produced_total) {
+            self.stop.notify();
+        }
+    }
+};
+
+fn producer(shared: *Shared, work: *Async, count: usize) void {
+    for (0..count) |_| {
+        shared.queue_mutex.lock();
+        shared.queue_items += 1;
+        shared.queue_mutex.unlock();
+        work.notify();
+    }
+}
+
+test "Async: cross-thread notify storm with rearm never strands work" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    const num_producers = 4;
+    const per_producer = 25_000;
+
+    var loop: Loop = undefined;
+    try loop.init(.{});
+    defer loop.deinit();
+
+    var stop = Async.init();
+    stop.c.callback = struct {
+        fn cb(l: *Loop, _: *Completion) void {
+            l.stop();
+        }
+    }.cb;
+    loop.add(&stop.c);
+
+    var shared = Shared{
+        .produced_total = num_producers * per_producer,
+        .stop = &stop,
+    };
+
+    var work = Async.init();
+    work.c.callback = Shared.drainCallback;
+    work.c.userdata = &shared;
+    // rearm: the loop re-adds the handle after each callback; the re-add
+    // completes it again on the spot whenever a notify already landed, which
+    // must iterate through the completions queue, not recurse.
+    work.c.flags.rearm = true;
+    loop.add(&work.c);
+
+    var threads: [num_producers]std.Thread = undefined;
+    for (&threads) |*t| {
+        t.* = try std.Thread.spawn(.{}, producer, .{ &shared, &work, per_producer });
+    }
+
+    try loop.run(.until_done);
+
+    for (threads) |t| t.join();
+
+    // The callback that saw the final count may have left a raced remainder;
+    // one more explicit drain settles it.
+    shared.queue_mutex.lock();
+    const leftover = shared.queue_items;
+    shared.queue_mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 0), leftover);
+    try std.testing.expectEqual(shared.produced_total, shared.consumed);
+}
+
+test "Async: notify racing the rearm re-add is never lost" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    // Tight ping-pong: a single producer notifies exactly once per observed
+    // consumption, maximizing the chance that the notify lands inside the
+    // callback/re-add window. A single lost wake deadlocks the loop (caught
+    // by the iteration bound below).
+    const rounds = 50_000;
+
+    var loop: Loop = undefined;
+    try loop.init(.{});
+    defer loop.deinit();
+
+    var stop = Async.init();
+    stop.c.callback = struct {
+        fn cb(l: *Loop, _: *Completion) void {
+            l.stop();
+        }
+    }.cb;
+    loop.add(&stop.c);
+
+    const Ctx = struct {
+        seen: std.atomic.Value(usize) = .init(0),
+        stop: *Async,
+
+        fn cb(l: *Loop, c: *Completion) void {
+            _ = l;
+            const async_handle: *Async = c.cast(Async);
+            const self: *@This() = @ptrCast(@alignCast(async_handle.c.userdata.?));
+            const n = self.seen.fetchAdd(1, .acq_rel) + 1;
+            if (n >= rounds) self.stop.notify();
+        }
+    };
+
+    var ctx = Ctx{ .stop = &stop };
+
+    var work = Async.init();
+    work.c.callback = Ctx.cb;
+    work.c.userdata = &ctx;
+    work.c.flags.rearm = true;
+    loop.add(&work.c);
+
+    const t = try std.Thread.spawn(.{}, struct {
+        fn run(w: *Async, c: *Ctx) void {
+            var last: usize = 0;
+            while (last < rounds) {
+                w.notify();
+                // Wait until the callback observed this notify before sending
+                // the next one, so every notify races a fresh re-add window.
+                while (true) {
+                    const seen = c.seen.load(.acquire);
+                    if (seen > last or seen >= rounds) break;
+                    std.atomic.spinLoopHint();
+                }
+                last = c.seen.load(.acquire);
+            }
+        }
+    }.run, .{ &work, &ctx });
+
+    try loop.run(.until_done);
+    t.join();
+
+    try std.testing.expect(ctx.seen.load(.acquire) >= rounds);
+}

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -131,9 +131,10 @@ test "group: gather member freed by the group callback is not used-after-free (#
     // the group to completion and runs the group's user callback, which in real
     // code frees the frame the member's completion lives on — then the trailing
     // `call` dereferenced the freed member (GP fault on the poisoned callback ptr).
-    // Inline callbacks (defer_callbacks=false) make the free happen mid-finish.
+    // The group opts out of deferred finishing so the free happens mid-finish,
+    // the shape the regression needs.
     var loop: Loop = undefined;
-    try loop.init(.{ .defer_callbacks = false });
+    try loop.init(.{});
     defer loop.deinit();
 
     const Ctx = struct {
@@ -156,6 +157,8 @@ test "group: gather member freed by the group callback is not used-after-free (#
     var group: Group = .init(.gather);
     group.c.userdata = &ctx;
     group.c.callback = Ctx.onGroup;
+    group.c.flags.defer_callback = false;
+    member.c.flags.defer_callback = false;
     group.add(&member.c);
     loop.add(&group.c);
 

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -29,6 +29,7 @@ test {
     _ = @import("test/group.zig");
     _ = @import("test/blocking_sockets.zig");
     _ = @import("test/process_wait.zig");
+    _ = @import("test/async_stress.zig");
 }
 
 test "Loop: empty run(.no_wait)" {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -432,7 +432,6 @@ pub const Executor = struct {
             .allocator = self.runtime.allocator,
             .thread_pool = &self.runtime.thread_pool,
             .loop_group = &self.runtime.loop_group,
-            .defer_callbacks = false,
         });
         errdefer self.loop.deinit();
 
@@ -443,6 +442,7 @@ pub const Executor = struct {
         // Register periodic stack pool eviction timer (skipped when max_age is zero)
         if (self.runtime.options.stack_pool.max_age.value > 0) {
             self.stack_pool_eviction_timer.c.callback = stackPoolEvictionCallback;
+            self.stack_pool_eviction_timer.c.flags.rearm = true;
             self.loop.add(&self.stack_pool_eviction_timer.c);
         }
 
@@ -468,9 +468,6 @@ pub const Executor = struct {
         const timer = c.cast(ev.Timer);
         const self: *Executor = @alignCast(@fieldParentPtr("stack_pool_eviction_timer", timer));
         self.runtime.stack_pool.cleanup(loop.now(), 16);
-        if (self.runtime.options.stack_pool.max_age.value > 0) {
-            loop.add(c);
-        }
     }
 
     pub const YieldCancelMode = enum { allow_cancel, no_cancel };


### PR DESCRIPTION
Groundwork for #582 (and the steal-notification idea), extracted so ev.Async gets hardened on its own.

Whether a completion's callback may run synchronously is a property of the completion, not the loop — it depends on what the callback does. The loop-wide `defer_callbacks` option is gone; `Completion` gains a packed flags struct:

- **`defer_callback` (default `true`)** — finish through the completions queue instead of synchronously from whatever context completed the op. Deferred is the safe default: a deferred callback may freely chain further operations, where a synchronous one recurses into `Loop.add` the moment a chained op completes inline (io_uring does this — the old loop-wide `true` default was papering over exactly that for bare-ev usage). Completions whose callback only wakes a waiter opt out: the waitForIo family skips the queue round trip on the runtime's hot path, and the #561 regression test opts out to keep exercising the mid-finish free.

- **`rearm` (default `false`)** — the loop re-adds the completion after its callback returns, so persistent handles (recurring timers, notification handles) never call `add()` from their own callback. This kills the recursion class found in #581/#582 at the design level: re-adding an already-notified Async completes it on the spot, and the deferred finish turns that into an iteration through the completions queue instead of a recursion. The stack pool eviction timer converts to it.

`processCompletions` drains a snapshot per tick, so a handle that keeps re-completing itself (a notify storm against a rearm Async) is bounded per tick instead of pinning the loop; the remainder runs next tick, which stays non-blocking because a non-empty queue already forces a zero poll timeout. The cancel path routes through the same dispatch.

Two new stress tests hammer the Async contract from other threads:
- four producers × 25k notifies against a draining rearm callback — the stranding check (this shape caught the #582 bug that CI found and local runs missed)
- a ping-pong that lands every notify inside the callback/re-add window — the lost-wake check

All backends pass (io_uring, epoll, poll), including the full suite pinned to 2 CPUs — the configuration where the #582 CI hangs reproduced. Runtime benchmarks unchanged (task wakes keep the synchronous path).