### PR TITLE
runtime: gate worker teardown on shutdown notifications being delivered

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,11 @@ All notable changes to this project will be documented in this file.
   progress, as long as the spawn happens before the group drains. This matches
   `std.Io.Threaded` and the `select`-based wait.
 
+- Fixed a crash in `Runtime.deinit()` on multi-threaded runtimes. A worker could act on
+  its shutdown notification and close its waker descriptors before the notifying thread
+  had made the syscall that wakes a sleeping loop, so that write hit a closed descriptor,
+  or a recycled one belonging to an unrelated file or socket.
+
 ## [0.16.0] - 2026-07-12
 
 - Blocking operations running on thread-pool workers are now cancelable. Previously,

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1100,6 +1100,11 @@ pub const Runtime = struct {
     workers: std.ArrayList(Worker) = .empty,
     task_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0), // Active task counter
     shutting_down: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    // Permission for worker threads to tear down their executors. Set by
+    // shutdownWorkers() once every shutdown notification has been delivered,
+    // so a worker cannot close its waker fds while a notifier is still using
+    // them. See the wait in runWorker().
+    teardown: os.ResetEvent = .init(),
     own_self: bool = false,
 
     resolver: ?dns.Resolver = null,
@@ -1193,6 +1198,10 @@ pub const Runtime = struct {
                 worker.executor.shutdown.notify();
             }
         }
+
+        // Every notify() above has returned, so no waker syscall is in flight
+        // against a worker loop any more; workers may now tear theirs down.
+        self.teardown.set();
 
         // Join worker threads
         for (self.workers.items) |*worker| {
@@ -1311,7 +1320,17 @@ pub const Runtime = struct {
             worker.ready.set();
             return;
         };
-        defer worker.executor.deinit();
+        defer {
+            // A cross-thread notifier publishes its wake (Async.pending plus the
+            // loop's wake_requested bit) before it performs the waker syscall,
+            // and the loop is free to act on that publication in between: it can
+            // run the shutdown callback, stop, and get here while the notifier
+            // is still short of its write(). Deiniting now would close the waker
+            // fds underneath it, so wait until shutdownWorkers() reports that
+            // every notification has been delivered.
+            self.teardown.wait();
+            worker.executor.deinit();
+        }
 
         worker.ready.set();
 


### PR DESCRIPTION
Fixes the `poll: waker write failed: PIPE` panic seen on the FreeBSD job of
[run 30116278272](https://github.com/lalinsky/zio/actions/runs/30116278272/job/89557624408).

## What happens

`Async.notify()` publishes the wakeup before it performs the waker syscall, and the loop
needs only that publication to act on it:

```zig
pending.swap(1, .release);                                    // published
if (wake_requested.fetchOr(wake_async, .acq_rel) == 0)        // published
    self.backend.wake(&self.state);                           // syscall, still to come
```

`tick()` takes the flag straight out of `wake_requested`, polls with a zero timeout
because it is set, and runs `processAsyncHandles()`. The byte only matters for a loop
already asleep in `poll()`.

So a worker notified from `shutdownWorkers()` can complete the whole shutdown while the
notifier sits between the `fetchOr` and its `write()`:

1. main: `pending = 1`, `fetchOr` returns 0, preempted before the syscall
2. worker: `wake_requested.swap(0)` sees the bit, polls with `.zero`, `processAsyncHandles()`
3. worker: `shutdownCallback` -> `loop.stop()` -> `run()` returns -> `runWorker` breaks
4. worker: `executor.deinit()` -> `loop.deinit()` -> `backend.deinit()` closes the waker fds
5. main: `write(waker_write_fd)` -> `EPIPE`

Joining the threads after the notify loop does not close this: the race lives entirely
inside one `notify()` call. Running the callback on the loop thread (which is what the
`ev.Async` is for) does not either, since it is the delivery that races, not the decision.

`EPIPE` specifically means the write landed between the two `close()` calls in
`poll.deinit()`; a slightly later write gives `EBADF`, and once the number is recycled it
puts a stray `0x01` into an unrelated file or socket. Before the wakers were hardened in
#610 all of that was swallowed by `catch {}`.

## Fix

Workers wait on a shared `ResetEvent` before deinitializing their executor;
`shutdownWorkers()` sets it after every `notify()` has returned. `runWorker` already takes
`self: *Runtime`, so there is no new per-worker state and nothing is added to the wake
path.

Alternatives considered and rejected: a refcount/gate around `wake()` (pays on a path that
only matters at shutdown), and closing the waker fds after `join()` (moves loop teardown
off its owner thread and breaks the `assertOwnThread` invariant).

## Testing

Diagnosis confirmed by forcing the window open: `wakeAsync` sleeping 50 ms between the
`fetchOr` and `backend.wake`, plus `max_wait` at 1 ms so workers cycle through `tick`
instead of sleeping.

- without the fix, `Semaphore: multiple permits` panics on the CI stack (`BADF` rather
  than `EPIPE`, since 50 ms lands past both `close()` calls)
- with the fix, 3/3 clean runs with the injection still in place

Full suite green on io_uring (569/569), epoll (569/569) and poll (568/568).

## Note

This covers every wake the main thread issues. A peer worker waking a loop already past
the gate stays theoretically open, but all of those paths (`armSearcher`, the
home-executor wake, `loopWorkComplete`, the cross-loop cancel) need a live task or op, and
the pool is joined and `task_count == 0` asserted by then. Closing that by construction
would need a second per-worker signal, which did not seem worth it.
