### PR TITLE
ev: don't complete a socket op the owner loop already resolved

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fixed a race on the epoll and kqueue backends where a socket operation whose timeout
+  expired at the exact moment its data arrived could be completed twice. A socket op is
+  serviced by the loop that owns the fd's poller registration, which is not necessarily
+  the loop that submitted it, so an expiring timeout could cancel the op from one thread
+  while another was already storing its result. In safe builds this tripped an assertion;
+  in `ReleaseFast` it overwrote the natural result, so a read reported `error.Timeout`
+  after the bytes had already been consumed from the socket, and the event loop's
+  completion accounting was corrupted. This only affected multi-executor runtimes where
+  a socket is used from more than one executor.
+
 ## [0.16.0] - 2026-07-12
 
 - Blocking operations running on thread-pool workers are now cancelable. Previously,

--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -594,11 +594,17 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
 /// Note: target.canceled is already set by loop.add() or loop.cancel() before this is called.
 pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
     if (sockreg.isSocketOp(target.op)) {
-        // Sockets are parked in the shared (fd, dir) waiter queue of their owner
-        // loop. cancel routes to that owner (target.loop), so this runs on the
-        // owner's thread and just detaches from the waiter queue. The epoll
-        // registration is persistent and left in place for the fd's lifetime.
-        sockreg.detach(self, target);
+        // Sockets are parked in the shared (fd, dir) waiter queue of the loop that
+        // owns the poller registration, which need not be this one: the op stays
+        // owned by its submitting loop (see sockreg.park), so this cancel can run
+        // concurrently with the owner servicing the op on another thread. detach
+        // claims the op against that race; if it lost, the owner already produced
+        // a natural result, so leave the op alone rather than overwriting it with
+        // Canceled and completing it twice. cancel is advisory - the callback
+        // still fires exactly once, and cancelLocal's epilogue dispatches the
+        // completion once the owner marks it completed. The epoll registration is
+        // persistent and left in place for the fd's lifetime.
+        if (!sockreg.detach(self, target)) return;
     } else {
         const fd = getHandle(target);
         self.removeFromPollQueue(fd, target) catch |err| {

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -546,11 +546,17 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
 /// Note: target.canceled is already set by loop.add() or loop.cancel() before this is called.
 pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
     if (sockreg.isSocketOp(target.op)) {
-        // Sockets are parked in the shared (fd, dir) waiter queue of their owner
-        // loop. cancel routes to that owner (target.loop), so this runs on the
-        // owner's thread and just detaches from the waiter queue. The kqueue
-        // registration is persistent and left in place for the fd's lifetime.
-        sockreg.detach(self, target);
+        // Sockets are parked in the shared (fd, dir) waiter queue of the loop that
+        // owns the poller registration, which need not be this one: the op stays
+        // owned by its submitting loop (see sockreg.park), so this cancel can run
+        // concurrently with the owner servicing the op on another thread. detach
+        // claims the op against that race; if it lost, the owner already produced
+        // a natural result, so leave the op alone rather than overwriting it with
+        // Canceled and completing it twice. cancel is advisory - the callback
+        // still fires exactly once, and cancelLocal's epilogue dispatches the
+        // completion once the owner marks it completed. The kqueue registration is
+        // persistent and left in place for the fd's lifetime.
+        if (!sockreg.detach(self, target)) return;
     } else {
         self.removeFromPollQueue(target);
     }

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -304,15 +304,34 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
 }
 
 /// Detach a parked socket completion from its owner's waiter queue (cancel).
-pub fn detach(self: anytype, target: *Completion) void {
+///
+/// Returns true if `target` was still parked and this call removed it, meaning
+/// the caller now owns it and must finish it. Returns false if it was already
+/// gone, i.e. `service` claimed it and is completing it with its natural result;
+/// the caller must then leave it alone.
+///
+/// The shard lock makes that answer exact rather than advisory: `service` runs
+/// the syscall and sets the result while holding the same lock it removes the
+/// waiter under, so "still in the queue" and "no result set yet" are the same
+/// condition. The reverse - inferring it from `cancel_state.completed` - would
+/// race, because `service` deliberately marks the op completed only after
+/// dropping the lock.
+pub fn detach(self: anytype, target: *Completion) bool {
     const fd = netHandle(target);
     const dir = dirForOp(target);
     const shard = self.shared.sock_table.shardForFd(fd);
     shard.mutex.lock();
-    if (shard.map.getPtr(@as(u32, @bitCast(fd)))) |entry| {
-        _ = entry.waiters(dir).remove(target);
-    }
-    shard.mutex.unlock();
+    defer shard.mutex.unlock();
+    // A live parked op always has an entry: detach only runs while the op is not
+    // yet completed (loop.cancel and cancelLocal both bail on cancel_state
+    // .completed), and an entry is only dropped by `unregister` on close, which
+    // cannot happen until the op completes and wakes its owner. So this branch is
+    // unreachable in practice. Return false anyway (not true): a missing entry
+    // could only mean the waiter was already removed - i.e. `service` is finishing
+    // the op - so claiming it here would double-complete an op that is already on
+    // its way out. Leaving it alone is the safe default.
+    const entry = shard.map.getPtr(@as(u32, @bitCast(fd))) orelse return false;
+    return entry.waiters(dir).remove(target);
 }
 
 /// Tear down the shared registration for a socket fd about to be closed. Closing

--- a/src/net.zig
+++ b/src/net.zig
@@ -18,6 +18,7 @@ const waitForIo = common.waitForIo;
 const waitForIoUncancelable = common.waitForIoUncancelable;
 const timedWaitForIo = common.timedWaitForIo;
 const Timeout = @import("time.zig").Timeout;
+const Duration = @import("time.zig").Duration;
 const fillBuf = @import("utils/writer.zig").fillBuf;
 
 const Handle = ev.Backend.NetHandle;
@@ -2622,6 +2623,134 @@ test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reu
     try std.testing.expectEqual(@as(u32, 0), sh.errors.load(.monotonic));
     try std.testing.expectEqual(@as(u32, H.waves * H.per_wave), sh.conns.load(.monotonic));
     try std.testing.expectEqual(@as(u32, H.waves * H.per_wave), sh.verified.load(.monotonic));
+}
+
+// Regression test for the cancel/readiness race on cross-loop socket ops.
+//
+// A socket op parks in the (fd, dir) waiter queue of the loop that owns the fd's
+// poller registration, but stays owned by the loop that submitted it. So a recv
+// carrying a timeout gets cancelled by its timer on the submitting loop while the
+// owner services it on another thread. The owner runs the syscall and stores the
+// result under the shard lock but marks the op completed only after unlocking, so
+// a cancel landing in that window must not complete it a second time, and must
+// not discard bytes the kernel already moved out of the socket.
+//
+// Each pair writes one byte per jittered tick against a reader whose recv timeout
+// is drawn from the same distribution, so recvs park and their timers expire
+// alongside arriving data. The reader hops to another executor after every byte,
+// so the loop submitting the recv is usually not the loop owning the fd.
+//
+// The failure is asserted as byte loss rather than as a crash: a recv whose
+// result the racing cancel overwrote consumed bytes that nobody will ever
+// receive, so the reader runs out of input and sees EOF early. That holds in any
+// build mode, though safe builds usually trip the double-completion assertion
+// first.
+test "multi-executor: timeout cancel racing a cross-loop readiness edge" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    const H = struct {
+        const pairs = 8;
+        const per_pair = 300;
+
+        const Shared = struct {
+            errors: std.atomic.Value(u32) = .init(0),
+            // u32, not u64: 32-bit targets have no lock-free 64-bit atomics, and
+            // the total (pairs * per_pair) is far below 2^32 anyway.
+            bytes: std.atomic.Value(u32) = .init(0),
+            timeouts: std.atomic.Value(u32) = .init(0),
+        };
+
+        fn nudge() void {}
+
+        /// Reader timeouts and writer ticks are drawn from this same
+        /// distribution, so an expiring timer and an arriving byte land together
+        /// often enough to hit the window.
+        fn delay(rand: std.Random) Duration {
+            return .fromMicroseconds(200 + rand.uintLessThan(u64, 2_000));
+        }
+
+        fn reader(stream: Stream, sh: *Shared, seed: u64) void {
+            defer stream.close();
+            var rng = std.Random.DefaultPrng.init(seed);
+            var buf: [64]u8 = undefined;
+            var got: usize = 0;
+            while (got < per_pair) {
+                const n = stream.read(&buf, .{ .duration = delay(rng.random()) }) catch |err| switch (err) {
+                    // The timer won the race: expected, and the whole point.
+                    error.Timeout => {
+                        _ = sh.timeouts.fetchAdd(1, .monotonic);
+                        continue;
+                    },
+                    else => {
+                        _ = sh.errors.fetchAdd(1, .monotonic);
+                        return;
+                    },
+                };
+                // The peer sends per_pair bytes before it closes, so EOF here means
+                // bytes went missing: a completed recv was overwritten by a cancel.
+                // This is also what terminates the loop if the race eats a byte,
+                // instead of hanging.
+                if (n == 0) {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                }
+                got += n;
+                _ = sh.bytes.fetchAdd(@intCast(n), .monotonic);
+                // Hop to another executor, so the next recv is submitted from a
+                // loop other than the one owning this fd's registration.
+                var h = runtime_mod.spawn(nudge, .{}) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+                h.join();
+            }
+        }
+
+        fn writer(stream: Stream, sh: *Shared, seed: u64) void {
+            defer stream.close();
+            var rng = std.Random.DefaultPrng.init(seed);
+            for (0..per_pair) |_| {
+                runtime_mod.sleep(delay(rng.random())) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+                stream.writeAll("x", .none) catch {
+                    _ = sh.errors.fetchAdd(1, .monotonic);
+                    return;
+                };
+            }
+        }
+    };
+
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
+    defer runtime.deinit();
+
+    const listen_addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const srv = try listen_addr.listen(.{ .reuse_address = true });
+    defer srv.close();
+    const connect_addr = try IpAddress.parseIp4("127.0.0.1", srv.socket.address.ip.getPort());
+
+    var sh: H.Shared = .{};
+    var tasks: Group = .init;
+    errdefer tasks.cancel();
+
+    // connect() returns once the handshake is queued in the backlog, so both ends
+    // can be built inline here: no acceptor task, and every task lives in one
+    // group, so a single join settles every counter read below.
+    for (0..H.pairs) |i| {
+        const client = try connect_addr.connect(.{ .timeout = Timeout.fromSeconds(5) });
+        const server = try srv.accept(.{ .timeout = Timeout.fromSeconds(5) });
+        try tasks.spawn(H.reader, .{ server, &sh, i * 2 });
+        try tasks.spawn(H.writer, .{ client, &sh, i * 2 + 1 });
+    }
+    try tasks.wait();
+
+    try std.testing.expectEqual(0, sh.errors.load(.monotonic));
+    try std.testing.expectEqual(H.pairs * H.per_pair, sh.bytes.load(.monotonic));
+    // The cancel path has to have been taken at all, or nothing above is evidence.
+    // How often it lands in the window is machine-dependent, so this asserts only
+    // the floor that means the same thing everywhere.
+    try std.testing.expect(sh.timeouts.load(.monotonic) > 0);
 }
 
 // Migration-disabled bypass: with enable_task_migration=false the executors do


