### PR TITLE
Allow compiling with task-migration=false

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1324,7 +1324,7 @@ pub const Runtime = struct {
     }
 
     /// Whether other executors can currently steal from this runtime's queues.
-    pub fn stealingActive(self: *Runtime) bool {
+    pub inline fn stealingActive(self: *Runtime) bool {
         return zio_options.task_migration and self.options.enable_task_migration and self.executors_stealable.load(.acquire);
     }
 


### PR DESCRIPTION
When the option is set to false, compilation failed with
```
zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/utils/local_run_queue.zig:212:29: error: steal() is unavailable: this queue was built without task migration / work stealing
            if (!stealable) @compileError("steal() is unavailable: this queue was built without task migration / work stealing");
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    stealWork: zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/runtime.zig:734:37
    parkAndSearch: zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/runtime.zig:689:31
    run: zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/runtime.zig:588:82
    runWorker: zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/runtime.zig:1315:32
    callFn__anon_58953: /opt/zig-x86_64-linux-0.16.0/lib/std/Thread.zig:422:13
    entryFn: /opt/zig-x86_64-linux-0.16.0/lib/std/Thread.zig:752:30
    spawn__anon_58914: /opt/zig-x86_64-linux-0.16.0/lib/std/Thread.zig:773:21
    spawn__anon_34649: /opt/zig-x86_64-linux-0.16.0/lib/std/Thread.zig:349:32
    initStatic: zig-pkg/zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2/src/runtime.zig:1161:53
```