### PR TITLE
Always free Tsan fibers

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -920,10 +920,7 @@ pub const Executor = struct {
             .finish => |task| {
                 self.pending_cleanup = .none;
                 task.state.store(.{ .tag = .finished }, .release);
-                if (task.coro.context.stack_info.allocation_len > 0) {
-                    self.runtime.stack_pool.release(task.coro.context.stack_info, self.loop.now());
-                    task.coro.context.stack_info.allocation_len = 0;
-                }
+                task.releaseCoro(self.runtime, self.loop.now());
                 finishTask(self.runtime, &task.awaitable);
             },
         }

--- a/src/task.zig
+++ b/src/task.zig
@@ -17,6 +17,7 @@ const Group = @import("group.zig").Group;
 const registerGroupTask = @import("group.zig").registerGroupTask;
 const unregisterGroupTask = @import("group.zig").unregisterGroupTask;
 const os = @import("os/root.zig");
+const Timestamp = @import("time.zig").Timestamp;
 
 pub const Closure = struct {
     start: Start,
@@ -459,12 +460,24 @@ pub const AnyTask = struct {
         Executor.scheduleTask(self);
     }
 
+    /// Return the coroutine's stack to the pool and retire its TSan fiber.
+    ///
+    /// Both are owned by the coroutine, not by the task, so they are reclaimed
+    /// as soon as the coroutine is done rather than when the last reference to
+    /// the task goes away: the executor calls this from its finish cleanup,
+    /// once control has left the coroutine's stack. `destroy` calls it again
+    /// for tasks that were created but never ran. Idempotent, with a zeroed
+    /// `allocation_len` marking the resources as already released.
+    pub fn releaseCoro(self: *AnyTask, rt: *Runtime, now: Timestamp) void {
+        if (self.coro.context.stack_info.allocation_len == 0) return;
+        rt.stack_pool.release(self.coro.context.stack_info, now);
+        self.coro.context.stack_info.allocation_len = 0;
+        self.coro.deinit();
+    }
+
     pub fn destroy(self: *AnyTask) void {
         const rt = self.getRuntime();
-        if (self.coro.context.stack_info.allocation_len > 0) {
-            rt.stack_pool.release(self.coro.context.stack_info, rt.now());
-        }
-        self.coro.deinit();
+        self.releaseCoro(rt, rt.now());
 
         self.closure.free(AnyTask, rt, self);
     }

--- a/src/task.zig
+++ b/src/task.zig
@@ -463,8 +463,8 @@ pub const AnyTask = struct {
         const rt = self.getRuntime();
         if (self.coro.context.stack_info.allocation_len > 0) {
             rt.stack_pool.release(self.coro.context.stack_info, rt.now());
-            self.coro.deinit();
         }
+        self.coro.deinit();
 
         self.closure.free(AnyTask, rt, self);
     }


### PR DESCRIPTION
Partially solves #585

It does not fully solve the leak, but the memory usage growth is now much milder

```
~/git/zig-playground$ ./run.sh
RSS 22:01:29 = 20188 KB
RSS 22:01:31 = 75140 KB
RSS 22:01:33 = 95284 KB
RSS 22:01:35 = 125088 KB
```

(125M in 6 seconds instead of original 5G)

I couldn't find where the remaining leak is coming from, but I couldn't figure out if it is due to zio's tsan handling (because when tsan handling is disabled, tsan just crashes the example program), or if it just a TSan thing.  Fibers now seem to be freed correctly and zio does nothing else with tsan.

Also this does not at all touch the issue mentioned in [comment](https://github.com/lalinsky/zio/issues/585#issuecomment-5035862059) where TSan caused segfault after destroying seemingly already destroyed fiber, and that issue still persists.

Also as a side effect of this change, weird pause during program exit has disappeared in my program when run with thread sanitizer.