### PR TITLE
io: mark the std.Io workarounds that the 0.17 port should undo

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,7 @@ Testing:
 Random notes on Zig usage:
 - We are using Zig 0.16+, so modules like `std.posix`, `std.Thread`, `std.fs`, `std.net` no longer exist or are mostly empty, look at `src/os/` for replacements.
 - Use `zig env` to get the path to the Zig standard library and read the source code, if you need to check something.
+- Code that is written a certain way only because it has to work with the Zig 0.16 standard library is marked with a `TODO(zig-0.17):` comment saying what to do instead. Grep for it when porting the `zig-0.17` branch.
 
 LLM usage:
 - We explicitly allow using LLMs for code changes, but:

--- a/src/io.zig
+++ b/src/io.zig
@@ -1889,6 +1889,9 @@ fn bindErrToListenErr(err: BindOrCancel) Io.net.IpAddress.ListenError {
         error.NetworkDown => error.NetworkDown,
         error.SystemResources => error.SystemResources,
         error.Canceled => error.Canceled,
+        // TODO(zig-0.17): map `error.AccessDenied` through once `ListenError` has it
+        // (https://codeberg.org/ziglang/zig/pulls/36307). Binding a privileged port
+        // without the permission to do so is a normal error, not something unexpected.
         error.AccessDenied,
         error.FileDescriptorNotASocket,
         error.SymLinkLoop,
@@ -1993,6 +1996,9 @@ fn bindErrToBindErr(err: BindOrCancel) Io.net.IpAddress.BindError {
         error.NetworkDown => error.NetworkDown,
         error.SystemResources => error.SystemResources,
         error.Canceled => error.Canceled,
+        // TODO(zig-0.17): same as in `bindErrToListenErr`, map `error.AccessDenied`
+        // through once `BindError` has it
+        // (https://codeberg.org/ziglang/zig/pulls/36307).
         error.AccessDenied,
         error.FileDescriptorNotASocket,
         error.SymLinkLoop,

--- a/src/io.zig
+++ b/src/io.zig
@@ -2017,6 +2017,9 @@ fn netBindIpImpl(_: ?*anyopaque, address: *const Io.net.IpAddress, options: Io.n
         waitForIoUncancelable(&close_op.c);
     }
 
+    // TODO(zig-0.17): `ip6_only` became `?bool`, where null means "leave it to the system
+    // configuration" (ziglang/zig a0aba69c11). Set the option only when it is non-null,
+    // with `@intFromBool` as the value, instead of only ever turning it on.
     if (options.ip6_only) {
         if (zio_addr.any.family != os_net.AF.INET6) return error.OptionUnsupported;
         const value: c_int = 1;
@@ -2176,11 +2179,14 @@ fn netConnectUnixImpl(
         error.WouldBlock => error.WouldBlock,
         error.NetworkDown => error.NetworkDown,
         error.Canceled => error.Canceled,
+        // TODO(zig-0.17): map `error.ConnectionRefused` through once it is part of
+        // `Io.net.UnixAddress.ConnectError` (ziglang/zig 9726270846). Connecting to a
+        // socket path with no listener is a normal error, not something unexpected.
+        error.ConnectionRefused,
         error.AddressInUse,
         error.AddressUnavailable,
         error.AlreadyConnected,
         error.ConnectionPending,
-        error.ConnectionRefused,
         error.ConnectionResetByPeer,
         error.Timeout,
         error.NetworkUnreachable,


### PR DESCRIPTION
Three spots in the `std.Io` vtable are written the way they are only because of the 0.16 standard library. None of them would fail to compile against 0.17, so they are easy to carry over unnoticed:

- `netConnectUnixImpl` folds `error.ConnectionRefused` into `error.Unexpected` because `Io.net.UnixAddress.ConnectError` has no such member. Upstream added it (ziglang/zig 9726270846), so connecting to a socket path with no listener should report it directly.
- `bindErrToListenErr` and `bindErrToBindErr` fold `error.AccessDenied` into `error.Unexpected` for the same reason, so binding a privileged port as a regular user comes out as `Unexpected` through the vtable, while the native API reports `AccessDenied`. An open upstream pull request adds it to both error sets: https://codeberg.org/ziglang/zig/pulls/36307
- `netBindIpImpl` can only ever turn `IPV6_V6ONLY` on, because `ip6_only` is a plain `bool`. Upstream made it `?bool`, where null means "leave it to the system configuration" (ziglang/zig a0aba69c11), so the option should be set only when non-null, with `@intFromBool` as the value.

All of them now carry a `TODO(zig-0.17):` comment saying what to do instead, and `DEVELOPMENT.md` documents the marker so the port can start with a grep. No behavior change.
