### PR TITLE
ev: track active per loop, move inflight tracking into backends

### DIFF
--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -36,19 +36,14 @@ const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
 pub const capabilities: BackendCapabilities = .{
     .process_wait = true,
     .native_wall_timers = true,
-    // A socket fd is registered in exactly one loop's epoll (per direction), but
-    // the op can be submitted from another loop and is serviced/completed by the
-    // registering loop when its edge fires - i.e. completions finish on a thread
-    // other than the one that submitted them. That makes the group's
-    // active/inflight accounting shared, exactly like IOCP.
-    .is_multi_threaded = true,
 };
 
 pub const SharedState = struct {
-    /// Group-shared accounting: a completion submitted on one loop may be
-    /// finished by the loop that owns the fd registration, so active/inflight_io
-    /// are shared atomics rather than per-LoopState fields (see LoopState).
-    active: std.atomic.Value(usize) = .init(0),
+    /// Backend-internal inflight count: ops accepted by submit() and not yet
+    /// completed. A completion submitted on one loop may be finished by the
+    /// loop that owns the fd registration, so the count is a group-shared
+    /// atomic (either loop's decrInflight hits the same storage). Read by
+    /// hasInflight() to skip the poll syscall when nothing can arrive.
     inflight_io: std.atomic.Value(usize) = .init(0),
     /// Cross-loop single-owner socket registration table, shared by every loop
     /// in the group. See sockreg.zig.
@@ -484,11 +479,27 @@ pub fn probeEvent(fd: NetHandle, dir: sockreg.Dir) linux.epoll_event {
     return .{ .data = .{ .u64 = sockData(fd) }, .events = 0 };
 }
 
+/// Drop one inflight op. Called via LoopState.markCompletedFromBackend from
+/// whichever loop finishes the op; the storage is group-shared, so any
+/// instance's decrement balances any instance's increment.
+pub fn decrInflight(self: *Self) void {
+    _ = self.shared.inflight_io.fetchSub(1, .monotonic);
+}
+
+/// Whether poll() could produce completions. Used by the loop to skip the
+/// wait syscall in no-wait ticks when nothing can arrive.
+pub fn hasInflight(self: *const Self) bool {
+    return self.shared.inflight_io.load(.monotonic) > 0;
+}
+
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.incrActive();
+    // Counted for every accepted op (sync completers decrement right back via
+    // markCompletedFromBackend), mirroring the decrInflight in every completion
+    // path so the balance needs no per-path reasoning.
+    _ = self.shared.inflight_io.fetchAdd(1, .monotonic);
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -221,6 +221,12 @@ wall_ts: [2]linux.kernel_timespec = undefined,
 /// so there is no aliasing concern.
 cqe_buf: [256]linux.io_uring_cqe = undefined,
 shared_state: *SharedState,
+/// Backend-internal inflight count: ops accepted by submit() and not yet
+/// completed (in the SQ/kernel or parked on `pending`). This backend is
+/// strictly per-loop (submit, poll, and completion on the owner thread), so a
+/// plain counter suffices. Read by hasInflight() to skip the enter syscall
+/// when nothing can arrive.
+inflight: usize = 0,
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
     var flags: u32 = 0;
@@ -343,6 +349,18 @@ fn drainWaker(self: *Self, cqe: linux.io_uring_cqe) void {
     if (cqe.flags & linux.IORING_CQE_F_MORE == 0) self.waker_needs_rearm = true;
 }
 
+/// Drop one inflight op. Called via LoopState.markCompletedFromBackend on the
+/// owner thread.
+pub fn decrInflight(self: *Self) void {
+    self.inflight -= 1;
+}
+
+/// Whether poll() could produce completions. Used by the loop to skip the
+/// wait syscall in no-wait ticks when nothing can arrive.
+pub fn hasInflight(self: *const Self) bool {
+    return self.inflight > 0;
+}
+
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 /// Can be called for initial submission (state == .new) or resubmission after EINTR (state == .running).
@@ -350,7 +368,10 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     const is_new = c.state == .new;
     if (is_new) {
         c.state = .running;
-        state.incrActive();
+        // Counted once per accepted op (sync completers decrement right back
+        // via markCompletedFromBackend); EINTR resubmissions are not new and
+        // stay counted from their first submit.
+        self.inflight += 1;
     } else {
         std.debug.assert(c.state == .running);
     }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -170,7 +170,6 @@ pub const capabilities: BackendCapabilities = .{
     // Loop routes pollable fds here; seekable fds go to the thread pool.
     .file_read_streaming = false,
     .file_write_streaming = false,
-    .is_multi_threaded = true,
     .process_wait = true,
     // Zero-copy file-to-socket transfer via the TransmitFile extension.
     .net_send_file = true,
@@ -251,10 +250,11 @@ pub const SharedState = struct {
     refcount: usize = 0,
     iocp: windows.HANDLE = windows.INVALID_HANDLE_VALUE,
 
-    /// Multi-threaded counters: multiple loops may submit and
-    /// complete I/O on the same IOCP port, so active/inflight_io
-    /// are shared atomics rather than per-LoopState fields.
-    active: std.atomic.Value(u64) = .init(0),
+    /// Backend-internal inflight count: ops accepted by submit() and not yet
+    /// completed. Any loop of the group may dequeue any completion from the
+    /// shared port, so the count is a group-shared atomic (any instance's
+    /// decrInflight balances any instance's increment). Read by hasInflight()
+    /// to skip the wait syscall when nothing can arrive.
     inflight_io: std.atomic.Value(u64) = .init(0),
 
     // Extension functions loaded once globally (family-independent)
@@ -282,7 +282,6 @@ pub const SharedState = struct {
 
             // Reset shared accounting in case this SharedState is being
             // reused after a previous teardown that left stale counters.
-            self.active.store(0, .release);
             self.inflight_io.store(0, .release);
 
             // Load all extension functions using a temporary socket
@@ -450,9 +449,25 @@ pub fn wake(self: *Self, state: *LoopState) void {
     }
 }
 
+/// Drop one inflight op. Called via LoopState.markCompletedFromBackend from
+/// whichever loop dequeues the completion; the storage is group-shared, so
+/// any instance's decrement balances any instance's increment.
+pub fn decrInflight(self: *Self) void {
+    _ = self.shared_state.inflight_io.fetchSub(1, .monotonic);
+}
+
+/// Whether poll() could produce completions. Used by the loop to skip the
+/// wait syscall in no-wait ticks when nothing can arrive.
+pub fn hasInflight(self: *const Self) bool {
+    return self.shared_state.inflight_io.load(.monotonic) > 0;
+}
+
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.incrActive();
+    // Counted for every accepted op (sync completers decrement right back via
+    // markCompletedFromBackend), mirroring the decrInflight in every completion
+    // path so the balance needs no per-path reasoning.
+    _ = self.shared_state.inflight_io.fetchAdd(1, .monotonic);
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -39,18 +39,14 @@ pub const capabilities: BackendCapabilities = .{
     // The BSDs' EVFILT_TIMER absolute clock is monotonic-only and underspecified
     // with no CLOCK_REALTIME timer, so they keep the capped poll-timeout fallback.
     .native_wall_timers = builtin.os.tag.isDarwin(),
-    // A socket fd is registered in exactly one loop's kqueue (per direction), but
-    // the op can be submitted from another loop and is serviced/completed by the
-    // registering loop when its edge fires - completions finish on a thread other
-    // than the submitter. That makes active/inflight accounting shared, like IOCP.
-    .is_multi_threaded = true,
 };
 
 pub const SharedState = struct {
-    /// Group-shared accounting: a completion submitted on one loop may be
-    /// finished by the loop that owns the fd registration, so active/inflight_io
-    /// are shared atomics rather than per-LoopState fields (see LoopState).
-    active: std.atomic.Value(usize) = .init(0),
+    /// Backend-internal inflight count: ops accepted by submit() and not yet
+    /// completed. A completion submitted on one loop may be finished by the
+    /// loop that owns the fd registration, so the count is a group-shared
+    /// atomic (either loop's decrInflight hits the same storage). Read by
+    /// hasInflight() to skip the poll syscall when nothing can arrive.
     inflight_io: std.atomic.Value(usize) = .init(0),
     /// Cross-loop single-owner socket registration table, shared by every loop
     /// in the group. See sockreg.zig.
@@ -457,11 +453,27 @@ pub fn probeEvent(fd: NetHandle, dir: sockreg.Dir) std.c.Kevent {
     };
 }
 
+/// Drop one inflight op. Called via LoopState.markCompletedFromBackend from
+/// whichever loop finishes the op; the storage is group-shared, so any
+/// instance's decrement balances any instance's increment.
+pub fn decrInflight(self: *Self) void {
+    _ = self.shared.inflight_io.fetchSub(1, .monotonic);
+}
+
+/// Whether poll() could produce completions. Used by the loop to skip the
+/// wait syscall in no-wait ticks when nothing can arrive.
+pub fn hasInflight(self: *const Self) bool {
+    return self.shared.inflight_io.load(.monotonic) > 0;
+}
+
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.incrActive();
+    // Counted for every accepted op (sync completers decrement right back via
+    // markCompletedFromBackend), mirroring the decrInflight in every completion
+    // path so the balance needs no per-path reasoning.
+    _ = self.shared.inflight_io.fetchAdd(1, .monotonic);
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -282,8 +282,6 @@ fn getHandle(completion: *Completion) NetHandle {
     };
 }
 
-/// Submit a completion to the backend - infallible.
-/// On error, completes the operation immediately with error.Unexpected.
 /// Drop one inflight op. Called via LoopState.markCompletedFromBackend on the
 /// owner thread.
 pub fn decrInflight(self: *Self) void {
@@ -296,6 +294,8 @@ pub fn hasInflight(self: *const Self) bool {
     return self.inflight > 0;
 }
 
+/// Submit a completion to the backend - infallible.
+/// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
     // Counted for every accepted op (sync completers decrement right back via

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -62,6 +62,11 @@ waker_read_fd: net.fd_t = undefined,
 waker_write_fd: net.fd_t = undefined,
 queue_size: u16,
 pending_changes: usize = 0,
+/// Backend-internal inflight count: ops accepted by submit() and not yet
+/// completed. This backend is strictly per-loop (submit and completion on the
+/// owner thread), so a plain counter suffices. Read by hasInflight() to skip
+/// the poll syscall when nothing can arrive.
+inflight: usize = 0,
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
     _ = shared_state;
@@ -279,9 +284,24 @@ fn getHandle(completion: *Completion) NetHandle {
 
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
+/// Drop one inflight op. Called via LoopState.markCompletedFromBackend on the
+/// owner thread.
+pub fn decrInflight(self: *Self) void {
+    self.inflight -= 1;
+}
+
+/// Whether poll() could produce completions. Used by the loop to skip the
+/// wait syscall in no-wait ticks when nothing can arrive.
+pub fn hasInflight(self: *const Self) bool {
+    return self.inflight > 0;
+}
+
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    state.incrActive();
+    // Counted for every accepted op (sync completers decrement right back via
+    // markCompletedFromBackend), mirroring the decrInflight in every completion
+    // path so the balance needs no per-path reasoning.
+    self.inflight += 1;
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -56,9 +56,6 @@ pub const BackendCapabilities = struct {
     net_send_file: bool = false,
     device_io_control: bool = false,
     process_wait: bool = false,
-    /// When true, completions submitted to one loop in a group may be completed
-    /// on another loop's thread. Timer operations are protected by a mutex.
-    is_multi_threaded: bool = false,
     /// When true, the backend arms boot/real (wall-clock) timers natively via
     /// `syncWallTimers`, so the loop must not fold them into the poll timeout.
     /// When false, the loop falls back to the capped poll-timeout re-evaluation.

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -430,6 +430,12 @@ pub const LoopState = struct {
 
     pub fn setTimer(self: *LoopState, timer: *Timer) void {
         const idx = clockIndex(timer.clock);
+        // Rearming a timer that is mid-fire (out of the heap, result set, its
+        // markCompleted still pending outside this lock) cannot work: the timer
+        // is already completing and inserting it would double-complete it.
+        // Callers must rearm from the completion callback (or after it), never
+        // concurrently with the fire.
+        std.debug.assert(!(timer.c.state == .running and timer.c.has_result));
         // `.running` means the timer is already in its heap (resetting it);
         // anything else means it's newly activated. Don't key this off
         // `deadline.value`, which can legitimately be 0 for an absolute
@@ -632,6 +638,13 @@ pub const Loop = struct {
     pub fn setTimer(self: *Loop, timer: *Timer, timeout: Timeout) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        // Rearming a fired (completed/dead) timer: drop the stale result so
+        // that a running timer with a result set unambiguously means "mid-fire"
+        // (the limbo state clearTimer must leave alone).
+        if (timer.c.state != .running) {
+            timer.c.has_result = false;
+            timer.c.err = null;
+        }
         // Advance the scan so this timer's deadline is computed against a fresh
         // `now` in its own clock (via `nowFor` in `setTimer`).
         self.state.updateNow();
@@ -640,10 +653,20 @@ pub const Loop = struct {
         self.state.setTimer(timer);
     }
 
-    /// Clear a timer without completing it (works immediately, no cancellation completion required)
+    /// Clear a timer without completing it (works immediately, no cancellation
+    /// completion required). Thread-safe: may be called from a thread that does
+    /// not own the loop (a migrated task clearing its sleep timer).
     pub fn clearTimer(self: *Loop, timer: *Timer) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        // A running timer that already has its result is in the fired/canceled
+        // limbo window: checkTimers (or cancelLocal) removed it from the heap
+        // and set its result under this lock, but its markCompleted runs after
+        // unlocking. Touching it here would remove a non-member from the heap
+        // (corrupting it), clear the result that markCompleted asserts on, and
+        // decrement active a second time (finishCompletion will decrement for
+        // the same timer). It is already on its way to completion; leave it be.
+        if (timer.c.state == .running and timer.c.has_result) return;
         const was_active = timer.c.state == .running;
         self.state.clearTimer(timer);
         if (was_active) {
@@ -735,8 +758,12 @@ pub const Loop = struct {
             },
             .timer => {
                 const timer = completion.cast(Timer);
-                timer.c.setError(error.Canceled);
                 self.state.lockTimers();
+                // Set the result under the timer lock: a cross-thread
+                // Loop.clearTimer keys "already fired/canceled, hands off" on
+                // (.running and has_result) under this lock, so the result must
+                // never appear outside it while the timer is running.
+                timer.c.setError(error.Canceled);
                 self.state.clearTimer(timer);
                 self.state.unlockTimers();
                 self.state.markCompleted(&timer.c);

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -225,11 +225,13 @@ pub const LoopState = struct {
     running: bool = false,
     stopped: bool = false,
 
-    active: usize = 0,
-    /// I/O operations submitted to backend awaiting completion
-    // Plain counter mutated only by the owner thread, but read cross-thread
-    // by the scheduler's load shedding, hence the atomic accessors below.
-    inflight_io: usize = 0,
+    /// Not-yet-finished completions owned by this loop. The count lives on the
+    /// completion's owning loop (`completion.loop`): incremented at the submit
+    /// sites, decremented in `finishCompletion` routed through
+    /// `completion.loop`, which may run on a different loop's thread (epoll
+    /// single-owner servicing, the shared IOCP port) - hence the atomic. The
+    /// scheduler's load shedding also reads other loops' counters.
+    active: std.atomic.Value(usize) = .init(0),
 
     wake_requested: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
@@ -284,67 +286,30 @@ pub const LoopState = struct {
     pub const wake_async: u32 = 2;
     pub const wake_cancel: u32 = 4;
 
-    /// Increment the inflight I/O counter. On multi-threaded backends
-    /// (IOCP) this routes to a shared atomic; on single-threaded backends
-    /// only the owner thread mutates, but other executors read the count for
-    /// load shedding, so the access is a monotonic atomic either way.
-    pub fn incrInflight(self: *LoopState) void {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            _ = self.loop.loop_group.shared.inflight_io.fetchAdd(1, .monotonic);
-        } else {
-            @atomicStore(usize, &self.inflight_io, self.inflight_io + 1, .monotonic);
-        }
-    }
-
-    /// Decrement the inflight I/O counter.
-    pub fn decrInflight(self: *LoopState) void {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            _ = self.loop.loop_group.shared.inflight_io.fetchSub(1, .monotonic);
-        } else {
-            @atomicStore(usize, &self.inflight_io, self.inflight_io - 1, .monotonic);
-        }
-    }
-
-    /// Read the inflight I/O counter (any thread).
-    pub fn loadInflight(self: *const LoopState) usize {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            return @intCast(self.loop.loop_group.shared.inflight_io.load(.monotonic));
-        } else {
-            return @atomicLoad(usize, &self.inflight_io, .monotonic);
-        }
-    }
-
-    /// Increment the active (not-yet-finished) completion counter.
+    /// Increment this loop's active completion counter. Counted by the loop at
+    /// every submit site (backends do no accounting).
     pub fn incrActive(self: *LoopState) void {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            _ = self.loop.loop_group.shared.active.fetchAdd(1, .monotonic);
-        } else {
-            self.active += 1;
-        }
+        _ = self.active.fetchAdd(1, .monotonic);
     }
 
-    /// Decrement the active (not-yet-finished) completion counter.
+    /// Decrement this loop's active completion counter. Callers must invoke
+    /// this on the completion's owning loop (`completion.loop`), not on
+    /// whichever loop happens to run the finish (see `finishCompletion`).
     pub fn decrActive(self: *LoopState) void {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            _ = self.loop.loop_group.shared.active.fetchSub(1, .monotonic);
-        } else {
-            self.active -= 1;
-        }
+        _ = self.active.fetchSub(1, .monotonic);
     }
 
-    /// Read the active completion counter.
+    /// Read this loop's active completion counter (any thread).
     pub fn loadActive(self: *const LoopState) usize {
-        if (comptime Backend.capabilities.is_multi_threaded) {
-            return @intCast(self.loop.loop_group.shared.active.load(.monotonic));
-        } else {
-            return self.active;
-        }
+        return self.active.load(.monotonic);
     }
 
-    /// Called by backends when an I/O operation completes.
-    /// Decrements inflight_io counter and marks the completion done.
+    /// Called by backends when an operation they accepted completes. Tells the
+    /// backend to drop its inflight count (the backend of the loop running the
+    /// completion, whose storage covers the op on every backend) and marks the
+    /// completion done.
     pub fn markCompletedFromBackend(self: *LoopState, completion: *Completion) void {
-        self.decrInflight();
+        self.loop.backend.decrInflight();
         self.markCompleted(completion);
     }
 
@@ -384,7 +349,10 @@ pub const LoopState = struct {
         std.debug.assert(completion.state == .completed);
 
         completion.state = .dead;
-        self.decrActive();
+        // Route the decrement to the loop that owns the completion: `self` here
+        // can be a different loop (epoll single-owner servicing, the shared
+        // IOCP port, a group finished by the loop that ran its last member).
+        completion.loop.?.state.decrActive();
 
         // Both callbacks below can free `completion`, so whichever may free it must
         // run LAST, with nothing touching `completion` afterward. Cache the owner
@@ -629,6 +597,12 @@ pub const Loop = struct {
         return self.state.stopped;
     }
 
+    /// Whether this loop has nothing left to do: every completion it owns
+    /// (`completion.loop == this`) has finished. An op may be *serviced* by
+    /// another loop of the group, but the active count stays with the owning
+    /// loop until the op finishes, so `done()` cannot report true early.
+    /// Completions handed out via `nextDispatched` are already finished and do
+    /// not keep the loop running.
     pub fn done(self: *const Loop) bool {
         return self.state.stopped or (self.state.loadActive() == 0 and self.state.completions.empty());
     }
@@ -957,7 +931,6 @@ pub const Loop = struct {
                 completion.state = .running;
                 self.state.incrActive();
                 if (comptime Backend.capabilities.net_send_file) {
-                    self.state.incrInflight();
                     self.backend.submit(&self.state, completion);
                 } else {
                     netSendFileStart(self, op);
@@ -991,7 +964,7 @@ pub const Loop = struct {
                             // Route pollable fds to the backend readiness/overlapped path;
                             // seekable fds (regular files, block devices) to the thread pool.
                             if (pollable) {
-                                self.state.incrInflight();
+                                self.state.incrActive();
                                 self.backend.submit(&self.state, completion);
                             } else {
                                 self.submitFileOpToThreadPool(completion);
@@ -1010,7 +983,7 @@ pub const Loop = struct {
                     .file_set_size => {
                         if (comptime @hasDecl(Backend, "fileSetSizeSupported")) {
                             if (self.backend.fileSetSizeSupported()) {
-                                self.state.incrInflight();
+                                self.state.incrActive();
                                 self.backend.submit(&self.state, completion);
                                 return;
                             }
@@ -1032,7 +1005,7 @@ pub const Loop = struct {
                     },
                 }
 
-                self.state.incrInflight();
+                self.state.incrActive();
                 self.backend.submit(&self.state, completion);
                 return;
             },
@@ -1493,7 +1466,7 @@ pub const Loop = struct {
 
         // Skip backend poll in no_wait mode if there's nothing to retrieve.
         // This avoids syscall overhead for pure CPU-bound workloads.
-        const should_poll = wait or self.state.loadInflight() > 0;
+        const should_poll = wait or self.backend.hasInflight();
         const wake_flags = self.state.wake_requested.swap(0, .acq_rel);
         const timed_out = if (should_poll) try self.backend.poll(&self.state, if (wake_flags != 0) .zero else timeout) else false;
 

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -251,9 +251,9 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
     // timer, and cancel routing are unchanged. The owner loop only holds the
     // poller registration and services the op in place when its edge fires,
     // completing it cross-thread through the synchronized completion machinery.
-    // Accounting is group-shared (is_multi_threaded), so it balances regardless of
-    // which loop finishes the op (the owner on a readiness edge, or the submitter
-    // on cancel/timeout).
+    // Accounting balances regardless of which loop finishes the op (the owner on
+    // a readiness edge, or the submitter on cancel/timeout): the active decrement
+    // is routed to `completion.loop` and the inflight storage is group-shared.
     completion.prev = null;
     completion.next = null;
     entry.waiters(dir).push(completion);

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -179,3 +179,65 @@ test "timer on real clock fires (absolute deadline)" {
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("real timer: expected=100ms, actual={f}", .{elapsed});
 }
+
+test "clearTimer racing a firing timer (cross-thread)" {
+    // Regression test: a task migrated to another executor clears its sleep
+    // timer on the loop that armed it, racing the owner thread's checkTimers.
+    // A fired timer sits in a limbo window (out of the heap, result set, its
+    // markCompleted pending outside the timer lock); clearTimer touching it
+    // there corrupted the heap, double-decremented active, and cleared the
+    // result markCompleted asserts on.
+    // The loop is initialized and driven entirely on the runner thread (an
+    // io_uring SINGLE_ISSUER ring must be entered by its creating thread);
+    // this thread only uses the thread-safe setTimer/clearTimer/wake APIs,
+    // exactly like a migrated task's timedWaitClock does.
+    var loop: Loop = undefined;
+    var ready = std.atomic.Value(bool).init(false);
+    var stop = std.atomic.Value(bool).init(false);
+    const runner = try std.Thread.spawn(.{}, struct {
+        fn run(l: *Loop, r: *std.atomic.Value(bool), s: *std.atomic.Value(bool)) void {
+            l.init(.{}) catch @panic("loop init failed");
+            r.store(true, .release);
+            while (!s.load(.acquire)) {
+                l.run(.once) catch return;
+            }
+        }
+    }.run, .{ &loop, &ready, &stop });
+    defer loop.deinit();
+    defer runner.join();
+    defer {
+        stop.store(true, .release);
+        loop.wake();
+    }
+    while (!ready.load(.acquire)) std.Thread.yield() catch {};
+
+    const callback = struct {
+        fn cb(_: *Loop, c: *@import("../completion.zig").Completion) void {
+            const fired: *std.atomic.Value(bool) = @ptrCast(@alignCast(c.userdata.?));
+            fired.store(true, .release);
+        }
+    }.cb;
+
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        var fired = std.atomic.Value(bool).init(false);
+        var timer: Timer = .init(.{ .duration = .zero });
+        timer.c.userdata = &fired;
+        timer.c.callback = callback;
+
+        // Arm with a tiny, varying delay so the clear below lands at different
+        // points relative to the fire: before it, after it, and inside the
+        // limbo window.
+        loop.setTimer(&timer, .{ .duration = .fromNanoseconds((i % 64) * 1000) });
+        if (i % 2 == 0) std.Thread.yield() catch {};
+        loop.clearTimer(&timer);
+
+        // If the clear won, the timer is ours again (.new, written by this
+        // thread under the lock). Anything else means the fire got there
+        // first (or is mid-flight): wait for its callback before the stack
+        // timer goes out of scope.
+        if (@atomicLoad(@TypeOf(timer.c.state), &timer.c.state, .acquire) != .new) {
+            while (!fired.load(.acquire)) std.Thread.yield() catch {};
+        }
+    }
+}

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -625,20 +625,21 @@ pub const Executor = struct {
     /// queue into the primary scheduling path.
     const max_shed_per_tick = 4;
 
-    /// Once per tick, compare this executor's I/O-resident load (in-flight
-    /// ops == tasks parked on this ring) against the runtime average; the
-    /// excess becomes this tick's shed quota (see scheduleTaskLocal). Purely
-    /// decentralized: every executor reads the per-loop counters and makes
-    /// its own call.
+    /// Once per tick, compare this executor's resident load (active ops
+    /// submitted on this loop, mostly tasks parked on I/O) against the
+    /// runtime average; the excess becomes this tick's shed quota (see
+    /// scheduleTaskLocal). Purely decentralized: every executor reads the
+    /// per-loop counters and makes its own call. Every executor carries the
+    /// same +1 baseline (its shutdown handle), so comparisons are unaffected.
     fn recomputeShedQuota(self: *Executor) void {
         self.shed_quota = 0;
         if (!self.runtime.stealingActive()) return;
 
         const executors = self.runtime.executors.items;
-        const mine = self.loop.state.loadInflight();
+        const mine = self.loop.state.loadActive();
         if (mine < 2) return; // nothing worth shedding
         var total: usize = 0;
-        for (executors) |e| total += e.loop.state.loadInflight();
+        for (executors) |e| total += e.loop.state.loadActive();
         const avg = total / executors.len;
         // The +1 keeps neighbors one apart from trading the same task back
         // and forth forever.


### PR DESCRIPTION
Rework of the loop's op accounting, first step of the Linux backend unification (runtime io_uring/epoll selection and later a hybrid mode).

## active

- Per-loop `std.atomic.Value(usize)` on `LoopState`, replacing the comptime split between a plain per-loop field and group-shared storage in the backend `SharedState`.
- Incremented at the loop's submit sites (backends no longer do any accounting in `submit`).
- Decremented in `finishCompletion` **routed through `completion.loop`**, the loop that owns the completion. The finish can run on a different loop's thread (epoll single-owner servicing, the shared IOCP port, and notably a group/`net_send_file` parent finished by whichever loop ran its last child) - routing keeps the counter exact in all of these with one uniform rule.
- `done()` is now per-loop: everything submitted on a loop holds that loop open, regardless of which loop services it. This is groundwork for the follow-up PR, where the epoll/kqueue park path will hand full completion custody (`completion.loop`, count included) to the fd's owner loop.

## inflight

- Removed from `LoopState` entirely; it is an internal backend optimization for skipping the poll syscall when nothing can arrive.
- Each backend counts ops it accepted in its own storage: plain field for io_uring/poll (single-threaded ownership, no atomics), group-shared atomic for epoll/kqueue/iocp (a completion can be finished by another loop of the group).
- The loop asks `backend.hasInflight()` in `tick` and tells the backend to drop one via the `decrInflight` hook in `markCompletedFromBackend`.

## Removed

- `BackendCapabilities.is_multi_threaded` - it conflated "where does active live" with "where does inflight live"; both questions now have per-backend answers and the flag has no readers left.

## Side effect

`recomputeShedQuota` now compares per-loop active counts instead of inflight. On backends where inflight was group-shared, every executor read the same value (`mine == avg` always), so load shedding was silently inert there; per-loop counts make it meaningful. The uniform +1 baseline from each executor's shutdown handle cancels out in the comparison.

## Testing

- `./check.sh` (io_uring): 563/563
- `-Dbackend=epoll`: 563/563, `-Dbackend=poll`: 562/562
- `./check.sh --target x86_64-windows --wine` (iocp): 499/499
- `x86_64-macos` cross-compile (kqueue): builds
- `./check.sh --full` (examples): passes

## Follow-up (custody handover PR)

- `sockreg.park` hands full completion custody to the fd's owner loop: repoint `completion.loop` and move the active count under the shard lock; `detach` reclaims both on a cancel win. Cancel routing then converges on the servicing thread.
- epoll/kqueue inflight becomes per-instance (how many ops THIS poller is responsible for producing) instead of group-shared, transferred at the same park/detach points. A loop with nothing parked then correctly skips the poll syscall instead of polling because some other loop has work.


## Bug fix: cross-thread clearTimer racing a firing timer (second commit)

A fired timer sits in a limbo window (removed from the heap and result set under the timer lock, `markCompleted` after unlock, state still `.running`). A cross-thread `Loop.clearTimer` in that window corrupted the timer heap, double-decremented `active`, and cleared the result `markCompleted` asserts on. On main the double decrement panics (plain `active -= 1` underflow); this PR's atomic counter would have silenced that symptom while leaving the corruption, so the fix belongs here. Under the lock, `.running and has_result` now unambiguously means mid-fire and `clearTimer` leaves the timer alone; `cancelLocal` sets its result inside the lock and `Loop.setTimer` drops stale results on rearm to keep the invariant exact. A regression test reproduces the original crash reliably with the guard reverted. Cherry-pickable onto main if a hotfix release is needed before this PR merges.
