### PR TITLE
fs: report EBUSY and ETXTBSY from file writes instead of Unexpected

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- File writes now report `EBUSY` as `error.DeviceBusy` and `ETXTBSY` as `error.FileBusy`
+  instead of `error.Unexpected`, which in debug builds also asked the user to file a bug
+  report and dumped a stack trace to stderr. Writing to a
+  device that is in use, or to a file the kernel is currently executing, is a normal
+  failure. Both are new members of `os.fs.FileWriteError`, so exhaustive switches over
+  file write errors need to handle them.
+
 - Fixed a use-after-free in timed waits, where a task could return and drop the stack
   frame holding its timeout timer before the event loop was done with it. A timer that
   has already fired cannot be disarmed, so `Loop.clearTimer` now returns false to say the

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -235,6 +235,11 @@ pub const FileWriteError = error{
     FileTooBig,
     LockViolation,
     Unseekable,
+    /// The device backing the file is busy.
+    DeviceBusy,
+    /// The file is an executable image that is currently being executed, or is
+    /// otherwise in use by the kernel.
+    FileBusy,
     Canceled,
     Unexpected,
 };
@@ -1866,6 +1871,8 @@ pub fn errnoToFileWriteError(err: E) FileWriteError {
                 .BADF => error.NotOpenForWriting,
                 .DQUOT => error.DiskQuota,
                 .FBIG => error.FileTooBig,
+                .BUSY => error.DeviceBusy,
+                .TXTBSY => error.FileBusy,
                 // ESPIPE is the usual "not seekable" answer for a positional
                 // write, but macOS returns ENXIO for a tty, and EOVERFLOW when
                 // the offset is past what the device can represent.


### PR DESCRIPTION
A write returning `EBUSY` (the backing device is in use) or `ETXTBSY` (the file is an executable image the kernel is currently running) was not mapped in `errnoToFileWriteError`, so both surfaced as `error.Unexpected`. In debug builds that also prints "please file a bug report" and dumps a stack trace, for what are ordinary failures.

`os.fs.FileWriteError` gains `DeviceBusy` and `FileBusy`, which is a breaking change for exhaustive switches over file write errors. Nothing else needed adjusting: `std.Io.File.WritePositionalError` already contains both, and `std.Io.Threaded` maps the same two errnos in its `pwritev` path, so the errors pass through zio's `std.Io` vtable unchanged.

The Windows branch of the mapping is left alone; it works off Win32 error codes and std has no equivalent mapping there.

Tests compile clean for `x86_64-windows` and `aarch64-macos` in addition to the native run.