### PR TITLE
fix: pass real environment to Threaded io for process spawning

### DIFF
--- a/src/ev/test/process_wait.zig
+++ b/src/ev/test/process_wait.zig
@@ -17,7 +17,7 @@ else
 const argv_kill_self: []const []const u8 = if (builtin.os.tag == .windows)
     &.{}
 else
-    &.{ "sh", "-c", "kill -TERM $$" };
+    &.{ "sh", "-c", "kill -KILL $$" };
 
 test "ProcessWait: wait for child process exit code 0" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
@@ -40,8 +40,8 @@ test "ProcessWait: wait for child process exit code 0" {
 
     const result = try wait.getResult();
     child.id = null;
-    try std.testing.expectEqual(@as(u8, 0), result.code);
-    try std.testing.expectEqual(@as(?u8, null), result.signal);
+    try std.testing.expectEqual(0, result.code);
+    try std.testing.expectEqual(null, result.signal);
 }
 
 test "ProcessWait: wait for child process exit code 1" {
@@ -65,8 +65,8 @@ test "ProcessWait: wait for child process exit code 1" {
 
     const result = try wait.getResult();
     child.id = null;
-    try std.testing.expectEqual(@as(u8, 1), result.code);
-    try std.testing.expectEqual(@as(?u8, null), result.signal);
+    try std.testing.expectEqual(1, result.code);
+    try std.testing.expectEqual(null, result.signal);
 }
 
 test "ProcessWait: wait for child process killed by signal" {
@@ -90,5 +90,5 @@ test "ProcessWait: wait for child process killed by signal" {
 
     const result = try wait.getResult();
     child.id = null;
-    try std.testing.expectEqual(@as(?u8, @intFromEnum(std.posix.SIG.TERM)), result.signal);
+    try std.testing.expectEqual(@as(u8, @intFromEnum(std.posix.SIG.KILL)), result.signal);
 }

--- a/src/ev/test/process_wait.zig
+++ b/src/ev/test/process_wait.zig
@@ -7,17 +7,17 @@ const ThreadPool = @import("../thread_pool.zig").ThreadPool;
 const argv_exit0: []const []const u8 = if (builtin.os.tag == .windows)
     &.{ "cmd.exe", "/c", "exit 0" }
 else
-    &.{ "/bin/sh", "-c", "exit 0" };
+    &.{ "sh", "-c", "exit 0" };
 
 const argv_exit1: []const []const u8 = if (builtin.os.tag == .windows)
     &.{ "cmd.exe", "/c", "exit 1" }
 else
-    &.{ "/bin/sh", "-c", "exit 1" };
+    &.{ "sh", "-c", "exit 1" };
 
 const argv_kill_self: []const []const u8 = if (builtin.os.tag == .windows)
     &.{}
 else
-    &.{ "/bin/sh", "-c", "kill -TERM $$" };
+    &.{ "sh", "-c", "kill -TERM $$" };
 
 test "ProcessWait: wait for child process exit code 0" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;

--- a/src/ev/test/process_wait.zig
+++ b/src/ev/test/process_wait.zig
@@ -4,14 +4,91 @@ const Loop = @import("../loop.zig").Loop;
 const ProcessWait = @import("../completion.zig").ProcessWait;
 const ThreadPool = @import("../thread_pool.zig").ThreadPool;
 
-// TODO: re-enable once process spawning is ported to Zig 0.16
-// (std.process.Child.init was removed; need to use std.process.spawn(io, .{...}) or fork/execvp directly)
-//
-// fn processWaitCallback(loop: *Loop, c: *@import("../completion.zig").Completion) void {
-//     _ = loop;
-//     _ = c;
-// }
-//
-// test "ProcessWait: wait for child process exit code 0" { ... }
-// test "ProcessWait: wait for child process exit code 1" { ... }
-// test "ProcessWait: wait for child process killed by signal" { ... }
+const argv_exit0: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "exit 0" }
+else
+    &.{ "/bin/sh", "-c", "exit 0" };
+
+const argv_exit1: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "exit 1" }
+else
+    &.{ "/bin/sh", "-c", "exit 1" };
+
+const argv_kill_self: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{}
+else
+    &.{ "/bin/sh", "-c", "kill -TERM $$" };
+
+test "ProcessWait: wait for child process exit code 0" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var tp: ThreadPool = undefined;
+    try tp.init(std.testing.allocator, .{ .min_threads = 1 });
+    defer tp.deinit();
+
+    var loop: Loop = undefined;
+    try loop.init(.{ .thread_pool = &tp });
+    defer loop.deinit();
+
+    const io = std.testing.io;
+    var child = try std.process.spawn(io, .{ .argv = argv_exit0 });
+    defer if (child.id != null) child.kill(io);
+
+    var wait = ProcessWait.init(child.id.?);
+    loop.add(&wait.c);
+    try loop.run(.until_done);
+
+    const result = try wait.getResult();
+    child.id = null;
+    try std.testing.expectEqual(@as(u8, 0), result.code);
+    try std.testing.expectEqual(@as(?u8, null), result.signal);
+}
+
+test "ProcessWait: wait for child process exit code 1" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var tp: ThreadPool = undefined;
+    try tp.init(std.testing.allocator, .{ .min_threads = 1 });
+    defer tp.deinit();
+
+    var loop: Loop = undefined;
+    try loop.init(.{ .thread_pool = &tp });
+    defer loop.deinit();
+
+    const io = std.testing.io;
+    var child = try std.process.spawn(io, .{ .argv = argv_exit1 });
+    defer if (child.id != null) child.kill(io);
+
+    var wait = ProcessWait.init(child.id.?);
+    loop.add(&wait.c);
+    try loop.run(.until_done);
+
+    const result = try wait.getResult();
+    child.id = null;
+    try std.testing.expectEqual(@as(u8, 1), result.code);
+    try std.testing.expectEqual(@as(?u8, null), result.signal);
+}
+
+test "ProcessWait: wait for child process killed by signal" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var tp: ThreadPool = undefined;
+    try tp.init(std.testing.allocator, .{ .min_threads = 1 });
+    defer tp.deinit();
+
+    var loop: Loop = undefined;
+    try loop.init(.{ .thread_pool = &tp });
+    defer loop.deinit();
+
+    const io = std.testing.io;
+    var child = try std.process.spawn(io, .{ .argv = argv_kill_self });
+    defer if (child.id != null) child.kill(io);
+
+    var wait = ProcessWait.init(child.id.?);
+    loop.add(&wait.c);
+    try loop.run(.until_done);
+
+    const result = try wait.getResult();
+    child.id = null;
+    try std.testing.expectEqual(@as(?u8, @intFromEnum(std.posix.SIG.TERM)), result.signal);
+}

