### PR TITLE
net: count the trailing dot toward the hostname length limit

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `net.HostName.validate` now counts the trailing dot of a fully qualified domain name
+  toward the 255 byte limit, matching how the name is encoded in a DNS packet. A 255 byte
+  name written with a trailing dot used to validate at 256 bytes, so a validated
+  `HostName` could be longer than `HostName.max_len`.
+
 - Fixed a use-after-free in timed waits, where a task could return and drop the stack
   frame holding its timeout timer before the event loop was done with it. A timer that
   has already fired cannot be disarmed, so `Loop.clearTimer` now returns false to say the

--- a/src/dns/test.zig
+++ b/src/dns/test.zig
@@ -38,6 +38,7 @@ test "HostName: validate" {
     try std.testing.expectError(error.InvalidHostName, HostName.validate("."));
     try std.testing.expectError(error.InvalidHostName, HostName.validate(".."));
     try std.testing.expectError(error.InvalidHostName, HostName.validate(@as([64]u8, @splat('a')) ++ ".com")); // Label length 64 (too long)
+    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "a.")); // Total length 255 + trailing dot (too long)
     try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "ab")); // Total length 256 (too long)
 }
 

--- a/src/net.zig
+++ b/src/net.zig
@@ -86,13 +86,16 @@ pub const HostName = struct {
         if (IpAddress.parseIp(bytes, 0)) |_| return else |_| {}
         if (bytes[0] == '.') return error.InvalidHostName;
 
-        // Ignore trailing dot (FQDN). It doesn't count toward our length.
+        // The trailing dot of an FQDN counts toward the length. In a DNS packet it is
+        // the zero-length root label, which still takes up a byte. Checking the full
+        // length here also keeps `max_len` big enough to hold any validated hostname.
+        if (bytes.len > max_len) return error.NameTooLong;
+
+        // Ignore trailing dot (FQDN) when validating labels.
         const end = if (bytes[bytes.len - 1] == '.') end: {
             if (bytes.len == 1) return error.InvalidHostName;
             break :end bytes.len - 1;
         } else bytes.len;
-
-        if (end > max_len) return error.NameTooLong;
 
         // Hostnames are divided into dot-separated "labels", which:
         // - Start with a letter or digit


### PR DESCRIPTION
`HostName.validate` stripped the trailing dot of an FQDN before checking the length, so a 255 byte name written with a trailing dot validated at 256 bytes. That breaks the invariant that a validated `HostName` fits in `HostName.max_len`, which callers may rely on when copying a name into a fixed buffer.

The 255 byte limit comes from the DNS packet encoding, where the trailing dot is the zero-length root label and still occupies a byte, so it should count toward the length. The dot is still ignored when validating the individual labels.

Same fix as upstream `std.Io.net.HostName` (ziglang/zig a6f7722b32).