### PR DESCRIPTION
On epoll and kqueue, a socket op whose timeout expires at the same moment its
data arrives can be completed twice. Shipped in v0.16.0.

## Cause

A socket op parks in the `(fd, dir)` waiter queue of the loop that owns the fd's
poller registration, but since 59d61603 it stays owned by its *submitting* loop:
that commit moved the registration to the owner, not the completion (the earlier
`completion.loop = owner_loop` reassignment caused a use-after-free). So a cancel
runs on one thread while the owner services the op on another. The usual trigger
is an op's own timeout: `timedWaitForIo` puts the I/O and its timer in a race
group on the submitting loop, and the expiring timer cancels the I/O from there.

`cancel` discarded `detach()`'s result and then unconditionally ran
`setError(error.Canceled)` + `markCompletedFromBackend`. `service()` sets the
result under the shard lock but calls `markCompleted` only after unlocking, so a
cancel landing in that window found `cancel_state.completed` still clear,
detached nothing, and completed the op a second time.

The comment claiming `cancel` routes to the owner's thread predates 59d61603,
which deleted the invariant that made it true.

## Impact

- Safe builds: trips `assert(!c.has_result)` in `setError`.
- `ReleaseFast`: overwrites the natural result, so a read reports `error.Timeout`
  after the bytes were already consumed off the socket. Silent data loss. The op
  is also dispatched twice with `active`/`inflight` double-decremented.

