### PR TITLE
ev: keep the io_uring CQE drain buffer on the loop, not the stack

### DIFF
--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -214,6 +214,12 @@ wall_generation: [2]u32 = .{ 0, 0 },
 /// Backing storage for the wall timeout `kernel_timespec`s; must outlive the
 /// SQE until the next `io_uring_enter2` reads it.
 wall_ts: [2]linux.kernel_timespec = undefined,
+/// Reusable batch buffer for draining ready CQEs each poll. Kept on the struct
+/// rather than as a per-poll stack array so safe builds poison it (0xAA) once
+/// at init instead of memset-ing 4 KB on every tick — that fill showed up as
+/// ~6% of a wake-heavy workload under ReleaseSafe. A single loop thread polls,
+/// so there is no aliasing concern.
+cqe_buf: [256]linux.io_uring_cqe = undefined,
 shared_state: *SharedState,
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
@@ -941,8 +947,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
     };
 
     // Process all available completions
-    var cqes: [256]linux.io_uring_cqe = undefined;
-    const count = try self.ring.copy_cqes(&cqes, 0);
+    const count = try self.ring.copy_cqes(&self.cqe_buf, 0);
 
     if (count == 0) {
         self.drainPending(state);
@@ -950,7 +955,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
     }
 
     var wall_fired = false;
-    for (cqes[0..count]) |cqe| {
+    for (self.cqe_buf[0..count]) |cqe| {
         // Internal ops carry the special low bit; completions are pointers.
         if (udIsSpecial(cqe.user_data)) {
             switch (udKind(cqe.user_data)) {


### PR DESCRIPTION
## Problem

The io_uring poll drained completions into a per-poll stack array:

```zig
var cqes: [256]linux.io_uring_cqe = undefined; // 4 KB
const count = try self.ring.copy_cqes(&cqes, 0);
```

Safe builds (Debug/ReleaseSafe) poison `undefined` with 0xAA, so **every poll `memset`s 4 KB** before draining — a *fixed* cost per poll regardless of how many CQEs it actually drains. On a wake-heavy scheduler profile under ReleaseSafe this was **~6% of CPU** (`compiler_rt.memset`, called from `Loop.tick`). ReleaseFast never poisons, so it was unaffected.

## Fix

Hoist the buffer to a backend struct field (`cqe_buf`), so it's poisoned once at init instead of on every tick. A single loop thread polls, so there's no aliasing concern.

## Numbers — TCP echo (io_uring, ReleaseSafe, interleaved A/B, 4 rounds)

| scenario | before | after | Δ |
|---|---|---|---|
| echo-lat (1 conn) | 24.0k msgs/s | 24.9k msgs/s | **+3.6%** (every round) |
| echo-pipe (64c, pl16) | ~273k msgs/s | ~278k msgs/s | **+1.8%** |
| echo-many (1000 conns) | ~140k | ~136k | within noise (neutral) |

The benefit scales inversely with batch size, exactly as the mechanism predicts: at low CQEs-per-poll (1-conn latency) the fixed 4 KB memset dominates each poll → biggest win; when a poll drains a large CQE batch (1000 conns) it amortizes to nothing. ReleaseFast is unchanged.

Full test suite green.