### PR TITLE
Make a TSan fiber current before destroying it

### DIFF
--- a/src/coro/tsan.zig
+++ b/src/coro/tsan.zig
@@ -31,9 +31,26 @@ pub inline fn createFiber() Fiber {
 
 /// Retire a coroutine's fiber. Must not be called while `fiber` is the running
 /// fiber (destroy from a different context after the coroutine has finished).
+///
+/// Destroying a fiber that never recorded a trace event walks uninitialized
+/// memory in TSan and segfaults once its allocator starts handing back reused
+/// blocks. Fixed upstream by llvm/llvm-project#171766, which is in LLVM 22 but
+/// not in the 21.x that Zig 0.16 bundles, so this can go once we require a
+/// newer toolchain. We reach it with tasks that are created and then torn down
+/// without ever running, so make the fiber current for an instant first.
+///
+/// flags must be 0 here; the no-sync form records nothing and does not help.
+/// The pair is otherwise harmless: nothing ever runs as this fiber, so the only
+/// clock it can hand back is the one we just gave it, and the previously
+/// current fiber is restored before the destroy.
 pub inline fn destroyFiber(fiber: Fiber) void {
     if (enabled) {
-        if (fiber) |f| c.__tsan_destroy_fiber(f);
+        if (fiber) |f| {
+            const current = c.__tsan_get_current_fiber();
+            c.__tsan_switch_to_fiber(f, 0);
+            if (current) |cur| c.__tsan_switch_to_fiber(cur, 0);
+            c.__tsan_destroy_fiber(f);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #597.

The crash is a bug in libtsan, not in our instrumentation, and it is already fixed upstream: llvm/llvm-project#171766 ("[TSan] Zero-initialize Trace.local_head", commit `cdfdb06c9155`, 2025-12-12). Their commit message describes exactly what we hit:

> `Trace.local_head` is currently uninitialized when `Trace` is created. It is first initialized when the first event is added to the trace, via the first call to `TraceSwitchPartImpl`. However, `ThreadContext::OnFinished` uses `local_head`, assuming that it is initialized. If it has not been initialized, we have undefined behavior, likely crashing if the contents are garbage. The allocator (`Alloc`) reuses previous allocations, so the contents of the uninitialized memory are arbitrary.

They found it from Go, and assumed C/C++ was mostly safe: "In a C/C++ TSAN binary it is likely very difficult for a thread to start and exit without a single event inbetween." Fibers are the other way to get there. A fiber that is created and destroyed without ever being switched to records nothing, and we create the fiber in `Coroutine.setup`, so any task that is created and then torn down without running destroys such a fiber.

The fix is not in a release we can use yet. Zig 0.16 bundles LLVM 21.1, and `release/21.x` still has the uninitialized field with no backport, so every Zig 0.16 toolchain has this. The workaround can be dropped once we require an LLVM 22 based toolchain, which is why the code comment names the upstream PR.

Workaround: make the fiber current for an instant before destroying it, which gets its trace state initialized. flags must be 0; I tried the no-sync form first and it does not help, because it records nothing.

Why this is safe: the pair only moves our own clock into a fiber that runs nothing and back again, so our clock is unchanged and no other thread's ordering is affected; a fiber that performed no accesses cannot suppress a report; the previously current fiber is restored before the destroy; and it leaves a sync object at the fiber's address exactly as an ordinary context switch already does for every fiber that ran. Without `-fsanitize-thread` the whole thing compiles away.

Verification:

* psznm's reproduction from #597 crashed at iteration 3939 on main and now runs to completion.
* Reduced to a standalone program with no zio in it: `__tsan_create_fiber` followed by `__tsan_destroy_fiber` in a loop dies just after 8000 pairs, while the same loop with a switch to the fiber and back survives 100k.
* `examples/tsan` still reports the race in `race` mode and stays silent in `clean` mode, so detection is unaffected in both directions.
* Full suite passes.
