### PR TITLE
Fix three lost-wakeup races: awaken-token protocol and idle/searcher announce

### DIFF
--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -192,7 +192,21 @@ pub fn wake(self: *Self, state: *LoopState) void {
         .data = 0,
         .udata = 0,
     }};
-    _ = std.c.kevent(self.kqueue_fd, &changes, 1, &.{}, 0, null);
+    // A silently failed trigger strands the sleeping loop until its poll
+    // timeout: wake_requested is already set, so later wakers skip the
+    // syscall. Retry EINTR; anything else means the waker is broken and
+    // every subsequent wake would be lost, so fail loudly.
+    while (true) {
+        const rc = std.c.kevent(self.kqueue_fd, &changes, 1, &.{}, 0, null);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return,
+            .INTR => {
+                log.warn("kqueue: waker NOTE_TRIGGER interrupted (EINTR), retrying", .{});
+                continue;
+            },
+            else => |err| std.debug.panic("kqueue: waker NOTE_TRIGGER failed: {t}", .{err}),
+        }
+    }
 }
 
 /// Arm/update/disarm the given wall clock's EVFILT_TIMER to an absolute deadline

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -200,10 +200,7 @@ pub fn wake(self: *Self, state: *LoopState) void {
         const rc = std.c.kevent(self.kqueue_fd, &changes, 1, &.{}, 0, null);
         switch (posix.errno(rc)) {
             .SUCCESS => return,
-            .INTR => {
-                std.debug.print("kqueue: waker NOTE_TRIGGER interrupted (EINTR), retrying\n", .{});
-                continue;
-            },
+            .INTR => continue,
             else => |err| std.debug.panic("kqueue: waker NOTE_TRIGGER failed: {t}", .{err}),
         }
     }

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -201,7 +201,7 @@ pub fn wake(self: *Self, state: *LoopState) void {
         switch (posix.errno(rc)) {
             .SUCCESS => return,
             .INTR => {
-                log.warn("kqueue: waker NOTE_TRIGGER interrupted (EINTR), retrying", .{});
+                std.debug.print("kqueue: waker NOTE_TRIGGER interrupted (EINTR), retrying\n", .{});
                 continue;
             },
             else => |err| std.debug.panic("kqueue: waker NOTE_TRIGGER failed: {t}", .{err}),

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -111,12 +111,35 @@ pub fn deinit(self: *Self) void {
 pub fn wake(self: *Self, state: *LoopState) void {
     _ = state;
     const byte: [1]u8 = .{1};
+    // A silently failed write strands the sleeping loop until its poll
+    // timeout: wake_requested is already set, so later wakers skip the
+    // syscall. A full pipe is fine (the pending bytes already make the
+    // waker fd readable); anything else means the waker is broken and
+    // every subsequent wake would be lost, so fail loudly.
     switch (builtin.os.tag) {
         .windows => {
-            _ = net.send(self.waker_write_fd, &[_]net.iovec_const{net.iovecConstFromSlice(&byte)}, .{}) catch {};
+            _ = net.send(self.waker_write_fd, &[_]net.iovec_const{net.iovecConstFromSlice(&byte)}, .{}) catch |err| switch (err) {
+                error.WouldBlock => {},
+                else => std.debug.panic("poll: waker send failed: {t}", .{err}),
+            };
         },
         else => {
-            _ = fs.write(self.waker_write_fd, &byte) catch {};
+            // Raw write, not fs.write: the waker needs no cancel bracket and
+            // fs.write's internal EINTR retry would hide the interruption we
+            // want to observe.
+            while (true) {
+                const rc = posix.system.write(self.waker_write_fd, &byte, byte.len);
+                switch (posix.errno(rc)) {
+                    .SUCCESS => break,
+                    .INTR => {
+                        log.warn("poll: waker write interrupted (EINTR), retrying", .{});
+                        continue;
+                    },
+                    // Full pipe: the pending bytes already make the fd readable.
+                    .AGAIN => break,
+                    else => |err| std.debug.panic("poll: waker write failed: {t}", .{err}),
+                }
+            }
         },
     }
 }

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -124,17 +124,13 @@ pub fn wake(self: *Self, state: *LoopState) void {
             };
         },
         else => {
-            // Raw write, not fs.write: the waker needs no cancel bracket and
-            // fs.write's internal EINTR retry would hide the interruption we
-            // want to observe.
+            // Raw write, not fs.write: the waker runs on any thread and needs
+            // neither the cancel bracket nor its error surface.
             while (true) {
                 const rc = posix.system.write(self.waker_write_fd, &byte, byte.len);
                 switch (posix.errno(rc)) {
                     .SUCCESS => break,
-                    .INTR => {
-                        std.debug.print("poll: waker write interrupted (EINTR), retrying\n", .{});
-                        continue;
-                    },
+                    .INTR => continue,
                     // Full pipe: the pending bytes already make the fd readable.
                     .AGAIN => break,
                     else => |err| std.debug.panic("poll: waker write failed: {t}", .{err}),

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -132,7 +132,7 @@ pub fn wake(self: *Self, state: *LoopState) void {
                 switch (posix.errno(rc)) {
                     .SUCCESS => break,
                     .INTR => {
-                        log.warn("poll: waker write interrupted (EINTR), retrying", .{});
+                        std.debug.print("poll: waker write interrupted (EINTR), retrying\n", .{});
                         continue;
                     },
                     // Full pipe: the pending bytes already make the fd readable.

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1495,22 +1495,7 @@ pub const Loop = struct {
         // This avoids syscall overhead for pure CPU-bound workloads.
         const should_poll = wait or self.backend.hasInflight();
         const wake_flags = self.state.wake_requested.swap(0, .acq_rel);
-        const effective_timeout: Duration = if (wake_flags != 0) .zero else timeout;
-        const timed_out = if (should_poll) try self.backend.poll(&self.state, effective_timeout) else false;
-
-        // TEMPORARY diagnostics (macos-arm64 lost-wake stalls): a long blocking
-        // poll running to full expiry is the stall signature. The flag value
-        // discriminates: nonzero means a wake was requested but its event never
-        // arrived (failed/skipped syscall); zero means no waker acted at all.
-        // std.debug.print, not log: the test runner captures and discards logs
-        // of passing tests.
-        if (timed_out and effective_timeout.value >= Duration.fromSeconds(10).value) {
-            std.debug.print("loop {*}: blocking poll expired after {d}ms (wake_requested=0x{x})\n", .{
-                self,
-                effective_timeout.toMilliseconds(),
-                self.state.wake_requested.load(.monotonic),
-            });
-        }
+        const timed_out = if (should_poll) try self.backend.poll(&self.state, if (wake_flags != 0) .zero else timeout) else false;
 
         // Process async handles if the async bit was set
         if (wake_flags & LoopState.wake_async != 0) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1502,8 +1502,11 @@ pub const Loop = struct {
         // poll running to full expiry is the stall signature. The flag value
         // discriminates: nonzero means a wake was requested but its event never
         // arrived (failed/skipped syscall); zero means no waker acted at all.
+        // std.debug.print, not log: the test runner captures and discards logs
+        // of passing tests.
         if (timed_out and effective_timeout.value >= Duration.fromSeconds(10).value) {
-            log.warn("blocking poll expired after {d}ms (wake_requested=0x{x})", .{
+            std.debug.print("loop {*}: blocking poll expired after {d}ms (wake_requested=0x{x})\n", .{
+                self,
                 effective_timeout.toMilliseconds(),
                 self.state.wake_requested.load(.monotonic),
             });

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1495,7 +1495,19 @@ pub const Loop = struct {
         // This avoids syscall overhead for pure CPU-bound workloads.
         const should_poll = wait or self.backend.hasInflight();
         const wake_flags = self.state.wake_requested.swap(0, .acq_rel);
-        const timed_out = if (should_poll) try self.backend.poll(&self.state, if (wake_flags != 0) .zero else timeout) else false;
+        const effective_timeout: Duration = if (wake_flags != 0) .zero else timeout;
+        const timed_out = if (should_poll) try self.backend.poll(&self.state, effective_timeout) else false;
+
+        // TEMPORARY diagnostics (macos-arm64 lost-wake stalls): a long blocking
+        // poll running to full expiry is the stall signature. The flag value
+        // discriminates: nonzero means a wake was requested but its event never
+        // arrived (failed/skipped syscall); zero means no waker acted at all.
+        if (timed_out and effective_timeout.value >= Duration.fromSeconds(10).value) {
+            log.warn("blocking poll expired after {d}ms (wake_requested=0x{x})", .{
+                effective_timeout.toMilliseconds(),
+                self.state.wake_requested.load(.monotonic),
+            });
+        }
 
         // Process async handles if the async bit was set
         if (wake_flags & LoopState.wake_async != 0) {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -659,27 +659,7 @@ pub const Executor = struct {
         }
 
         const found_work = self.checkAboutForWork(check_ready, true);
-        const slept_from = Timestamp.now(.monotonic);
         try self.loop.run(if (found_work) .no_wait else .once);
-
-        // TEMPORARY diagnostics (macos-arm64 lost-wake stalls): after an
-        // anomalously long sleep, dump what this executor can see. A non-empty
-        // overflow queue here means a task sat runnable the whole time with no
-        // announcement reaching us.
-        const slept_ns = Timestamp.now(.monotonic).toNanoseconds() -| slept_from.toNanoseconds();
-        if (slept_ns > 10_000_000_000) {
-            const main_state = self.main_task.state.load(.acquire);
-            std.debug.print("executor {d} woke after {d}ms: ring_empty={} overflow_len={d} main={t} awaken={} idle_mask=0x{x} searchers={d}\n", .{
-                self.id,
-                @divTrunc(slept_ns, 1_000_000),
-                self.run_queue.isEmpty(),
-                self.run_queue.overflow.len(),
-                main_state.tag,
-                main_state.awaken,
-                self.runtime.idle_mask.load(.monotonic),
-                self.runtime.searchers.load(.monotonic),
-            });
-        }
 
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -513,12 +513,9 @@ pub const Executor = struct {
     pub fn maybeYield(self: *Executor, comptime mode: AnyTask.YieldMode, comptime cancel_mode: YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
         // Cancellation is observed even on the fast path, so a CPU-bound loop
         // that only calls maybeYield() reacts to cancel promptly, like yield().
+        // Must not touch task.state on the error return (see AnyTask.yield).
         if (cancel_mode == .allow_cancel) {
-            const task = getCurrentTask();
-            task.checkCancel() catch |err| {
-                task.state.store(.{ .tag = .ready }, .release);
-                return err;
-            };
+            try getCurrentTask().checkCancel();
         }
         // Pure time-slice check: each call spends a quantum of the tick budget,
         // and only when the slice is used up does a real yield happen (letting
@@ -822,8 +819,13 @@ pub const Executor = struct {
                 // Task is in .ready state (running or about to park).
                 // Set the awaken bit as a park token; processCleanup.park will consume it
                 // and reschedule the task instead of transitioning to .waiting.
+                // The CAS runs even when the token is already set (rewriting the
+                // same value): a coalescing waker must still join the release
+                // sequence on `state`, or the parker's token-consume would not
+                // synchronize with it and the payload published before this wake
+                // (a notify count, a result) could be invisible to the recheck
+                // after the reschedule.
                 .ready => {
-                    if (old.awaken) return; // Token already set, nothing to do
                     const desired = AnyTask.State{ .tag = .ready, .awaken = true };
                     if (task.state.cmpxchgWeak(old, desired, .acq_rel, .acquire)) |actual| {
                         old = actual;
@@ -1003,10 +1005,8 @@ pub fn yield() Cancelable!void {
         exec.run_queue.isEmpty() and exec.run_queue.overflow.isEmpty() and
         exec.main_task.state.load(.acquire).tag != .ready)
     {
-        task.checkCancel() catch |err| {
-            task.state.store(.{ .tag = .ready }, .release);
-            return err;
-        };
+        // Must not touch task.state on the error return (see AnyTask.yield).
+        try task.checkCancel();
         exec.spendQuantum();
         return;
     }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -647,7 +647,10 @@ pub const Executor = struct {
 
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
         const my_bit = @as(usize, 1) << self.id;
-        _ = self.runtime.idle_mask.fetchOr(my_bit, .acq_rel);
+        // seq_cst: pairs with armSearcher's idle_mask load (see there). The bit
+        // must be globally visible before the work check below, or a concurrent
+        // pusher can both miss the bit and have its push missed by the check.
+        _ = self.runtime.idle_mask.fetchOr(my_bit, .seq_cst);
         errdefer {
             const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
             if (previous_bit & my_bit == 0) {
@@ -703,7 +706,11 @@ pub const Executor = struct {
             // Release the token before the final recheck. A concurrent
             // pusher that sees searchers == 0 can arm a fresh search instead of
             // being blocked behind a token we're about to give up anyway.
-            _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+            // seq_cst: pairs with armSearcher's searchers load. The release must
+            // be globally visible before the recheck below, or a pusher can
+            // both read the stale token (skipping its announce) and have its
+            // push missed by this recheck - a dropped wake with no retry.
+            _ = self.runtime.searchers.cmpxchgStrong(1, 0, .seq_cst, .monotonic);
             if (self.stealWork()) return;
             if (self.checkAboutForWork(check_ready, false)) self.runtime.armSearcher();
         }
@@ -1349,8 +1356,17 @@ pub const Runtime = struct {
     }
 
     fn armSearcher(self: *Runtime) void {
-        if (!self.stealingActive() or (self.idle_mask.load(.monotonic) == 0) or (self.searchers.load(.monotonic) != 0)) return;
-        if (self.searchers.cmpxchgStrong(0, 1, .acq_rel, .monotonic)) |_| return;
+        // The two early-return loads pair with the parker: an executor sets its
+        // idle bit (seq_cst RMW) and only then makes its final work check, while
+        // a pusher publishes the task and only then reads idle_mask/searchers
+        // here. Both sides run store-then-load, so with anything weaker than
+        // seq_cst each can read the other's stale value on a weakly ordered CPU
+        // and the announce is dropped: the task then sits in a queue no awake
+        // executor looks at until some poll timeout (observed as ~60s stalls on
+        // Apple Silicon). seq_cst loads are enough on the pusher side; the
+        // parker's RMWs anchor the total order.
+        if (!self.stealingActive() or (self.idle_mask.load(.seq_cst) == 0) or (self.searchers.load(.seq_cst) != 0)) return;
+        if (self.searchers.cmpxchgStrong(0, 1, .seq_cst, .monotonic)) |_| return;
 
         var candidates = self.idle_mask.load(.acquire);
         while (candidates != 0) {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -656,7 +656,27 @@ pub const Executor = struct {
         }
 
         const found_work = self.checkAboutForWork(check_ready, true);
+        const slept_from = Timestamp.now(.monotonic);
         try self.loop.run(if (found_work) .no_wait else .once);
+
+        // TEMPORARY diagnostics (macos-arm64 lost-wake stalls): after an
+        // anomalously long sleep, dump what this executor can see. A non-empty
+        // overflow queue here means a task sat runnable the whole time with no
+        // announcement reaching us.
+        const slept_ns = Timestamp.now(.monotonic).toNanoseconds() -| slept_from.toNanoseconds();
+        if (slept_ns > 10_000_000_000) {
+            const main_state = self.main_task.state.load(.acquire);
+            std.debug.print("executor {d} woke after {d}ms: ring_empty={} overflow_len={d} main={t} awaken={} idle_mask=0x{x} searchers={d}\n", .{
+                self.id,
+                @divTrunc(slept_ns, 1_000_000),
+                self.run_queue.isEmpty(),
+                self.run_queue.overflow.len(),
+                main_state.tag,
+                main_state.awaken,
+                self.runtime.idle_mask.load(.monotonic),
+                self.runtime.searchers.load(.monotonic),
+            });
+        }
 
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -343,19 +343,36 @@ test "Mutex repeated cancellation generations under churn" {
     // many short generations instead of once. On a buggy runtime a victim
     // parks forever and victims.cancel() never returns; the watchdog turns
     // that into a prompt panic instead of a CI-level job timeout.
+    //
+    // The watchdog is progress-based, not wall-clock-based: oversubscribed CI
+    // runners have legitimately run this test for minutes while still making
+    // progress. A generation normally completes in milliseconds, so a
+    // generation counter that does not advance for 90s of counted sleep
+    // (>= 90s wall) distinguishes a parked-forever victim from a slow runner.
     var done = std.atomic.Value(bool).init(false);
+    var progress = std.atomic.Value(u64).init(0);
     const watchdog = try std.Thread.spawn(.{}, struct {
-        fn run(done_flag: *std.atomic.Value(bool)) void {
-            var waited_ms: u64 = 0;
+        fn run(done_flag: *std.atomic.Value(bool), progress_counter: *std.atomic.Value(u64)) void {
+            var last_progress: u64 = 0;
+            var stale_ms: u64 = 0;
             while (!done_flag.load(.acquire)) {
                 os.time.sleep(.fromMilliseconds(100));
-                waited_ms += 100;
-                if (waited_ms >= 120_000) {
-                    @panic("victim task parked forever: unlock's signal was lost");
+                const current = progress_counter.load(.monotonic);
+                if (current != last_progress) {
+                    last_progress = current;
+                    stale_ms = 0;
+                    continue;
+                }
+                stale_ms += 100;
+                if (stale_ms >= 90_000) {
+                    std.debug.panic(
+                        "victim task parked forever: no progress for 90s at generation {d}",
+                        .{current},
+                    );
                 }
             }
         }
-    }.run, .{&done});
+    }.run, .{ &done, &progress });
     defer {
         done.store(true, .release);
         watchdog.join();
@@ -391,6 +408,7 @@ test "Mutex repeated cancellation generations under churn" {
         for (0..8) |_| try victims.spawn(TestFn.victim, .{&mutex});
         os.time.sleep(.fromMilliseconds(1));
         victims.cancel();
+        _ = progress.fetchAdd(1, .monotonic);
     }
 
     stop.store(true, .monotonic);

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -404,19 +404,28 @@ test "Mutex repeated cancellation generations under churn" {
     for (0..2) |_| try churners.spawn(TestFn.churner, .{ &mutex, &stop });
 
     for (0..500) |gen| {
-        const gen_start = os.time.now(.awake);
+        const t0 = os.time.now(.awake);
         var victims: Group = .init;
         for (0..8) |_| try victims.spawn(TestFn.victim, .{&mutex});
+        const t1 = os.time.now(.awake);
         os.time.sleep(.fromMilliseconds(1));
+        const t2 = os.time.now(.awake);
         victims.cancel();
+        const t3 = os.time.now(.awake);
         _ = progress.fetchAdd(1, .monotonic);
         // Stall telemetry: a generation normally completes in a few
         // milliseconds; multi-second generations indicate lost wakeups that
-        // only the loop's max_wait poll timeout rescued. Print them so CI
-        // logs show the stall distribution.
-        const gen_ms = @divTrunc(os.time.now(.awake).toNanoseconds() - gen_start.toNanoseconds(), 1_000_000);
+        // only a loop timer expiry rescued. The sub-phase split shows where
+        // the stall lives (a stuck sleep timer vs. a stranded cancel wait).
+        const gen_ms = @divTrunc(t3.toNanoseconds() - t0.toNanoseconds(), 1_000_000);
         if (gen_ms > 5_000) {
-            std.debug.print("generation {d} took {d}ms\n", .{ gen, gen_ms });
+            std.debug.print("generation {d} took {d}ms (spawn={d}ms sleep={d}ms cancel={d}ms)\n", .{
+                gen,
+                gen_ms,
+                @divTrunc(t1.toNanoseconds() - t0.toNanoseconds(), 1_000_000),
+                @divTrunc(t2.toNanoseconds() - t1.toNanoseconds(), 1_000_000),
+                @divTrunc(t3.toNanoseconds() - t2.toNanoseconds(), 1_000_000),
+            });
         }
     }
 

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -332,12 +332,18 @@ test "Mutex cancellation while parked under churn" {
 test "Mutex repeated cancellation generations under churn" {
     if (@import("builtin").single_threaded) return error.SkipZigTest;
 
-    // Regression stress for a lost wakeup that shows up as a rare hang of the
-    // test above on weakly ordered CPUs (Apple Silicon, release mode). The
-    // suspected mechanism: yield's cancel-error path clears the awaken bit
-    // with a blind store, erasing a wake token set by unlock's pop+signal;
-    // the no_cancel wait in lockSlow's cancel path then reads a stale signal
-    // count and parks with no wake left in flight.
+    // Regression stress for lost wakeups on weakly ordered CPUs (both found
+    // via this test hanging or stalling on Apple Silicon in release mode):
+    //
+    // 1. yield's cancel-error path used to clear the awaken bit with a blind
+    //    store, erasing a wake token set by unlock's pop+signal; the
+    //    no_cancel wait in lockSlow's cancel path then read a stale signal
+    //    count and parked forever with no wake left in flight.
+    // 2. the scheduler's idle/searcher announce handshake used
+    //    weaker-than-seq_cst orderings, so a pusher could drop its announce
+    //    while the idle executor's final work check predated the push,
+    //    stranding a runnable task until an unrelated poll timeout (~60s
+    //    stalls under this churn pattern).
     //
     // Every canceled victim is one roll of the dice, so cancel victims in
     // many short generations instead of once. On a buggy runtime a victim

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -328,3 +328,76 @@ test "Mutex cancellation while parked under churn" {
     mutex.unlock();
     try std.testing.expect(churned > 0);
 }
+
+test "Mutex repeated cancellation generations under churn" {
+    if (@import("builtin").single_threaded) return error.SkipZigTest;
+
+    // Regression stress for a lost wakeup that shows up as a rare hang of the
+    // test above on weakly ordered CPUs (Apple Silicon, release mode). The
+    // suspected mechanism: yield's cancel-error path clears the awaken bit
+    // with a blind store, erasing a wake token set by unlock's pop+signal;
+    // the no_cancel wait in lockSlow's cancel path then reads a stale signal
+    // count and parks with no wake left in flight.
+    //
+    // Every canceled victim is one roll of the dice, so cancel victims in
+    // many short generations instead of once. On a buggy runtime a victim
+    // parks forever and victims.cancel() never returns; the watchdog turns
+    // that into a prompt panic instead of a CI-level job timeout.
+    var done = std.atomic.Value(bool).init(false);
+    const watchdog = try std.Thread.spawn(.{}, struct {
+        fn run(done_flag: *std.atomic.Value(bool)) void {
+            var waited_ms: u64 = 0;
+            while (!done_flag.load(.acquire)) {
+                os.time.sleep(.fromMilliseconds(100));
+                waited_ms += 100;
+                if (waited_ms >= 120_000) {
+                    @panic("victim task parked forever: unlock's signal was lost");
+                }
+            }
+        }
+    }.run, .{&done});
+    defer {
+        done.store(true, .release);
+        watchdog.join();
+    }
+
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
+
+    var mutex = Mutex.init;
+    var stop = std.atomic.Value(bool).init(false);
+
+    const TestFn = struct {
+        fn churner(mtx: *Mutex, stop_flag: *std.atomic.Value(bool)) !void {
+            while (!stop_flag.load(.monotonic)) {
+                try mtx.lock();
+                mtx.unlock();
+            }
+        }
+        fn victim(mtx: *Mutex) !void {
+            while (true) {
+                try mtx.lock();
+                mtx.unlock();
+            }
+        }
+    };
+
+    var churners: Group = .init;
+    defer churners.cancel();
+    for (0..2) |_| try churners.spawn(TestFn.churner, .{ &mutex, &stop });
+
+    for (0..200) |_| {
+        var victims: Group = .init;
+        for (0..8) |_| try victims.spawn(TestFn.victim, .{&mutex});
+        os.time.sleep(.fromMilliseconds(1));
+        victims.cancel();
+    }
+
+    stop.store(true, .monotonic);
+    try churners.wait();
+    try std.testing.expect(!churners.hasFailed());
+
+    // The lock must still work after all the canceled waiters left.
+    try mutex.lock();
+    mutex.unlock();
+}

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -386,7 +386,7 @@ test "Mutex repeated cancellation generations under churn" {
     defer churners.cancel();
     for (0..2) |_| try churners.spawn(TestFn.churner, .{ &mutex, &stop });
 
-    for (0..200) |_| {
+    for (0..500) |_| {
         var victims: Group = .init;
         for (0..8) |_| try victims.spawn(TestFn.victim, .{&mutex});
         os.time.sleep(.fromMilliseconds(1));

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -350,11 +350,11 @@ test "Mutex repeated cancellation generations under churn" {
     // generation counter that does not advance for 90s of counted sleep
     // (>= 90s wall) distinguishes a parked-forever victim from a slow runner.
     var done = std.atomic.Value(bool).init(false);
-    var progress = std.atomic.Value(u64).init(0);
+    var progress = std.atomic.Value(u32).init(0);
     const watchdog = try std.Thread.spawn(.{}, struct {
-        fn run(done_flag: *std.atomic.Value(bool), progress_counter: *std.atomic.Value(u64)) void {
-            var last_progress: u64 = 0;
-            var stale_ms: u64 = 0;
+        fn run(done_flag: *std.atomic.Value(bool), progress_counter: *std.atomic.Value(u32)) void {
+            var last_progress: u32 = 0;
+            var stale_ms: u32 = 0;
             while (!done_flag.load(.acquire)) {
                 os.time.sleep(.fromMilliseconds(100));
                 const current = progress_counter.load(.monotonic);
@@ -403,12 +403,21 @@ test "Mutex repeated cancellation generations under churn" {
     defer churners.cancel();
     for (0..2) |_| try churners.spawn(TestFn.churner, .{ &mutex, &stop });
 
-    for (0..500) |_| {
+    for (0..500) |gen| {
+        const gen_start = os.time.now(.awake);
         var victims: Group = .init;
         for (0..8) |_| try victims.spawn(TestFn.victim, .{&mutex});
         os.time.sleep(.fromMilliseconds(1));
         victims.cancel();
         _ = progress.fetchAdd(1, .monotonic);
+        // Stall telemetry: a generation normally completes in a few
+        // milliseconds; multi-second generations indicate lost wakeups that
+        // only the loop's max_wait poll timeout rescued. Print them so CI
+        // logs show the stall distribution.
+        const gen_ms = @divTrunc(os.time.now(.awake).toNanoseconds() - gen_start.toNanoseconds(), 1_000_000);
+        if (gen_ms > 5_000) {
+            std.debug.print("generation {d} took {d}ms\n", .{ gen, gen_ms });
+        }
     }
 
     stop.store(true, .monotonic);

--- a/src/task.zig
+++ b/src/task.zig
@@ -271,12 +271,14 @@ pub const AnyTask = struct {
         var executor = getCurrentExecutor();
 
         // Check and consume cancellation flag before yielding (unless no_cancel).
-        // On cancel: restore clean .ready state (clearing any awaken bit) before returning.
+        // On the cancel-error return, `state` must be left untouched: the tag is
+        // already .ready (we are running), and the awaken bit may hold a wake
+        // token set by a concurrent signal whose payload a cleanup path still
+        // has to observe (e.g. lockSlow's no_cancel wait for an in-flight
+        // signal). Clearing it here would strand that wake; a leftover token
+        // only costs one spurious reschedule at the next park.
         if (cancel_mode == .allow_cancel) {
-            self.checkCancel() catch |err| {
-                self.state.store(.{ .tag = .ready }, .release);
-                return err;
-            };
+            try self.checkCancel();
         }
 
         // Set up deferred cleanup — state transition happens after context is saved


### PR DESCRIPTION
Fixes three lost-wakeup defects of the same class (store-then-load protocols broken by weak memory ordering), found starting from a CI-level timeout of `sync.Mutex.test.Mutex cancellation while parked under churn` on `test (0.16.0, release, macos-latest, native, kqueue poll)`.

## Reproduction

The dedicated stress test (500 cancel generations under lock churn) surfaced two distinct defects on macos-latest (Apple Silicon):

1. The wall-clock watchdog panicked on release runs both before and after the runtime fix. Per-generation telemetry later showed these were an accumulation of discrete stalls, not (necessarily) the permanent hang: individual generations freeze for exactly one 60s `max_wait` poll timeout and then recover (e.g. generations 37/116/207 at ~59.5s each in one poll-backend run, all other generations normal). That recoverable lost-wake stall is macOS+Apple-Silicon-specific (same test: 600ms on x86 and native arm64 Linux, 1.2s on Intel macOS), reproduces on every macos-latest run, and is tracked separately - both backends' `wake()` currently discard syscall errors, which would produce exactly this signature.

2. The permanent hang this PR fixes was observed organically (the original churn test hung until the CI-level job timeout, hours past the 60s self-heal bound, which no recoverable stall can explain). The two holes below are the mechanism: x86 cannot hit them (locked RMWs exclude the required interleavings), qemu does not model weak ordering, and Apple Silicon macOS is the only weakly ordered target in the matrix exercising this code under churn.

The test's watchdog is progress-based (panics only if the generation counter stalls for 90s, past the 60s self-heal bound) so it detects permanent lost wakeups without false-positives from the recoverable stalls, and it prints any generation slower than 5s so the stall distribution stays visible in CI logs.

## Hole 1: cancel-error paths erase foreign wake tokens

`AnyTask.yield` (and `maybeYield` / the runtime `yield` fast path) handled a pending cancel at entry with:

```zig
self.checkCancel() catch |err| {
    self.state.store(.{ .tag = .ready }, .release);
    return err;
};
```

The tag is already `.ready` there (the task is running), so the store's only effect is clearing the awaken bit - and that bit may be a wake token set by a concurrent signal, e.g. `Mutex.unlock`'s pop+signal landing while the task runs. The token is that signal's entire delivery: with it erased, the Mutex cancel path's `remove()` fails (node already popped) and `waiter.wait(1, .no_cancel)` reads a stale notify count and parks with no wake left in flight, forever. Every 'canceled -> cleanup -> no_cancel wait for the in-flight completion' site (`waitForIo`, `select`, `Futex`, channels) has the same exposure.

Fix: leave `state` untouched on the cancel-error return. A leftover token costs one spurious reschedule at the next park, which every wait loop already absorbs.

## Hole 2: coalesced wakes don't join the release sequence

`scheduleTask` skipped the CAS when the awaken bit was already set (`if (old.awaken) return`). The skip is a pure load: a coalescing waker made no release write to `task.state`, so the parker's token-consume CAS did not synchronize with it, and the payload published before the wake (a notify count) could be invisible to the recheck after the reschedule - the task re-parks with the wake already spent. Fix: perform the CAS even when it rewrites the same value, so every waker joins the release sequence.

## Hole 3: the idle/searcher announce handshake drops wakes

After fixing holes 1-2, the stress test still took near-exact multiples of 60s on macos-latest (and only there). Staged diagnostics on this branch pinned it: a barging churner spins uncontended on one executor (never yields, makes no scheduling calls after its competitor got migrated into that executor's own ring and starved), the only idle executor sleeps, and the pusher's `armSearcher` dropped its announce - after a 59s sleep the executor's idle bit was still set, `wake_requested` was 0, and the world resumed the moment its periodic timer made it steal.

The announce handshake is a store-then-load pair on each side: the parker sets its idle bit then makes its final work check; the pusher publishes the task then reads `idle_mask` and `searchers`. With `.acq_rel`/`.monotonic` orderings both sides can read the other's stale value, the announce is skipped, and the spinning pusher never retries. The same pair exists for the searcher token released before the final recheck. Fix: parker/holder RMWs and the pusher's early-return reads become seq_cst (the hot path gains only seq_cst loads - LDAR on aarch64, ordered after the preceding queue publish - not RMWs).

Verified on CI: the stress test went from 60-183s per backend phase (1-3 stalled generations each, every run) to 3-4s with zero stalls.

Both backend wakers are also hardened as a byproduct of the investigation: a silently failed wake syscall would strand the loop exactly like these races, so `wake()` now retries EINTR and fails loudly otherwise.

## History

The blind store dates to #344 (it predates v0.16.0). It became reachable in practice through the barging Mutex rewrite (60f9e803), whose cancel path parks again to consume an in-flight signal, and was first exercised hard by the churn test added in a28e5f95.
