### PR TITLE
os: implement the working directory and tty queries natively

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added `os.process.getCurrentPath`, `os.process.setCurrentPath` and
+  `os.process.setCurrentDir` for the working directory, and `os.fs.isTty` and
+  `os.fs.supportsAnsiEscapeCodes` for terminal detection. These also back the matching
+  `std.Io` operations.
+
 - Added `os.fs.fileSeekBy` and `os.fs.fileSeekTo`, which now also back the `std.Io` file
   seek operations.
 

--- a/src/io.zig
+++ b/src/io.zig
@@ -43,6 +43,7 @@ const os_net = @import("os/net.zig");
 const os_fs = @import("os/fs.zig");
 const zio_fs = @import("fs.zig");
 const os_posix = @import("os/posix.zig");
+const os_process = @import("os/process.zig");
 const process_impl = @import("process.zig");
 const zio_net = @import("net.zig");
 const zio_dns = @import("dns/root.zig");
@@ -1537,18 +1538,19 @@ fn fileSyncImpl(_: ?*anyopaque, file: Io.File) Io.File.SyncError!void {
 }
 
 fn fileIsTtyImpl(_: ?*anyopaque, file: Io.File) Io.Cancelable!bool {
-    const io = globalIo();
-    return io.vtable.fileIsTty(io.userdata, file);
+    return os_fs.isTty(stdIoHandleToZio(file.handle));
 }
 
 fn fileEnableAnsiEscapeCodesImpl(_: ?*anyopaque, file: Io.File) Io.File.EnableAnsiEscapeCodesError!void {
+    // Turning the mode on for a Windows console is the one thing this does that
+    // is not a query, and it goes through the console driver protocol that std
+    // implements.
     const io = globalIo();
     return io.vtable.fileEnableAnsiEscapeCodes(io.userdata, file);
 }
 
 fn fileSupportsAnsiEscapeCodesImpl(_: ?*anyopaque, file: Io.File) Io.Cancelable!bool {
-    const io = globalIo();
-    return io.vtable.fileSupportsAnsiEscapeCodes(io.userdata, file);
+    return os_fs.supportsAnsiEscapeCodes(stdIoHandleToZio(file.handle));
 }
 
 fn fileSetLengthImpl(_: ?*anyopaque, file: Io.File, new_length: u64) Io.File.SetLengthError!void {
@@ -1715,19 +1717,47 @@ fn unlockStderrImpl(_: ?*anyopaque) void {
     stderr_mutex.unlock();
 }
 
-fn processCurrentPathImpl(_: ?*anyopaque, buffer: []u8) std.process.CurrentPathError!usize {
-    const io = globalIo();
-    return io.vtable.processCurrentPath(io.userdata, buffer);
+fn processCurrentPathImpl(userdata: ?*anyopaque, buffer: []u8) std.process.CurrentPathError!usize {
+    const rt: *Runtime = @ptrCast(@alignCast(userdata));
+    return os_process.getCurrentPath(rt.allocator, buffer) catch |err| switch (err) {
+        error.NameTooLong => error.NameTooLong,
+        error.CurrentDirUnlinked => error.CurrentDirUnlinked,
+        error.Canceled => error.Canceled,
+        // CurrentPathError has neither member, so a directory we are not
+        // allowed to read the path of, and a failed allocation, both have to
+        // come out as Unexpected.
+        error.AccessDenied, error.SystemResources => error.Unexpected,
+        error.Unexpected => error.Unexpected,
+    };
 }
 
-fn processSetCurrentDirImpl(_: ?*anyopaque, dir: Io.Dir) std.process.SetCurrentDirError!void {
-    const io = globalIo();
-    return io.vtable.processSetCurrentDir(io.userdata, dir);
+fn processSetCurrentDirImpl(userdata: ?*anyopaque, dir: Io.Dir) std.process.SetCurrentDirError!void {
+    const rt: *Runtime = @ptrCast(@alignCast(userdata));
+    return os_process.setCurrentDir(rt.allocator, stdIoHandleToZio(dir.handle)) catch |err| switch (err) {
+        error.AccessDenied => error.AccessDenied,
+        error.NotDir => error.NotDir,
+        error.InputOutput => error.FileSystem,
+        error.BadPathName => error.BadPathName,
+        error.Canceled => error.Canceled,
+        // SetCurrentDirError has no SystemResources.
+        error.SystemResources, error.Unexpected => error.Unexpected,
+    };
 }
 
-fn processSetCurrentPathImpl(_: ?*anyopaque, path: []const u8) std.process.SetCurrentPathError!void {
-    const io = globalIo();
-    return io.vtable.processSetCurrentPath(io.userdata, path);
+fn processSetCurrentPathImpl(userdata: ?*anyopaque, path: []const u8) std.process.SetCurrentPathError!void {
+    const rt: *Runtime = @ptrCast(@alignCast(userdata));
+    return os_process.setCurrentPath(rt.allocator, path) catch |err| switch (err) {
+        error.AccessDenied => error.AccessDenied,
+        error.SymLinkLoop => error.SymLinkLoop,
+        error.NameTooLong => error.NameTooLong,
+        error.FileNotFound => error.FileNotFound,
+        error.NotDir => error.NotDir,
+        error.BadPathName => error.BadPathName,
+        error.InputOutput => error.FileSystem,
+        error.SystemResources => error.SystemResources,
+        error.Canceled => error.Canceled,
+        error.Unexpected => error.Unexpected,
+    };
 }
 
 // TODO: implement using our own execve wrapper
@@ -2697,6 +2727,102 @@ test "io: processExecutablePath returns a non-empty path" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const len = try std.process.executablePath(io, &buf);
     try std.testing.expect(len > 0);
+}
+
+test "io: processCurrentPath agrees with the working directory" {
+    if (builtin.os.tag == .netbsd) return error.SkipZigTest; // no realPath to compare against
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try std.process.currentPath(io, &buf);
+    try std.testing.expect(len > 0);
+
+    var real_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const real_len = Io.Dir.cwd().realPath(io, &real_buf) catch |err| switch (err) {
+        error.OperationUnsupported => return error.SkipZigTest,
+        else => return err,
+    };
+    try std.testing.expectEqualStrings(real_buf[0..real_len], buf[0..len]);
+}
+
+test "io: processSetCurrentPath and processSetCurrentDir move the working directory" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const sub_path = "test_io_set_current_dir";
+
+    // Remember where we started, so the move can be undone by path even after
+    // the working directory is somewhere else.
+    var original_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const original = original_buf[0..try std.process.currentPath(io, &original_buf)];
+
+    try dir.createDir(io, sub_path, .default_dir);
+    defer dir.deleteDir(io, sub_path) catch {};
+
+    {
+        var sub = try dir.openDir(io, sub_path, .{});
+        defer sub.close(io);
+        errdefer std.process.setCurrentPath(io, original) catch {};
+
+        // Once by handle, and back, then once by path, so both entry points
+        // move the working directory.
+        try std.process.setCurrentDir(io, sub);
+
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const len = try std.process.currentPath(io, &buf);
+        try std.testing.expect(std.mem.endsWith(u8, buf[0..len], sub_path));
+    }
+
+    try std.process.setCurrentPath(io, original);
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try std.process.currentPath(io, &buf);
+    try std.testing.expectEqualStrings(original, buf[0..len]);
+
+    // The cwd handle names the directory we are in, so moving to it is a no-op
+    // rather than an error, even where it is a sentinel and not a descriptor.
+    try std.process.setCurrentDir(io, .cwd());
+}
+
+test "io: file isTty is false for a pipe" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    // On Windows this is a named pipe, which is also what an MSYS2/Cygwin pty
+    // is, so it goes through the name check that tells the two apart.
+    const fds = try os_fs.pipe();
+    var read_file: Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = true } };
+    var write_file: Io.File = .{ .handle = fds[1], .flags = .{ .nonblocking = true } };
+    defer read_file.close(io);
+    defer write_file.close(io);
+
+    try std.testing.expect(!try io.vtable.fileIsTty(io.userdata, read_file));
+    try std.testing.expect(!try io.vtable.fileSupportsAnsiEscapeCodes(io.userdata, read_file));
+}
+
+test "io: file isTty is true for a terminal" {
+    // A pty master is a terminal on Linux, but not on the BSDs, where the
+    // terminal is the slave side and opening it takes the whole grantpt dance.
+    // CI has no terminal attached to the test process to use instead.
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const tty_handle = os_fs.openat(std.testing.allocator, os_fs.cwd(), "/dev/ptmx", .{ .mode = .read_write }) catch
+        return error.SkipZigTest;
+    var tty_file: Io.File = .{ .handle = tty_handle, .flags = .{ .nonblocking = false } };
+    defer tty_file.close(io);
+
+    try std.testing.expect(try io.vtable.fileIsTty(io.userdata, tty_file));
+    try std.testing.expect(try io.vtable.fileSupportsAnsiEscapeCodes(io.userdata, tty_file));
 }
 
 test "io: now returns monotonically increasing awake timestamps" {

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -3384,6 +3384,89 @@ fn dirRealPathFileWindows(allocator: std.mem.Allocator, dir: fd_t, path: []const
     return dirRealPathWindows(handle, buffer);
 }
 
+/// Returns true if `fd` refers to a terminal.
+pub fn isTty(fd: fd_t) bool {
+    if (builtin.os.tag == .windows) {
+        // A console handle is one the console driver will report a mode for.
+        var mode: w.DWORD = undefined;
+        if (w.GetConsoleMode(fd, &mode) != w.FALSE) return true;
+        return isCygwinPty(fd);
+    }
+
+    if (builtin.os.tag == .linux) {
+        // Asking a descriptor for its window size is a question only a terminal
+        // answers, and unlike `isatty` it does not need libc. The answer itself
+        // is four u16 we do not read.
+        var wsz: [4]u16 = undefined;
+        return ioctlPosix(fd, @intCast(posix.system.T.IOCGWINSZ), &wsz) >= 0;
+    }
+
+    // Everywhere else libc is linked and `isatty` is the canonical answer. The
+    // window size ioctl is not a stand-in for it there: a pty master on macOS
+    // rejects the ioctl, and which devices answer it is a per-system detail we
+    // would rather not carry.
+    return posix.system.isatty(fd) != 0;
+}
+
+/// Returns true if ANSI escape codes written to `fd` will be interpreted.
+pub fn supportsAnsiEscapeCodes(fd: fd_t) bool {
+    if (builtin.os.tag == .windows) {
+        var mode: w.DWORD = undefined;
+        if (w.GetConsoleMode(fd, &mode) != w.FALSE) {
+            // A console that already has the mode set needs nothing further.
+            // One that does not can still have it turned on, which is what
+            // `enableAnsiEscapeCodes` is for, so it counts as supporting them.
+            return true;
+        }
+        return isCygwinPty(fd);
+    }
+
+    return isTty(fd);
+}
+
+/// An MSYS2/Cygwin pty is a named pipe rather than a console, named
+/// `msys-[...]-ptyN-[...]` or `cygwin-[...]-ptyN-[...]`.
+fn isCygwinPty(handle: fd_t) bool {
+    if (builtin.os.tag != .windows) return false;
+
+    // Checking the device type first keeps the more expensive name query off
+    // every handle that is not a pipe at all.
+    var iosb: w.IO_STATUS_BLOCK = undefined;
+    var device_info: w.FILE_FS_DEVICE_INFORMATION = undefined;
+    if (w.NtQueryVolumeInformationFile(
+        handle,
+        &iosb,
+        &device_info,
+        @sizeOf(w.FILE_FS_DEVICE_INFORMATION),
+        .FileFsDeviceInformation,
+    ) != .SUCCESS) return false;
+    if (device_info.DeviceType != w.FILE_DEVICE_NAMED_PIPE) return false;
+
+    // The names we are looking for are far shorter than a full path, so a
+    // buffer that cannot hold every possible name is enough; anything that does
+    // not fit is not one of ours.
+    const name_offset = @offsetOf(w.FILE_NAME_INFORMATION, "FileName");
+    var name_bytes align(@alignOf(w.FILE_NAME_INFORMATION)) = [_]u8{0} ** (name_offset + 256 * 2);
+    if (w.NtQueryInformationFile(
+        handle,
+        &iosb,
+        &name_bytes,
+        @intCast(name_bytes.len),
+        .FileNameInformation,
+    ) != .SUCCESS) return false;
+
+    const name_info: *const w.FILE_NAME_INFORMATION = @ptrCast(&name_bytes);
+    const len = @min(name_info.FileNameLength, name_bytes.len - name_offset);
+    const name = std.mem.bytesAsSlice(u16, name_bytes[name_offset..][0..len]);
+
+    // The queried name is prefixed with a '\', e.g. \msys-1888ae32e00d56aa-pty0-to-master
+    const msys = std.unicode.utf8ToUtf16LeStringLiteral("\\msys-");
+    const cygwin = std.unicode.utf8ToUtf16LeStringLiteral("\\cygwin-");
+    const pty = std.unicode.utf8ToUtf16LeStringLiteral("-pty");
+    return (std.mem.startsWith(u16, name, msys) or std.mem.startsWith(u16, name, cygwin)) and
+        std.mem.indexOf(u16, name, pty) != null;
+}
+
 /// Call ioctl(2) on `fd`, retrying on EINTR. Returns the raw ioctl return
 /// value on success, or a negative errno value on failure, matching the
 /// `std.Io.Operation.DeviceIoControl.Result` contract.

--- a/src/os/process.zig
+++ b/src/os/process.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = @import("posix.zig");
+const w = @import("windows.zig");
+const fs = @import("fs.zig");
+
+const unexpectedError = @import("base.zig").unexpectedError;
+const syscall_cancel = @import("syscall_cancel.zig");
+
+pub const CurrentPathError = error{
+    /// The path does not fit in the buffer the caller provided.
+    NameTooLong,
+    /// The working directory was removed while the process was in it. Cannot
+    /// happen on Windows, which holds a handle to it.
+    CurrentDirUnlinked,
+    AccessDenied,
+    SystemResources,
+    Canceled,
+    Unexpected,
+};
+
+pub const SetCurrentPathError = error{
+    AccessDenied,
+    SymLinkLoop,
+    NameTooLong,
+    FileNotFound,
+    NotDir,
+    /// The path is not valid for the platform. Windows only.
+    BadPathName,
+    InputOutput,
+    SystemResources,
+    Canceled,
+    Unexpected,
+};
+
+pub const SetCurrentDirError = error{
+    AccessDenied,
+    NotDir,
+    InputOutput,
+    /// The directory has no path to name it by. Windows only.
+    BadPathName,
+    SystemResources,
+    Canceled,
+    Unexpected,
+};
+
+/// Write the path of the current working directory into `buffer`, returning its
+/// length. On Windows the result is WTF-8; elsewhere it is whatever bytes the
+/// system stores, with no particular encoding.
+pub fn getCurrentPath(allocator: std.mem.Allocator, buffer: []u8) CurrentPathError!usize {
+    if (builtin.os.tag == .windows) {
+        // Asking for a zero-length buffer returns the size that would be
+        // needed, counting the terminating null.
+        const needed = w.GetCurrentDirectoryW(0, null);
+        if (needed == 0) return unexpectedError(w.GetLastError());
+
+        const wide = allocator.alloc(w.WCHAR, needed) catch return error.SystemResources;
+        defer allocator.free(wide);
+
+        // The second call reports the length without the terminating null, so
+        // it is one short of `needed` unless the directory changed underneath.
+        const len = w.GetCurrentDirectoryW(needed, wide.ptr);
+        if (len == 0) return unexpectedError(w.GetLastError());
+        if (len >= needed) return error.Unexpected;
+
+        if (std.unicode.calcWtf8Len(wide[0..len]) > buffer.len) return error.NameTooLong;
+        return std.unicode.wtf16LeToWtf8(buffer, wide[0..len]);
+    }
+
+    if (buffer.len == 0) return error.NameTooLong;
+
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+    while (true) {
+        // libc returns null on failure, the raw syscall a negative errno.
+        const err = if (builtin.os.tag == .linux)
+            posix.errno(posix.system.getcwd(buffer.ptr, buffer.len))
+        else if (posix.system.getcwd(buffer.ptr, buffer.len) != null)
+            posix.system.E.SUCCESS
+        else
+            posix.errno(@as(c_int, -1));
+
+        switch (err) {
+            // The path is written null terminated, and the terminator is not
+            // part of the length we report.
+            .SUCCESS => return std.mem.indexOfScalar(u8, buffer, 0) orelse return error.Unexpected,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => return errnoToCurrentPathError(err),
+        }
+    }
+}
+
+pub fn errnoToCurrentPathError(errno: posix.system.E) CurrentPathError {
+    return switch (errno) {
+        .SUCCESS => unreachable,
+        .RANGE => error.NameTooLong,
+        .NAMETOOLONG => error.NameTooLong,
+        .NOENT => error.CurrentDirUnlinked,
+        .ACCES, .PERM => error.AccessDenied,
+        .NOMEM => error.SystemResources,
+        .CANCELED => error.Canceled,
+        else => |e| unexpectedError(e),
+    };
+}
+
+/// Change the working directory to `path`.
+pub fn setCurrentPath(allocator: std.mem.Allocator, path: []const u8) SetCurrentPathError!void {
+    if (builtin.os.tag == .windows) {
+        const path_w = try w.pathToWide(allocator, w.FDCWD, path);
+        defer allocator.free(path_w);
+
+        if (w.SetCurrentDirectoryW(path_w.ptr) == w.FALSE) {
+            return win32ErrorToSetCurrentPathError(w.GetLastError());
+        }
+        return;
+    }
+
+    const path_z = allocator.dupeSentinel(u8, path, 0) catch return error.SystemResources;
+    defer allocator.free(path_z);
+
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+    while (true) {
+        switch (posix.errno(posix.system.chdir(path_z.ptr))) {
+            .SUCCESS => return,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return errnoToSetCurrentPathError(err),
+        }
+    }
+}
+
+pub fn errnoToSetCurrentPathError(errno: posix.system.E) SetCurrentPathError {
+    return switch (errno) {
+        .SUCCESS => unreachable,
+        .ACCES, .PERM => error.AccessDenied,
+        .LOOP => error.SymLinkLoop,
+        .NAMETOOLONG => error.NameTooLong,
+        .NOENT => error.FileNotFound,
+        .NOTDIR => error.NotDir,
+        .IO => error.InputOutput,
+        .NOMEM => error.SystemResources,
+        .CANCELED => error.Canceled,
+        else => |e| unexpectedError(e),
+    };
+}
+
+fn win32ErrorToSetCurrentPathError(err: w.Win32Error) SetCurrentPathError {
+    return switch (err) {
+        .SUCCESS => unreachable,
+        .ACCESS_DENIED => error.AccessDenied,
+        .FILE_NOT_FOUND, .PATH_NOT_FOUND => error.FileNotFound,
+        .DIRECTORY => error.NotDir,
+        .INVALID_NAME, .BAD_PATHNAME => error.BadPathName,
+        .NOT_ENOUGH_MEMORY, .OUTOFMEMORY => error.SystemResources,
+        else => |e| unexpectedError(e),
+    };
+}
+
+/// Change the working directory to an already open directory.
+pub fn setCurrentDir(allocator: std.mem.Allocator, fd: fs.fd_t) SetCurrentDirError!void {
+    // The cwd sentinel is not a descriptor fchdir can take, and asking for the
+    // directory we are already in is a no-op anyway.
+    if (fd == fs.cwd()) return;
+
+    if (builtin.os.tag == .windows) {
+        // Windows has no fchdir: the directory has to be named, and the only
+        // name we have for an open handle is the one we can query back out of
+        // it.
+        const path_buf = allocator.alloc(u8, std.os.windows.PATH_MAX_WIDE) catch return error.SystemResources;
+        defer allocator.free(path_buf);
+
+        const len = fs.dirRealPath(fd, path_buf) catch |err| switch (err) {
+            error.AccessDenied, error.PermissionDenied => return error.AccessDenied,
+            error.NotDir => return error.NotDir,
+            error.InputOutput, error.FileSystem => return error.InputOutput,
+            error.SystemResources => return error.SystemResources,
+            error.Canceled => return error.Canceled,
+            // A handle we cannot name is one we cannot chdir to.
+            error.NameTooLong, error.FileNotFound, error.SymLinkLoop, error.OperationUnsupported => return error.BadPathName,
+            error.Unexpected => return error.Unexpected,
+        };
+
+        return setCurrentPath(allocator, path_buf[0..len]) catch |err| switch (err) {
+            error.AccessDenied => error.AccessDenied,
+            error.NotDir => error.NotDir,
+            error.InputOutput => error.InputOutput,
+            error.SystemResources => error.SystemResources,
+            error.Canceled => error.Canceled,
+            error.BadPathName, error.FileNotFound, error.NameTooLong, error.SymLinkLoop => error.BadPathName,
+            error.Unexpected => error.Unexpected,
+        };
+    }
+
+    const sc = try syscall_cancel.Syscall.begin();
+    defer sc.finish();
+    while (true) {
+        switch (posix.errno(posix.system.fchdir(fd))) {
+            .SUCCESS => return,
+            .INTR => {
+                try sc.checkCancel();
+                continue;
+            },
+            else => |err| return errnoToSetCurrentDirError(err),
+        }
+    }
+}
+
+pub fn errnoToSetCurrentDirError(errno: posix.system.E) SetCurrentDirError {
+    return switch (errno) {
+        .SUCCESS => unreachable,
+        .ACCES, .PERM => error.AccessDenied,
+        .NOTDIR => error.NotDir,
+        .IO => error.InputOutput,
+        .NOMEM => error.SystemResources,
+        .CANCELED => error.Canceled,
+        else => |e| unexpectedError(e),
+    };
+}

--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 pub const time = @import("time.zig");
 pub const net = @import("net.zig");
 pub const fs = @import("fs.zig");
+pub const process = @import("process.zig");
 pub const path = std.fs.path;
 
 pub const posix = @import("posix.zig");

--- a/src/os/windows.zig
+++ b/src/os/windows.zig
@@ -652,6 +652,50 @@ pub fn pipe() !([2]HANDLE) {
     return .{ read_handle, write_handle };
 }
 
+// Current directory
+pub extern "kernel32" fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: ?[*]WCHAR) callconv(.winapi) DWORD;
+pub extern "kernel32" fn SetCurrentDirectoryW(lpPathName: [*:0]const WCHAR) callconv(.winapi) BOOL;
+
+// Console
+pub extern "kernel32" fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *DWORD) callconv(.winapi) BOOL;
+
+/// Console mode bit for interpreting ANSI escape sequences in written output.
+pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: DWORD = 0x0004;
+
+// Handle queries used to recognize an MSYS2/Cygwin pty (ntdll)
+pub extern "ntdll" fn NtQueryInformationFile(
+    FileHandle: HANDLE,
+    IoStatusBlock: *IO_STATUS_BLOCK,
+    FileInformation: [*]u8,
+    Length: ULONG,
+    FileInformationClass: FILE_INFORMATION_CLASS,
+) callconv(.winapi) NTSTATUS;
+
+pub extern "ntdll" fn NtQueryVolumeInformationFile(
+    FileHandle: HANDLE,
+    IoStatusBlock: *IO_STATUS_BLOCK,
+    FsInformation: *anyopaque,
+    Length: ULONG,
+    FsInformationClass: FS_INFORMATION_CLASS,
+) callconv(.winapi) NTSTATUS;
+
+/// Only the one class we query; values match the Windows DDK.
+pub const FS_INFORMATION_CLASS = enum(c_int) {
+    FileFsDeviceInformation = 4,
+};
+
+pub const FILE_FS_DEVICE_INFORMATION = extern struct {
+    DeviceType: ULONG,
+    Characteristics: ULONG,
+};
+
+pub const FILE_DEVICE_NAMED_PIPE: ULONG = 0x00000011;
+
+pub const FILE_NAME_INFORMATION = extern struct {
+    FileNameLength: ULONG,
+    FileName: [1]WCHAR,
+};
+
 // Path utilities (shlwapi)
 pub extern "shlwapi" fn PathIsRelativeW(pszPath: LPCWSTR) callconv(.winapi) BOOL;
 


