### PR TITLE
Take the caller ref before adding a task to a group

### DIFF
--- a/src/blocking_task.zig
+++ b/src/blocking_task.zig
@@ -162,13 +162,14 @@ pub fn spawnBlockingTask(
     );
     errdefer task.destroy();
 
-    if (group) |g| try registerGroupTask(g, &task.awaitable);
-    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
-
-    // +1 ref for the caller (JoinHandle) before scheduling, to prevent
-    // race where task completes before caller can take ownership
+    // +1 ref before the task is reachable by anyone else, to prevent a race
+    // where it completes before the caller can take ownership. See spawnTask
+    // for why this has to come before registerGroupTask.
     task.awaitable.ref_count.incr();
     errdefer _ = task.awaitable.ref_count.decr();
+
+    if (group) |g| try registerGroupTask(g, &task.awaitable);
+    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
 
     try registerBlockingTask(rt, task);
 

--- a/src/group.zig
+++ b/src/group.zig
@@ -593,3 +593,24 @@ test "Group: wait() future protocol drains without closing" {
     try group.spawn(quick, .{});
     _ = try waitFuture(&group);
 }
+
+test "Group: failed spawnBlocking frees the task exactly once" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    // Make registerBlockingTask fail after the task has already been pushed
+    // into the group, which is the state a spawn racing with shutdown ends up
+    // in. The group's cleanup and spawnBlockingTask's errdefer must not both
+    // free the task. A large context takes the direct allocator path (over
+    // TaskPool.pool_item_size), so testing.allocator catches a double free.
+    rt.shutting_down.store(true, .release);
+
+    const bigWork = struct {
+        fn call(_: [3000]u8) void {}
+    }.call;
+
+    try std.testing.expectError(error.RuntimeShutdown, group.spawnBlocking(bigWork, .{[_]u8{0} ** 3000}));
+}

--- a/src/task.zig
+++ b/src/task.zig
@@ -740,13 +740,18 @@ pub fn spawnTask(
     );
     errdefer task.destroy();
 
-    if (group) |g| try registerGroupTask(g, &task.awaitable);
-    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
-
-    // +1 ref for the caller (JoinHandle) before scheduling, to prevent
-    // race where task completes before caller can take ownership
+    // +1 ref before the task is reachable by anyone else, to prevent a race
+    // where it completes before the caller can take ownership. For a task with
+    // a JoinHandle this is the caller's ref; for a group task, which returns no
+    // handle, it is the group's, dropped by unregisterGroupTask or by cancel
+    // popping the node. Taking it before registerGroupTask matters: once the
+    // node is in the group's list, a concurrent cancel() can pop it and release,
+    // and with no ref of our own that would free the task under us.
     task.awaitable.ref_count.incr();
     errdefer _ = task.awaitable.ref_count.decr();
+
+    if (group) |g| try registerGroupTask(g, &task.awaitable);
+    errdefer if (group) |g| unregisterGroupTask(g, &task.awaitable);
 
     try registerTask(rt, task);
 


### PR DESCRIPTION
Found this while digging into the TSan crash reported in #585.

`spawnTask` pushes the task into the group before it takes the +1 reference for the caller. That leaves two windows:

* Between the push and the incr, the task is in the group's list with a refcount of 1. A `cancel()` from another thread pops the node, releases the last reference and frees the task while we are still setting it up.
* If `registerTask` then fails, the errdefers run in reverse order: the caller ref is given back first, so `unregisterGroupTask` drops what is now the last reference and destroys the task, and `errdefer task.destroy()` frees it a second time.

Taking the reference before the task is reachable by anyone else closes both. Same change in `spawnBlockingTask`.

The test covers the blocking path because that one is reachable without a race: `spawnBlockingTask` has no early shutdown check, unlike `spawnTask`, which bails out in `getNextExecutor` before the task exists. Setting `shutting_down` makes `registerBlockingTask` fail with the task already in the group. A large context takes the direct allocator path so the double free is not hidden by the task pool. Without the fix the test segfaults, with it the full suite passes.

I suspect this is what psznm's `__tsan_destroy_fiber` segfault in #585 bottoms out in. The second `destroy()` also re-releases the same stack into the stack pool, so two later tasks end up sharing one stack and one fiber handle, and the second one to finish destroys an already dead fiber.

Independent of #595, no conflicts with it.
