### PR TITLE
fs: implement file seek natively instead of delegating to std

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added `os.fs.fileSeekBy` and `os.fs.fileSeekTo`, which now also back the `std.Io` file
+  seek operations.
+
+- Fixed pipes, FIFOs and terminals being treated as seekable on 32-bit Linux. Streaming
+  reads and writes on them were routed to a thread pool worker, where they occupy the
+  worker until they complete, instead of to the event loop.
+
 - `net.HostName.validate` now counts the trailing dot of a fully qualified domain name
   toward the 255 byte limit, matching how the name is encoded in a DNS packet. A 255 byte
   name written with a trailing dot used to validate at 256 bytes, so a validated

--- a/src/io.zig
+++ b/src/io.zig
@@ -1523,13 +1523,11 @@ fn fileReadPositionalImpl(_: ?*anyopaque, file: Io.File, data: []const []u8, off
 }
 
 fn fileSeekByImpl(_: ?*anyopaque, file: Io.File, offset: i64) Io.File.SeekError!void {
-    const io = globalIo();
-    return io.vtable.fileSeekBy(io.userdata, file, offset);
+    return os_fs.fileSeekBy(stdIoHandleToZio(file.handle), offset);
 }
 
 fn fileSeekToImpl(_: ?*anyopaque, file: Io.File, offset: u64) Io.File.SeekError!void {
-    const io = globalIo();
-    return io.vtable.fileSeekTo(io.userdata, file, offset);
+    return os_fs.fileSeekTo(stdIoHandleToZio(file.handle), offset);
 }
 
 fn fileSyncImpl(_: ?*anyopaque, file: Io.File) Io.File.SyncError!void {
@@ -3333,6 +3331,60 @@ test "io: file streaming write advances position and appends" {
     var buf: [14]u8 = undefined;
     try std.testing.expectEqual(14, try file.readPositional(io, &.{&buf}, 0));
     try std.testing.expectEqualStrings("HELLO WORLD!!!", &buf);
+}
+
+test "io: file seek moves the streaming position" {
+    // See note on Windows in the streaming-read test above: without an implicit
+    // file position there is nothing for a seek to move.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const file_path = "test_io_file_seek.txt";
+    defer dir.deleteFile(io, file_path) catch {};
+
+    var file = try dir.createFile(io, file_path, .{ .read = true });
+    defer file.close(io);
+
+    try std.testing.expectEqual(10, try file.writePositional(io, &.{"HELLOWORLD"}, 0));
+
+    var buf: [5]u8 = undefined;
+    try io.vtable.fileSeekTo(io.userdata, file, 5);
+    try std.testing.expectEqual(5, try file.readStreaming(io, &.{&buf}));
+    try std.testing.expectEqualStrings("WORLD", &buf);
+
+    // The read above left the position at the end of the file.
+    try io.vtable.fileSeekBy(io.userdata, file, -10);
+    try std.testing.expectEqual(5, try file.readStreaming(io, &.{&buf}));
+    try std.testing.expectEqualStrings("HELLO", &buf);
+
+    // No signed file offset can represent this, so it is not a position the
+    // file can be moved to.
+    try std.testing.expectError(error.Unseekable, io.vtable.fileSeekTo(io.userdata, file, std.math.maxInt(u64)));
+
+    // Seeking before the start of the file leaves the position untouched.
+    try io.vtable.fileSeekTo(io.userdata, file, 0);
+    try std.testing.expectError(error.Unseekable, io.vtable.fileSeekBy(io.userdata, file, -1));
+    try std.testing.expectEqual(5, try file.readStreaming(io, &.{&buf}));
+    try std.testing.expectEqualStrings("HELLO", &buf);
+}
+
+test "io: file seek on a pipe reports Unseekable" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const fds = try os_fs.pipe();
+    var read_file: Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = true } };
+    var write_file: Io.File = .{ .handle = fds[1], .flags = .{ .nonblocking = true } };
+    defer read_file.close(io);
+    defer write_file.close(io);
+
+    try std.testing.expectError(error.Unseekable, io.vtable.fileSeekTo(io.userdata, read_file, 0));
+    try std.testing.expectError(error.Unseekable, io.vtable.fileSeekBy(io.userdata, read_file, 1));
 }
 
 test "io: streaming read/write over a pollable (pipe) fd" {

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -262,6 +262,15 @@ pub const FileSyncError = error{
     Unexpected,
 };
 
+pub const FileSeekError = error{
+    /// The file does not have a position that can be set: a pipe, FIFO, socket
+    /// or tty, or an offset the device cannot represent.
+    Unseekable,
+    AccessDenied,
+    Canceled,
+    Unexpected,
+};
+
 pub const DirRenameError = error{
     AccessDenied,
     PermissionDenied,
@@ -1399,6 +1408,51 @@ pub fn fileSync(fd: fd_t, flags: FileSyncFlags) FileSyncError!void {
     }
 }
 
+/// Move the file position by `offset` bytes, relative to the current position.
+pub fn fileSeekBy(fd: fd_t, offset: i64) FileSeekError!void {
+    if (builtin.os.tag == .windows) {
+        return seekWindows(fd, offset, w.FILE_CURRENT);
+    }
+    return seekPosix(fd, offset, posix.system.SEEK.CUR);
+}
+
+/// Set the file position to `offset` bytes from the start of the file.
+pub fn fileSeekTo(fd: fd_t, offset: u64) FileSeekError!void {
+    // Both `LARGE_INTEGER` and `off_t` are signed, so an offset past 2^63 has
+    // no representation to seek to.
+    const signed = std.math.cast(i64, offset) orelse return error.Unseekable;
+    if (builtin.os.tag == .windows) {
+        return seekWindows(fd, signed, w.FILE_BEGIN);
+    }
+    return seekPosix(fd, signed, posix.system.SEEK.SET);
+}
+
+fn seekWindows(handle: fd_t, offset: i64, move_method: w.DWORD) FileSeekError!void {
+    if (w.SetFilePointerEx(handle, offset, null, move_method) == w.FALSE) {
+        return errnoToFileSeekError(w.GetLastError());
+    }
+}
+
+fn seekPosix(fd: fd_t, offset: i64, whence: u32) FileSeekError!void {
+    // `off_t` is narrower than 64 bits on some platforms; an offset that does
+    // not fit is one the file cannot be positioned at.
+    const off = std.math.cast(posix.off_t, offset) orelse return error.Unseekable;
+
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+    while (true) {
+        const rc = posix.sys.lseek(fd, off, whence, null);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return errnoToFileSeekError(err),
+        }
+    }
+}
+
 /// Rename a file using renameat() syscall
 pub fn renameat(allocator: std.mem.Allocator, old_dir: fd_t, old_path: []const u8, new_dir: fd_t, new_path: []const u8) DirRenameError!void {
     if (builtin.os.tag == .windows) {
@@ -1911,6 +1965,39 @@ pub fn errnoToFileSyncError(errno: posix.system.E) FileSyncError {
         .CANCELED => error.Canceled,
         else => |e| unexpectedError(e),
     };
+}
+
+pub fn errnoToFileSeekError(err: E) FileSeekError {
+    switch (builtin.os.tag) {
+        .windows => {
+            return switch (err) {
+                .SUCCESS => unreachable,
+                // The answers for "this handle has no file position": a pipe or
+                // socket (INVALID_FUNCTION, or BAD_DEV_TYPE for the named pipes
+                // we create in `w.pipe`), a character device (SEEK_ON_DEVICE),
+                // or a position before the start of the file (NEGATIVE_SEEK).
+                .INVALID_FUNCTION, .BAD_DEV_TYPE, .SEEK_ON_DEVICE, .NEGATIVE_SEEK => error.Unseekable,
+                .ACCESS_DENIED => error.AccessDenied,
+                .OPERATION_ABORTED => error.Canceled,
+                else => |e| unexpectedError(e),
+            };
+        },
+        else => {
+            return switch (err) {
+                .SUCCESS => unreachable,
+                .CANCELED => error.Canceled,
+                // ESPIPE is the usual "not seekable" answer, but macOS returns
+                // ENXIO for a tty, and EOVERFLOW when the resulting offset is
+                // past what the device can represent. EINVAL is a resulting
+                // offset before the start of the file.
+                .SPIPE, .NXIO, .OVERFLOW, .INVAL => error.Unseekable,
+                // Not specified by POSIX for lseek, but sandboxes that filter
+                // the syscall report a denied seek this way.
+                .ACCES, .PERM => error.AccessDenied,
+                else => |e| unexpectedError(e),
+            };
+        },
+    }
 }
 
 pub fn errnoToDirRenameError(errno: posix.system.E) DirRenameError {
@@ -2936,7 +3023,7 @@ pub fn dirRead(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
 fn dirReadPosix(handle: fd_t, buffer: []u8, restart: bool) DirReadError!usize {
     // Seek to beginning if restart requested
     if (restart) {
-        const rc = posix.sys.lseek(handle, 0, posix.system.SEEK.SET);
+        const rc = posix.sys.lseek(handle, 0, posix.system.SEEK.SET, null);
         switch (posix.errno(rc)) {
             .SUCCESS => {},
             .BADF => return error.Unexpected,

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -1972,11 +1972,20 @@ pub fn errnoToFileSeekError(err: E) FileSeekError {
         .windows => {
             return switch (err) {
                 .SUCCESS => unreachable,
-                // The answers for "this handle has no file position": a pipe or
-                // socket (INVALID_FUNCTION, or BAD_DEV_TYPE for the named pipes
-                // we create in `w.pipe`), a character device (SEEK_ON_DEVICE),
-                // or a position before the start of the file (NEGATIVE_SEEK).
-                .INVALID_FUNCTION, .BAD_DEV_TYPE, .SEEK_ON_DEVICE, .NEGATIVE_SEEK => error.Unseekable,
+                // The answers for "this handle has no file position". Windows
+                // reports a pipe as INVALID_PARAMETER and Wine reports one as
+                // BAD_DEV_TYPE; INVALID_FUNCTION is the documented answer for a
+                // handle type that cannot seek, and SEEK_ON_DEVICE for a
+                // character device. The move method is a constant and the
+                // distance is range checked before the call, so the handle is
+                // the only parameter left for INVALID_PARAMETER to be about.
+                // NEGATIVE_SEEK is a position before the start of the file.
+                .INVALID_FUNCTION,
+                .INVALID_PARAMETER,
+                .BAD_DEV_TYPE,
+                .SEEK_ON_DEVICE,
+                .NEGATIVE_SEEK,
+                => error.Unseekable,
                 .ACCESS_DENIED => error.AccessDenied,
                 .OPERATION_ABORTED => error.Canceled,
                 else => |e| unexpectedError(e),

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -368,3 +368,20 @@ test "isPollable: a pipe is pollable" {
     defer close(fds[1]);
     try std.testing.expect(isPollable(fds[0]));
 }
+
+test "isPollable: a terminal is pollable" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    // NetBSD is the one system where the no-op seek succeeds on a terminal, so
+    // the probe cannot tell one from a regular file there and its streaming I/O
+    // goes to the thread pool. Linux and macOS both answer ESPIPE.
+    if (builtin.os.tag == .netbsd) return error.SkipZigTest;
+
+    // A pty is a terminal we can open without one being attached to the test
+    // process. Systems without the multiplexer at this path skip.
+    const fs = @import("fs.zig");
+    const fd = fs.openat(std.testing.allocator, fs.cwd(), "/dev/ptmx", .{ .mode = .read_write }) catch
+        return error.SkipZigTest;
+    defer close(fd);
+
+    try std.testing.expect(isPollable(fd));
+}

--- a/src/os/posix.zig
+++ b/src/os/posix.zig
@@ -188,7 +188,7 @@ pub fn setNonblocking(fd: fd_t) error{Unexpected}!void {
 /// non-seekable descriptors without disturbing the file offset.
 pub fn isPollable(fd: fd_t) bool {
     while (true) {
-        const rc = sys.lseek(fd, 0, system.SEEK.CUR);
+        const rc = sys.lseek(fd, 0, system.SEEK.CUR, null);
         switch (errno(rc)) {
             .SUCCESS => return false,
             .INTR => continue,
@@ -358,4 +358,13 @@ pub fn getrandom(buffer: []u8) (GetRandomError || syscall_cancel.Cancelable)!voi
             }
         },
     }
+}
+
+test "isPollable: a pipe is pollable" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const fds = try pipe(.{});
+    defer close(fds[0]);
+    defer close(fds[1]);
+    try std.testing.expect(isPollable(fds[0]));
 }

--- a/src/os/system/c.zig
+++ b/src/os/system/c.zig
@@ -350,6 +350,12 @@ pub const mmap = libc.mmap;
 pub const sigaltstack = libc.sigaltstack;
 pub const utimensat = libc.utimensat;
 
-pub fn lseek(fd: i32, offset: off_t, whence: u32) off_t {
-    return libc.lseek(fd, offset, @intCast(whence));
+/// Returns 0 on success, or -1 on failure. The resulting file position is
+/// reported through `new_offset`, to match the Linux syscall wrapper, which
+/// cannot return it on 32-bit platforms.
+pub fn lseek(fd: i32, offset: off_t, whence: u32, new_offset: ?*u64) off_t {
+    const rc = libc.lseek(fd, offset, @intCast(whence));
+    if (rc == -1) return -1;
+    if (new_offset) |out| out.* = @intCast(rc);
+    return 0;
 }

--- a/src/os/system/linux.zig
+++ b/src/os/system/linux.zig
@@ -276,9 +276,13 @@ pub fn mmap(addr: ?[*]u8, len: usize, prot: u32, flags: u32, fd: i32, offset: i6
     }
 }
 
-pub fn lseek(fd: i32, offset: off_t, whence: u32) usize {
+/// Returns 0 on success, or the negative errno on failure. The resulting file
+/// position is reported through `new_offset`, because it does not fit in the
+/// return value on 32-bit platforms.
+pub fn lseek(fd: i32, offset: off_t, whence: u32, new_offset: ?*u64) usize {
     if (@sizeOf(usize) == 4) {
-        // 32-bit platforms use llseek which returns result via pointer
+        // 32-bit platforms use llseek, which returns 0 on success and reports
+        // the resulting position through a pointer.
         var result: u64 = undefined;
         const rc = linux.syscall5(
             .llseek,
@@ -288,11 +292,9 @@ pub fn lseek(fd: i32, offset: off_t, whence: u32) usize {
             @intFromPtr(&result),
             whence,
         );
-        if (rc == 0) {
-            return @truncate(result); // TODO: do not truncate
-        } else {
-            return @bitCast(@as(isize, -1));
-        }
+        if (rc != 0) return rc;
+        if (new_offset) |out| out.* = result;
+        return 0;
     } else {
         const rc = linux.syscall3(
             .lseek,
@@ -300,7 +302,9 @@ pub fn lseek(fd: i32, offset: off_t, whence: u32) usize {
             @as(usize, @bitCast(offset)),
             whence,
         );
-        return rc;
+        if (errno(rc) != .SUCCESS) return rc;
+        if (new_offset) |out| out.* = rc;
+        return 0;
     }
 }
 


### PR DESCRIPTION
`fileSeekBy` and `fileSeekTo` handed the operation to `std.Io.Threaded.global_single_threaded`, so it ran with std's `lseek` and std's error mapping. `os.fs.fileSeekBy` and `os.fs.fileSeekTo` replace it, with the positional errno set the read/write mappers already have: `ESPIPE`, plus the `ENXIO` a macOS terminal answers with and the `EOVERFLOW` of an offset the device cannot represent, all map to `Unseekable`. On Windows it goes through `SetFilePointerEx`, like `fileSetSize`.

The `lseek` wrapper needed fixing first. On 32-bit Linux it takes the `llseek` path, which returned a bare `-1` on failure. That is the libc convention, but `linux.errno` decodes a raw syscall return, so every failure came out as `EPERM` and `ESPIPE` never reached the caller. `isPollable` reads the same errno, so pipes, FIFOs and terminals were classified as seekable there, and their streaming reads and writes went to a thread pool worker instead of the readiness path. The wrapper now returns 0 or the negative errno, and reports the resulting position through an out-parameter, which no caller needs but which the return value has no room for on 32-bit.

Tests: seek moving the streaming position (including the two out-of-range cases), seek on a pipe reporting `Unseekable`, and an `isPollable` test that fails on `arm-linux` without the wrapper fix.

Checked with the full suite on x86_64 (io_uring, epoll, poll) and on `arm-linux` under qemu, the seek tests under Wine, and cross-compiles for macOS x86_64/aarch64, FreeBSD, NetBSD, OpenBSD and Windows.

Fixes #600