### PR TITLE
test: make Waiter futex timed wait test robust on slow CI runners

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -404,9 +404,14 @@ test "Waiter: futex-based timed wait with timeout" {
     waiter.timedWait(1, .fromMilliseconds(50), .no_cancel);
     const elapsed = timer.read();
 
+    errdefer std.debug.print("timedWait(50ms) returned after {d}ms\n", .{elapsed.toMilliseconds()});
+
     // Should return normally after timeout expires (allow slight undershoot for timer resolution)
     try std.testing.expect(elapsed.toMilliseconds() >= 40);
-    try std.testing.expect(elapsed.toMilliseconds() < 200); // Sanity check
+    // Generous upper bound: only meant to catch gross timeout miscalculation
+    // (wrong units, waiting forever). Loaded CI runners can delay the wakeup
+    // by hundreds of milliseconds, so anything tighter is flaky.
+    try std.testing.expect(elapsed.toMilliseconds() < 5000);
 }
 
 /// Execute a blocking function on the thread pool, blocking the current task until completion.


### PR DESCRIPTION
## Problem

`common.test.Waiter: futex-based timed wait with timeout` failed on macOS CI with `TestUnexpectedResult` after 221ms. The test does a 50ms futex timed wait and asserts elapsed < 200ms as a sanity check. The Darwin implementation is correct (`__ulock_wait` gets the timeout in microseconds, maps `TIMEDOUT`, and the retry loop recomputes the remaining time from the deadline), so the wait fired on time; the thread just wasn't rescheduled for ~170ms afterwards, which is routine on oversubscribed macOS runners. The test predates the recent fs changes and the failure is unrelated to them.

## Fix

The upper bound only exists to catch gross timeout miscalculation (wrong units, waiting forever, the realtime-vs-monotonic confusion mentioned in `futexTimeout`). A 5s bound catches that entire class just as reliably while being immune to scheduler noise; the meaningful assertion is the 40ms lower bound, which is unchanged. Also print the measured elapsed time on failure, so a future trip is diagnosable straight from the CI log.