Only affects multi-executor runtimes where a socket is driven from more than one
executor. The existing cross-loop stress test uses 5s timeouts, so it practically
never fires the cancel path, which is why this went unnoticed.

## Fix

`detach()` now reports whether it actually removed the op from the waiter queue,
and `cancel` finishes the op only when it did. The shard lock makes that answer
exact rather than conservative: `service()` removes the waiter under the same
lock it sets the result under, so "still queued" and "no result yet" are the same
condition. (`cancel_state.completed` cannot serve here, since it is published
after the unlock.) When the cancel loses, `cancelLocal`'s existing epilogue
already hands the dispatch back to the owner, and the callback still fires
exactly once.

This is the same claim-before-commit discipline `Channel` uses via `tryClaim`:
the claim has to be atomic with the side effect. The old code performed the claim
and ignored its answer.

## Test

The regression test drives short jittered recv timeouts against a matching write
cadence, with the reader bouncing executors every round so the submitter is not
the owner and an expiring timeout collides with a cross-loop readiness edge. It
fails 6/6 without the fix and passes 10/10 with it.

Full suite passes on epoll (Debug and ReleaseSafe) and io_uring. kqueue and iocp
cross-compile for macos/freebsd/netbsd/windows; the kqueue half of the fix is
identical in shape but is not executed by CI on this machine.