--- a/src/io.zig
+++ b/src/io.zig
@@ -1743,10 +1743,21 @@ fn processReplacePathImpl(_: ?*anyopaque, dir: Io.Dir, options: std.process.Repl
     return io.vtable.processReplacePath(io.userdata, dir, options);
 }
 
+fn processEnviron() std.process.Environ {
+    if (builtin.os.tag == .windows) {
+        return .{ .block = .global };
+    }
+    if (builtin.link_libc) {
+        const slice = std.mem.sliceTo(std.c.environ, null);
+        return .{ .block = .{ .slice = @ptrCast(slice) } };
+    }
+    return .empty;
+}
+
 // TODO: implement using our own posix_spawn/fork+exec wrapper
 fn processSpawnImpl(userdata: ?*anyopaque, options: std.process.SpawnOptions) std.process.SpawnError!std.process.Child {
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    var threaded: Io.Threaded = .init(rt.allocator, .{});
+    var threaded: Io.Threaded = .init(rt.allocator, .{ .environ = processEnviron() });
     defer threaded.deinit();
     const io = threaded.io();
     var child = try io.vtable.processSpawn(io.userdata, options);
@@ -1757,7 +1768,7 @@ fn processSpawnImpl(userdata: ?*anyopaque, options: std.process.SpawnOptions) st
 // TODO: implement using our own posix_spawn/fork+exec wrapper
 fn processSpawnPathImpl(userdata: ?*anyopaque, dir: Io.Dir, options: std.process.SpawnOptions) std.process.SpawnError!std.process.Child {
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    var threaded: Io.Threaded = .init(rt.allocator, .{});
+    var threaded: Io.Threaded = .init(rt.allocator, .{ .environ = processEnviron() });
     defer threaded.deinit();
     const io = threaded.io();
     var child = try io.vtable.processSpawnPath(io.userdata, dir, options);

--- a/src/process.zig
+++ b/src/process.zig
@@ -113,3 +113,11 @@ test "childKill: terminates process" {
     childKill(&child);
     try std.testing.expect(child.id == null);
 }
+
+test "childWait: spawn nonexistent binary returns FileNotFound" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const result = std.process.spawn(rt.io(), .{ .argv = &.{"definitely-not-a-real-binary-xyz123"} });
+    try std.testing.expectError(error.FileNotFound, result);
+}


### PR DESCRIPTION
Process spawn fails with FileNotFound for PATH-dependent binaries

processSpawnImpl in src/io.zig created a temporary Io.Threaded with default InitOptions, where environ defaults to .empty. This caused std.process.spawn(rt.io(), ...) to fail with FileNotFound for any binary requiring PATH resolution (e.g. "true", "false", "sleep"), because the Threaded io had no PATH variable to look up.

Root Cause
Io.Threaded.InitOptions.environ defaults to .empty ([`std/Io/Threaded.zig:1600`](https://github.com/...)). With no PATH, the fallback default_PATH (/usr/local/bin:/bin:/usr/bin) misses binaries on NixOS, Homebrew, and other non-standard layouts.