### PR TITLE
ev: make clearTimer report whether it stopped the callback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed a use-after-free in timed waits, where a task could return and drop the stack
+  frame holding its timeout timer before the event loop was done with it. A timer that
+  has already fired cannot be disarmed, so `Loop.clearTimer` now returns false to say the
+  callback is still coming; low-level `ev` users need to handle the result.
+
+- `Waiter.timedWait` now returns `error.Timeout` instead of leaving callers to work out
+  whether the timeout or a real wakeup ended the wait. `CompletionQueue.timedWait` no
+  longer reports a timeout when a completion woke it.
+
 - Reworked completion state tracking in the low-level `ev` API: the lifecycle phase and
   the cancellation flags now live in a single atomic `Completion.state` word, read
   through `Completion.loadState()`. The separate `cancel_state` field is gone; code that

--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -19,14 +19,29 @@ pub const AutoCancel = struct {
     timer: ev.Timer = .init(.{ .duration = .zero }),
     triggered: bool = false,
     task: ?*AnyTask = null,
+    /// Set by the callback, before it wakes the owner task, as its last touch
+    /// of this struct. A `clear` that lost the disarm race parks on it, which
+    /// keeps this struct (and the timer inside it) alive for exactly as long
+    /// as the callback needs them.
+    fired: std.atomic.Value(u32) = .init(0),
 
     pub const init: AutoCancel = .{};
 
     pub fn clear(self: *AutoCancel) void {
         const loop = self.timer.c.getLoop() orelse return;
-        if (self.timer.c.loadState().phase != .running) return;
 
-        loop.clearTimer(&self.timer);
+        if (loop.clearTimer(&self.timer)) {
+            self.task = null;
+            return;
+        }
+
+        // The timer already fired or is completing, so its callback runs (or
+        // has run) against this struct. Park until it is done with it; it
+        // wakes this task after setting the flag.
+        const task = getCurrentTask();
+        while (self.fired.load(.acquire) == 0) {
+            task.yield(.park, .no_cancel);
+        }
         self.task = null;
     }
 
@@ -40,9 +55,10 @@ pub const AutoCancel = struct {
         const task = getCurrentTask();
         const executor = task.getExecutor();
 
-        // Set task reference and reset triggered flag
+        // Set task reference and reset the per-arm flags
         self.task = task;
         self.triggered = false;
+        self.fired.store(0, .monotonic);
 
         // Initialize ev.Timer
         self.timer.c.userdata = self;
@@ -68,19 +84,29 @@ fn autoCancelCallback(
     completion: *ev.Completion,
 ) void {
     const autocancel: *AutoCancel = @ptrCast(@alignCast(completion.userdata.?));
-    const task = autocancel.task orelse return;
+    const task = autocancel.task;
 
     // Clear the associated task
     autocancel.task = null;
 
-    // If there's an error, the timer was cancelled - don't wake the task
-    if (completion.err != null) return;
-
-    // Try to cancel and wake only if we triggered (not shadowed by user cancel)
-    if (task.setCanceled(.auto)) {
-        autocancel.triggered = true;
-        task.wake();
+    // An error means the timer was cancelled, so don't cancel the task; only
+    // cancel if we triggered (not shadowed by user cancel).
+    if (completion.err == null) {
+        if (task) |t| {
+            if (t.setCanceled(.auto)) autocancel.triggered = true;
+        }
     }
+
+    // Last touch of `autocancel`: publishes the writes above to a `clear` that
+    // lost the disarm race and is parked on this flag. Nothing below may touch
+    // the struct or the completion again, since observing the flag lets the
+    // owner drop the frame both live in.
+    autocancel.fired.store(1, .release);
+
+    // Wake unconditionally: the owner may be parked in `clear` waiting for the
+    // flag even when the cancel did not take. A wake with nothing parked just
+    // leaves an awaken token, which the park loops consume harmlessly.
+    if (task) |t| t.wake();
 }
 
 const Cancelable = @import("common.zig").Cancelable;

--- a/src/common.zig
+++ b/src/common.zig
@@ -139,6 +139,21 @@ pub const Waiter = struct {
         };
     }
 
+    /// Top bit of a direct waiter's notify state, set when its timeout timer
+    /// fired. It is deliberately not a signal: the timer never touches the
+    /// count, so the count keeps meaning "signals from real sources", and the
+    /// bit alone says the timeout won.
+    const timeout_flag: u32 = 1 << 31;
+
+    fn signalCount(state: u32) u32 {
+        return state & ~timeout_flag;
+    }
+
+    /// Whether this waiter's timeout timer fired.
+    fn timedOut(self: *const Waiter) bool {
+        return self.mode.direct.notify.state.load(.acquire) & timeout_flag != 0;
+    }
+
     /// Wait for at least `expected` signals, handling spurious wakeups internally.
     /// Only valid for direct waiters.
     pub fn wait(self: *Waiter, expected: u32, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
@@ -150,39 +165,92 @@ pub const Waiter = struct {
         }
     }
 
+    /// Error set of a timed wait: `error.Timeout` says the timer fired with no
+    /// signal in hand, which the count alone cannot tell you (the timer does
+    /// not signal).
+    ///
+    /// It reports which source ended the wait, not who won a contested
+    /// handoff: a caller racing a wait queue still settles that with its own
+    /// bookkeeping, since a signal can land right behind the timeout.
+    pub fn TimedWaitError(comptime cancel_mode: Executor.YieldCancelMode) type {
+        return if (cancel_mode == .allow_cancel) (Timeoutable || Cancelable) else Timeoutable;
+    }
+
     /// Wait for at least `expected` signals with a timeout.
-    /// The caller must check their condition to determine if timeout actually won
-    /// (e.g., by trying to remove from a wait queue).
     /// Only valid for direct waiters.
-    pub fn timedWait(self: *Waiter, expected: u32, timeout: Timeout, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
+    pub fn timedWait(self: *Waiter, expected: u32, timeout: Timeout, comptime cancel_mode: Executor.YieldCancelMode) TimedWaitError(cancel_mode)!void {
         return self.timedWaitClock(expected, timeout, .awake, cancel_mode);
     }
 
     /// Like `timedWait`, but the timeout is measured against `clock`. The
     /// no-task futex fallback only supports the monotonic (`awake`) clock, so
     /// boot/real timeouts there degrade to awake semantics.
-    pub fn timedWaitClock(self: *Waiter, expected: u32, timeout: Timeout, clock: Clock, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
+    pub fn timedWaitClock(self: *Waiter, expected: u32, timeout: Timeout, clock: Clock, comptime cancel_mode: Executor.YieldCancelMode) TimedWaitError(cancel_mode)!void {
         if (timeout == .none) {
-            return self.wait(expected, cancel_mode);
+            if (cancel_mode == .allow_cancel) {
+                try self.wait(expected, cancel_mode);
+            } else {
+                self.wait(expected, cancel_mode);
+            }
+            return;
         }
 
         const d = &self.mode.direct;
         const task = d.task orelse return timedWaitFutex(d, expected, futexTimeout(timeout, clock));
 
+        // Drop a flag left behind by an earlier timed wait on this waiter.
+        _ = d.notify.state.fetchAnd(~timeout_flag, .monotonic);
+
         var timer: ev.Timer = .initClock(timeout, clock);
         timer.c.userdata = self;
-        timer.c.callback = callback;
+        timer.c.callback = timeoutCallback;
 
         task.getExecutor().loop.setTimer(&timer, timeout);
-        defer timer.c.getLoop().?.clearTimer(&timer);
+        defer {
+            // A clear that loses its race leaves the timer completing, and its
+            // callback still runs against `timer`, which lives in this frame.
+            // The callback sets the flag before waking us, so parking on it
+            // keeps the frame alive for exactly as long as the callback needs.
+            if (!timer.c.getLoop().?.clearTimer(&timer)) {
+                while (!self.timedOut()) {
+                    task.yield(.park, .no_cancel);
+                }
+            }
+        }
 
-        return waitTask(d, task, expected, cancel_mode);
+        // Park until the count is reached or the timer fires. The count is
+        // checked first, so a signal landing together with the timeout still
+        // counts as a signal.
+        while (true) {
+            const state = d.notify.state.load(.acquire);
+            if (signalCount(state) >= expected) return;
+            if (state & timeout_flag != 0) return error.Timeout;
+            if (cancel_mode == .allow_cancel) {
+                try task.yield(.park, .allow_cancel);
+            } else {
+                task.yield(.park, .no_cancel);
+            }
+        }
+    }
+
+    /// Callback for the `timedWaitClock` timer.
+    fn timeoutCallback(_: *ev.Loop, c: *ev.Completion) void {
+        const self: *Waiter = @ptrCast(@alignCast(c.userdata.?));
+        const d = &self.mode.direct;
+        // Read the task before publishing: once the flag is visible the waiter
+        // may return and drop the frame holding the timer, so nothing below may
+        // touch `self` or the completion again.
+        const task = d.task.?;
+        _ = d.notify.state.fetchOr(timeout_flag, .release);
+        task.wake();
     }
 
     fn waitFutex(d: *Direct, expected: u32) void {
         while (true) {
+            // The raw word is what the futex compares against; only the count
+            // half of it is the wait condition.
             const current = d.notify.state.load(.acquire);
-            if (current >= expected) return;
+            if (signalCount(current) >= expected) return;
             d.notify.wait(current);
         }
     }
@@ -204,23 +272,28 @@ pub const Waiter = struct {
         };
     }
 
-    fn timedWaitFutex(d: *Direct, expected: u32, timeout: Timeout) void {
+    fn timedWaitFutex(d: *Direct, expected: u32, timeout: Timeout) Timeoutable!void {
         const deadline = timeout.toDeadline();
         while (true) {
             const current = d.notify.state.load(.acquire);
-            if (current >= expected) {
+            if (signalCount(current) >= expected) {
                 return;
             }
             const remaining = deadline.durationFromNow();
             if (remaining.value <= 0) {
-                return;
+                return error.Timeout;
             }
-            d.notify.timedWait(current, remaining) catch return;
+            d.notify.timedWait(current, remaining) catch {
+                // Deadline reached; one last look before calling it a timeout.
+                const final = d.notify.state.load(.acquire);
+                if (signalCount(final) >= expected) return;
+                return error.Timeout;
+            };
         }
     }
 
     fn waitTask(d: *Direct, task: *AnyTask, expected: u32, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
-        var current = d.notify.state.load(.acquire);
+        var current = signalCount(d.notify.state.load(.acquire));
         if (current >= expected) return;
 
         // Park loop: yield until the condition is met.
@@ -237,7 +310,7 @@ pub const Waiter = struct {
                 task.yield(.park, .no_cancel);
             }
 
-            current = d.notify.state.load(.acquire);
+            current = signalCount(d.notify.state.load(.acquire));
             if (current >= expected) return;
         }
     }
@@ -401,12 +474,12 @@ test "Waiter: futex-based timed wait with timeout" {
     };
 
     var timer = Stopwatch.start();
-    waiter.timedWait(1, .fromMilliseconds(50), .no_cancel);
+    try std.testing.expectError(error.Timeout, waiter.timedWait(1, .fromMilliseconds(50), .no_cancel));
     const elapsed = timer.read();
 
     errdefer std.debug.print("timedWait(50ms) returned after {d}ms\n", .{elapsed.toMilliseconds()});
 
-    // Should return normally after timeout expires (allow slight undershoot for timer resolution)
+    // Should return after the timeout expires (allow slight undershoot for timer resolution)
     try std.testing.expect(elapsed.toMilliseconds() >= 40);
     // Generous upper bound: only meant to catch gross timeout miscalculation
     // (wrong units, waiting forever). Loaded CI runners can delay the wakeup

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -134,15 +134,16 @@ pub const CompletionQueue = struct {
                 return null;
             }
 
-            self.waiter.timedWait(1, timeout, .allow_cancel) catch |err| switch (err) {
+            const timed_out = if (self.waiter.timedWait(1, timeout, .allow_cancel)) |_| false else |err| switch (err) {
                 error.Canceled => {
                     self.cancelAll();
                     self.drainPending();
                     return error.Canceled;
                 },
+                error.Timeout => true,
             };
 
-            // Check if we got a completion or timed out
+            // A completion can still have landed together with the timeout.
             self.mutex.lock();
             const node = self.completed.pop();
             self.mutex.unlock();
@@ -151,7 +152,13 @@ pub const CompletionQueue = struct {
                 return completionFromGroup(n);
             }
 
-            return error.Timeout;
+            if (timed_out) {
+                return error.Timeout;
+            }
+
+            // Signaled without a completion to hand out (a pending op finished
+            // into the queue and was taken, or the signal raced the pop): go
+            // around rather than reporting a timeout that did not happen.
         }
     }
 

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -396,12 +396,20 @@ pub const Completion = struct {
         c.state.store(.{ .phase = .dead, .cancel_requested = old.cancel_requested }, .monotonic);
     }
 
-    /// running -> new (disarm a timer without completing it).
-    pub fn disarm(c: *Completion) void {
+    /// running -> new (disarm a timer without completing it). A latched cancel
+    /// request is kept for the next incarnation, exactly as if it had arrived
+    /// while the completion sat in `.new`.
+    ///
+    /// Fails when a cancel pass has claimed the completion: that pass owns the
+    /// finish dispatch, and clearing `cancel_inflight` under it would let both
+    /// it and the next incarnation dispatch the same completion.
+    pub fn tryDisarm(c: *Completion) bool {
         var old = c.loadState();
         while (true) {
             std.debug.assert(old.phase == .running);
-            old = c.state.cmpxchgWeak(old, .{}, .acq_rel, .monotonic) orelse return;
+            if (old.cancel_inflight) return false;
+            const new_state: State = .{ .phase = .new, .cancel_requested = old.cancel_requested };
+            old = c.state.cmpxchgWeak(old, new_state, .acq_rel, .monotonic) orelse return true;
         }
     }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -644,18 +644,30 @@ pub const Loop = struct {
     /// Clear a timer without completing it (works immediately, no cancellation
     /// completion required). Thread-safe: may be called from a thread that does
     /// not own the loop (a migrated task clearing its sleep timer).
-    pub fn clearTimer(self: *Loop, timer: *Timer) void {
+    ///
+    /// Returns true when the timer is the caller's again: it was disarmed here
+    /// (or was never armed), and its callback will not run. Returns false when
+    /// the timer is already on its way to completion, which means its callback
+    /// has run or is still to run, and both the timer and whatever its
+    /// `userdata` points at must stay alive until it does.
+    pub fn clearTimer(self: *Loop, timer: *Timer) bool {
         self.state.lockTimers();
         defer self.state.unlockTimers();
-        if (timer.c.loadState().phase != .running) return;
+        const st = timer.c.loadState();
+        // Not armed: `.new` is ours to hand back, anything else is a fired
+        // incarnation whose callback ran or is queued to run.
+        if (st.phase != .running) return st.phase == .new;
         // A running timer that already has its result is in the fired/canceled
         // limbo window: checkTimers (or cancelLocal) removed it from the heap
         // and set its result under this lock, but its markCompleted runs after
         // unlocking. It is already on its way to completion; leave it be.
-        if (timer.c.has_result) return;
+        if (timer.c.has_result) return false;
+        // A cancel pass claimed it (possibly on another loop's thread, still
+        // sitting in this loop's cancel queue); it owns the finish dispatch.
+        if (!timer.c.tryDisarm()) return false;
         self.state.disarmTimer(timer);
-        timer.c.disarm();
         self.state.decrActive();
+        return true;
     }
 
     /// Cancel a completion directly without requiring a Cancel completion struct.

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -36,7 +36,7 @@ test "clearTimer before expiration" {
     try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     // Clear it immediately
-    loop.clearTimer(&timer);
+    try std.testing.expect(loop.clearTimer(&timer));
     try std.testing.expectEqual(.new, timer.c.loadState().phase);
 
     // Run the loop - should complete immediately with no active timers
@@ -48,6 +48,42 @@ test "clearTimer before expiration" {
     try std.testing.expect(elapsed.toMilliseconds() < 200);
     try std.testing.expect(loop.done());
     std.log.info("clearTimer: elapsed={f}", .{elapsed});
+}
+
+test "clearTimer reports a callback it could not stop" {
+    // A timer whose callback has not run yet is not the caller's to reclaim:
+    // the clear must report that, so the caller keeps the timer (and whatever
+    // its userdata points at) alive until the callback is done with them.
+    // `do_not_call_callbacks` holds a finished completion in the dispatch queue
+    // and reproduces that window without a second thread.
+    var loop: Loop = undefined;
+    try loop.init(.{ .do_not_call_callbacks = true });
+    defer loop.deinit();
+
+    var fired = false;
+    var timer: Timer = .init(.{ .duration = .zero });
+    timer.c.userdata = &fired;
+    timer.c.callback = struct {
+        fn cb(_: *Loop, c: *@import("../completion.zig").Completion) void {
+            const flag: *bool = @ptrCast(@alignCast(c.userdata.?));
+            flag.* = true;
+        }
+    }.cb;
+
+    loop.setTimer(&timer, .{ .duration = .zero });
+    try loop.run(.once);
+    try std.testing.expect(!fired);
+
+    try std.testing.expect(!loop.clearTimer(&timer));
+
+    const dispatched = loop.nextDispatched().?;
+    try std.testing.expectEqual(&timer.c, dispatched);
+    dispatched.call(&loop);
+    try std.testing.expect(fired);
+
+    // Still not reclaimable afterwards: the callback ran, so the clear has
+    // nothing to hand back and must not claim it does.
+    try std.testing.expect(!loop.clearTimer(&timer));
 }
 
 test "setTimer multiple times" {
@@ -85,7 +121,7 @@ test "clearTimer and reuse timer" {
 
     // Set and clear
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(200) });
-    loop.clearTimer(&timer);
+    try std.testing.expect(loop.clearTimer(&timer));
     try std.testing.expectEqual(.new, timer.c.loadState().phase);
 
     // Reuse the same timer
@@ -238,13 +274,14 @@ test "clearTimer racing a firing timer (cross-thread)" {
         // limbo window.
         loop.setTimer(&timer, .{ .duration = .fromNanoseconds((i % 64) * 1000) });
         if (i % 2 == 0) std.Thread.yield() catch {};
-        loop.clearTimer(&timer);
 
-        // If the clear won, the timer is ours again (.new, written by this
-        // thread under the lock). Anything else means the fire got there
-        // first (or is mid-flight): wait for its callback before the stack
-        // timer goes out of scope.
-        if (timer.c.loadState().phase != .new) {
+        // A clear that won hands the timer back and rules out the callback.
+        // Anything else means the fire got there first (or is mid-flight):
+        // wait for its callback before the stack timer goes out of scope.
+        if (loop.clearTimer(&timer)) {
+            try std.testing.expectEqual(.new, timer.c.loadState().phase);
+            try std.testing.expect(!fired.load(.acquire));
+        } else {
             while (!fired.load(.acquire)) std.Thread.yield() catch {};
         }
     }

--- a/src/io.zig
+++ b/src/io.zig
@@ -1809,7 +1809,12 @@ fn clockResolutionImpl(_: ?*anyopaque, clock: Io.Clock) Io.Clock.ResolutionError
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {
     if (timeout == .none) return;
     var waiter: Waiter = .init();
-    try waiter.timedWaitClock(1, .fromStd(timeout), .fromStdTimeout(timeout), .allow_cancel);
+    // Nothing ever signals this waiter, so the timeout firing is the sleep
+    // finishing.
+    waiter.timedWaitClock(1, .fromStd(timeout), .fromStdTimeout(timeout), .allow_cancel) catch |err| switch (err) {
+        error.Timeout => {},
+        error.Canceled => return error.Canceled,
+    };
 }
 
 fn randomImpl(_: ?*anyopaque, buffer: []u8) void {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1075,7 +1075,12 @@ pub fn now() Timestamp {
 /// Sleep for a specified duration.
 pub fn sleep(duration: Duration) Cancelable!void {
     var waiter: Waiter = .init();
-    try waiter.timedWait(1, .{ .duration = duration }, .allow_cancel);
+    // Nothing ever signals this waiter, so the timeout firing is the sleep
+    // finishing.
+    waiter.timedWait(1, .{ .duration = duration }, .allow_cancel) catch |err| switch (err) {
+        error.Timeout => {},
+        error.Canceled => return error.Canceled,
+    };
 }
 
 // Runtime - orchestrator for one or more Executors

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -166,27 +166,39 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
     mutex.unlock();
 
     // Wait for signal or timeout, handling spurious wakeups internally
-    waiter.timedWait(1, timeout, .allow_cancel) catch |err| {
-        // On cancellation, try to remove from queue
-        const was_in_queue = self.wait_queue.remove(&waiter.node);
-        if (!was_in_queue) {
-            // Removed by signal() - wait for signal to complete before destroying waiter
-            waiter.wait(1, .no_cancel);
-            // Since we're being cancelled and won't process the signal,
-            // wake another waiter to receive the signal instead.
-            if (self.wait_queue.pop()) |next_waiter| {
-                Waiter.fromNode(next_waiter).signal();
+    var timed_out = false;
+    waiter.timedWait(1, timeout, .allow_cancel) catch |err| switch (err) {
+        // The timer fired, but signal() may have claimed this waiter just
+        // behind it: whoever can still remove the node decides.
+        error.Timeout => {
+            if (self.wait_queue.remove(&waiter.node)) {
+                timed_out = true;
+            } else {
+                // Claimed by signal() - take the signal instead of the
+                // timeout, and wait for it to land before destroying the
+                // waiter.
+                waiter.wait(1, .no_cancel);
             }
-        }
+        },
+        error.Canceled => {
+            // On cancellation, try to remove from queue
+            const was_in_queue = self.wait_queue.remove(&waiter.node);
+            if (!was_in_queue) {
+                // Removed by signal() - wait for signal to complete before destroying waiter
+                waiter.wait(1, .no_cancel);
+                // Since we're being cancelled and won't process the signal,
+                // wake another waiter to receive the signal instead.
+                if (self.wait_queue.pop()) |next_waiter| {
+                    Waiter.fromNode(next_waiter).signal();
+                }
+            }
 
-        // Must reacquire mutex before returning
-        mutex.lockUncancelable();
+            // Must reacquire mutex before returning
+            mutex.lockUncancelable();
 
-        return err;
+            return err;
+        },
     };
-
-    // Determine winner: can we remove ourselves from queue?
-    const timed_out = self.wait_queue.remove(&waiter.node);
 
     // Re-acquire mutex after waking - propagate cancellation if it occurred during lock
     mutex.lockUncancelable();

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -179,21 +179,25 @@ pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clo
     bucket.mutex.unlock();
 
     // Wait for signal or timeout, handling spurious wakeups internally
-    futex_waiter.waiter.timedWaitClock(1, timeout, clock, .allow_cancel) catch |err| {
-        // On cancellation, try to remove from queue
-        const was_in_queue = removeFromBucket(bucket, &futex_waiter);
-        if (!was_in_queue) {
-            // Removed by wake() - wait for signal to complete before destroying waiter
+    futex_waiter.waiter.timedWaitClock(1, timeout, clock, .allow_cancel) catch |err| switch (err) {
+        // The timer fired, but wake() may have claimed this waiter just behind
+        // it: whoever can still remove the node decides.
+        error.Timeout => {
+            if (removeFromBucket(bucket, &futex_waiter)) return error.Timeout;
+            // Claimed by wake() - take the signal instead of the timeout, and
+            // wait for it to land before destroying the waiter.
             futex_waiter.waiter.wait(1, .no_cancel);
-        }
-        return err;
+        },
+        error.Canceled => {
+            // On cancellation, try to remove from queue
+            const was_in_queue = removeFromBucket(bucket, &futex_waiter);
+            if (!was_in_queue) {
+                // Removed by wake() - wait for signal to complete before destroying waiter
+                futex_waiter.waiter.wait(1, .no_cancel);
+            }
+            return err;
+        },
     };
-
-    // Determine winner: can we remove ourselves from queue?
-    if (removeFromBucket(bucket, &futex_waiter)) {
-        // We were still in queue - timer won
-        return error.Timeout;
-    }
 }
 
 /// Remove a waiter from its bucket (for cancellation/timeout).

--- a/src/sync/Notify.zig
+++ b/src/sync/Notify.zig
@@ -143,26 +143,30 @@ pub fn timedWait(self: *Notify, timeout: Timeout) (Timeoutable || Cancelable)!vo
     self.wait_queue.push(&waiter.node);
 
     // Wait for signal or timeout, handling spurious wakeups internally
-    waiter.timedWait(1, timeout, .allow_cancel) catch |err| {
-        // On cancellation, try to remove from queue
-        const was_in_queue = self.wait_queue.remove(&waiter.node);
-        if (!was_in_queue) {
-            // Removed by signal() - wait for signal to complete before destroying waiter
+    waiter.timedWait(1, timeout, .allow_cancel) catch |err| switch (err) {
+        // The timer fired, but signal() may have claimed this waiter just
+        // behind it: whoever can still remove the node decides.
+        error.Timeout => {
+            if (self.wait_queue.remove(&waiter.node)) return error.Timeout;
+            // Claimed by signal() - take the signal instead of the timeout,
+            // and wait for it to land before destroying the waiter.
             waiter.wait(1, .no_cancel);
-            // Since we're being cancelled and won't process the signal,
-            // wake another waiter to receive the signal instead.
-            if (self.wait_queue.pop()) |node| {
-                Waiter.fromNode(node).signal();
+        },
+        error.Canceled => {
+            // On cancellation, try to remove from queue
+            const was_in_queue = self.wait_queue.remove(&waiter.node);
+            if (!was_in_queue) {
+                // Removed by signal() - wait for signal to complete before destroying waiter
+                waiter.wait(1, .no_cancel);
+                // Since we're being cancelled and won't process the signal,
+                // wake another waiter to receive the signal instead.
+                if (self.wait_queue.pop()) |node| {
+                    Waiter.fromNode(node).signal();
+                }
             }
-        }
-        return err;
+            return err;
+        },
     };
-
-    // Determine winner: can we remove ourselves from queue?
-    if (self.wait_queue.remove(&waiter.node)) {
-        // We were still in queue - timer won
-        return error.Timeout;
-    }
 
     // Acquire fence: synchronize-with signal()/broadcast()'s wake
     // Ensures visibility of all writes made before signal() was called

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -162,21 +162,25 @@ pub fn timedWait(self: *ResetEvent, timeout: Timeout) (Timeoutable || Cancelable
     }
 
     // Wait for signal or timeout, handling spurious wakeups internally
-    waiter.timedWait(1, timeout, .allow_cancel) catch |err| {
-        // On cancellation, try to remove from queue
-        const was_in_queue = self.wait_queue.remove(&waiter.node);
-        if (!was_in_queue) {
-            // Removed by set() - wait for signal to complete before destroying waiter
+    waiter.timedWait(1, timeout, .allow_cancel) catch |err| switch (err) {
+        // The timer fired, but set() may have claimed this waiter just behind
+        // it: whoever can still remove the node decides.
+        error.Timeout => {
+            if (self.wait_queue.remove(&waiter.node)) return error.Timeout;
+            // Claimed by set() - take the signal instead of the timeout, and
+            // wait for it to land before destroying the waiter.
             waiter.wait(1, .no_cancel);
-        }
-        return err;
+        },
+        error.Canceled => {
+            // On cancellation, try to remove from queue
+            const was_in_queue = self.wait_queue.remove(&waiter.node);
+            if (!was_in_queue) {
+                // Removed by set() - wait for signal to complete before destroying waiter
+                waiter.wait(1, .no_cancel);
+            }
+            return err;
+        },
     };
-
-    // Determine winner: can we remove ourselves from queue?
-    if (self.wait_queue.remove(&waiter.node)) {
-        // We were still in queue - timer won
-        return error.Timeout;
-    }
 
     // Acquire fence: synchronize-with set()'s .release in setFlag
     // Ensures visibility of all writes made before set() was called

--- a/src/time.zig
+++ b/src/time.zig
@@ -568,18 +568,21 @@ pub const Timeout = union(enum) {
 
     fn timerCallback(_: *ev.Loop, c: *ev.Completion) void {
         const ctx: *WaitContext = @ptrCast(@alignCast(c.userdata.?));
-        if (ctx.waiter) |waiter| {
-            waiter.signal();
-        }
+        // Every dispatch signals: the wait protocol keeps `ctx` alive until the
+        // signal arrives whenever `asyncCancelWait` reported the timer as still
+        // completing, so a missed signal would park the waiter forever.
+        ctx.waiter.?.signal();
     }
 
     pub fn asyncCancelWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
         _ = self;
         _ = waiter;
+        // `.none` never arms a timer, so there is nothing to remove.
         const loop = ctx.timer.c.getLoop() orelse return true;
-        ctx.waiter = null; // Prevent callback from waking a stale/reused waiter
-        loop.clearTimer(&ctx.timer);
-        return true; // Timer operations don't have values to re-add if we lost the race
+        // Disarmed: no callback, no signal. Otherwise the timer is completing
+        // and its callback still signals `ctx.waiter`, so report the wake as
+        // in flight and let the caller wait for it.
+        return loop.clearTimer(&ctx.timer);
     }
 
     pub fn getResult(self: *const Timeout, ctx: *WaitContext) void {


### PR DESCRIPTION
A timer that has already fired cannot be disarmed, and `Loop.clearTimer` quietly did nothing in that case. A task woken by the other side of the race (a channel send, an I/O completion, anything that migrates it to another executor) then returned and dropped the stack frame holding the timer while the loop was still on its way to invoking its callback.

`clearTimer` now returns whether the timer is the caller's again. False means the callback has run or is still to run, and the caller keeps the timer alive until it has. This is a breaking change for low-level `ev` users that call `clearTimer`.

`Waiter.timedWait` reports `error.Timeout` instead of leaving callers to infer the winner by trying to remove themselves from a wait queue. The timeout timer no longer signals; it sets a bit in the waiter's state, so the signal count only ever reflects real wakeups. That bit doubles as the handshake a lost clear parks on.

Along the way this fixes the cancel paths of `Notify`, `ResetEvent`, `Condition` and `Futex`: their `waiter.wait(1, .no_cancel)` drain could be satisfied by the timer's phantom signal and let the waiter be destroyed while a real signal was still being delivered to it. `CompletionQueue.timedWait` also stops reporting `error.Timeout` when a completion woke it but was gone by the time it looked.

`Completion.disarm` becomes `tryDisarm`: it keeps a latched cancel request and refuses to disarm while a cancel pass owns the completion, which would otherwise let both that pass and the next incarnation dispatch it.

## Testing

`./check.sh` passes (565 tests). Added `clearTimer reports a callback it could not stop`, which reproduces the window deterministically via `do_not_call_callbacks`, and the cross-thread `clearTimer` stress test now asserts the contract instead of working around it.

Not covered by a test: the `cancel_inflight` bail in `clearTimer`. Reaching it needs a cross-loop cancel queued while another thread clears, so it needs two loops on two threads, and no in-tree path both cancels and clears the same timer.