### PR TITLE
ev: unify completion lifecycle and cancellation into one atomic state word

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Reworked completion state tracking in the low-level `ev` API: the lifecycle phase and
+  the cancellation flags now live in a single atomic `Completion.state` word, read
+  through `Completion.loadState()`. The separate `cancel_state` field is gone; code that
+  checked `c.state == .dead` now reads `c.loadState().phase == .dead`, and cancellation
+  checks use `loadState().cancel_requested`, which stays readable from the completion's
+  callback. Canceling a timer that was already cleared is now a harmless no-op instead
+  of hitting an assertion when the queued cancel arrived.
+
+- The loop's thread-affine entry points (`Loop.add`, `Loop.cancel`, `Loop.setTimer` on
+  an armed timer, `Loop.deinit`) now assert in debug builds that they run on the thread
+  that owns the loop. `Loop.cancel` must be called on the calling thread's loop, which
+  routes the cancellation to the completion's loop; calling it on the completion's loop
+  from another thread was never safe and two internal callers doing so were fixed.
+
 - Fixed writing to a terminal on macOS crashing with an unexpected `ENXIO` error. A
   reader or writer starts in positional mode and expects the first `pread`/`pwrite` to
   fail with `ESPIPE` if the file turns out not to be seekable, which is how it learns to

