### PR TITLE
Treat ENXIO and EOVERFLOW as Unseekable

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed writing to a terminal on macOS crashing with an unexpected `ENXIO` error. A
+  reader or writer starts in positional mode and expects the first `pread`/`pwrite` to
+  fail with `ESPIPE` if the file turns out not to be seekable, which is how it learns to
+  switch to streaming reads and writes. macOS reports a terminal as `ENXIO` instead, so
+  the fallback never happened and the error escaped to the caller as `error.Unexpected`,
+  with a stack trace dumped to stderr. `ENXIO` and `EOVERFLOW` are now both translated to
+  `error.Unseekable`, matching `std.Io.Threaded`.
+
 - Added `Dir.createFileAtomic()` and `AtomicFile` to the native API, mirroring the
   equivalent `std.Io` interface. The data is written to a randomly named temporary file
   in the destination's directory and then moved into place with an atomic rename:

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1827,7 +1827,10 @@ pub fn errnoToFileReadError(err: E) FileReadError {
                 .PIPE => error.BrokenPipe,
                 .NOMEM => error.SystemResources,
                 .BADF => error.NotOpenForReading,
-                .SPIPE => error.Unseekable,
+                // ESPIPE is the usual "not seekable" answer for a positional
+                // read, but macOS returns ENXIO for a tty, and EOVERFLOW when
+                // the offset is past what the device can represent.
+                .SPIPE, .NXIO, .OVERFLOW => error.Unseekable,
                 else => |e| unexpectedError(e),
             };
         },
@@ -1863,7 +1866,10 @@ pub fn errnoToFileWriteError(err: E) FileWriteError {
                 .BADF => error.NotOpenForWriting,
                 .DQUOT => error.DiskQuota,
                 .FBIG => error.FileTooBig,
-                .SPIPE => error.Unseekable,
+                // ESPIPE is the usual "not seekable" answer for a positional
+                // write, but macOS returns ENXIO for a tty, and EOVERFLOW when
+                // the offset is past what the device can represent.
+                .SPIPE, .NXIO, .OVERFLOW => error.Unseekable,
                 else => |e| unexpectedError(e),
             };
         },


### PR DESCRIPTION
Writing to a terminal on macOS crashed with `unexpected error: .NXIO`.

A reader/writer starts in positional mode and expects the first `pread`/`pwrite` to fail with `ESPIPE` when the file is not seekable, which is how it learns to switch to streaming. macOS returns `ENXIO` for a tty instead, so the fallback never ran and the error escaped as `error.Unexpected`.

Map `ENXIO` and `EOVERFLOW` to `error.Unseekable`, same grouping `std.Io.Threaded` uses in its positional paths.