### PR DESCRIPTION
Follow-up to #620, which listed the other vtable methods that hand their work to `std.Io.Threaded.global_single_threaded`. This takes the five that are plain queries.

`os.process` gets `getCurrentPath`, `setCurrentPath` and `setCurrentDir`, each a single syscall on POSIX. Windows has no `fchdir`, so `setCurrentDir` names the handle with `GetFinalPathNameByHandle` first, the way std does, and the cwd sentinel short-circuits since moving to the directory we are already in is a no-op.

`os.fs` gets `isTty` and `supportsAnsiEscapeCodes`. On POSIX they ask for the terminal window size, which is the same ioctl libc's `isatty` makes, without needing libc linked. On Windows they ask the console driver for a mode, plus the MSYS2/Cygwin pty check, which a console-handle test alone would miss and whose absence would cost those terminals their color.

`fileEnableAnsiEscapeCodes` still delegates: it is the one of these that writes rather than reads, through a console driver protocol worth leaving to std.

Delegation was never wrong for these, but it does mean std's cancellation machinery, which binds to std's own threads, is a no-op on a fiber, and that the error sets are std's rather than ours. Two errors have nowhere to go in the std sets and are folded into `Unexpected`, marked at the mapping.

Tests: cwd round trip through a subdirectory and back by handle, `currentPath` against `Dir.realPath`, `isTty` false for a pipe (which on Windows is a named pipe, so it exercises the Cygwin name check) and true for a pty.

Checked with the full suite on x86_64 (io_uring, epoll, poll), `arm-linux` under qemu, the full suite under Wine, and cross-compiles for macOS x86_64/aarch64, FreeBSD, NetBSD, OpenBSD.