### PR TITLE
Keep the group usable after wait()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,14 @@ All notable changes to this project will be documented in this file.
   completion accounting was corrupted. This only affected multi-executor runtimes where
   a socket is used from more than one executor.
 
+- `Group.wait()` no longer closes the group. Waiting used to close it permanently, so
+  every spawn afterwards failed with `error.Closed`, and through the `std.Io` vtable,
+  where `Group.async` cannot report an error, those spawns silently ran their work
+  synchronously on the calling task instead of concurrently. A group can now be spawned
+  into again after `wait()` returns, and a wait covers tasks spawned while it is in
+  progress, as long as the spawn happens before the group drains. This matches
+  `std.Io.Threaded` and the `select`-based wait.
+
 ## [0.16.0] - 2026-07-12
 
 - Blocking operations running on thread-pool workers are now cancelable. Previously,

--- a/src/group.zig
+++ b/src/group.zig
@@ -108,10 +108,6 @@ pub const Group = struct {
         return (@atomicLoad(u32, self.getState(), .acquire) & fail_fast_bit) != 0;
     }
 
-    fn setClosed(self: *Group) void {
-        _ = @atomicRmw(u32, self.getState(), .Or, closed_bit, .acq_rel);
-    }
-
     fn isClosed(self: *Group) bool {
         return (@atomicLoad(u32, self.getState(), .acquire) & closed_bit) != 0;
     }
@@ -172,8 +168,18 @@ pub const Group = struct {
         return groupSpawnBlockingTask(self, rt, std.mem.asBytes(&context), .fromByteUnits(@alignOf(Context)), &Wrapper.start);
     }
 
+    /// Wait for every task currently in the group to finish.
+    ///
+    /// The group stays usable: it can be spawned into again afterwards, and
+    /// waited on again, which matches `std.Io.Threaded` and the `select`-based
+    /// wait. Tasks spawned while this is running are waited for too, though the
+    /// caller has to make sure such a spawn happens before the group drains,
+    /// otherwise the wait can return without having seen it.
+    ///
+    /// Neither this nor `cancel` closes a group permanently: `cancel` clears the
+    /// flag again on its way out, so a canceled group is reusable too. Only a
+    /// failure or cancelation with `fail_fast` set leaves a group closed.
     pub fn wait(group: *Group) Cancelable!void {
-        group.setClosed();
         errdefer group.cancel();
 
         // Wait for all tasks to complete
@@ -613,4 +619,59 @@ test "Group: failed spawnBlocking frees the task exactly once" {
     }.call;
 
     try std.testing.expectError(error.RuntimeShutdown, group.spawnBlocking(bigWork, .{[_]u8{0} ** 3000}));
+}
+
+test "Group: reusable after wait" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var counter: usize = 0;
+    const bump = struct {
+        fn call(c: *usize) void {
+            sleep(.fromMilliseconds(1)) catch {};
+            c.* += 1;
+        }
+    }.call;
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    // wait() used to close the group, which turned every later spawn into
+    // error.Closed (and, through the std.Io vtable, into silently running the
+    // work synchronously).
+    try group.spawn(bump, .{&counter});
+    try group.spawn(bump, .{&counter});
+    try group.wait();
+    try std.testing.expectEqual(2, counter);
+
+    try group.spawn(bump, .{&counter});
+    try group.wait();
+    try std.testing.expectEqual(3, counter);
+}
+
+test "Group: spawning while waiting" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var counter: usize = 0;
+    const spawner = struct {
+        fn bump(c: *usize) void {
+            c.* += 1;
+        }
+
+        fn call(group: *Group, c: *usize) void {
+            // Spawned into the group that our caller is waiting on. The wait
+            // must cover this task too, so the count is 2 when it returns.
+            sleep(.fromMilliseconds(1)) catch {};
+            group.spawn(bump, .{c}) catch {};
+            c.* += 1;
+        }
+    };
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(spawner.call, .{ &group, &counter });
+    try group.wait();
+    try std.testing.expectEqual(2, counter);
 }


### PR DESCRIPTION
Follows from the discussion in #585. `Group.wait()` closed the group before draining it, so once you awaited a group you could never spawn into it again.

Through the native API that at least gives you an `error.Closed` to look at. Through the `std.Io` vtable it is much worse: `Io.Group.async` returns `void` and cannot report an error, so `groupAsyncImpl` takes its fallback path and runs the work synchronously on the calling task. A loop that spawns into a group and awaits every so often silently stops being concurrent after the first await, with nothing to indicate it. That is what psznm's reproduction in #597 was doing, 3999 times.

`std.Io.Threaded` treats a group as reusable after both of its terminal operations. `groupAwait` clears `have_awaiter` on the way out (and `canceled` on the cancel path), and `groupCancel` ends by resetting the whole status to `.{ .num_running = 0, .have_awaiter = false, .canceled = false }`. The comments there talk about spawning being illegal "until we return", not afterwards.

Our `cancel()` already did the same thing, ending with `clearFlag()` and the comment "Clear the canceled flag for reuse", and our `select`-based wait already drained without closing, with a test asserting exactly that ("wait() future protocol drains without closing"). Only `wait()` was the odd one out, so the two waits disagreed with each other and `wait()` disagreed with `cancel()`.

So after this a group is usable again after either `wait()` or `cancel()`. The only thing that leaves a group closed is a failure or a cancelation while `fail_fast` is set, which is what `closed_bit` is now exclusively for. `setClosed()` had no callers left once `wait()` stopped calling it, since `setFailed`/`setCanceled` set the bit inline in their cmpxchg loops, so it is gone.

Two tests, both of which fail without the change:

* spawn, wait, spawn again, wait again, and check both rounds ran. Without the change the second spawn returns `error.Closed`.
* spawn a task that itself spawns into the group while the caller is inside `wait()`, and check the wait covers it. Without the change the count comes back 1 instead of 2.

On that second one, coverage comes from the counter, not the task list: registration increments before pushing the node, completion removes the node before decrementing and wakes the futex on the last one, and both waiters park on the state word rather than on the list. So a spawn during a wait is picked up, and a counter of zero implies an empty list, which is what the assert at the end of `wait()` relies on. The case that is not covered is a spawn arriving after the counter already hit zero, which is the same contract violation std carves out ("provided that the group does not complete until the call to `Group.async` returns"), and which is documented on `wait()`.

Two things worth deciding separately:

* Whether an awaiting flag is worth it, so that a spawn arriving after the counter hits zero fails with `error.Closed` instead of being silently dropped. std has such a flag (`have_awaiter`) but uses it for wakeup coordination, which we do not need since tasks wake the state-word futex directly.
* Whether `groupAsyncImpl` should keep falling back to synchronous execution for `error.Closed`. It makes sense for the cases std has in mind (out of memory, thread limit, single-threaded), but for a group that refused the task it turns a semantic mismatch into a silent behavior change. After this PR that path is only reachable for a fail-fast group that already failed.