--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -24,7 +24,7 @@ pub const AutoCancel = struct {
 
     pub fn clear(self: *AutoCancel) void {
         const loop = self.timer.c.getLoop() orelse return;
-        if (self.timer.c.state != .running) return;
+        if (self.timer.c.loadState().phase != .running) return;
 
         loop.clearTimer(&self.timer);
         self.task = null;

--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -23,7 +23,7 @@ pub const AutoCancel = struct {
     pub const init: AutoCancel = .{};
 
     pub fn clear(self: *AutoCancel) void {
-        const loop = self.timer.c.loop orelse return;
+        const loop = self.timer.c.getLoop() orelse return;
         if (self.timer.c.state != .running) return;
 
         loop.clearTimer(&self.timer);

--- a/src/common.zig
+++ b/src/common.zig
@@ -174,7 +174,7 @@ pub const Waiter = struct {
         timer.c.callback = callback;
 
         task.getExecutor().loop.setTimer(&timer, timeout);
-        defer timer.c.loop.?.clearTimer(&timer);
+        defer timer.c.getLoop().?.clearTimer(&timer);
 
         return waitTask(d, task, expected, cancel_mode);
     }

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -202,10 +202,11 @@ pub const CompletionQueue = struct {
 
         // Cancel each pending operation. We don't hold the lock while calling
         // loop.cancel() because the callback needs to acquire it.
+        const loop = &getCurrentExecutor().loop;
         while (node) |n| {
             const next_node = n.next;
             const c = completionFromGroup(n);
-            if (c.loop) |loop| loop.cancel(c);
+            loop.cancel(c);
             node = next_node;
         }
     }

--- a/src/ev/backends/epoll.zig
+++ b/src/ev/backends/epoll.zig
@@ -495,7 +495,6 @@ pub fn hasInflight(self: *const Self) bool {
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
-    c.state = .running;
     // Counted for every accepted op (sync completers decrement right back via
     // markCompletedFromBackend), mirroring the decrInflight in every completion
     // path so the balance needs no per-path reasoning.
@@ -717,7 +716,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
             iter = completion.next;
 
             // Skip if already completed (can happen with cancellations)
-            if (completion.state == .completed or completion.state == .dead) {
+            if (completion.loadState().phase != .running) {
                 continue;
             }
 

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -363,19 +363,22 @@ pub fn hasInflight(self: *const Self) bool {
 
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
-/// Can be called for initial submission (state == .new) or resubmission after EINTR (state == .running).
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
-    const is_new = c.state == .new;
-    if (is_new) {
-        c.state = .running;
-        // Counted once per accepted op (sync completers decrement right back
-        // via markCompletedFromBackend); EINTR resubmissions are not new and
-        // stay counted from their first submit.
-        self.inflight += 1;
-    } else {
-        std.debug.assert(c.state == .running);
-    }
+    // Counted once per accepted op (sync completers decrement right back via
+    // markCompletedFromBackend); EINTR resubmissions go through resubmit and
+    // stay counted from their first submit.
+    self.inflight += 1;
+    self.submitInner(state, c, true);
+}
 
+fn resubmit(self: *Self, state: *LoopState, c: *Completion) void {
+    std.debug.assert(c.loadState().phase == .running);
+    self.submitInner(state, c, false);
+}
+
+/// `is_new` distinguishes the first submission (allocate op-owned resources)
+/// from an EINTR/SQ-full resubmission (reuse them).
+fn submitInner(self: *Self, state: *LoopState, c: *Completion, is_new: bool) void {
     switch (c.op) {
         .group, .timer, .async, .work => unreachable, // Managed by the loop
 
@@ -846,10 +849,9 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
 /// Cancel a completion - infallible.
 /// Note: target.canceled is already set by loop.add() or loop.cancel() before this is called.
 pub fn cancel(self: *Self, _: *LoopState, target: *Completion) void {
-    switch (target.state) {
+    switch (target.loadState().phase) {
         .new => {
-            // UNREACHABLE: When cancel is added via loop.add() and target.state == .new,
-            // loop.add() handles it directly and doesn't call backend.cancel().
+            // UNREACHABLE: cancelLocal only forwards running completions.
             unreachable;
         },
         .running => {
@@ -1008,7 +1010,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
         // When a target is canceled, it recursively completes the cancel operation
         // So when we get the cancel's CQE, it's already completed
         // Similarly, when we get the target's CQE after the cancel already completed it
-        if (completion.state == .completed or completion.state == .dead) {
+        if (completion.loadState().phase != .running) {
             continue;
         }
 
@@ -1040,15 +1042,15 @@ fn drainPending(self: *Self, state: *LoopState) void {
     self.pending = .{};
 
     while (to_drain.pop()) |c| {
-        if (c.cancel_state.load(.acquire).requested) {
+        if (c.loadState().cancel_requested) {
             // Complete canceled pending ops immediately rather than writing a SQE.
             // storeResult handles resource cleanup (e.g. allocated paths).
             self.storeResult(c, -@as(i32, @intFromEnum(linux.E.CANCELED)));
             state.markCompletedFromBackend(c);
         } else {
-            // submit() will call getSqeOrDefer(); if the SQ fills up again the
+            // resubmit() will call getSqeOrDefer(); if the SQ fills up again the
             // completion lands in self.pending and will be retried next poll.
-            self.submit(state, c);
+            self.resubmit(state, c);
         }
     }
 }

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -463,7 +463,6 @@ pub fn hasInflight(self: *const Self) bool {
 }
 
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
-    c.state = .running;
     // Counted for every accepted op (sync completers decrement right back via
     // markCompletedFromBackend), mirroring the decrInflight in every completion
     // path so the balance needs no per-path reasoning.
@@ -1496,10 +1495,9 @@ pub fn cancel(self: *Self, state: *LoopState, target: *Completion) void {
     _ = self;
     _ = state;
 
-    switch (target.state) {
+    switch (target.loadState().phase) {
         .new => {
-            // UNREACHABLE: When cancel is added via loop.add() and target.state == .new,
-            // loop.add() handles it directly and doesn't call backend.cancel().
+            // UNREACHABLE: cancelLocal only forwards running completions.
             unreachable;
         },
         .running => {
@@ -1806,7 +1804,7 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                     // Whole requested range sent.
                     c.setResult(.net_send_file, data.internal.total);
                     state.markCompletedFromBackend(c);
-                } else if (c.cancel_state.load(.acquire).requested) {
+                } else if (c.loadState().cancel_requested) {
                     // Cancel was requested between this chunk completing and the
                     // re-arm. CancelIoEx already returned NOT_FOUND (the chunk
                     // had already completed), so we must check the flag here to
@@ -2057,7 +2055,7 @@ fn processCompletion(self: *Self, state: *LoopState, entry: *const windows.OVERL
                 data.internal.wait_handle = windows.INVALID_HANDLE_VALUE;
             }
 
-            if (c.cancel_state.load(.acquire).requested) {
+            if (c.loadState().cancel_requested) {
                 c.setError(error.Canceled);
             } else {
                 var exit_code: windows.DWORD = 0;

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -480,7 +480,6 @@ pub fn hasInflight(self: *const Self) bool {
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
-    c.state = .running;
     // Counted for every accepted op (sync completers decrement right back via
     // markCompletedFromBackend), mirroring the decrInflight in every completion
     // path so the balance needs no per-path reasoning.
@@ -664,7 +663,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
             while (iter) |completion| {
                 iter = completion.next;
 
-                if (completion.state == .completed or completion.state == .dead) {
+                if (completion.loadState().phase != .running) {
                     continue;
                 }
 

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -316,7 +316,6 @@ pub fn hasInflight(self: *const Self) bool {
 /// Submit a completion to the backend - infallible.
 /// On error, completes the operation immediately with error.Unexpected.
 pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
-    c.state = .running;
     // Counted for every accepted op (sync completers decrement right back via
     // markCompletedFromBackend), mirroring the decrInflight in every completion
     // path so the balance needs no per-path reasoning.
@@ -505,7 +504,7 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
             iter = completion.next;
 
             // Skip if already completed (can happen with cancellations)
-            if (completion.state == .completed or completion.state == .dead) {
+            if (completion.loadState().phase != .running) {
                 continue;
             }
 

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -44,10 +44,9 @@ const time = @import("../time.zig");
 /// Supports file, pipe, and socket operations (read/write use poll+I/O on POSIX).
 /// Timer and async/work/group operations are not supported (require event loop).
 pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
-    // Mark completion as having no loop (including a stale `loop_set` from a
-    // previous submitted incarnation)
+    // Reset the completion: no loop, fresh state
     c.setLoop(null);
-    c.cancel_state.store(.{}, .monotonic);
+    c.state.store(.{}, .monotonic);
 
     switch (c.op) {
         .file_open => common.handleFileOpen(c, allocator),

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -45,7 +45,7 @@ const time = @import("../time.zig");
 /// Timer and async/work/group operations are not supported (require event loop).
 pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
     // Mark completion as having no loop
-    c.loop = null;
+    c.setLoop(null);
 
     switch (c.op) {
         .file_open => common.handleFileOpen(c, allocator),

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -44,8 +44,10 @@ const time = @import("../time.zig");
 /// Supports file, pipe, and socket operations (read/write use poll+I/O on POSIX).
 /// Timer and async/work/group operations are not supported (require event loop).
 pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
-    // Mark completion as having no loop
+    // Mark completion as having no loop (including a stale `loop_set` from a
+    // previous submitted incarnation)
     c.setLoop(null);
+    c.cancel_state.store(.{}, .monotonic);
 
     switch (c.op) {
         .file_open => common.handleFileOpen(c, allocator),

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -278,23 +278,21 @@ pub const Completion = struct {
     };
 
     op: Op,
-    state: State = .new,
+
+    /// One atomic word holding the lifecycle phase and the cancel flags; all
+    /// cross-thread races on a completion resolve through the modification
+    /// order of this word. Access only through the transition methods below.
+    state: std.atomic.Value(State) = .init(.{}),
 
     flags: Flags = .{},
 
     userdata: ?*anyopaque = null,
     callback: ?*const CallbackFn = null,
 
-    /// Loop this completion was submitted to. Set by `Loop.add`/`Loop.setTimer`,
-    /// cleared by `reset`. Read cross-thread (`Async.notify`, cancel routing,
-    /// finish routing), so always access through `setLoop`/`getLoop`. Both are
-    /// monotonic (plain machine loads/stores); visibility is guaranteed by the
-    /// RMW handshakes instead: `publishLoop` vs the cancel CAS, and the
-    /// `pending` swaps for async notify.
+    /// Loop this completion was submitted to. Monotonic accesses; visibility
+    /// comes from `state`: a thread that observed phase `.running` sees the
+    /// loop published by `enterRunning` (async notify pairs via `pending`).
     loop: ?*Loop = null,
-
-    /// Cross-thread cancellation state (atomic for thread-safe cancel)
-    cancel_state: std.atomic.Value(CancelState) = .init(.{}),
 
     /// Cancel queue intrusive linked list
     cancel_next: ?*Completion = null,
@@ -316,7 +314,9 @@ pub const Completion = struct {
     /// Stored here instead of in each operation type to simplify error handling.
     err: ?anyerror = null,
 
-    /// Whether a result has been set (for debugging/assertions).
+    /// Whether a result has been set. Written only by the servicing thread
+    /// (under the timer mutex for timers, where `.running` plus a result means
+    /// mid-fire).
     has_result: bool = false,
 
     /// Backend-specific internal data for async operations.
@@ -328,15 +328,15 @@ pub const Completion = struct {
     prev: ?*Completion = null,
     next: ?*Completion = null,
 
-    pub const State = enum { new, running, completed, dead };
+    pub const State = packed struct(u8) {
+        phase: Phase = .new,
+        /// Cancel was requested; backends poll it to stop retrying.
+        cancel_requested: bool = false,
+        /// A cancel pass (cancelLocal) owns the finish dispatch.
+        cancel_inflight: bool = false,
+        _reserved: u4 = 0,
 
-    /// Atomic state for cross-thread cancellation coordination
-    pub const CancelState = packed struct(u8) {
-        requested: bool = false, // Cancel was requested
-        in_queue: bool = false, // Completion is in cancel queue, queue will call finish
-        completed: bool = false, // markCompleted ran, result is set
-        loop_set: bool = false, // `loop` is published; set by the publishLoop RMW
-        _pad: u4 = 0,
+        pub const Phase = enum(u2) { new, running, completed, dead };
     };
 
     pub const CallbackFn = fn (
@@ -356,23 +356,83 @@ pub const Completion = struct {
         return @atomicLoad(?*Loop, &c.loop, .monotonic);
     }
 
-    /// Set `loop_set` in cancel_state and return the previous flags. The
-    /// acq_rel RMW publishes the preceding `setLoop` and orders against the
-    /// CAS in `Loop.cancel`: whichever lands second in the modification order
-    /// sees the other's flag, so a cancel is never lost between the two.
-    pub fn publishLoop(c: *Completion) CancelState {
-        const bits: u8 = @bitCast(CancelState{ .loop_set = true });
-        return @bitCast(@atomicRmw(u8, @as(*u8, @ptrCast(&c.cancel_state.raw)), .Or, bits, .acq_rel));
+    pub fn loadState(c: *const Completion) State {
+        return c.state.load(.monotonic);
     }
 
+    /// {new,dead} -> running. Publishes the preceding `setLoop`. A cancel
+    /// latched before the first submission is kept; one aimed at a dead
+    /// incarnation is dropped on rearm. Returns the previous state.
+    pub fn enterRunning(c: *Completion) State {
+        var old = c.loadState();
+        while (true) {
+            std.debug.assert(old.phase == .new or old.phase == .dead);
+            std.debug.assert(!old.cancel_inflight);
+            const new_state: State = .{
+                .phase = .running,
+                .cancel_requested = old.cancel_requested and old.phase == .new,
+            };
+            old = c.state.cmpxchgWeak(old, new_state, .acq_rel, .monotonic) orelse return old;
+        }
+    }
+
+    /// running -> completed. Returns the previous state; `cancel_inflight` in
+    /// it means a cancel pass owns the dispatch.
+    pub fn enterCompleted(c: *Completion) State {
+        var old = c.loadState();
+        while (true) {
+            std.debug.assert(old.phase == .running);
+            var new_state = old;
+            new_state.phase = .completed;
+            old = c.state.cmpxchgWeak(old, new_state, .acq_rel, .monotonic) orelse return old;
+        }
+    }
+
+    /// completed -> dead, keeping `cancel_requested` so callbacks can see it.
+    /// No concurrent writers remain at this point.
+    pub fn enterDead(c: *Completion) void {
+        const old = c.loadState();
+        std.debug.assert(old.phase == .completed);
+        c.state.store(.{ .phase = .dead, .cancel_requested = old.cancel_requested }, .monotonic);
+    }
+
+    /// running -> new (disarm a timer without completing it).
+    pub fn disarm(c: *Completion) void {
+        var old = c.loadState();
+        while (true) {
+            std.debug.assert(old.phase == .running);
+            old = c.state.cmpxchgWeak(old, .{}, .acq_rel, .monotonic) orelse return;
+        }
+    }
+
+    /// Latch a cancel request. Returns the previous state: phase `.running`
+    /// without `cancel_requested` means the caller latched `cancel_inflight`
+    /// and must run (or route) the cancel pass. On `.new` only the request is
+    /// latched; `enterRunning` picks it up. Completed/dead: too late, no-op.
+    pub fn requestCancel(c: *Completion) State {
+        var old = c.loadState();
+        while (true) {
+            if (old.cancel_requested) return old;
+            if (old.phase == .completed or old.phase == .dead) return old;
+            var new_state = old;
+            new_state.cancel_requested = true;
+            new_state.cancel_inflight = old.phase == .running;
+            old = c.state.cmpxchgWeak(old, new_state, .acq_rel, .monotonic) orelse return old;
+        }
+    }
+
+    /// Clear `cancel_inflight` at the end of a cancel pass. Returns the
+    /// previous state: phase `.completed` means the completion finished during
+    /// the pass and the caller owns its dispatch.
+    pub fn finishCancelPass(c: *Completion) State {
+        const mask: u8 = @bitCast(State{ .cancel_inflight = true });
+        return @bitCast(@atomicRmw(u8, @as(*u8, @ptrCast(&c.state.raw)), .And, ~mask, .acq_rel));
+    }
+
+    /// Clear per-incarnation fields when re-adding a dead completion.
     pub fn reset(c: *Completion) void {
-        c.state = .new;
         c.has_result = false;
         c.err = null;
-        // An Async.notify() landing in the null window between this and the
-        // re-add's setLoop is picked up by add() via the `pending` flag.
-        c.setLoop(null);
-        c.cancel_state.store(.{}, .release);
         c.cancel_next = null;
         c.group.next = null;
         c.group.prev = null;
@@ -443,8 +503,8 @@ pub const Group = struct {
 
     /// Add a completion to this group. Must be called before submitting the group.
     pub fn add(self: *Group, c: *Completion) void {
-        std.debug.assert(c.state == .new);
-        std.debug.assert(self.c.state == .new); // Group must not be submitted yet
+        std.debug.assert(c.loadState().phase == .new);
+        std.debug.assert(self.c.loadState().phase == .new); // Group must not be submitted yet
         std.debug.assert(c.group.owner == null);
         std.debug.assert(!c.flags.rearm); // groups are single-shot
         c.group.next = self.head;
@@ -485,7 +545,7 @@ pub const Group = struct {
 
         const prev = self.remaining.fetchSub(1, .acq_rel);
         if (prev == 1) {
-            if (self.c.cancel_state.load(.acquire).requested) {
+            if (self.c.loadState().cancel_requested) {
                 self.c.setError(error.Canceled);
             } else {
                 self.c.setResult(.group, {});

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -287,7 +287,10 @@ pub const Completion = struct {
 
     /// Loop this completion was submitted to. Set by `Loop.add`/`Loop.setTimer`,
     /// cleared by `reset`. Read cross-thread (`Async.notify`, cancel routing,
-    /// finish routing), so always access through `setLoop`/`getLoop`.
+    /// finish routing), so always access through `setLoop`/`getLoop`. Both are
+    /// monotonic (plain machine loads/stores); visibility is guaranteed by the
+    /// RMW handshakes instead: `publishLoop` vs the cancel CAS, and the
+    /// `pending` swaps for async notify.
     loop: ?*Loop = null,
 
     /// Cross-thread cancellation state (atomic for thread-safe cancel)
@@ -332,7 +335,8 @@ pub const Completion = struct {
         requested: bool = false, // Cancel was requested
         in_queue: bool = false, // Completion is in cancel queue, queue will call finish
         completed: bool = false, // markCompleted ran, result is set
-        _pad: u5 = 0,
+        loop_set: bool = false, // `loop` is published; set by the publishLoop RMW
+        _pad: u4 = 0,
     };
 
     pub const CallbackFn = fn (
@@ -345,11 +349,20 @@ pub const Completion = struct {
     }
 
     pub fn setLoop(c: *Completion, loop: ?*Loop) void {
-        @atomicStore(?*Loop, &c.loop, loop, .release);
+        @atomicStore(?*Loop, &c.loop, loop, .monotonic);
     }
 
     pub fn getLoop(c: *const Completion) ?*Loop {
-        return @atomicLoad(?*Loop, &c.loop, .acquire);
+        return @atomicLoad(?*Loop, &c.loop, .monotonic);
+    }
+
+    /// Set `loop_set` in cancel_state and return the previous flags. The
+    /// acq_rel RMW publishes the preceding `setLoop` and orders against the
+    /// CAS in `Loop.cancel`: whichever lands second in the modification order
+    /// sees the other's flag, so a cancel is never lost between the two.
+    pub fn publishLoop(c: *Completion) CancelState {
+        const bits: u8 = @bitCast(CancelState{ .loop_set = true });
+        return @bitCast(@atomicRmw(u8, @as(*u8, @ptrCast(&c.cancel_state.raw)), .Or, bits, .acq_rel));
     }
 
     pub fn reset(c: *Completion) void {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -285,7 +285,9 @@ pub const Completion = struct {
     userdata: ?*anyopaque = null,
     callback: ?*const CallbackFn = null,
 
-    /// Loop this completion was submitted to (set by loop.add())
+    /// Loop this completion was submitted to. Set by `Loop.add`/`Loop.setTimer`,
+    /// cleared by `reset`. Read cross-thread (`Async.notify`, cancel routing,
+    /// finish routing), so always access through `setLoop`/`getLoop`.
     loop: ?*Loop = null,
 
     /// Cross-thread cancellation state (atomic for thread-safe cancel)
@@ -342,13 +344,21 @@ pub const Completion = struct {
         return .{ .op = op };
     }
 
+    pub fn setLoop(c: *Completion, loop: ?*Loop) void {
+        @atomicStore(?*Loop, &c.loop, loop, .release);
+    }
+
+    pub fn getLoop(c: *const Completion) ?*Loop {
+        return @atomicLoad(?*Loop, &c.loop, .acquire);
+    }
+
     pub fn reset(c: *Completion) void {
         c.state = .new;
         c.has_result = false;
         c.err = null;
-        // `loop` is kept: Async.notify() reads it cross-thread, and a null
-        // window during a rearm re-add loses the wake. A stale pointer only
-        // causes a spurious wake, and add() overwrites it.
+        // An Async.notify() landing in the null window between this and the
+        // re-add's setLoop is picked up by add() via the `pending` flag.
+        c.setLoop(null);
         c.cancel_state.store(.{}, .release);
         c.cancel_next = null;
         c.group.next = null;
@@ -524,12 +534,15 @@ pub const Async = struct {
 
     /// Notify the loop to wake up and complete this async handle (thread-safe)
     pub fn notify(self: *Async) void {
-        // Atomically set pending flag
-        const was_pending = self.pending.swap(1, .release);
+        // Pairs with the `pending` swap in Loop.add: both are acq_rel RMWs on
+        // the same variable, so they order against each other. If add's swap
+        // came first, the acquire here makes its setLoop visible and we wake
+        // the loop; if ours came first, add sees `pending` set and completes
+        // the handle itself. Reading a null loop therefore proves add will
+        // handle it.
+        const was_pending = self.pending.swap(1, .acq_rel);
         if (was_pending == 0) {
-            // Only notify loop if transitioning from not-pending to pending
-            // If loop is not set (never added), this is a no-op
-            if (@atomicLoad(?*Loop, &self.c.loop, .acquire)) |loop| {
+            if (self.c.getLoop()) |loop| {
                 loop.wakeAsync();
             }
         }

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -358,7 +358,7 @@ pub const LoopState = struct {
         // Route the decrement to the loop that owns the completion: `self` here
         // can be a different loop (epoll single-owner servicing, the shared
         // IOCP port, a group finished by the loop that ran its last member).
-        completion.loop.?.state.decrActive();
+        completion.getLoop().?.state.decrActive();
 
         // Both callbacks below can free `completion`, so whichever may free it must
         // run LAST, with nothing touching `completion` afterward. Cache the owner
@@ -663,7 +663,7 @@ pub const Loop = struct {
         // Advance the scan so this timer's deadline is computed against a fresh
         // `now` in its own clock (via `nowFor` in `setTimer`).
         self.state.updateNow();
-        timer.c.loop = self;
+        timer.c.setLoop(self);
         timer.timeout = timeout;
         self.state.setTimer(timer);
     }
@@ -701,8 +701,7 @@ pub const Loop = struct {
         self.assertOwnThread();
 
         // Check if completion has been added to a loop
-        // (loop is set once by addInternal and never changes)
-        const target = completion.loop orelse {
+        const target = completion.getLoop() orelse {
             // Not yet submitted - just set requested, addInternal will handle it
             var old = completion.cancel_state.load(.acquire);
             while (true) {
@@ -895,7 +894,7 @@ pub const Loop = struct {
         std.debug.assert(completion.state == .new);
 
         // Set the loop reference for cross-thread cancellation
-        @atomicStore(?*Loop, &completion.loop, self, .release);
+        completion.setLoop(self);
 
         if (completion.cancel_state.load(.acquire).requested) {
             // Directly mark it as canceled
@@ -1174,7 +1173,10 @@ pub const Loop = struct {
     /// Returns true if the async was pending and had its result set.
     /// Caller is responsible for managing queues and calling markCompleted.
     fn checkAndSetAsyncResult(async_handle: *Async) bool {
-        const was_pending = async_handle.pending.swap(0, .acquire);
+        // acq_rel: pairs with the swap in Async.notify (see the comment there).
+        // The release half publishes addInternal's setLoop to a notifier that
+        // misses this pending flag.
+        const was_pending = async_handle.pending.swap(0, .acq_rel);
         if (was_pending != 0) {
             async_handle.c.setResult(.async, {});
             return true;

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -653,6 +653,10 @@ pub const Loop = struct {
     pub fn setTimer(self: *Loop, timer: *Timer, timeout: Timeout) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        // A running timer sits in its owning loop's heap; re-arming it here
+        // would remove it from this loop's heap instead and leak the owner's
+        // active count. Clear it on the owning loop first.
+        std.debug.assert(timer.c.state != .running or timer.c.getLoop() == self);
         // Rearming a fired (completed/dead) timer: drop the stale result so
         // that a running timer with a result set unambiguously means "mid-fire"
         // (the limbo state clearTimer must leave alone).

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -661,7 +661,8 @@ pub const Loop = struct {
     /// Cancel a completion directly without requiring a Cancel completion struct.
     /// This is a fire-and-forget, idempotent operation - the completion's callback will still be
     /// invoked when the operation completes (either with error.Canceled or its natural result).
-    /// Thread-safe: can be called from any thread.
+    /// Must be called on this loop's own thread. The completion may be owned by a
+    /// different loop; cross-loop cancels are routed through its cancel queue.
     pub fn cancel(self: *Loop, completion: *Completion) void {
         self.assertOwnThread();
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -664,6 +664,7 @@ pub const Loop = struct {
         // `now` in its own clock (via `nowFor` in `setTimer`).
         self.state.updateNow();
         timer.c.setLoop(self);
+        _ = timer.c.publishLoop();
         timer.timeout = timeout;
         self.state.setTimer(timer);
     }
@@ -700,29 +701,23 @@ pub const Loop = struct {
     pub fn cancel(self: *Loop, completion: *Completion) void {
         self.assertOwnThread();
 
-        // Check if completion has been added to a loop
-        const target = completion.getLoop() orelse {
-            // Not yet submitted - just set requested, addInternal will handle it
-            var old = completion.cancel_state.load(.acquire);
-            while (true) {
-                if (old.requested) return;
-                var new = old;
-                new.requested = true;
-                old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse return;
-            }
-            return;
-        };
-
-        // Atomically set requested and in_queue flags
-        var old = completion.cancel_state.load(.acquire);
+        var old = completion.cancel_state.load(.monotonic);
         while (true) {
             if (old.requested) return; // Already requested
             if (old.completed) return; // Already completed
             var new = old;
             new.requested = true;
-            new.in_queue = true;
-            old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
+            // Only a submitted completion can be routed; an unsubmitted one
+            // gets `requested` alone and the submitting add() picks it up.
+            new.in_queue = old.loop_set;
+            old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .monotonic) orelse break;
         }
+
+        if (!old.loop_set) return;
+
+        // The successful CAS observed `loop_set`, so the loop reference
+        // published by add() is visible.
+        const target = completion.getLoop().?;
 
         if (self == target) {
             // Same loop - cancel directly
@@ -893,10 +888,13 @@ pub const Loop = struct {
 
         std.debug.assert(completion.state == .new);
 
-        // Set the loop reference for cross-thread cancellation
+        // Set the loop reference and publish it; the RMW also returns whether
+        // a cancel arrived before submission (see Completion.publishLoop).
         completion.setLoop(self);
+        const old = completion.publishLoop();
 
-        if (completion.cancel_state.load(.acquire).requested) {
+        if (old.requested) {
+            std.debug.assert(!old.in_queue);
             // Directly mark it as canceled
             completion.setError(error.Canceled);
             self.state.incrActive();

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -320,23 +320,10 @@ pub const LoopState = struct {
     }
 
     pub fn markCompleted(self: *LoopState, completion: *Completion) void {
-        std.debug.assert(completion.state == .running);
         std.debug.assert(completion.has_result);
-
-        // Atomically set completed flag
-        var old = completion.cancel_state.load(.acquire);
-        while (true) {
-            var new = old;
-            new.completed = true;
-            old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
-        }
-
-        // Always set state
-        completion.state = .completed;
-
-        // Only call finish if not in cancel queue
-        // If in_queue, cancel queue processing will call finishCompletion
-        if (!old.in_queue) {
+        const old = completion.enterCompleted();
+        // With a cancel pass in flight, that pass owns the dispatch.
+        if (!old.cancel_inflight) {
             self.dispatchCompletion(completion);
         }
     }
@@ -352,9 +339,7 @@ pub const LoopState = struct {
     }
 
     pub fn finishCompletion(self: *LoopState, completion: *Completion) void {
-        std.debug.assert(completion.state == .completed);
-
-        completion.state = .dead;
+        completion.enterDead();
         // Route the decrement to the loop that owns the completion: `self` here
         // can be a different loop (epoll single-owner servicing, the shared
         // IOCP port, a group finished by the loop that ran its last member).
@@ -399,11 +384,6 @@ pub const LoopState = struct {
         }
     }
 
-    pub fn markRunning(self: *LoopState, completion: *Completion) void {
-        _ = self;
-        completion.state = .running;
-    }
-
     /// Advance the scan counter and refresh the awake snapshot. Bumping `tick`
     /// invalidates the lazily-cached boot/real values for the new scan.
     pub fn updateNow(self: *LoopState) void {
@@ -434,37 +414,20 @@ pub const LoopState = struct {
         self.timer_mutex.unlock();
     }
 
-    pub fn setTimer(self: *LoopState, timer: *Timer) void {
-        const idx = clockIndex(timer.clock);
-        // Rearming a timer that is mid-fire (out of the heap, result set, its
-        // markCompleted still pending outside this lock) cannot work: the timer
-        // is already completing and inserting it would double-complete it.
-        // Callers must rearm from the completion callback (or after it), never
-        // concurrently with the fire.
-        std.debug.assert(!(timer.c.state == .running and timer.c.has_result));
-        // `.running` means the timer is already in its heap (resetting it);
-        // anything else means it's newly activated. Don't key this off
-        // `deadline.value`, which can legitimately be 0 for an absolute
-        // deadline at/at-before the epoch and would then leak/double-fire.
-        if (timer.c.state == .running) {
-            self.timers[idx].remove(timer);
-        } else {
-            self.incrActive();
-        }
+    /// Compute the deadline from `timer.timeout` and insert into the heap.
+    /// The timer must not be in a heap.
+    pub fn armTimer(self: *LoopState, timer: *Timer) void {
         switch (timer.timeout) {
             .none => timer.deadline = .{ .value = std.math.maxInt(time.TimeInt) },
             .duration => |d| timer.deadline = self.nowFor(timer.clock).addDuration(d),
             .deadline => |ts| timer.deadline = ts,
         }
-        timer.c.state = .running;
-        self.timers[idx].insert(timer);
+        self.timers[clockIndex(timer.clock)].insert(timer);
     }
 
-    pub fn clearTimer(self: *LoopState, timer: *Timer) void {
-        const was_active = timer.c.state == .running;
-        if (was_active) {
-            self.timers[clockIndex(timer.clock)].remove(timer);
-        }
+    /// Remove from the heap. The timer must be in it (armed and not mid-fire).
+    pub fn disarmTimer(self: *LoopState, timer: *Timer) void {
+        self.timers[clockIndex(timer.clock)].remove(timer);
         timer.deadline = .zero;
     }
 
@@ -653,24 +616,29 @@ pub const Loop = struct {
     pub fn setTimer(self: *Loop, timer: *Timer, timeout: Timeout) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        const st = timer.c.loadState();
         // A running timer sits in its owning loop's heap; re-arming it here
         // would remove it from this loop's heap instead and leak the owner's
         // active count. Clear it on the owning loop first.
-        std.debug.assert(timer.c.state != .running or timer.c.getLoop() == self);
-        // Rearming a fired (completed/dead) timer: drop the stale result so
-        // that a running timer with a result set unambiguously means "mid-fire"
-        // (the limbo state clearTimer must leave alone).
-        if (timer.c.state != .running) {
+        std.debug.assert(st.phase != .running or timer.c.getLoop() == self);
+        // A running timer with a result set is mid-fire (out of the heap, its
+        // markCompleted pending outside this lock); rearm from the callback
+        // (or after it), never concurrently with the fire.
+        std.debug.assert(!(st.phase == .running and timer.c.has_result));
+        // Advance the scan so this timer's deadline is computed against a fresh
+        // `now` in its own clock (via `nowFor` in `armTimer`).
+        self.state.updateNow();
+        timer.timeout = timeout;
+        if (st.phase == .running) {
+            self.state.disarmTimer(timer);
+        } else {
             timer.c.has_result = false;
             timer.c.err = null;
+            timer.c.setLoop(self);
+            _ = timer.c.enterRunning();
+            self.state.incrActive();
         }
-        // Advance the scan so this timer's deadline is computed against a fresh
-        // `now` in its own clock (via `nowFor` in `setTimer`).
-        self.state.updateNow();
-        timer.c.setLoop(self);
-        _ = timer.c.publishLoop();
-        timer.timeout = timeout;
-        self.state.setTimer(timer);
+        self.state.armTimer(timer);
     }
 
     /// Clear a timer without completing it (works immediately, no cancellation
@@ -679,23 +647,15 @@ pub const Loop = struct {
     pub fn clearTimer(self: *Loop, timer: *Timer) void {
         self.state.lockTimers();
         defer self.state.unlockTimers();
+        if (timer.c.loadState().phase != .running) return;
         // A running timer that already has its result is in the fired/canceled
         // limbo window: checkTimers (or cancelLocal) removed it from the heap
         // and set its result under this lock, but its markCompleted runs after
-        // unlocking. Touching it here would remove a non-member from the heap
-        // (corrupting it), clear the result that markCompleted asserts on, and
-        // decrement active a second time (finishCompletion will decrement for
-        // the same timer). It is already on its way to completion; leave it be.
-        if (timer.c.state == .running and timer.c.has_result) return;
-        const was_active = timer.c.state == .running;
-        self.state.clearTimer(timer);
-        if (was_active) {
-            // Reset state so timer can be reused
-            timer.c.state = .new;
-            timer.c.has_result = false;
-            timer.c.err = null;
-            self.state.decrActive();
-        }
+        // unlocking. It is already on its way to completion; leave it be.
+        if (timer.c.has_result) return;
+        self.state.disarmTimer(timer);
+        timer.c.disarm();
+        self.state.decrActive();
     }
 
     /// Cancel a completion directly without requiring a Cancel completion struct.
@@ -705,22 +665,13 @@ pub const Loop = struct {
     pub fn cancel(self: *Loop, completion: *Completion) void {
         self.assertOwnThread();
 
-        var old = completion.cancel_state.load(.monotonic);
-        while (true) {
-            if (old.requested) return; // Already requested
-            if (old.completed) return; // Already completed
-            var new = old;
-            new.requested = true;
-            // Only a submitted completion can be routed; an unsubmitted one
-            // gets `requested` alone and the submitting add() picks it up.
-            new.in_queue = old.loop_set;
-            old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .monotonic) orelse break;
-        }
+        const old = completion.requestCancel();
+        // Nothing to route: already requested, too late, or not yet submitted
+        // (enterRunning picks the latched request up).
+        if (old.cancel_requested or old.phase != .running) return;
 
-        if (!old.loop_set) return;
-
-        // The successful CAS observed `loop_set`, so the loop reference
-        // published by add() is visible.
+        // The CAS observed `.running`, so the loop published by enterRunning
+        // is visible.
         const target = completion.getLoop().?;
 
         if (self == target) {
@@ -743,20 +694,14 @@ pub const Loop = struct {
     /// Cancel a completion on the local loop (must be called from the loop's thread)
     fn cancelLocal(self: *Loop, completion: *Completion) void {
         defer {
-            // Clear in_queue and call finishCompletion if completed
-            var old = completion.cancel_state.load(.acquire);
-            while (true) {
-                var new = old;
-                new.in_queue = false;
-                old = completion.cancel_state.cmpxchgWeak(old, new, .acq_rel, .acquire) orelse break;
-            }
-            if (old.completed) {
+            const old = completion.finishCancelPass();
+            if (old.phase == .completed) {
                 self.state.dispatchCompletion(completion);
             }
         }
 
-        // If already completed, skip cancel work (defer will still run)
-        if (completion.cancel_state.load(.acquire).completed) {
+        // Completed while queued, or disarmed in the meantime (timers)
+        if (completion.loadState().phase != .running) {
             return;
         }
 
@@ -774,12 +719,17 @@ pub const Loop = struct {
             .timer => {
                 const timer = completion.cast(Timer);
                 self.state.lockTimers();
-                // Set the result under the timer lock: a cross-thread
-                // Loop.clearTimer keys "already fired/canceled, hands off" on
-                // (.running and has_result) under this lock, so the result must
-                // never appear outside it while the timer is running.
+                // Re-check under the lock: a cross-thread clearTimer may have
+                // disarmed it, or the fire may have won (mid-fire limbo:
+                // running with a result set, out of the heap already).
+                if (timer.c.loadState().phase != .running or timer.c.has_result) {
+                    self.state.unlockTimers();
+                    return;
+                }
+                // Set the result under the timer lock: clearTimer keys
+                // "already fired/canceled, hands off" on it.
                 timer.c.setError(error.Canceled);
-                self.state.clearTimer(timer);
+                self.state.disarmTimer(timer);
                 self.state.unlockTimers();
                 self.state.markCompleted(&timer.c);
             },
@@ -885,24 +835,19 @@ pub const Loop = struct {
     }
 
     fn addInternal(self: *Loop, completion: *Completion) void {
-        // If completion is dead (callback was called), reset it to new state for rearming
-        if (completion.state == .dead) {
+        completion.setLoop(self);
+        const old = completion.enterRunning();
+        if (old.phase == .dead) {
             completion.reset();
         }
+        self.state.incrActive();
 
-        std.debug.assert(completion.state == .new);
-
-        // Set the loop reference and publish it; the RMW also returns whether
-        // a cancel arrived before submission (see Completion.publishLoop).
-        completion.setLoop(self);
-        const old = completion.publishLoop();
-
-        if (old.requested) {
-            std.debug.assert(!old.in_queue);
-            // Directly mark it as canceled
+        if (old.cancel_requested) {
+            // Groups cannot be canceled before submission
+            if (completion.op == .group) {
+                @panic("cannot cancel a group before adding it to the loop");
+            }
             completion.setError(error.Canceled);
-            self.state.incrActive();
-            completion.state = .running;
             self.state.markCompleted(completion);
             return;
         }
@@ -910,14 +855,6 @@ pub const Loop = struct {
         switch (completion.op) {
             .group => {
                 const group = completion.cast(Group);
-
-                // Groups cannot be canceled before submission
-                if (group.c.cancel_state.load(.acquire).requested) {
-                    @panic("cannot cancel a group before adding it to the loop");
-                }
-
-                group.c.state = .running;
-                self.state.incrActive();
 
                 if (group.remaining.load(.acquire) == 0) {
                     // Empty group - complete immediately
@@ -938,14 +875,12 @@ pub const Loop = struct {
             .timer => {
                 const timer = completion.cast(Timer);
                 self.state.lockTimers();
-                self.state.setTimer(timer);
+                self.state.armTimer(timer);
                 self.state.unlockTimers();
                 return;
             },
             .async => {
                 const async = completion.cast(Async);
-                async.c.state = .running;
-                self.state.incrActive();
 
                 // Check if already notified before submission
                 if (checkAndSetAsyncResult(async)) {
@@ -961,8 +896,6 @@ pub const Loop = struct {
                 const work = completion.cast(Work);
                 work.completion_fn = loopWorkComplete;
                 work.completion_context = @ptrCast(self);
-                work.c.state = .running;
-                self.state.incrActive();
                 if (self.thread_pool) |thread_pool| {
                     thread_pool.submit(work);
                 } else {
@@ -974,8 +907,6 @@ pub const Loop = struct {
             },
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
-                completion.state = .running;
-                self.state.incrActive();
                 if (comptime Backend.capabilities.net_send_file) {
                     self.backend.submit(&self.state, completion);
                 } else {
@@ -1010,7 +941,6 @@ pub const Loop = struct {
                             // Route pollable fds to the backend readiness/overlapped path;
                             // seekable fds (regular files, block devices) to the thread pool.
                             if (pollable) {
-                                self.state.incrActive();
                                 self.backend.submit(&self.state, completion);
                             } else {
                                 self.submitFileOpToThreadPool(completion);
@@ -1029,7 +959,6 @@ pub const Loop = struct {
                     .file_set_size => {
                         if (comptime @hasDecl(Backend, "fileSetSizeSupported")) {
                             if (self.backend.fileSetSizeSupported()) {
-                                self.state.incrActive();
                                 self.backend.submit(&self.state, completion);
                                 return;
                             }
@@ -1051,7 +980,6 @@ pub const Loop = struct {
                     },
                 }
 
-                self.state.incrActive();
                 self.backend.submit(&self.state, completion);
                 return;
             },
@@ -1131,7 +1059,7 @@ pub const Loop = struct {
                         break;
                     }
                     timer.c.setResult(.timer, {});
-                    self.state.clearTimer(timer);
+                    self.state.disarmTimer(timer);
                     batch[batch_count] = timer;
                     batch_count += 1;
                     if (batch_count >= batch.len) break;
@@ -1256,7 +1184,7 @@ pub const Loop = struct {
             const next = completion.cancel_next;
             completion.cancel_next = null;
 
-            // cancelLocal handles completed check and clears in_queue
+            // cancelLocal re-checks the phase and clears cancel_inflight
             self.cancelLocal(completion);
 
             c = next;
@@ -1267,15 +1195,10 @@ pub const Loop = struct {
         const tp = self.thread_pool orelse {
             // No thread pool - complete with error
             log.err("No thread pool available for file operation", .{});
-            completion.state = .running;
-            self.state.incrActive();
             completion.setError(error.Unexpected);
             self.state.markCompleted(completion);
             return;
         };
-
-        completion.state = .running;
-        self.state.incrActive();
 
         switch (completion.op) {
             inline .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .file_size, .file_stat, .dir_open, .dir_close, .dir_read, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control, .process_wait => |op| {
@@ -1404,7 +1327,7 @@ pub const Loop = struct {
         const f = &op.internal;
 
         // A cancel that arrived between callbacks turns into a parked error.
-        if (op.c.cancel_state.load(.acquire).requested and f.pending_err == null) {
+        if (op.c.loadState().cancel_requested and f.pending_err == null) {
             f.pending_err = error.Canceled;
         }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -28,6 +28,12 @@ const common = @import("backends/common.zig");
 const log = @import("../common.zig").log;
 
 const in_safe_mode = builtin.mode == .Debug or builtin.mode == .ReleaseSafe;
+const in_debug_mode = builtin.mode == .Debug;
+
+/// The loop bound to the current thread (debug builds only), used by
+/// `assertOwnThread`. Set by `Loop.init`, cleared by `Loop.deinit`.
+threadlocal var current_loop: if (in_debug_mode) ?*Loop else void =
+    if (in_debug_mode) null else {};
 
 /// How the NetSendFile fallback lays out its scratch from the (up to two)
 /// caller-provided buffers.
@@ -582,10 +588,19 @@ pub const Loop = struct {
         errdefer self.backend.deinit();
 
         self.state.initialized = true;
+
+        if (in_debug_mode) current_loop = self;
     }
 
     pub fn deinit(self: *Loop) void {
+        self.assertOwnThread();
+        if (in_debug_mode) current_loop = null;
         self.backend.deinit();
+    }
+
+    /// Debug-only: assert we're on the thread that owns this loop.
+    inline fn assertOwnThread(self: *const Loop) void {
+        if (in_debug_mode) std.debug.assert(current_loop == self);
     }
 
     pub fn stop(self: *Loop) void {
@@ -683,6 +698,8 @@ pub const Loop = struct {
     /// invoked when the operation completes (either with error.Canceled or its natural result).
     /// Thread-safe: can be called from any thread.
     pub fn cancel(self: *Loop, completion: *Completion) void {
+        self.assertOwnThread();
+
         // Check if completion has been added to a loop
         // (loop is set once by addInternal and never changes)
         const target = completion.loop orelse {
@@ -856,6 +873,7 @@ pub const Loop = struct {
     }
 
     pub fn add(self: *Loop, completion: *Completion) void {
+        self.assertOwnThread();
         if (in_safe_mode) {
             if (self.in_add) {
                 @panic("recursive call to Loop.add() is not allowed");

--- a/src/ev/sockreg.zig
+++ b/src/ev/sockreg.zig
@@ -278,7 +278,7 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
     var iter: ?*Completion = entry.waiters(dir).head;
     while (iter) |c| {
         iter = c.next;
-        if (c.state == .completed or c.state == .dead) {
+        if (c.loadState().phase != .running) {
             _ = entry.waiters(dir).remove(c);
             continue;
         }
@@ -313,7 +313,7 @@ pub fn service(self: anytype, state: anytype, fd: net.fd_t, dir: Dir, event: any
 /// The shard lock makes that answer exact rather than advisory: `service` runs
 /// the syscall and sets the result while holding the same lock it removes the
 /// waiter under, so "still in the queue" and "no result set yet" are the same
-/// condition. The reverse - inferring it from `cancel_state.completed` - would
+/// condition. The reverse - inferring it from the `.completed` phase - would
 /// race, because `service` deliberately marks the op completed only after
 /// dropping the lock.
 pub fn detach(self: anytype, target: *Completion) bool {
@@ -323,8 +323,8 @@ pub fn detach(self: anytype, target: *Completion) bool {
     shard.mutex.lock();
     defer shard.mutex.unlock();
     // A live parked op always has an entry: detach only runs while the op is not
-    // yet completed (loop.cancel and cancelLocal both bail on cancel_state
-    // .completed), and an entry is only dropped by `unregister` on close, which
+    // yet completed (loop.cancel and cancelLocal both bail on the `.completed`
+    // phase), and an entry is only dropped by `unregister` on close, which
     // cannot happen until the op completes and wakes its owner. So this branch is
     // unreachable in practice. Return false anyway (not true): a missing entry
     // could only mean the waiter was already removed - i.e. `service` is finishing

--- a/src/ev/test/cancel.zig
+++ b/src/ev/test/cancel.zig
@@ -31,7 +31,7 @@ test "cancel: timer with loop.cancel()" {
     try loop.run(.until_done);
     const elapsed_ms = wall_timer.read().toMilliseconds();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expectError(error.Canceled, timer.getResult());
     try std.testing.expect(elapsed_ms < 50);
 }
@@ -62,7 +62,7 @@ test "cancel: cancel completed operation is no-op" {
 
     // Wait for timer to complete
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try timer.getResult();
 
     // Cancel after completion is no-op
@@ -98,7 +98,7 @@ test "cancel: async handle with loop.cancel()" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, async_handle.c.state);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try std.testing.expectError(error.Canceled, async_handle.getResult());
 }
 
@@ -136,14 +136,14 @@ test "cancel: net_accept with loop.cancel()" {
     loop.add(&accept_comp.c);
 
     try loop.run(.no_wait);
-    try std.testing.expectEqual(.running, accept_comp.c.state);
+    try std.testing.expectEqual(.running, accept_comp.c.loadState().phase);
 
     // Cancel with loop.cancel()
     loop.cancel(&accept_comp.c);
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, accept_comp.c.state);
+    try std.testing.expectEqual(.dead, accept_comp.c.loadState().phase);
     try std.testing.expectError(error.Canceled, accept_comp.getResult());
 
     // Close server socket
@@ -207,14 +207,14 @@ test "cancel: net_recv with loop.cancel()" {
     loop.add(&recv.c);
 
     try loop.run(.no_wait);
-    try std.testing.expectEqual(.running, recv.c.state);
+    try std.testing.expectEqual(.running, recv.c.loadState().phase);
 
     // Cancel with loop.cancel()
     loop.cancel(&recv.c);
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, recv.c.state);
+    try std.testing.expectEqual(.dead, recv.c.loadState().phase);
     try std.testing.expectError(error.Canceled, recv.getResult());
 
     // Close sockets
@@ -227,7 +227,7 @@ test "cancel: net_recv with loop.cancel()" {
     try loop.run(.until_done);
 }
 
-test "cancel: cancel_state.requested flag is set on completion" {
+test "cancel: cancel_requested flag is set on completion" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();
@@ -235,11 +235,11 @@ test "cancel: cancel_state.requested flag is set on completion" {
     var timer: Timer = .init(.{ .duration = .fromMilliseconds(100) });
     loop.add(&timer.c);
 
-    try std.testing.expect(!timer.c.cancel_state.load(.acquire).requested);
+    try std.testing.expect(!timer.c.loadState().cancel_requested);
 
     loop.cancel(&timer.c);
 
-    try std.testing.expect(timer.c.cancel_state.load(.acquire).requested);
+    try std.testing.expect(timer.c.loadState().cancel_requested);
 
     try loop.run(.until_done);
 }
@@ -257,7 +257,7 @@ test "cancel: callback is invoked on canceled operation" {
             _ = l;
             const self: *@This() = @ptrCast(@alignCast(c.userdata.?));
             self.called = true;
-            self.was_canceled = c.cancel_state.load(.acquire).requested;
+            self.was_canceled = c.loadState().cancel_requested;
         }
     };
 
@@ -286,7 +286,7 @@ test "cancel: race - operation completes before cancel" {
 
     // Wait for it to complete
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try timer.getResult(); // Should succeed
 
     // Cancel after completion is no-op
@@ -349,7 +349,7 @@ test "cancel: work after completion is no-op" {
 
     // Wait for work to complete
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, work.c.state);
+    try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try work.getResult();
     try std.testing.expect(test_fn.called);
 
@@ -420,7 +420,7 @@ test "cancel: work before run" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, work.c.state);
+    try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try std.testing.expectError(error.Canceled, work.getResult());
     try std.testing.expect(!test_fn.called);
 }
@@ -601,6 +601,6 @@ test "cancel: cross-thread cancellation" {
 
     cancel_thread.join();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expectError(error.Canceled, timer.getResult());
 }

--- a/src/ev/test/fs.zig
+++ b/src/ev/test/fs.zig
@@ -22,7 +22,7 @@ test "File: open/close" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, file_create.c.state);
+    try std.testing.expectEqual(.dead, file_create.c.loadState().phase);
     try std.testing.expectEqual(true, file_create.c.has_result);
 
     const fd = (try file_create.getResult()).fd;
@@ -38,7 +38,7 @@ test "File: open/close" {
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_write.c.state);
+    try std.testing.expectEqual(.dead, file_write.c.loadState().phase);
     try std.testing.expectEqual(true, file_write.c.has_result);
     const bytes_written = try file_write.getResult();
     try std.testing.expectEqual(write_data.len, bytes_written);
@@ -47,7 +47,7 @@ test "File: open/close" {
     var file_sync1 = ev.FileSync.init(fd, .{ .only_data = false });
     loop.add(&file_sync1.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_sync1.c.state);
+    try std.testing.expectEqual(.dead, file_sync1.c.loadState().phase);
     try std.testing.expectEqual(true, file_sync1.c.has_result);
     try file_sync1.getResult();
 
@@ -57,7 +57,7 @@ test "File: open/close" {
     var file_read = ev.FileRead.init(fd, .fromSlice(&read_buffer, &read_iov), 0);
     loop.add(&file_read.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_read.c.state);
+    try std.testing.expectEqual(.dead, file_read.c.loadState().phase);
     try std.testing.expectEqual(true, file_read.c.has_result);
     const bytes_read = try file_read.getResult();
     try std.testing.expectEqual(write_data.len, bytes_read);
@@ -67,7 +67,7 @@ test "File: open/close" {
     var file_sync2 = ev.FileSync.init(fd, .{ .only_data = true });
     loop.add(&file_sync2.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_sync2.c.state);
+    try std.testing.expectEqual(.dead, file_sync2.c.loadState().phase);
     try std.testing.expectEqual(true, file_sync2.c.has_result);
     try file_sync2.getResult();
 
@@ -76,7 +76,7 @@ test "File: open/close" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, file_close.c.state);
+    try std.testing.expectEqual(.dead, file_close.c.loadState().phase);
     try std.testing.expectEqual(true, file_close.c.has_result);
 
     try file_close.getResult();
@@ -100,7 +100,7 @@ test "File: rename/delete" {
     var file_create = ev.FileCreate.init(cwd, "test-rename-src", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_create.c.state);
+    try std.testing.expectEqual(.dead, file_create.c.loadState().phase);
     const fd = (try file_create.getResult()).fd;
 
     // Write some data
@@ -109,19 +109,19 @@ test "File: rename/delete" {
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_write.c.state);
+    try std.testing.expectEqual(.dead, file_write.c.loadState().phase);
 
     // Close the file
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_close.c.state);
+    try std.testing.expectEqual(.dead, file_close.c.loadState().phase);
 
     // Rename the file
     var file_rename = ev.DirRename.init(cwd, "test-rename-src", cwd, "test-rename-dst");
     loop.add(&file_rename.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_rename.c.state);
+    try std.testing.expectEqual(.dead, file_rename.c.loadState().phase);
     try std.testing.expectEqual(true, file_rename.c.has_result);
     try file_rename.getResult();
 
@@ -129,7 +129,7 @@ test "File: rename/delete" {
     var file_open = ev.FileOpen.init(cwd, "test-rename-dst", .{ .mode = .read_only });
     loop.add(&file_open.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_open.c.state);
+    try std.testing.expectEqual(.dead, file_open.c.loadState().phase);
     const fd2 = (try file_open.getResult()).fd;
 
     // Read and verify the data
@@ -138,7 +138,7 @@ test "File: rename/delete" {
     var file_read = ev.FileRead.init(fd2, .fromSlice(&read_buffer, &read_iov2), 0);
     loop.add(&file_read.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_read.c.state);
+    try std.testing.expectEqual(.dead, file_read.c.loadState().phase);
     const bytes_read = try file_read.getResult();
     try std.testing.expectEqual(write_data.len, bytes_read);
     try std.testing.expectEqualStrings(write_data, read_buffer[0..bytes_read]);
@@ -147,13 +147,13 @@ test "File: rename/delete" {
     var file_close2 = ev.FileClose.init(fd2);
     loop.add(&file_close2.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_close2.c.state);
+    try std.testing.expectEqual(.dead, file_close2.c.loadState().phase);
 
     // Delete the file
     var file_delete = ev.DirDeleteFile.init(cwd, "test-rename-dst");
     loop.add(&file_delete.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_delete.c.state);
+    try std.testing.expectEqual(.dead, file_delete.c.loadState().phase);
     try std.testing.expectEqual(true, file_delete.c.has_result);
     try file_delete.getResult();
 
@@ -161,7 +161,7 @@ test "File: rename/delete" {
     var file_open_fail = ev.FileOpen.init(cwd, "test-rename-dst", .{ .mode = .read_only });
     loop.add(&file_open_fail.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_open_fail.c.state);
+    try std.testing.expectEqual(.dead, file_open_fail.c.loadState().phase);
     try std.testing.expectError(error.FileNotFound, file_open_fail.getResult());
 }
 
@@ -208,7 +208,7 @@ test "File: read EOF" {
     var file_read2 = ev.FileRead.init(fd, .fromSlice(&read_buffer2, &read_iov2), write_data.len);
     loop.add(&file_read2.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_read2.c.state);
+    try std.testing.expectEqual(.dead, file_read2.c.loadState().phase);
     try std.testing.expectEqual(true, file_read2.c.has_result);
     const bytes_read2 = try file_read2.getResult();
     try std.testing.expectEqual(0, bytes_read2);
@@ -249,7 +249,7 @@ test "File: size" {
     var file_size1 = ev.FileSize.init(fd);
     loop.add(&file_size1.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_size1.c.state);
+    try std.testing.expectEqual(.dead, file_size1.c.loadState().phase);
     try std.testing.expectEqual(true, file_size1.c.has_result);
     const size1 = try file_size1.getResult();
     try std.testing.expectEqual(0, size1);
@@ -266,7 +266,7 @@ test "File: size" {
     var file_size2 = ev.FileSize.init(fd);
     loop.add(&file_size2.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_size2.c.state);
+    try std.testing.expectEqual(.dead, file_size2.c.loadState().phase);
     try std.testing.expectEqual(true, file_size2.c.has_result);
     const size2 = try file_size2.getResult();
     try std.testing.expectEqual(write_data.len, size2);
@@ -322,7 +322,7 @@ test "File: stat" {
     var file_stat1 = ev.FileStat.init(fd, null, .{});
     loop.add(&file_stat1.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_stat1.c.state);
+    try std.testing.expectEqual(.dead, file_stat1.c.loadState().phase);
     try std.testing.expectEqual(true, file_stat1.c.has_result);
     const stat1 = try file_stat1.getResult();
     try std.testing.expectEqual(0, stat1.size);
@@ -397,7 +397,7 @@ test "File: stat_path" {
     var file_stat = ev.FileStat.init(cwd, "test-stat-path", .{});
     loop.add(&file_stat.c);
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, file_stat.c.state);
+    try std.testing.expectEqual(.dead, file_stat.c.loadState().phase);
     try std.testing.expectEqual(true, file_stat.c.has_result);
     const stat = try file_stat.getResult();
     try std.testing.expectEqual(write_data.len, stat.size);

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -19,7 +19,7 @@ test "group: empty group completes immediately" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, group.c.state);
+    try std.testing.expectEqual(.dead, group.c.loadState().phase);
     try group.getResult();
 }
 
@@ -36,8 +36,8 @@ test "group: single completion" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, timer.c.state);
-    try std.testing.expectEqual(.dead, group.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
+    try std.testing.expectEqual(.dead, group.c.loadState().phase);
     try timer.getResult();
     try group.getResult();
 }
@@ -59,10 +59,10 @@ test "group: multiple completions" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, timer1.c.state);
-    try std.testing.expectEqual(.dead, timer2.c.state);
-    try std.testing.expectEqual(.dead, timer3.c.state);
-    try std.testing.expectEqual(.dead, group.c.state);
+    try std.testing.expectEqual(.dead, timer1.c.loadState().phase);
+    try std.testing.expectEqual(.dead, timer2.c.loadState().phase);
+    try std.testing.expectEqual(.dead, timer3.c.loadState().phase);
+    try std.testing.expectEqual(.dead, group.c.loadState().phase);
 
     try timer1.getResult();
     try timer2.getResult();
@@ -242,9 +242,9 @@ test "group: mixed completion types" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, timer.c.state);
-    try std.testing.expectEqual(.dead, async_handle.c.state);
-    try std.testing.expectEqual(.dead, group.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
+    try std.testing.expectEqual(.dead, group.c.loadState().phase);
 
     try timer.getResult();
     try async_handle.getResult();

--- a/src/ev/test/thread_pool.zig
+++ b/src/ev/test/thread_pool.zig
@@ -36,7 +36,7 @@ test "ev.ThreadPool: one task" {
 
     try loop.run(.until_done);
 
-    try std.testing.expectEqual(.dead, work.c.state);
+    try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try std.testing.expectEqual(1, test_fn.called);
 }
 

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -194,20 +194,28 @@ test "clearTimer racing a firing timer (cross-thread)" {
     var loop: Loop = undefined;
     var ready = std.atomic.Value(bool).init(false);
     var stop = std.atomic.Value(bool).init(false);
+    var wake_done = std.atomic.Value(bool).init(false);
     const runner = try std.Thread.spawn(.{}, struct {
-        fn run(l: *Loop, r: *std.atomic.Value(bool), s: *std.atomic.Value(bool)) void {
+        fn run(l: *Loop, r: *std.atomic.Value(bool), s: *std.atomic.Value(bool), w: *std.atomic.Value(bool)) void {
             l.init(.{}) catch @panic("loop init failed");
+            defer {
+                // Deinit belongs to this thread, but must not race the main
+                // thread's final wake(): a stale wake from the last clearTimer
+                // can pop run(.once) before that wake() is issued.
+                while (!w.load(.acquire)) std.Thread.yield() catch {};
+                l.deinit();
+            }
             r.store(true, .release);
             while (!s.load(.acquire)) {
                 l.run(.once) catch return;
             }
         }
-    }.run, .{ &loop, &ready, &stop });
-    defer loop.deinit();
+    }.run, .{ &loop, &ready, &stop, &wake_done });
     defer runner.join();
     defer {
         stop.store(true, .release);
         loop.wake();
+        wake_done.store(true, .release);
     }
     while (!ready.load(.acquire)) std.Thread.yield() catch {};
 

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -12,13 +12,13 @@ test "setTimer and clearTimer basic" {
 
     // Test setTimer
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(100) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 90);
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("setTimer: expected=100ms, actual={f}", .{elapsed});
@@ -33,11 +33,11 @@ test "clearTimer before expiration" {
 
     // Set a timer with a long delay
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(1000) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     // Clear it immediately
     loop.clearTimer(&timer);
-    try std.testing.expectEqual(.new, timer.c.state);
+    try std.testing.expectEqual(.new, timer.c.loadState().phase);
 
     // Run the loop - should complete immediately with no active timers
     var wall_timer = time.Stopwatch.start();
@@ -59,18 +59,18 @@ test "setTimer multiple times" {
 
     // Set timer with a long delay
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(2000) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     // Reset it with a short delay
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(10) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     // Should complete after ~10ms, not 2000ms
     var wall_timer = time.Stopwatch.start();
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 5);
     try std.testing.expect(elapsed.toMilliseconds() <= 100);
     std.log.info("setTimer multiple: expected=10ms, actual={f}", .{elapsed});
@@ -86,17 +86,17 @@ test "clearTimer and reuse timer" {
     // Set and clear
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(200) });
     loop.clearTimer(&timer);
-    try std.testing.expectEqual(.new, timer.c.state);
+    try std.testing.expectEqual(.new, timer.c.loadState().phase);
 
     // Reuse the same timer
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(10) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 5);
     try std.testing.expect(elapsed.toMilliseconds() <= 100);
     std.log.info("clearTimer reuse: expected=10ms, actual={f}", .{elapsed});
@@ -114,7 +114,7 @@ test "timer with zero duration completes immediately" {
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() < 50);
     std.log.info("zero duration timer: elapsed={f}", .{elapsed});
 }
@@ -133,7 +133,7 @@ test "timer with explicit deadline" {
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 90);
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("deadline timer: expected=100ms, actual={f}", .{elapsed});
@@ -146,13 +146,13 @@ test "timer on boot clock fires (duration)" {
 
     var timer: Timer = .initClock(.{ .duration = .zero }, .boot);
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(100) });
-    try std.testing.expectEqual(.running, timer.c.state);
+    try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 90);
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("boot timer: expected=100ms, actual={f}", .{elapsed});
@@ -174,7 +174,7 @@ test "timer on real clock fires (absolute deadline)" {
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 90);
     try std.testing.expect(elapsed.toMilliseconds() <= 250);
     std.log.info("real timer: expected=100ms, actual={f}", .{elapsed});
@@ -244,7 +244,7 @@ test "clearTimer racing a firing timer (cross-thread)" {
         // thread under the lock). Anything else means the fire got there
         // first (or is mid-flight): wait for its callback before the stack
         // timer goes out of scope.
-        if (@atomicLoad(@TypeOf(timer.c.state), &timer.c.state, .acquire) != .new) {
+        if (timer.c.loadState().phase != .new) {
             while (!fired.load(.acquire)) std.Thread.yield() catch {};
         }
     }

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -69,7 +69,7 @@ test "Loop: timer basic" {
     try loop.run(.until_done);
     const elapsed = wall_timer.read();
 
-    try std.testing.expectEqual(.dead, timer.c.state);
+    try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= timeout_ms - 5);
     try std.testing.expect(elapsed.toMilliseconds() <= timeout_ms + 100);
     std.log.info("timer: expected={}ms, actual={f}", .{ timeout_ms, elapsed });
@@ -137,7 +137,7 @@ test "Loop: async notification - same thread" {
 
     // Run loop - async should complete
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, async_handle.c.state);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try async_handle.c.getResult(.async);
 }
 
@@ -164,7 +164,7 @@ test "Loop: async notification - cross-thread" {
 
     // Run loop - should block until notified
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, async_handle.c.state);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try async_handle.c.getResult(.async);
 
     thread.join();
@@ -190,9 +190,9 @@ test "Loop: async notification - multiple handles" {
 
     // Run loop - all should complete
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, async1.c.state);
-    try std.testing.expectEqual(.dead, async2.c.state);
-    try std.testing.expectEqual(.dead, async3.c.state);
+    try std.testing.expectEqual(.dead, async1.c.loadState().phase);
+    try std.testing.expectEqual(.dead, async2.c.loadState().phase);
+    try std.testing.expectEqual(.dead, async3.c.loadState().phase);
 }
 
 test "Loop: async notification - re-arm" {
@@ -206,14 +206,14 @@ test "Loop: async notification - re-arm" {
     loop.add(&async_handle.c);
     async_handle.notify();
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, async_handle.c.state);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
 
     // Re-arm for second notification
     async_handle = .init();
     loop.add(&async_handle.c);
     async_handle.notify();
     try loop.run(.until_done);
-    try std.testing.expectEqual(.dead, async_handle.c.state);
+    try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
 }
 
 test "Pipe: write and read" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -907,6 +907,7 @@ fn batchCancelPending(batch: *Io.Batch, state: *BatchState) void {
     batchDrainReady(batch, state);
 
     // Cancel all pending operations (only those not yet ready)
+    const loop = &getCurrentExecutor().loop;
     var index = batch.pending.head;
     while (index != .none) {
         const storage = &batch.storage[index.toIndex()];
@@ -916,7 +917,7 @@ fn batchCancelPending(batch: *Io.Batch, state: *BatchState) void {
         if (data_ptr & 1 == 0) {
             const data: *BatchCompletionData = @ptrFromInt(data_ptr);
             const completion = data.getCompletion();
-            if (completion.loop) |l| l.cancel(completion);
+            loop.cancel(completion);
         }
         index = storage.pending.node.next;
     }

--- a/src/time.zig
+++ b/src/time.zig
@@ -576,7 +576,7 @@ pub const Timeout = union(enum) {
     pub fn asyncCancelWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
         _ = self;
         _ = waiter;
-        const loop = ctx.timer.c.loop orelse return true;
+        const loop = ctx.timer.c.getLoop() orelse return true;
         ctx.waiter = null; // Prevent callback from waking a stale/reused waiter
         loop.clearTimer(&ctx.timer);
         return true; // Timer operations don't have values to re-add if we lost the race


### PR DESCRIPTION
Unifies the completion lifecycle and cancellation coordination into a single atomic state word, and tightens the threading contract around the loop's entry points.

## Motivation

A completion's state was smeared across four variables: the plain `state` enum (custody plane), the atomic `cancel_state` byte (requested/in_queue/completed/loop_set), `has_result`, and the implicit "loop pointer is published" fact. Every cross-thread interaction needed a two-variable handshake, and each handshake required store-buffering analysis to prove no outcome where both sides read stale values. One such outcome was a real bug caught on aarch64 CI (f6983a30, the lost async wake); the cancel-before-add path had the same theoretical hole.

## Design

`Completion.state` is now one atomic `packed struct(u8)`:

```zig
pub const State = packed struct(u8) {
    phase: Phase = .new,            // new, running, completed, dead
    cancel_requested: bool = false, // latched by cancel(); backends poll it
    cancel_inflight: bool = false,  // a cancel pass owns the finish dispatch
    _reserved: u4 = 0,
};
```

All transitions are named single-RMW methods on `Completion` (`enterRunning`, `enterCompleted`, `enterDead`, `disarm`, `requestCancel`, `finishCancelPass`), each returning the previous state so the caller sees the full picture atomically. Every cross-thread race on a completion now resolves through the modification order of this one word; the store-buffering class of bugs is gone structurally, not carefully handled.

Consequences that fall out:

- `addInternal` gets a single prologue (`setLoop`, `enterRunning`, `incrActive`) replacing the per-branch running-transitions and active counting previously spread across its op branches, `submitFileOpToThreadPool`, and every backend's `submit`. Publication of the loop pointer is carried by the `new -> running` CAS, so the `loop_set` flag and `publishLoop` are deleted.
- `cancel()` collapses from a pre-read of the loop plus two CAS shapes into one CAS; `cancelLocal`'s defer becomes a single `fetchAnd`.
- `LoopState.setTimer`/`clearTimer` become pure heap operations (`armTimer`/`disarmTimer`); timer lifecycle is handled by `Loop.setTimer`, `Loop.clearTimer`, and the cancel pass, which re-checks under the timer lock instead of relying on state sniffing.
- io_uring's `is_new` state check becomes an explicit `submit`/`resubmit` split.
- `has_result` stays a plain custody field on purpose: a state bit would add an RMW to every `setResult`, and its only cross-thread use (the timer mid-fire limbo) is already protected by the timer mutex.

The branch also adds a debug-only `current_loop` threadlocal asserting that `add`, `cancel`, and `deinit` run on the loop's own thread. `cancel` must be called on the calling thread's loop (that is what routes local vs cross-loop); two internal callers cancelling through `completion.loop` from arbitrary threads were fixed.

## Behavior changes

- `cancel_requested` survives into `.dead`, so completion callbacks can still see it; `enterRunning` drops it on rearm, so a request aimed at a dead incarnation cannot cancel the next one (previously this hinged on `reset()` timing).
- `requestCancel` is a no-op on any non-running phase. This also covers cancelling a disarmed timer, which previously died on a `markCompleted` assert when the queued cancel arrived.

## Performance

The hot path drops from ~5 ordered atomic ops per completion to two CASes plus the active counter pair. Measured on x86-64 (ReleaseFast, io_uring): the timer add/fire/finish cycle runs ~3% faster while executing +0.8% more instructions per callgrind (CAS loops branch more but cost less), HTTP throughput via wrk is unchanged. The acquire/release fence savings on weakly ordered architectures are the larger expected win and remain unmeasured on real hardware; the aarch64 CI run of `async_stress` is the regression gate for the ordering itself.

## Testing

564/564 on io_uring (Debug and ReleaseSafe), epoll, poll (563), Windows/iocp under Wine, aarch64-epoll under QEMU, kqueue compile via aarch64-macos, plus the full examples build.

## Follow-up enabled

The transition methods are now the single switch point for a comptime `cross_loop` tier (plain state word, no cancel queue, per-loop accounting when task migration is compiled out and the backend has no shared servicing).
