### PR TITLE
ev: per-instance inflight on epoll/kqueue, Loop.cancel receiver contract

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -205,7 +205,7 @@ pub const CompletionQueue = struct {
         while (node) |n| {
             const next_node = n.next;
             const c = completionFromGroup(n);
-            if (c.loop) |loop| loop.cancel(c);
+            getCurrentExecutor().loop.cancel(c);
             node = next_node;
         }
     }

--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -7,6 +7,7 @@ const Clock = @import("../../time.zig").Clock;
 const common = @import("common.zig");
 
 const unexpectedError = @import("../../os/base.zig").unexpectedError;
+const Loop = @import("../loop.zig").Loop;
 const LoopState = @import("../loop.zig").LoopState;
 const Completion = @import("../completion.zig").Completion;
 const Op = @import("../completion.zig").Op;
@@ -470,10 +471,21 @@ pub fn registerSocket(self: *Self, fd: NetHandle, dir: sockreg.Dir, other_owned_
     }
 }
 
-/// Drop this loop's epoll entry for `fd` (best-effort: ENOENT if owned elsewhere;
-/// the kernel drops the rest when the fd is closed). Called by sockreg.unregister.
-pub fn unregisterCleanup(self: *Self, fd: NetHandle) void {
-    _ = linux.epoll_ctl(self.epoll_fd, linux.EPOLL.CTL_DEL, fd, null);
+/// Remove a closing socket's registration from the pollers that actually hold
+/// it: the direction owners. Must run while the fd is still open - an epoll
+/// subscription is keyed to the file description, and the fd is the only
+/// handle for removing it. Relying on close-time eviction instead would leave
+/// an unremovable registration firing events forever whenever another
+/// reference (dup, fork, SCM_RIGHTS) keeps the description alive. epoll_ctl
+/// is thread-safe, so deleting from another loop's epoll is fine. Called by
+/// sockreg.unregister.
+pub fn unregisterCleanup(self: *Self, fd: NetHandle, owners: [2]?*Loop) void {
+    _ = self;
+    for (owners, 0..) |maybe_owner, i| {
+        const owner = maybe_owner orelse continue;
+        if (i == 1 and owners[0] == owner) continue; // both directions, one loop
+        _ = linux.epoll_ctl(owner.backend.epoll_fd, linux.EPOLL.CTL_DEL, fd, null);
+    }
 }
 
 /// A no-error event for the optimistic (pre-park) checkCompletion attempt.

--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -39,12 +39,6 @@ pub const capabilities: BackendCapabilities = .{
 };
 
 pub const SharedState = struct {
-    /// Backend-internal inflight count: ops accepted by submit() and not yet
-    /// completed. A completion submitted on one loop may be finished by the
-    /// loop that owns the fd registration, so the count is a group-shared
-    /// atomic (either loop's decrInflight hits the same storage). Read by
-    /// hasInflight() to skip the poll syscall when nothing can arrive.
-    inflight_io: std.atomic.Value(usize) = .init(0),
     /// Cross-loop single-owner socket registration table, shared by every loop
     /// in the group. See sockreg.zig.
     sock_table: sockreg.Table = .{},
@@ -126,6 +120,13 @@ pending_changes: usize = 0,
 /// false the first time the syscall returns ENOSYS, after which we use the
 /// millisecond epoll_wait for the rest of this loop's lifetime.
 epoll_pwait2_supported: bool = true,
+/// The number of parked ops THIS poller instance will produce completions for
+/// (socket waiters on fds whose registration this loop owns, plus poll_queue
+/// entries). Maintained at the queue-membership points: sockreg
+/// park/service/detach for sockets (under the shard lock; a cross-loop park
+/// counts on the owner) and addToPollQueue/removeFromPollQueue for the rest.
+/// Read lock-free by hasInflight(), hence the atomic.
+inflight: std.atomic.Value(usize) = .init(0),
 
 pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_state: *SharedState) !void {
     shared_state.sock_table.acquire(allocator);
@@ -341,6 +342,7 @@ fn addToPollQueue(self: *Self, state: *LoopState, fd: NetHandle, completion: *Co
             .events = op_events,
         };
         entry.completions.push(completion);
+        self.incrParked();
         return;
     }
 
@@ -365,12 +367,13 @@ fn addToPollQueue(self: *Self, state: *LoopState, fd: NetHandle, completion: *Co
         entry.events = new_events;
     }
     entry.completions.push(completion);
+    self.incrParked();
 }
 
 fn removeFromPollQueue(self: *Self, fd: NetHandle, completion: *Completion) !void {
     const entry = self.poll_queue.getPtr(fd) orelse return;
 
-    _ = entry.completions.remove(completion);
+    if (entry.completions.remove(completion)) self.decrParked();
 
     if (entry.completions.head == null) {
         // No more completions - remove from epoll and poll queue
@@ -479,27 +482,36 @@ pub fn probeEvent(fd: NetHandle, dir: sockreg.Dir) linux.epoll_event {
     return .{ .data = .{ .u64 = sockData(fd) }, .events = 0 };
 }
 
-/// Drop one inflight op. Called via LoopState.markCompletedFromBackend from
-/// whichever loop finishes the op; the storage is group-shared, so any
-/// instance's decrement balances any instance's increment.
-pub fn decrInflight(self: *Self) void {
-    _ = self.shared.inflight_io.fetchSub(1, .monotonic);
+/// A parked op entered a queue this instance's poller services. Called by
+/// sockreg.park (under the shard lock, possibly from another loop's thread)
+/// and by addToPollQueue.
+pub fn incrParked(self: *Self) void {
+    _ = self.inflight.fetchAdd(1, .monotonic);
 }
 
-/// Whether poll() could produce completions. Used by the loop to skip the
-/// wait syscall in no-wait ticks when nothing can arrive.
+/// A parked op left a queue this instance's poller services.
+pub fn decrParked(self: *Self) void {
+    _ = self.inflight.fetchSub(1, .monotonic);
+}
+
+/// No-op: this backend counts parked ops at the queue-membership points (see
+/// `inflight`) instead of mirroring submit/complete, because an op it accepts
+/// may be parked on - and produced by - another instance's poller.
+pub fn decrInflight(self: *Self) void {
+    _ = self;
+}
+
+/// Whether poll() on THIS instance could produce completions. Used by the
+/// loop to skip the wait syscall in no-wait ticks; a loop with nothing of its
+/// own parked skips it even when other loops in the group have work.
 pub fn hasInflight(self: *const Self) bool {
-    return self.shared.inflight_io.load(.monotonic) > 0;
+    return self.inflight.load(.monotonic) > 0;
 }
 
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    // Counted for every accepted op (sync completers decrement right back via
-    // markCompletedFromBackend), mirroring the decrInflight in every completion
-    // path so the balance needs no per-path reasoning.
-    _ = self.shared.inflight_io.fetchAdd(1, .monotonic);
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -42,12 +42,6 @@ pub const capabilities: BackendCapabilities = .{
 };
 
 pub const SharedState = struct {
-    /// Backend-internal inflight count: ops accepted by submit() and not yet
-    /// completed. A completion submitted on one loop may be finished by the
-    /// loop that owns the fd registration, so the count is a group-shared
-    /// atomic (either loop's decrInflight hits the same storage). Read by
-    /// hasInflight() to skip the poll syscall when nothing can arrive.
-    inflight_io: std.atomic.Value(usize) = .init(0),
     /// Cross-loop single-owner socket registration table, shared by every loop
     /// in the group. See sockreg.zig.
     sock_table: sockreg.Table = .{},
@@ -120,6 +114,13 @@ events: []std.c.Kevent,
 /// Currently-armed absolute deadline (ns in the clock's epoch) for the boot/real
 /// EVFILT_TIMER, or null if disarmed. Index 0 = boot, 1 = real. Darwin only.
 wall_armed: [2]?u64 = .{ null, null },
+/// The number of parked ops THIS poller instance will produce completions for
+/// (socket waiters on fds whose registration this loop owns, plus poll_queue
+/// entries). Maintained at the queue-membership points: sockreg
+/// park/service/detach for sockets (under the shard lock; a cross-loop park
+/// counts on the owner) and addToPollQueue/removeFromPollQueue for the rest.
+/// Read lock-free by hasInflight(), hence the atomic.
+inflight: std.atomic.Value(usize) = .init(0),
 
 fn makeKey(ident: usize, filter: i32) u64 {
     std.debug.assert(ident <= std.math.maxInt(u32));
@@ -357,6 +358,7 @@ fn addToPollQueue(self: *Self, state: *LoopState, completion: *Completion) void 
     }
 
     gop.value_ptr.completions.push(completion);
+    self.incrParked();
 }
 
 fn removeFromPollQueue(self: *Self, completion: *Completion) void {
@@ -365,7 +367,7 @@ fn removeFromPollQueue(self: *Self, completion: *Completion) void {
     const key = makeKey(ident, filter);
     const entry = self.poll_queue.getPtr(key) orelse return;
 
-    _ = entry.completions.remove(completion);
+    if (entry.completions.remove(completion)) self.decrParked();
 
     if (entry.completions.head == null) {
         const change = self.reserveChange() catch {
@@ -453,27 +455,36 @@ pub fn probeEvent(fd: NetHandle, dir: sockreg.Dir) std.c.Kevent {
     };
 }
 
-/// Drop one inflight op. Called via LoopState.markCompletedFromBackend from
-/// whichever loop finishes the op; the storage is group-shared, so any
-/// instance's decrement balances any instance's increment.
-pub fn decrInflight(self: *Self) void {
-    _ = self.shared.inflight_io.fetchSub(1, .monotonic);
+/// A parked op entered a queue this instance's poller services. Called by
+/// sockreg.park (under the shard lock, possibly from another loop's thread)
+/// and by addToPollQueue.
+pub fn incrParked(self: *Self) void {
+    _ = self.inflight.fetchAdd(1, .monotonic);
 }
 
-/// Whether poll() could produce completions. Used by the loop to skip the
-/// wait syscall in no-wait ticks when nothing can arrive.
+/// A parked op left a queue this instance's poller services.
+pub fn decrParked(self: *Self) void {
+    _ = self.inflight.fetchSub(1, .monotonic);
+}
+
+/// No-op: this backend counts parked ops at the queue-membership points (see
+/// `inflight`) instead of mirroring submit/complete, because an op it accepts
+/// may be parked on - and produced by - another instance's poller.
+pub fn decrInflight(self: *Self) void {
+    _ = self;
+}
+
+/// Whether poll() on THIS instance could produce completions. Used by the
+/// loop to skip the wait syscall in no-wait ticks; a loop with nothing of its
+/// own parked skips it even when other loops in the group have work.
 pub fn hasInflight(self: *const Self) bool {
-    return self.shared.inflight_io.load(.monotonic) > 0;
+    return self.inflight.load(.monotonic) > 0;
 }
 
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
     c.state = .running;
-    // Counted for every accepted op (sync completers decrement right back via
-    // markCompletedFromBackend), mirroring the decrInflight in every completion
-    // path so the balance needs no per-path reasoning.
-    _ = self.shared.inflight_io.fetchAdd(1, .monotonic);
 
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -8,6 +8,7 @@ const Clock = @import("../../time.zig").Clock;
 const common = @import("common.zig");
 
 const unexpectedError = @import("../../os/base.zig").unexpectedError;
+const Loop = @import("../loop.zig").Loop;
 const LoopState = @import("../loop.zig").LoopState;
 const Completion = @import("../completion.zig").Completion;
 const Queue = @import("../queue.zig").Queue;
@@ -424,7 +425,15 @@ pub fn registerSocket(self: *Self, fd: NetHandle, dir: sockreg.Dir, other_owned_
 /// pending changes for this fd so they cannot outlive it. (We deliberately do not
 /// enqueue an EV_DELETE: a buffered delete flushes after the close and could hit a
 /// reused fd, reintroducing the same hazard.) Called by sockreg.unregister.
-pub fn unregisterCleanup(self: *Self, fd: NetHandle) void {
+/// The owners are unused: kqueue knotes are fd-keyed and close() removes
+/// applied ones from every kqueue regardless of other references to the
+/// description; only this loop's un-flushed buffered changes need scrubbing.
+/// (A cross-loop park whose ADD is still buffered on the owner is a known
+/// remaining gap - the owner's buffer is single-threaded, so it cannot be
+/// scrubbed from here; planned fix is registering sockets eagerly instead of
+/// buffering.)
+pub fn unregisterCleanup(self: *Self, fd: NetHandle, owners: [2]?*Loop) void {
+    _ = owners;
     const ident: usize = @intCast(fd);
     var i: usize = 0;
     while (i < self.change_buffer.items.len) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -510,6 +510,14 @@ pub const LoopState = struct {
     }
 };
 
+/// The loop owned by the current thread: claimed at init, refreshed at every
+/// tick, released at deinit. Used to enforce `Loop.cancel`'s receiver contract
+/// in safe builds: cancel must be invoked on the loop the calling thread
+/// drives, because its same-loop fast path touches single-threaded loop state
+/// directly. A nested loop run (e.g. executeBlocking) shadows the outer loop
+/// for its duration and the outer loop's next tick reclaims it.
+threadlocal var current_loop: ?*Loop = null;
+
 pub const Loop = struct {
     state: LoopState,
     backend: Backend,
@@ -581,10 +589,15 @@ pub const Loop = struct {
         );
         errdefer self.backend.deinit();
 
+        // Claim this thread as the loop's driver (init and tick are
+        // same-thread by contract), so the init->add->cancel pattern passes
+        // cancel's receiver check before the first tick.
+        current_loop = self;
         self.state.initialized = true;
     }
 
     pub fn deinit(self: *Loop) void {
+        if (current_loop == self) current_loop = null;
         self.backend.deinit();
     }
 
@@ -683,6 +696,14 @@ pub const Loop = struct {
     /// invoked when the operation completes (either with error.Canceled or its natural result).
     /// Thread-safe: can be called from any thread.
     pub fn cancel(self: *Loop, completion: *Completion) void {
+        // Contract: `self` is the loop the calling thread drives - the
+        // `self == target` fast path below runs cancelLocal, which touches the
+        // target's single-threaded state, so the receiver being the target
+        // must mean the caller is on its thread. Enforced here in safe builds;
+        // `current_loop == null` (a thread that has not driven any loop yet)
+        // is permitted for the single-threaded init->add->cancel->run pattern,
+        // where nothing else can be driving the target concurrently.
+        std.debug.assert(current_loop == self or current_loop == null);
         // Check if completion has been added to a loop
         // (loop is set once by addInternal and never changes)
         const target = completion.loop orelse {
@@ -709,7 +730,8 @@ pub const Loop = struct {
         }
 
         if (self == target) {
-            // Same loop - cancel directly
+            // Same loop - cancel directly (the assert above guarantees the
+            // calling thread drives it).
             self.cancelLocal(completion);
         } else {
             // Push to target's cancel queue (lock-free Treiber stack)
@@ -1465,6 +1487,11 @@ pub const Loop = struct {
     }
 
     pub fn tick(self: *Loop, wait: bool) !void {
+        // Re-claim this thread's driver slot (see `current_loop`): another
+        // loop on this thread may have claimed it since - a nested loop run,
+        // or an earlier loop's lifetime on the same thread.
+        current_loop = self;
+
         if (self.done()) return;
 
         const timer_result = self.checkTimers();

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -48,26 +48,32 @@ pub fn other(dir: Dir) Dir {
     };
 }
 
-/// Per-fd registration record. `owner`/`ready`/`waiters` are split per direction
-/// but kept in one entry so a single shard lock covers the whole fd and a close
-/// drops both directions at once.
+/// Per-fd registration record. The two directions are kept in one entry so a
+/// single shard lock covers the whole fd and a close drops both at once.
 pub const Entry = struct {
-    /// The loop (opaque `*Loop`) whose poller has this fd registered for the
-    /// direction, or null if no loop is registered for it yet.
-    read_owner: ?*anyopaque = null,
-    write_owner: ?*anyopaque = null,
-    /// Edge-triggered readiness latch: set when an edge fired but no waiter
-    /// consumed it, so a parker that raced the edge retries instead of sleeping.
+    /// Edge-triggered readiness latches: set when an edge fired but no waiter
+    /// consumed it, so a parker that raced the edge retries instead of
+    /// sleeping. Kept outside the per-direction state because an edge can be
+    /// latched for a direction nobody owns yet (ERR/HUP is serviced for both
+    /// directions regardless of registration).
     read_ready: bool = false,
     write_ready: bool = false,
-    /// Completions parked on this fd/direction, serviced by the owner.
-    read_waiters: Queue(Completion) = .{},
-    write_waiters: Queue(Completion) = .{},
+    /// Present iff the direction is registered with an owner's poller; a
+    /// waiter can only exist under an owner, structurally.
+    read: ?Owned = null,
+    write: ?Owned = null,
 
-    pub fn ownerPtr(self: *Entry, dir: Dir) *?*anyopaque {
+    /// A registered direction: the loop whose poller holds the registration
+    /// and the completions parked on it, serviced by that loop.
+    pub const Owned = struct {
+        owner: *Loop,
+        waiters: Queue(Completion) = .{},
+    };
+
+    pub fn dirPtr(self: *Entry, dir: Dir) *?Owned {
         return switch (dir) {
-            .read => &self.read_owner,
-            .write => &self.write_owner,
+            .read => &self.read,
+            .write => &self.write,
         };
     }
 
@@ -78,17 +84,9 @@ pub const Entry = struct {
         };
     }
 
-    pub fn waiters(self: *Entry, dir: Dir) *Queue(Completion) {
-        return switch (dir) {
-            .read => &self.read_waiters,
-            .write => &self.write_waiters,
-        };
-    }
-
     /// Whether the entry has nothing left to track and can be dropped.
     pub fn isEmpty(self: *const Entry) bool {
-        return self.read_owner == null and self.write_owner == null and
-            self.read_waiters.head == null and self.write_waiters.head == null;
+        return self.read == null and self.write == null;
     }
 };
 
@@ -208,7 +206,6 @@ pub fn netHandle(c: *Completion) net.fd_t {
 pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion) ParkResult {
     const dir = dirForOp(completion);
     const self_loop: *Loop = state.loop;
-    const self_opaque: *anyopaque = @ptrCast(self_loop);
     const table = &self.shared.sock_table;
     const shard = table.shardForFd(fd);
 
@@ -234,9 +231,9 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
         return .retry;
     }
 
-    const owner = entry.ownerPtr(dir);
-    if (owner.* == null) {
-        const other_owned_here = entry.ownerPtr(other(dir)).* == self_opaque;
+    const slot = entry.dirPtr(dir);
+    if (slot.* == null) {
+        const other_owned_here = if (entry.dirPtr(other(dir)).*) |o| o.owner == self_loop else false;
         if (!self.registerSocket(fd, dir, other_owned_here)) {
             if (created and entry.isEmpty()) _ = shard.map.remove(@as(u32, @bitCast(fd)));
             shard.mutex.unlock();
@@ -244,8 +241,9 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
             state.markCompletedFromBackend(completion);
             return .failed;
         }
-        owner.* = self_opaque;
+        slot.* = .{ .owner = self_loop };
     }
+    const owned = &slot.*.?;
 
     // The completion stays owned by its submitting loop: its `loop` field, timeout
     // timer, and cancel routing are unchanged. The owner loop only holds the
@@ -257,14 +255,10 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
     // its poller is the one that will produce this completion.
     completion.prev = null;
     completion.next = null;
-    entry.waiters(dir).push(completion);
-    loopFromOpaque(owner.*.?).backend.incrParked();
+    owned.waiters.push(completion);
+    owned.owner.backend.incrParked();
     shard.mutex.unlock();
     return .parked;
-}
-
-fn loopFromOpaque(ptr: *anyopaque) *Loop {
-    return @ptrCast(@alignCast(ptr));
 }
 
 /// Service ready waiters for one (fd, dir) on the owner loop. Runs each waiter's
@@ -281,22 +275,24 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
 
     var serviced_waiter = false;
     var to_finish: Queue(Completion) = .{};
-    var iter: ?*Completion = entry.waiters(dir).head;
-    while (iter) |c| {
-        iter = c.next;
-        if (c.state == .completed or c.state == .dead) {
-            _ = entry.waiters(dir).remove(c);
-            self.decrParked();
-            continue;
-        }
-        serviced_waiter = true;
-        switch (Backend.checkCompletion(c, event)) {
-            .completed => {
-                _ = entry.waiters(dir).remove(c);
+    if (entry.dirPtr(dir).*) |*owned| {
+        var iter: ?*Completion = owned.waiters.head;
+        while (iter) |c| {
+            iter = c.next;
+            if (c.state == .completed or c.state == .dead) {
+                _ = owned.waiters.remove(c);
                 self.decrParked();
-                to_finish.push(c);
-            },
-            .requeue => break, // drained to EAGAIN for this direction
+                continue;
+            }
+            serviced_waiter = true;
+            switch (Backend.checkCompletion(c, event)) {
+                .completed => {
+                    _ = owned.waiters.remove(c);
+                    self.decrParked();
+                    to_finish.push(c);
+                },
+                .requeue => break, // drained to EAGAIN for this direction
+            }
         }
     }
     // Latch a readiness edge that no live waiter consumed so a racing parker
@@ -339,31 +335,42 @@ pub fn detach(self: anytype, target: *Completion) bool {
     // the op - so claiming it here would double-complete an op that is already on
     // its way out. Leaving it alone is the safe default.
     const entry = shard.map.getPtr(@as(u32, @bitCast(fd))) orelse return false;
-    if (!entry.waiters(dir).remove(target)) return false;
+    const owned = if (entry.dirPtr(dir).*) |*o| o else return false;
+    if (!owned.waiters.remove(target)) return false;
     // The waiter left the owner's queue; drop it from the owner's parked count
     // (the canceling loop calling this need not be the owner).
-    loopFromOpaque(entry.ownerPtr(dir).*.?).backend.decrParked();
+    owned.owner.backend.decrParked();
     return true;
 }
 
-/// Tear down the shared registration for a socket fd about to be closed. Closing
-/// the fd removes it from every poller at the kernel level, so this only drops
-/// the software bookkeeping (for all loops at once) plus this loop's poller entry.
+/// Tear down the shared registration for a socket fd about to be closed. Must
+/// run while the fd is still open: the backend's cleanup may need the fd to
+/// deregister it from the owners' pollers (see epoll's unregisterCleanup - an
+/// epoll subscription is keyed to the file description and the fd is the only
+/// handle for removing it; after close, a description kept alive by another
+/// reference would leave an unremovable registration firing events forever).
 pub fn unregister(self: anytype, fd: net.fd_t) void {
     const shard = self.shared.sock_table.shardForFd(fd);
     shard.mutex.lock();
+    var owners: [2]?*Loop = .{ null, null };
     if (shard.map.getPtr(@as(u32, @bitCast(fd)))) |entry| {
         // Closing an fd with ops still parked on it would orphan those
         // completions (removed here without finishing) and leak their
         // active/inflight accounting. The contract is that callers cancel or
         // await outstanding socket ops before closing the fd; assert it so a
         // violation surfaces in safe builds rather than silently leaking.
-        std.debug.assert(entry.waiters(.read).head == null);
-        std.debug.assert(entry.waiters(.write).head == null);
+        if (entry.read) |*r| {
+            std.debug.assert(r.waiters.head == null);
+            owners[0] = r.owner;
+        }
+        if (entry.write) |*w| {
+            std.debug.assert(w.waiters.head == null);
+            owners[1] = w.owner;
+        }
     }
     _ = shard.map.remove(@as(u32, @bitCast(fd)));
     shard.mutex.unlock();
-    self.unregisterCleanup(fd);
+    self.unregisterCleanup(fd, owners);
 }
 
 /// Generic submit for socket read/write/accept-family ops: try the syscall

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -251,14 +251,20 @@ pub fn park(self: anytype, state: anytype, fd: net.fd_t, completion: *Completion
     // timer, and cancel routing are unchanged. The owner loop only holds the
     // poller registration and services the op in place when its edge fires,
     // completing it cross-thread through the synchronized completion machinery.
-    // Accounting balances regardless of which loop finishes the op (the owner on
-    // a readiness edge, or the submitter on cancel/timeout): the active decrement
-    // is routed to `completion.loop` and the inflight storage is group-shared.
+    // The active decrement is routed to `completion.loop`, so it balances
+    // regardless of which loop finishes the op (the owner on a readiness edge,
+    // or the submitter on cancel/timeout). The parked count goes to the owner:
+    // its poller is the one that will produce this completion.
     completion.prev = null;
     completion.next = null;
     entry.waiters(dir).push(completion);
+    loopFromOpaque(owner.*.?).backend.incrParked();
     shard.mutex.unlock();
     return .parked;
+}
+
+fn loopFromOpaque(ptr: *anyopaque) *Loop {
+    return @ptrCast(@alignCast(ptr));
 }
 
 /// Service ready waiters for one (fd, dir) on the owner loop. Runs each waiter's
@@ -280,12 +286,14 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
         iter = c.next;
         if (c.state == .completed or c.state == .dead) {
             _ = entry.waiters(dir).remove(c);
+            self.decrParked();
             continue;
         }
         serviced_waiter = true;
         switch (Backend.checkCompletion(c, event)) {
             .completed => {
                 _ = entry.waiters(dir).remove(c);
+                self.decrParked();
                 to_finish.push(c);
             },
             .requeue => break, // drained to EAGAIN for this direction
@@ -331,7 +339,11 @@ pub fn detach(self: anytype, target: *Completion) bool {
     // the op - so claiming it here would double-complete an op that is already on
     // its way out. Leaving it alone is the safe default.
     const entry = shard.map.getPtr(@as(u32, @bitCast(fd))) orelse return false;
-    return entry.waiters(dir).remove(target);
+    if (!entry.waiters(dir).remove(target)) return false;
+    // The waiter left the owner's queue; drop it from the owner's parked count
+    // (the canceling loop calling this need not be the owner).
+    loopFromOpaque(entry.ownerPtr(dir).*.?).backend.decrParked();
+    return true;
 }
 
 /// Tear down the shared registration for a socket fd about to be closed. Closing

--- a/src/ev/test/sockreg.zig
+++ b/src/ev/test/sockreg.zig
@@ -1,0 +1,136 @@
+const std = @import("std");
+const backend = @import("../backend.zig").backend;
+const Loop = @import("../loop.zig").Loop;
+const LoopGroup = @import("../loop.zig").LoopGroup;
+const Completion = @import("../completion.zig").Completion;
+const NetRecv = @import("../completion.zig").NetRecv;
+const ReadBuf = @import("../buf.zig").ReadBuf;
+const net = @import("../../os/net.zig");
+const os = @import("../../os/root.zig");
+
+fn setFlagCallback(_: *Loop, c: *Completion) void {
+    const flag: *std.atomic.Value(bool) = @ptrCast(@alignCast(c.userdata.?));
+    flag.store(true, .release);
+}
+
+// A socket op submitted on loop A but parked on the fd's owner loop B is
+// produced by B's poller: B's inflight must count it and A's must not (A has
+// nothing to poll for), while A's active keeps A's until_done open (A stays
+// the op's home). Also exercises the cancel path: a detach from the
+// non-owner loop must drop the owner's count.
+test "sockreg: cross-loop park counts inflight on the owner loop" {
+    if (backend != .epoll and backend != .kqueue) return error.SkipZigTest;
+
+    const fds = net.socketpair(.unix, .stream, .ip, .{ .nonblocking = true }) catch |err| switch (err) {
+        error.OperationUnsupported => return error.SkipZigTest,
+        else => return err,
+    };
+    defer net.close(fds[0]);
+    defer net.close(fds[1]);
+
+    var group: LoopGroup = .{};
+
+    // Loop B lives on its own thread: it inits there (init and tick are
+    // same-thread by contract), parks its own recv on fds[0] - becoming the
+    // read-side owner - and then services the fd for everyone.
+    var loop_b: Loop = undefined;
+    var b_fired = std.atomic.Value(bool).init(false);
+    var b_recv_buf: [1]u8 = undefined;
+    var b_recv_iov: [1]os.iovec = undefined;
+    var b_recv: NetRecv = undefined;
+    var ready = std.atomic.Value(bool).init(false);
+    var stop = std.atomic.Value(bool).init(false);
+
+    const Runner = struct {
+        fn run(
+            l: *Loop,
+            g: *LoopGroup,
+            recv: *NetRecv,
+            buf: []u8,
+            iov: []os.iovec,
+            fd: net.fd_t,
+            fired: *std.atomic.Value(bool),
+            r: *std.atomic.Value(bool),
+            s: *std.atomic.Value(bool),
+        ) void {
+            l.init(.{ .loop_group = g }) catch @panic("loop init failed");
+            recv.* = NetRecv.init(fd, ReadBuf.fromSlice(buf, iov), .{});
+            recv.c.userdata = fired;
+            recv.c.callback = setFlagCallback;
+            l.add(&recv.c); // no data yet -> parks, B owns (fd, read)
+            r.store(true, .release);
+            while (!s.load(.acquire)) {
+                l.run(.once) catch return;
+            }
+        }
+    };
+    const runner = try std.Thread.spawn(.{}, Runner.run, .{
+        &loop_b, &group, &b_recv, &b_recv_buf, &b_recv_iov, fds[0], &b_fired, &ready, &stop,
+    });
+    defer loop_b.deinit();
+    defer runner.join();
+    defer {
+        stop.store(true, .release);
+        loop_b.wake();
+    }
+    while (!ready.load(.acquire)) std.Thread.yield() catch {};
+
+    // Loop A on this thread, same group. It never needs to run: its op is
+    // serviced by B.
+    var loop_a: Loop = undefined;
+    try loop_a.init(.{ .loop_group = &group });
+    defer loop_a.deinit();
+
+    try std.testing.expect(loop_b.backend.hasInflight());
+    try std.testing.expect(!loop_a.backend.hasInflight());
+
+    // Submit a recv on the B-owned fd from A: the optimistic syscall sees no
+    // data and the op parks on B.
+    var a_fired = std.atomic.Value(bool).init(false);
+    var a_recv_buf: [1]u8 = undefined;
+    var a_recv_iov: [1]os.iovec = undefined;
+    var a_recv = NetRecv.init(fds[0], ReadBuf.fromSlice(&a_recv_buf, &a_recv_iov), .{});
+    a_recv.c.userdata = &a_fired;
+    a_recv.c.callback = setFlagCallback;
+    loop_a.add(&a_recv.c);
+
+    // A stays the home loop (active holds its until_done open), but the op is
+    // produced by B's poller: only B has it inflight.
+    try std.testing.expectEqual(1, loop_a.state.loadActive());
+    try std.testing.expect(!loop_a.backend.hasInflight());
+    try std.testing.expect(loop_b.backend.hasInflight());
+
+    // Two bytes, one per 1-byte recv buffer: one readiness edge on B services
+    // both waiters (B's own and A's).
+    var send_iov = [1]os.iovec_const{os.iovecConstFromSlice("ab")};
+    _ = try net.send(fds[1], &send_iov, .{});
+
+    while (!b_fired.load(.acquire) or !a_fired.load(.acquire)) std.Thread.yield() catch {};
+    try std.testing.expectEqual(1, try b_recv.getResult());
+    try std.testing.expectEqual(1, try a_recv.getResult());
+    try std.testing.expect(!loop_b.backend.hasInflight());
+    try std.testing.expectEqual(0, loop_a.state.loadActive());
+
+    // Cancel path: park another recv from A on B, cancel it from here (the
+    // thread driving A). The detach runs against B's waiter queue and must
+    // drop B's count.
+    var c_fired = std.atomic.Value(bool).init(false);
+    var c_recv_buf: [1]u8 = undefined;
+    var c_recv_iov: [1]os.iovec = undefined;
+    var c_recv = NetRecv.init(fds[0], ReadBuf.fromSlice(&c_recv_buf, &c_recv_iov), .{});
+    c_recv.c.userdata = &c_fired;
+    c_recv.c.callback = setFlagCallback;
+    loop_a.add(&c_recv.c);
+    try std.testing.expect(loop_b.backend.hasInflight());
+
+    loop_a.cancel(&c_recv.c);
+    // The canceled completion is dispatched on its home loop's completions
+    // queue (defer_callback defaults to true at the ev level); one no-wait
+    // tick of A delivers it. A's backend has nothing inflight, so this must
+    // not need (or make) a poll syscall.
+    try loop_a.run(.no_wait);
+    try std.testing.expect(c_fired.load(.acquire));
+    try std.testing.expectError(error.Canceled, c_recv.getResult());
+    try std.testing.expect(!loop_b.backend.hasInflight());
+    try std.testing.expectEqual(0, loop_a.state.loadActive());
+}

--- a/src/ev/test/sockreg.zig
+++ b/src/ev/test/sockreg.zig
@@ -134,3 +134,114 @@ test "sockreg: cross-loop park counts inflight on the owner loop" {
     try std.testing.expect(!loop_b.backend.hasInflight());
     try std.testing.expectEqual(0, loop_a.state.loadActive());
 }
+
+// Whether `epoll_fd`'s interest list contains `target` (via /proc fdinfo).
+fn epollListsTfd(epoll_fd: i32, target: i32) !bool {
+    const linux = std.os.linux;
+    var path_buf: [64]u8 = undefined;
+    const path = try std.fmt.bufPrintZ(&path_buf, "/proc/self/fdinfo/{d}", .{epoll_fd});
+    const fd_rc = linux.open(path, .{}, 0);
+    if (@as(isize, @bitCast(fd_rc)) < 0) return error.Unexpected;
+    const fd: i32 = @intCast(fd_rc);
+    defer _ = linux.close(fd);
+    var buf: [4096]u8 = undefined;
+    const n = linux.read(fd, &buf, buf.len);
+    if (@as(isize, @bitCast(n)) < 0) return error.Unexpected;
+    var lines = std.mem.tokenizeScalar(u8, buf[0..n], '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "tfd:")) continue;
+        var toks = std.mem.tokenizeScalar(u8, line[4..], ' ');
+        const num = toks.next() orelse continue;
+        if (std.fmt.parseInt(i32, num, 10) catch continue == target) return true;
+    }
+    return false;
+}
+
+// Closing a socket must deregister it from the poller that actually holds the
+// registration - the owner loop's epoll - while the fd is still open. An epoll
+// subscription is keyed to the file description and the fd is the only handle
+// for removing it: if another reference (here a dup) keeps the description
+// alive across the close, a registration left behind would be unremovable and
+// fire events forever.
+test "sockreg: close deregisters from the owner's epoll" {
+    if (comptime backend != .epoll) {
+        return error.SkipZigTest;
+    } else {
+        const linux = std.os.linux;
+
+        const fds = try net.socketpair(.unix, .stream, .ip, .{ .nonblocking = true });
+        var fd0_open = true;
+        defer if (fd0_open) net.close(fds[0]);
+        defer net.close(fds[1]);
+
+        var group: LoopGroup = .{};
+
+        // Loop B parks its own recv on fds[0], becoming the read-side owner.
+        var loop_b: Loop = undefined;
+        var b_fired = std.atomic.Value(bool).init(false);
+        var b_recv_buf: [1]u8 = undefined;
+        var b_recv_iov: [1]os.iovec = undefined;
+        var b_recv: NetRecv = undefined;
+        var ready = std.atomic.Value(bool).init(false);
+        var stop = std.atomic.Value(bool).init(false);
+
+        const Runner = struct {
+            fn run(
+                l: *Loop,
+                g: *LoopGroup,
+                recv: *NetRecv,
+                buf: []u8,
+                iov: []os.iovec,
+                fd: net.fd_t,
+                fired: *std.atomic.Value(bool),
+                r: *std.atomic.Value(bool),
+                s: *std.atomic.Value(bool),
+            ) void {
+                l.init(.{ .loop_group = g }) catch @panic("loop init failed");
+                recv.* = NetRecv.init(fd, ReadBuf.fromSlice(buf, iov), .{});
+                recv.c.userdata = fired;
+                recv.c.callback = setFlagCallback;
+                l.add(&recv.c);
+                r.store(true, .release);
+                while (!s.load(.acquire)) {
+                    l.run(.once) catch return;
+                }
+            }
+        };
+        const runner = try std.Thread.spawn(.{}, Runner.run, .{
+            &loop_b, &group, &b_recv, &b_recv_buf, &b_recv_iov, fds[0], &b_fired, &ready, &stop,
+        });
+        defer loop_b.deinit();
+        defer runner.join();
+        defer {
+            stop.store(true, .release);
+            loop_b.wake();
+        }
+        while (!ready.load(.acquire)) std.Thread.yield() catch {};
+
+        var loop_a: Loop = undefined;
+        try loop_a.init(.{ .loop_group = &group });
+        defer loop_a.deinit();
+
+        try std.testing.expect(try epollListsTfd(loop_b.backend.epoll_fd, fds[0]));
+
+        // Keep the file description alive across the close, so kernel
+        // close-time eviction cannot clean B's epoll for us.
+        const dup_rc = linux.dup(fds[0]);
+        try std.testing.expect(@as(isize, @bitCast(dup_rc)) >= 0);
+        const duped: i32 = @intCast(dup_rc);
+        defer _ = linux.close(duped);
+
+        // Drain B's parked op (close contract), then close fds[0] from loop A:
+        // sockreg.unregister must CTL_DEL on the owner's (B's) epoll.
+        loop_a.cancel(&b_recv.c);
+        while (!b_fired.load(.acquire)) std.Thread.yield() catch {};
+
+        var close_op = @import("../completion.zig").NetClose.init(fds[0]);
+        loop_a.add(&close_op.c);
+        fd0_open = false;
+        try loop_a.run(.no_wait);
+
+        try std.testing.expect(!try epollListsTfd(loop_b.backend.epoll_fd, fds[0]));
+    }
+}

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -25,6 +25,7 @@ test {
     _ = @import("test/dgram_server_msg.zig");
     _ = @import("test/fs.zig");
     _ = @import("test/timer.zig");
+    _ = @import("test/sockreg.zig");
     _ = @import("test/cancel.zig");
     _ = @import("test/group.zig");
     _ = @import("test/blocking_sockets.zig");

--- a/src/io.zig
+++ b/src/io.zig
@@ -916,7 +916,7 @@ fn batchCancelPending(batch: *Io.Batch, state: *BatchState) void {
         if (data_ptr & 1 == 0) {
             const data: *BatchCompletionData = @ptrFromInt(data_ptr);
             const completion = data.getCompletion();
-            if (completion.loop) |l| l.cancel(completion);
+            getCurrentExecutor().loop.cancel(completion);
         }
         index = storage.pending.node.next;
     }


### PR DESCRIPTION
Second step of the Linux backend work, following #602. Two commits, no custody movement: `completion.loop`, `active` accounting, and cancel routing all stay with the submitting loop (the home loop). Relocating fd ownership to follow tasks is a planned follow-up.

## Commit 1: enforce Loop.cancel's receiver contract

`Loop.cancel`'s receiver is meant to be the loop the calling thread drives: routing consults `completion.loop`, but when the receiver IS the target it runs `cancelLocal` directly, touching the target's single-threaded state. Two call sites drifted from that contract in 9e3ce1ad (`self.getLoop().cancel(c)` became `completion.loop.?.cancel(c)`), making receiver == target true by construction from any thread; a task that migrated executors between submitting and canceling would run `cancelLocal` against its old loop from the wrong thread.

- Both sites restored to `getCurrentExecutor().loop.cancel(c)` (matching their submit sides, and no longer skipping the not-yet-added case).
- The contract is now explicit: a threadlocal tracks the loop each thread drives (claimed at init, refreshed each tick, released at deinit) and cancel asserts it in safe builds.

## Commit 2: per-instance inflight on epoll/kqueue

`hasInflight()` was backed by group-shared storage, answering "does anyone in the group have work" - so a loop with nothing of its own registered still paid the wait syscall whenever any other loop had pending ops.

Now each poller instance counts exactly its queue membership: ops it will produce completions for, from queue entry to queue exit.

- `sockreg.park` counts a socket waiter on the (fd, dir) owner, under the shard lock; `service`/`detach` drop it on removal. An op submitted on loop A but parked on owner B is B's to produce: A's `hasInflight()` stays false and A skips polling for it - which is the point of the change. A's `active` still holds A's `until_done` open.
- poll_queue entries (pipes, pidfd, streaming, mach ports) count on their own loop at add/remove.
- Sync-completing ops are no longer transiently counted.
- The `decrInflight` hook becomes a no-op for these two backends (they don't mirror submit/complete); io_uring/poll/iocp keep mirror counting unchanged. `loop.zig` untouched by this commit.

New ev-level test (epoll/kqueue): two loops in a group; B owns the fd, A submits a recv that parks on B - asserts the counts land on B and not A, that one readiness edge on B services both loops' waiters, and that a cancel detached from A's thread drops B's count.

## Testing

- io_uring 564/564 (new test skipped), epoll 565/565, poll 563/563
- Wine (iocp): 499/500 - the failure is `Blocking sockets: basic smoke test`, a pre-existing load-sensitive Wine flake (`error.WouldBlock` from a blocking socket); A/B verified: 8 Wine runs with commit 1 fail 5, 8 runs without it fail 3 - flaky in both configurations, unrelated to this branch. Worth a separate issue.
- x86_64-macos (kqueue) compiles.

## Commit 3: deregister closing sockets from the owner's epoll

Review of the owner pointer surfaced a real bug: `sockreg.unregister` CTL_DELed on the **closing** loop's epoll, but the registration lives in the **owner's** epoll. That worked only by refcount luck (close-time eviction); with the description kept alive by another reference (dup/fork/SCM_RIGHTS), the owner is left with a permanently unremovable registration - epoll subscriptions are keyed to the file description and the closed fd was the only handle to remove them - firing events forever at whatever socket reuses the fd number.

- `unregister` captures the (fd, dir) owners under the shard lock and CTL_DELs on each owner's epoll while the fd is still open (`epoll_ctl` is thread-safe cross-thread).
- Direction ownership is structural now: optional `Owned { owner: *Loop, waiters }` per direction - a waiter cannot exist without an owner, and the owner is non-optional where used. Readiness latches stay outside (ERR/HUP can latch a direction nobody owns yet).
- kqueue is immune to the description footgun (knotes are fd-keyed, dropped at close regardless of refs) and keeps its local change-buffer scrub; its own cross-loop gap (un-flushed EV_ADD in the owner's buffer) is documented, to be removed by registering sockets eagerly in a follow-up.
- Regression test: dup the fd so eviction can't help, close via a non-owner loop, assert via `/proc/self/fdinfo` that the owner's epoll no longer lists it. Verified to fail with the old closer-side DEL.

Full matrix re-run: io_uring 564/564, epoll 566/566, poll 563/563, macOS compile OK.
