### PR TITLE
fix(fs): fall back to hardlink+delete when renameat2(RENAME_NOREPLACE) is unsupported

### DIFF
--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1485,6 +1485,9 @@ pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: [
                 .SUCCESS => return,
                 .INTR => continue,
                 .EXIST => return error.PathAlreadyExists,
+                // Some ZFS builds and pre-3.15 kernels lack RENAME_NOREPLACE
+                // (EINVAL/ENOSYS) — fall through to hardlink+delete.
+                .INVAL, .NOSYS => break,
                 else => |err| return errnoToDirRenameError(err),
             }
         }
@@ -1505,10 +1508,53 @@ pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: [
         }
     }
 
-    // Fallback for other POSIX and Darwin filesystems that don't support renameatx_np(RENAME_EXCL):
-    // hardlink + delete
+    // Atomic no-replace rename unavailable on this platform/filesystem.
+    return renameatPreserveFallback(allocator, old_dir, old_path, new_dir, new_path);
+}
+
+/// No-replace rename via hardlink + delete for filesystems that reject the
+/// atomic renameat2(RENAME_NOREPLACE)/renameatx_np(RENAME_EXCL). The hardlink
+/// returns EEXIST -> error.PathAlreadyExists when the destination exists.
+/// Regular files only (a directory source fails the hardlink with EPERM).
+fn renameatPreserveFallback(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u8, new_dir: fd_t, new_path: []const u8) DirRenamePreserveError!void {
     try dirHardLink(allocator, old_dir, old_path, new_dir, new_path, .{});
     dirDeleteFile(allocator, old_dir, old_path) catch {};
+}
+
+test renameatPreserveFallback {
+    const at_cwd = posix.AT.FDCWD;
+    const src = "zio_rnpf_src.tmp";
+    const dst = "zio_rnpf_dst.tmp";
+
+    const H = struct {
+        fn create(path: [*:0]const u8) !void {
+            const rc = posix.system.openat(posix.AT.FDCWD, path, .{ .ACCMODE = .WRONLY, .CLOEXEC = true, .CREAT = true }, @as(mode_t, 0o644));
+            if (posix.errno(rc) != .SUCCESS) return error.CreateFailed;
+            posix.close(@intCast(rc));
+        }
+        fn exists(path: [*:0]const u8) bool {
+            const rc = posix.system.openat(posix.AT.FDCWD, path, .{ .CLOEXEC = true }, @as(mode_t, 0));
+            if (posix.errno(rc) != .SUCCESS) return false;
+            posix.close(@intCast(rc));
+            return true;
+        }
+    };
+
+    dirDeleteFile(std.testing.allocator, at_cwd, src) catch {};
+    dirDeleteFile(std.testing.allocator, at_cwd, dst) catch {};
+    defer dirDeleteFile(std.testing.allocator, at_cwd, src) catch {};
+    defer dirDeleteFile(std.testing.allocator, at_cwd, dst) catch {};
+
+    // Free destination: source moves onto it.
+    try H.create(src);
+    try renameatPreserveFallback(std.testing.allocator, at_cwd, src, at_cwd, dst);
+    try std.testing.expect(!H.exists(src));
+    try std.testing.expect(H.exists(dst));
+
+    // Occupied destination: fails and leaves the source in place.
+    try H.create(src);
+    try std.testing.expectError(error.PathAlreadyExists, renameatPreserveFallback(std.testing.allocator, at_cwd, src, at_cwd, dst));
+    try std.testing.expect(H.exists(src));
 }
 
 /// Delete a file using unlinkat() syscall


### PR DESCRIPTION
## Problem

`renameatPreserve` uses `renameat2()` with `RENAME_NOREPLACE` on Linux. That flag needs **per-filesystem** support (in-tree filesystems gained it incrementally — ext4 in 3.15, btrfs/tmpfs 3.17, xfs 4.0, many more in 4.9), and a filesystem that lacks it returns `EINVAL`. Kernels before 3.15 have no `renameat2` at all and return `ENOSYS`. The Linux branch turned both into a hard error, even though the function already has a hardlink+delete fallback that Darwin uses (`renameatx_np(RENAME_EXCL)` → `OPNOTSUPP` → `break`) and other POSIX systems fall through to.

The concrete case that surfaced this: **QNAP QuTS hero (5.2.9, kernel 5.10.60-qnap)**, whose out-of-tree ZFS returns `EINVAL` for the flag. This is not a tunable — `RENAME_NOREPLACE` handling lives in the ZFS module's rename op, with no mount option, property, or setting to toggle it. Upstream OpenZFS only added `RENAME_*` flag support in [2.2.0](https://github.com/openzfs/zfs/pull/12209) (merged Oct 2022); QuTS ships a lagging fork that predates it, so the code is simply absent. TrueNAS SCALE (OpenZFS ≥ 2.2) and mainline ext4 handle it fine — see the table below.

Net effect: `renamePreserve` fails outright on those filesystems, breaking any caller that relies on it (atomic no-clobber renames, quarantine-then-delete cleanups).

## Fix

Route `EINVAL`/`ENOSYS` from the Linux `renameat2(RENAME_NOREPLACE)` path to the existing hardlink+delete fallback, mirroring the Darwin `OPNOTSUPP` handling. The fallback is extracted into `renameatPreserveFallback` and covered by a direct unit test.

## Evidence

Static-musl probe calling `renameat2(RENAME_NOREPLACE)` directly on each filesystem, plus plain `rename(2)` as a control:

| Filesystem / kernel | `renameat2(RENAME_NOREPLACE)` | plain `rename(2)` |
|---|---|---|
| QNAP QuTS hero ZFS, `5.10.60-qnap` (OpenZFS < 2.2 fork) | **EINVAL** (triggers the fallback) | OK |
| TrueNAS SCALE OpenZFS ≥ 2.2, `6.12` | OK | OK |
| NixOS ext4, `7.0.11` | OK | OK |

On the ext4 host the atomic path is taken as before; the new fallback is exercised directly by the added unit test, which passes there (`zig build test`). The existing `Dir: renamePreserve` and `io: dir renamePreserve` tests are unchanged.

## Notes

- Regular-files-only fallback (a directory source fails the hardlink with `EPERM`), same limitation the pre-existing Darwin/POSIX fallback already had.