### PR TITLE
fs: make the renameatPreserve fallback all-or-nothing

### DIFF
--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1518,9 +1518,24 @@ pub fn renameatPreserve(allocator: std.mem.Allocator, old_dir: fd_t, old_path: [
 /// atomic renameat2(RENAME_NOREPLACE)/renameatx_np(RENAME_EXCL). The hardlink
 /// returns EEXIST -> error.PathAlreadyExists when the destination exists.
 /// Regular files only (a directory source fails the hardlink with EPERM).
+/// All-or-nothing: if the source cannot be deleted after linking, the link is
+/// removed again and the error is returned.
 fn renameatPreserveFallback(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u8, new_dir: fd_t, new_path: []const u8) DirRenamePreserveError!void {
     try dirHardLink(allocator, old_dir, old_path, new_dir, new_path, .{});
-    dirDeleteFile(allocator, old_dir, old_path) catch {};
+    dirDeleteFile(allocator, old_dir, old_path) catch |err| switch (err) {
+        // The source vanished after the link was made, so the rename is
+        // complete; rolling back would delete the only name left for the data.
+        error.FileNotFound => {},
+        else => {
+            // Only undo the link while the source is verifiably still in
+            // place; if we can't confirm that, the new link may be the only
+            // name left for the data, so keep it.
+            if (dirAccess(allocator, old_dir, old_path, .{ .follow_symlinks = false })) |_| {
+                dirDeleteFile(allocator, new_dir, new_path) catch {};
+            } else |_| {}
+            return err;
+        },
+    };
 }
 
 test renameatPreserveFallback {
@@ -1547,6 +1562,47 @@ test renameatPreserveFallback {
     try close(try createat(allocator, at_cwd, src, .{}));
     try std.testing.expectError(error.PathAlreadyExists, renameatPreserveFallback(allocator, at_cwd, src, at_cwd, dst));
     try dirAccess(allocator, at_cwd, src, .{});
+}
+
+test "renameatPreserveFallback: rollback when source cannot be deleted" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    // Root bypasses the directory permission check the test relies on.
+    if (posix.system.geteuid() == 0) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    const at_cwd = posix.AT.FDCWD;
+    const src_dir_path = "zio_rnpf_rollback_dir.tmp";
+    const src = "src";
+    const dst = "zio_rnpf_rollback_dst.tmp";
+
+    dirDeleteFile(allocator, at_cwd, dst) catch {};
+    defer dirDeleteFile(allocator, at_cwd, dst) catch {};
+
+    try mkdirat(allocator, at_cwd, src_dir_path, 0o755);
+    defer {
+        dirSetFilePermissions(allocator, at_cwd, src_dir_path, 0o755, .{}) catch {};
+        dirDeleteFile(allocator, at_cwd, src_dir_path ++ "/" ++ src) catch {};
+        dirDeleteDir(allocator, at_cwd, src_dir_path) catch {};
+    }
+
+    const src_dir = try dirOpen(allocator, at_cwd, src_dir_path, .{});
+    defer posix.close(src_dir);
+
+    try close(try createat(allocator, src_dir, src, .{}));
+
+    // Make the source directory read-only so the post-link unlink fails.
+    try dirSetFilePermissions(allocator, at_cwd, src_dir_path, 0o555, .{});
+
+    if (renameatPreserveFallback(allocator, src_dir, src, at_cwd, dst)) |_| {
+        return error.TestUnexpectedResult;
+    } else |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => {},
+        else => return err,
+    }
+
+    // Nothing changed: source still present, destination link rolled back.
+    try dirAccess(allocator, src_dir, src, .{});
+    try std.testing.expectError(error.FileNotFound, dirAccess(allocator, at_cwd, dst, .{}));
 }
 
 /// Delete a file using unlinkat() syscall


### PR DESCRIPTION
## Problem

Follow-up to #589. The hardlink+delete fallback in `renameatPreserve` ignored failures when deleting the source (`dirDeleteFile(...) catch {}`). If the unlink failed (no write permission on the source directory, filesystem remounted read-only mid-operation), the call reported success while both names remained on disk, so a move silently turned into a copy. A caller doing quarantine-then-delete would re-process the source it believes it moved away.

## Fix

Propagate the source-delete error, and undo the new link first, so the fallback either fully completes or changes nothing (same as systemd's `rename_noreplace()`).

Two guards prevent the rollback itself from losing data, since in both cases the new link may be the only remaining name for the file:

- `FileNotFound` from the source delete means the source vanished after the link was made; the rename effectively completed, so it is treated as success.
- The new link is only removed while the source is verifiably still in place, checked with `dirAccess(..., .{ .follow_symlinks = false })` (no-follow so a symlink source is probed as the link itself, not its possibly-dangling target). If the probe fails for any reason, the new link is kept and the original error returned.

No error-set changes: `DirDeleteFileError` is a subset of `DirRenameError`, so the propagated error already fits `DirRenamePreserveError`.

## Testing

New unit test creates a source file inside a directory, chmods the directory to 0o555 so the post-link unlink fails, and asserts the call errors with `AccessDenied`/`PermissionDenied`, the source survives, and the destination link was rolled back. Skipped on Windows (the fallback is unreachable there) and under root (which bypasses the permission check, relevant for the FreeBSD/NetBSD CI VMs).

Verified locally: `zig fmt` clean, full native suite passes (555/555), and test binaries cross-compile for x86_64-windows-gnu, aarch64-macos, x86_64-freebsd and x86_64-netbsd.