### PR TITLE
dns: never truncate silently, never error on truncation

### DIFF
--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -9,9 +9,8 @@ const syscall_cancel = @import("../os/syscall_cancel.zig");
 const dns = @import("root.zig");
 
 /// Fills `storage` with canonical name (if requested) and addresses from
-/// a `getaddrinfo` linked list. Returns the number of entries written, or
-/// `error.TooManyAddresses` if the resolver returned more addresses than
-/// `storage` can hold (the buffer is fully populated in that case).
+/// a `getaddrinfo` linked list. Returns the number of entries written.
+/// Addresses beyond `storage.len` are dropped without error.
 pub fn fillResultsFromAddrinfo(
     storage: []dns.LookupResult,
     options: dns.LookupOptions,
@@ -36,7 +35,7 @@ pub fn fillResultsFromAddrinfo(
     while (current) |info| : (current = @ptrCast(info.next)) {
         const addr = info.addr orelse continue;
         if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
-        if (i >= storage.len) return error.TooManyAddresses;
+        if (i >= storage.len) break;
         storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.addrlen)) };
         i += 1;
     }

--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -29,6 +29,7 @@ comptime {
     // enough.
     if (node_count < max_entry_nodes) @compileError("node pool smaller than one maximal entry");
     if (node_count >= none) @compileError("node indices must fit u16 with a sentinel");
+    if (max_entry_addrs > std.math.maxInt(u8)) @compileError("CacheSlot.count cannot hold a maximal entry");
 }
 
 /// The shape of a lookup request. Cache and dedup are keyed by shape so that a

--- a/src/dns/resolver/cache.zig
+++ b/src/dns/resolver/cache.zig
@@ -2,15 +2,34 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const dns = @import("../root.zig");
 const net = @import("../../net.zig");
 const Timestamp = @import("../../time.zig").Timestamp;
 
-// A "both" entry holds addresses for both families, so allow room for a few of
-// each before we give up on caching the result.
-pub const max_cached_addrs = 6;
 const cache_capacity = 1024;
 const probe_limit = 8;
 pub const key_prefix_len = 22;
+
+// Addresses are stored in fixed chunks drawn from a shared pool, so one entry
+// can hold anything from a single address up to a full dual-stack answer
+// without inflating every slot to the maximum.
+const addrs_per_node = 4;
+const node_count = 1024;
+const none = std.math.maxInt(u16);
+
+/// The largest answer one entry can hold: both families at the resolver's
+/// per-family cap. Results larger than this are never offered to the cache.
+pub const max_entry_addrs = 2 * dns.max_addrs_per_family;
+
+const max_entry_nodes = (max_entry_addrs + addrs_per_node - 1) / addrs_per_node;
+
+comptime {
+    // `put` must never fail: a full sweep releases every node in the pool, so
+    // as long as the pool can hold one maximal entry, reclaim always frees
+    // enough.
+    if (node_count < max_entry_nodes) @compileError("node pool smaller than one maximal entry");
+    if (node_count >= none) @compileError("node indices must fit u16 with a sentinel");
+}
 
 /// The shape of a lookup request. Cache and dedup are keyed by shape so that a
 /// dual-stack ("both") lookup is a single unit — resolved against one search
@@ -48,15 +67,16 @@ comptime {
     if (@sizeOf(CacheKey) != 32) @compileError("CacheKey must be exactly 32 bytes");
 }
 
-pub const CacheEntry = struct {
-    addrs: [max_cached_addrs]net.IpAddress,
-    count: u8,
-    expiry: Timestamp,
+const Node = struct {
+    addrs: [addrs_per_node]net.IpAddress,
+    next: u16,
 };
 
 const CacheSlot = struct {
     key: CacheKey,
-    entry: CacheEntry,
+    head: u16,
+    count: u8,
+    expiry: Timestamp,
 };
 
 fn slotIndex(key: *const CacheKey) usize {
@@ -65,25 +85,66 @@ fn slotIndex(key: *const CacheKey) usize {
 
 pub const Cache = struct {
     slots: [cache_capacity]CacheSlot,
+    nodes: [node_count]Node,
+    free_head: u16,
+    free_count: u16,
+    sweep_cursor: u16,
 
-    // Returns the cached entry for key if present and not expired.
-    pub fn get(self: *const Cache, key: *const CacheKey, now: Timestamp) ?CacheEntry {
+    /// The freelist threads node indices, so — unlike the old inline layout —
+    /// a zeroed Cache is not a valid empty one.
+    pub fn init() Cache {
+        var cache: Cache = .{
+            .slots = undefined,
+            .nodes = undefined,
+            .free_head = 0,
+            .free_count = node_count,
+            .sweep_cursor = 0,
+        };
+        for (&cache.slots) |*slot| {
+            slot.* = .{
+                .key = std.mem.zeroes(CacheKey),
+                .head = none,
+                .count = 0,
+                .expiry = .{ .value = 0 },
+            };
+        }
+        for (&cache.nodes, 0..) |*node, i| {
+            node.next = if (i + 1 < node_count) @intCast(i + 1) else none;
+        }
+        return cache;
+    }
+
+    /// Copies the cached addresses for key into `out`, if present and not
+    /// expired, and returns how many were copied. Addresses beyond `out.len`
+    /// are dropped.
+    pub fn get(self: *const Cache, key: *const CacheKey, now: Timestamp, out: []net.IpAddress) ?usize {
         const start = slotIndex(key);
         for (0..probe_limit) |probe| {
             const slot = &self.slots[(start + probe) & (cache_capacity - 1)];
             if (slot.key.len == 0) return null;
             if (!slot.key.eql(key)) continue;
-            if (now.value < slot.entry.expiry.value) {
-                return slot.entry;
+            if (now.value >= slot.expiry.value) return null;
+
+            const n = @min(slot.count, out.len);
+            var node = slot.head;
+            var copied: usize = 0;
+            while (copied < n) {
+                const chunk = @min(addrs_per_node, n - copied);
+                @memcpy(out[copied..][0..chunk], self.nodes[node].addrs[0..chunk]);
+                copied += chunk;
+                node = self.nodes[node].next;
             }
-            return null;
+            return n;
         }
         return null;
     }
 
-    // Stores or updates an entry. Prefers an empty or exact-match slot, then the
-    // first expired slot found in the probe window, then the primary slot.
-    pub fn put(self: *Cache, key: *const CacheKey, entry: CacheEntry, now: Timestamp) void {
+    /// Stores or updates an entry. Prefers an empty or exact-match slot, then
+    /// the first expired slot found in the probe window, then the primary
+    /// slot. Never fails: when the pool runs short, other entries are evicted.
+    pub fn put(self: *Cache, key: *const CacheKey, addrs: []const net.IpAddress, expiry: Timestamp, now: Timestamp) void {
+        std.debug.assert(addrs.len > 0 and addrs.len <= max_entry_addrs);
+
         const start = slotIndex(key);
         var target: usize = cache_capacity; // sentinel: no preferred slot yet
         for (0..probe_limit) |probe| {
@@ -93,96 +154,241 @@ pub const Cache = struct {
                 target = idx;
                 break;
             }
-            if (target == cache_capacity and now.value >= slot.entry.expiry.value) {
+            if (target == cache_capacity and now.value >= slot.expiry.value) {
                 target = idx;
             }
         }
         if (target == cache_capacity) target = start;
-        self.slots[target] = .{ .key = key.*, .entry = entry };
+
+        const slot = &self.slots[target];
+        self.freeChain(slot);
+
+        const needed = (addrs.len + addrs_per_node - 1) / addrs_per_node;
+        if (self.free_count < needed) self.reclaim(needed, target);
+
+        var head: u16 = none;
+        var tail: u16 = none;
+        var copied: usize = 0;
+        while (copied < addrs.len) {
+            const idx = self.free_head;
+            self.free_head = self.nodes[idx].next;
+            self.free_count -= 1;
+
+            const node = &self.nodes[idx];
+            node.next = none;
+            const chunk = @min(addrs_per_node, addrs.len - copied);
+            @memcpy(node.addrs[0..chunk], addrs[copied..][0..chunk]);
+            copied += chunk;
+
+            if (tail == none) head = idx else self.nodes[tail].next = idx;
+            tail = idx;
+        }
+
+        slot.* = .{
+            .key = key.*,
+            .head = head,
+            .count = @intCast(addrs.len),
+            .expiry = expiry,
+        };
     }
 
-    // Marks a cached entry as expired so the slot can be reused without
-    // breaking probe chains for other keys.
+    /// Marks a cached entry as expired and releases its address chain. The
+    /// key is kept — zeroing it would punch a hole that orphans entries
+    /// further along the probe window.
     pub fn expire(self: *Cache, key: *const CacheKey) void {
         const start = slotIndex(key);
         for (0..probe_limit) |probe| {
             const slot = &self.slots[(start + probe) & (cache_capacity - 1)];
             if (slot.key.len == 0) break;
             if (slot.key.eql(key)) {
-                slot.entry.expiry = .{ .value = 0 };
+                self.freeChain(slot);
+                slot.expiry = .{ .value = 0 };
                 break;
             }
         }
     }
+
+    /// Splices a slot's whole chain back onto the freelist.
+    fn freeChain(self: *Cache, slot: *CacheSlot) void {
+        if (slot.head == none) return;
+        var freed: u16 = 1;
+        var tail = slot.head;
+        while (self.nodes[tail].next != none) : (tail = self.nodes[tail].next) freed += 1;
+        self.nodes[tail].next = self.free_head;
+        self.free_head = slot.head;
+        self.free_count += freed;
+        slot.head = none;
+        slot.count = 0;
+    }
+
+    /// Evicts entries starting at a rotating cursor until at least `needed`
+    /// nodes are free. The slot being written (`keep`) was already released
+    /// by the caller; skipping it is only bookkeeping hygiene. A full pass
+    /// releases every node, so this cannot come up short.
+    fn reclaim(self: *Cache, needed: usize, keep: usize) void {
+        var i: usize = 0;
+        while (i < cache_capacity and self.free_count < needed) : (i += 1) {
+            const idx = (self.sweep_cursor + i) & (cache_capacity - 1);
+            if (idx == keep) continue;
+            const slot = &self.slots[idx];
+            if (slot.head == none) continue;
+            self.freeChain(slot);
+            slot.expiry = .{ .value = 0 };
+        }
+        self.sweep_cursor = @intCast((self.sweep_cursor + i) & (cache_capacity - 1));
+    }
 };
 
+// -- Tests --------------------------------------------------------------------
+
+fn testAddr(i: usize) net.IpAddress {
+    return net.IpAddress.initIp4(.{ 10, 0, @intCast((i >> 8) & 0xff), @intCast(i & 0xff) }, 0);
+}
+
+fn expectAddrEql(expected: net.IpAddress, actual: net.IpAddress) !void {
+    try std.testing.expectEqual(net.IpAddress.Family.ipv4, expected.getFamily());
+    try std.testing.expectEqual(net.IpAddress.Family.ipv4, actual.getFamily());
+    const e = @as(*align(1) const u32, @ptrCast(&expected.in.addr)).*;
+    const a = @as(*align(1) const u32, @ptrCast(&actual.in.addr)).*;
+    try std.testing.expectEqual(e, a);
+}
+
+fn fillTestAddrs(buf: []net.IpAddress) void {
+    for (buf, 0..) |*a, i| a.* = testAddr(i);
+}
+
+/// Counts nodes reachable from live slot chains, for conservation checks.
+fn countUsedNodes(cache: *const Cache) usize {
+    var used: usize = 0;
+    for (&cache.slots) |*slot| {
+        var node = slot.head;
+        while (node != none) : (node = cache.nodes[node].next) used += 1;
+    }
+    return used;
+}
+
+const far_future: Timestamp = .{ .value = std.math.maxInt(u64) };
+
 test "Cache: put and get" {
-    var cache: Cache = std.mem.zeroes(Cache);
+    var cache: Cache = .init();
     var key: CacheKey = undefined;
     CacheKey.init(&key, "example.com", 0, .ipv4);
-    var entry: CacheEntry = std.mem.zeroes(CacheEntry);
-    entry.count = 1;
-    entry.expiry = .{ .value = std.math.maxInt(u64) };
+
+    var addrs: [3]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
 
     const now: Timestamp = .{ .value = 1 };
-    cache.put(&key, entry, now);
-    const result = cache.get(&key, now);
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u8, 1), result.?.count);
+    cache.put(&key, &addrs, far_future, now);
+
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    const n = cache.get(&key, now, &out);
+    try std.testing.expectEqual(3, n.?);
+    for (addrs, out[0..3]) |expected, actual| {
+        try expectAddrEql(expected, actual);
+    }
+}
+
+test "Cache: get truncates to the output buffer" {
+    var cache: Cache = .init();
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "example.com", 0, .ipv4);
+
+    var addrs: [12]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
+
+    const now: Timestamp = .{ .value = 1 };
+    cache.put(&key, &addrs, far_future, now);
+
+    var out: [5]net.IpAddress = undefined;
+    const n = cache.get(&key, now, &out);
+    try std.testing.expectEqual(5, n.?);
+    for (addrs[0..5], out) |expected, actual| {
+        try expectAddrEql(expected, actual);
+    }
+}
+
+test "Cache: maximal dual-stack entry round-trips" {
+    var cache: Cache = .init();
+    var key: CacheKey = undefined;
+    CacheKey.init(&key, "big.example.com", 0, .both);
+
+    var addrs: [max_entry_addrs]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
+
+    const now: Timestamp = .{ .value = 1 };
+    cache.put(&key, &addrs, far_future, now);
+
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    const n = cache.get(&key, now, &out);
+    try std.testing.expectEqual(max_entry_addrs, n.?);
+    for (addrs, out) |expected, actual| {
+        try expectAddrEql(expected, actual);
+    }
 }
 
 test "Cache: expired entry not returned" {
-    var cache: Cache = std.mem.zeroes(Cache);
+    var cache: Cache = .init();
     var key: CacheKey = undefined;
     CacheKey.init(&key, "example.com", 0, .ipv4);
-    var entry: CacheEntry = std.mem.zeroes(CacheEntry);
-    entry.count = 1;
-    entry.expiry = .{ .value = 0 };
+
+    var addrs: [1]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
 
     const now: Timestamp = .{ .value = 1 };
-    cache.put(&key, entry, now);
-    try std.testing.expect(cache.get(&key, now) == null);
+    cache.put(&key, &addrs, .{ .value = 0 }, now);
+
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    try std.testing.expect(cache.get(&key, now, &out) == null);
 }
 
-test "Cache: expire invalidates entry" {
-    var cache: Cache = std.mem.zeroes(Cache);
+test "Cache: expire invalidates entry and releases its nodes" {
+    var cache: Cache = .init();
     var key: CacheKey = undefined;
     CacheKey.init(&key, "example.com", 0, .ipv4);
-    var entry: CacheEntry = std.mem.zeroes(CacheEntry);
-    entry.count = 1;
-    entry.expiry = .{ .value = std.math.maxInt(u64) };
+
+    var addrs: [9]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
 
     const now: Timestamp = .{ .value = 1 };
-    cache.put(&key, entry, now);
-    try std.testing.expect(cache.get(&key, now) != null);
+    cache.put(&key, &addrs, far_future, now);
+    try std.testing.expectEqual(node_count - 3, cache.free_count);
+
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    try std.testing.expect(cache.get(&key, now, &out) != null);
+
     cache.expire(&key);
-    try std.testing.expect(cache.get(&key, now) == null);
+    try std.testing.expect(cache.get(&key, now, &out) == null);
+    try std.testing.expectEqual(node_count, cache.free_count);
+    try std.testing.expectEqual(0, countUsedNodes(&cache));
 }
 
-test "Cache: update existing entry" {
-    var cache: Cache = std.mem.zeroes(Cache);
+test "Cache: update existing entry conserves nodes" {
+    var cache: Cache = .init();
     var key: CacheKey = undefined;
     CacheKey.init(&key, "example.com", 0, .ipv4);
 
     const now: Timestamp = .{ .value = 1 };
 
-    var e1: CacheEntry = std.mem.zeroes(CacheEntry);
-    e1.count = 1;
-    e1.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&key, e1, now);
+    var addrs: [12]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
+    cache.put(&key, &addrs, far_future, now);
 
-    var e2: CacheEntry = std.mem.zeroes(CacheEntry);
-    e2.count = 2;
-    e2.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&key, e2, now);
+    var new_addrs: [2]net.IpAddress = undefined;
+    for (&new_addrs, 100..) |*a, i| a.* = testAddr(i);
+    cache.put(&key, &new_addrs, far_future, now);
 
-    const result = cache.get(&key, now);
-    try std.testing.expect(result != null);
-    try std.testing.expectEqual(@as(u8, 2), result.?.count);
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    const n = cache.get(&key, now, &out);
+    try std.testing.expectEqual(2, n.?);
+    for (new_addrs, out[0..2]) |expected, actual| {
+        try expectAddrEql(expected, actual);
+    }
+    try std.testing.expectEqual(node_count - 1, cache.free_count);
+    try std.testing.expectEqual(1, countUsedNodes(&cache));
 }
 
 test "Cache: multiple independent entries" {
-    var cache: Cache = std.mem.zeroes(Cache);
+    var cache: Cache = .init();
     const names = [_][]const u8{ "a.test", "b.test", "c.test", "d.test" };
 
     const now: Timestamp = .{ .value = 1 };
@@ -190,23 +396,22 @@ test "Cache: multiple independent entries" {
     for (names, 0..) |name, i| {
         var k: CacheKey = undefined;
         CacheKey.init(&k, name, 0, .ipv4);
-        var e: CacheEntry = std.mem.zeroes(CacheEntry);
-        e.count = @intCast(i + 1);
-        e.expiry = .{ .value = std.math.maxInt(u64) };
-        cache.put(&k, e, now);
+        var addrs: [1]net.IpAddress = .{testAddr(i)};
+        cache.put(&k, &addrs, far_future, now);
     }
 
+    var out: [max_entry_addrs]net.IpAddress = undefined;
     for (names, 0..) |name, i| {
         var k: CacheKey = undefined;
         CacheKey.init(&k, name, 0, .ipv4);
-        const result = cache.get(&k, now);
-        try std.testing.expect(result != null);
-        try std.testing.expectEqual(@as(u8, @intCast(i + 1)), result.?.count);
+        const n = cache.get(&k, now, &out);
+        try std.testing.expectEqual(1, n.?);
+        try expectAddrEql(testAddr(i), out[0]);
     }
 }
 
 test "Cache: long names with shared prefix stay distinct" {
-    var cache: Cache = std.mem.zeroes(Cache);
+    var cache: Cache = .init();
     const name1 = "abcdefghijklmnopqrstuvw-one.test";
     const name2 = "abcdefghijklmnopqrstuvw-two.test";
     comptime std.debug.assert(name1.len > key_prefix_len);
@@ -215,42 +420,100 @@ test "Cache: long names with shared prefix stay distinct" {
 
     var k1: CacheKey = undefined;
     CacheKey.init(&k1, name1, 0, .ipv4);
-    var e1: CacheEntry = std.mem.zeroes(CacheEntry);
-    e1.count = 1;
-    e1.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&k1, e1, now);
+    var a1: [1]net.IpAddress = .{testAddr(1)};
+    cache.put(&k1, &a1, far_future, now);
 
     var k2: CacheKey = undefined;
     CacheKey.init(&k2, name2, 0, .ipv4);
-    var e2: CacheEntry = std.mem.zeroes(CacheEntry);
-    e2.count = 2;
-    e2.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&k2, e2, now);
+    var a2: [1]net.IpAddress = .{testAddr(2)};
+    cache.put(&k2, &a2, far_future, now);
 
-    try std.testing.expectEqual(@as(u8, 1), cache.get(&k1, now).?.count);
-    try std.testing.expectEqual(@as(u8, 2), cache.get(&k2, now).?.count);
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    try std.testing.expectEqual(1, cache.get(&k1, now, &out).?);
+    try expectAddrEql(testAddr(1), out[0]);
+    try std.testing.expectEqual(1, cache.get(&k2, now, &out).?);
+    try expectAddrEql(testAddr(2), out[0]);
 }
 
 test "Cache: same name different shapes stay distinct" {
-    var cache: Cache = std.mem.zeroes(Cache);
+    var cache: Cache = .init();
     const name = "example.com";
     const now: Timestamp = .{ .value = 1 };
 
     var k4: CacheKey = undefined;
     CacheKey.init(&k4, name, 0, .ipv4);
-    var e4: CacheEntry = std.mem.zeroes(CacheEntry);
-    e4.count = 1;
-    e4.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&k4, e4, now);
+    var a4: [1]net.IpAddress = .{testAddr(4)};
+    cache.put(&k4, &a4, far_future, now);
 
     var kboth: CacheKey = undefined;
     CacheKey.init(&kboth, name, 0, .both);
-    var eboth: CacheEntry = std.mem.zeroes(CacheEntry);
-    eboth.count = 2;
-    eboth.expiry = .{ .value = std.math.maxInt(u64) };
-    cache.put(&kboth, eboth, now);
+    var aboth: [2]net.IpAddress = .{ testAddr(5), testAddr(6) };
+    cache.put(&kboth, &aboth, far_future, now);
 
     try std.testing.expect(!k4.eql(&kboth));
-    try std.testing.expectEqual(@as(u8, 1), cache.get(&k4, now).?.count);
-    try std.testing.expectEqual(@as(u8, 2), cache.get(&kboth, now).?.count);
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    try std.testing.expectEqual(1, cache.get(&k4, now, &out).?);
+    try std.testing.expectEqual(2, cache.get(&kboth, now, &out).?);
+}
+
+test "Cache: pool exhaustion evicts but conserves nodes" {
+    var cache: Cache = .init();
+    const now: Timestamp = .{ .value = 1 };
+
+    var addrs: [max_entry_addrs]net.IpAddress = undefined;
+    fillTestAddrs(&addrs);
+
+    // Far more maximal entries than the pool can hold, so reclaim must run
+    // repeatedly. Every put must succeed and be immediately retrievable, and
+    // no node may leak or be double-freed.
+    var name_buf: [32]u8 = undefined;
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    for (0..4 * cache_capacity) |i| {
+        const name = std.fmt.bufPrint(&name_buf, "host-{d}.test", .{i}) catch unreachable;
+        var k: CacheKey = undefined;
+        CacheKey.init(&k, name, 0, .both);
+        cache.put(&k, &addrs, far_future, now);
+
+        try std.testing.expectEqual(max_entry_addrs, cache.get(&k, now, &out).?);
+        try std.testing.expectEqual(node_count, countUsedNodes(&cache) + cache.free_count);
+    }
+}
+
+test "Cache: entries past a swept slot still resolve" {
+    var cache: Cache = .init();
+    const now: Timestamp = .{ .value = 1 };
+
+    // Two names landing on the same primary slot, so the second lives further
+    // along the probe window.
+    var first: CacheKey = undefined;
+    CacheKey.init(&first, "collide-0.test", 0, .ipv4);
+    var second: CacheKey = undefined;
+    var found = false;
+    var name_buf: [32]u8 = undefined;
+    var i: usize = 1;
+    while (i < 100_000) : (i += 1) {
+        const name = std.fmt.bufPrint(&name_buf, "collide-{d}.test", .{i}) catch unreachable;
+        var k: CacheKey = undefined;
+        CacheKey.init(&k, name, 0, .ipv4);
+        if (slotIndex(&k) == slotIndex(&first)) {
+            second = k;
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+
+    var a1: [1]net.IpAddress = .{testAddr(1)};
+    var a2: [1]net.IpAddress = .{testAddr(2)};
+    cache.put(&first, &a1, far_future, now);
+    cache.put(&second, &a2, far_future, now);
+
+    // Free the first entry's chain; its key must survive so the second stays
+    // reachable through the probe window.
+    cache.expire(&first);
+
+    var out: [max_entry_addrs]net.IpAddress = undefined;
+    try std.testing.expect(cache.get(&first, now, &out) == null);
+    try std.testing.expectEqual(1, cache.get(&second, now, &out).?);
+    try expectAddrEql(testAddr(2), out[0]);
 }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -36,7 +36,7 @@ const Shape = @import("cache.zig").Shape;
 const max_cached_addrs = @import("cache.zig").max_cached_addrs;
 
 // Maximum addresses parsed/returned per family within one batched query.
-const max_addrs_per_family = 8;
+const max_addrs_per_family = dns.max_addrs_per_family;
 
 const num_dedup_buckets = 64;
 
@@ -159,25 +159,31 @@ pub const Resolver = struct {
         // 0. Numeric IP literal — parse directly without touching hosts or DNS.
         if (net.IpAddress.parseIp4(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv4) {
-                if (addr_storage.len == 0) return error.TooManyAddresses;
-                addr_storage[0] = .{ .address = addr };
+                var i: usize = 0;
+                if (addr_storage.len > 0) {
+                    addr_storage[0] = .{ .address = addr };
+                    i = 1;
+                }
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return 2;
+                    return i + 1;
                 }
-                return 1;
+                return i;
             }
             return error.AddressFamilyUnsupported;
         }
         if (net.IpAddress.parseIp6(options.name, options.port) catch null) |addr| {
             if (options.family == null or options.family == .ipv6) {
-                if (addr_storage.len == 0) return error.TooManyAddresses;
-                addr_storage[0] = .{ .address = addr };
+                var i: usize = 0;
+                if (addr_storage.len > 0) {
+                    addr_storage[0] = .{ .address = addr };
+                    i = 1;
+                }
                 if (cname_buf) |buf| {
                     storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
-                    return 2;
+                    return i + 1;
                 }
-                return 1;
+                return i;
             }
             return error.AddressFamilyUnsupported;
         }
@@ -189,17 +195,22 @@ pub const Resolver = struct {
 
             if (self.hosts.lookupByName(options.name)) |addrs| {
                 var i: usize = 0;
+                // Track matches separately from what fits: a hosts entry that
+                // matched the family filter must answer the lookup even when
+                // nothing fits the buffer, rather than fall through to DNS.
+                var matched = false;
                 for (addrs) |addr_in| {
                     if (options.family) |f| {
                         if (addr_in.getFamily() != f) continue;
                     }
-                    if (i >= addr_storage.len) return error.TooManyAddresses;
+                    matched = true;
+                    if (i >= addr_storage.len) break;
                     var addr = addr_in;
                     addr.setPort(options.port);
                     addr_storage[i] = .{ .address = addr };
                     i += 1;
                 }
-                if (i > 0) {
+                if (matched) {
                     if (cname_buf) |buf| {
                         storage[0] = .{ .canonical_name = .{ .bytes = buf[0..options.name.len] } };
                         return i + 1;
@@ -252,7 +263,7 @@ pub const Resolver = struct {
             if (self.cache.get(&key, now)) |entry| {
                 var i: usize = 0;
                 for (entry.addrs[0..entry.count]) |addr_in| {
-                    if (i >= storage.len) return error.TooManyAddresses;
+                    if (i >= storage.len) break;
                     var addr = addr_in;
                     addr.setPort(options.port);
                     storage[i] = .{ .address = addr };
@@ -307,13 +318,15 @@ pub const Resolver = struct {
         bucket.waiters.push(&active_node);
         bucket.mutex.unlock();
 
+        // Always resolve into an internal buffer sized for the full answer, so
+        // what gets cached never depends on the caller's buffer; the caller
+        // receives whatever prefix fits.
         var tmp: [2 * max_addrs_per_family]dns.LookupResult = undefined;
-        const buf: []dns.LookupResult = if (storage.len >= tmp.len) storage else tmp[0..];
-        const result = self.lookupDnsBatched(buf, opts, shape);
+        const result = self.lookupDnsBatched(tmp[0..], opts, shape);
 
         if (result) |r| {
             const now_updated = getCurrentTime();
-            self.cacheInsert(options.name, shape, buf[0..r.count], r.ttl, now_updated);
+            self.cacheInsert(options.name, shape, tmp[0..r.count], r.truncated, r.ttl, now_updated);
         } else |_| {}
 
         // Notify all joiners, then remove the active node.
@@ -322,17 +335,14 @@ pub const Resolver = struct {
         while (wit) |n| : (wit = n.next) {
             if (!n.is_active and !n.done and n.key.eql(&key)) {
                 if (result) |r| {
-                    if (r.count > n.storage.len) {
-                        n.err = error.TooManyAddresses;
-                    } else {
-                        @memcpy(n.storage[0..r.count], buf[0..r.count]);
-                        n.count = r.count;
-                        n.canonical_name_len = r.canonical_name_len;
-                        if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
-                            @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
-                        };
-                        n.err = null;
-                    }
+                    const c = @min(r.count, n.storage.len);
+                    @memcpy(n.storage[0..c], tmp[0..c]);
+                    n.count = c;
+                    n.canonical_name_len = r.canonical_name_len;
+                    if (r.canonical_name_len > 0) if (n.canonical_name_buffer) |cbuf| {
+                        @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
+                    };
+                    n.err = null;
                 } else |err| {
                     n.count = 0;
                     n.err = err;
@@ -348,12 +358,9 @@ pub const Resolver = struct {
         if (r.canonical_name_len > 0) if (options.canonical_name_buffer) |cbuf| {
             @memcpy(cbuf[0..r.canonical_name_len], cname_buf[0..r.canonical_name_len]);
         };
-        if (buf.ptr != storage.ptr) {
-            if (r.count > storage.len) return error.TooManyAddresses;
-            @memcpy(storage[0..r.count], buf[0..r.count]);
-            return .{ .count = r.count, .canonical_name_len = r.canonical_name_len };
-        }
-        return .{ .count = r.count, .canonical_name_len = r.canonical_name_len };
+        const c = @min(r.count, storage.len);
+        @memcpy(storage[0..c], tmp[0..c]);
+        return .{ .count = c, .canonical_name_len = r.canonical_name_len };
     }
 
     fn lookupDnsBatched(
@@ -465,11 +472,11 @@ pub const Resolver = struct {
         return last_err;
     }
 
-    fn cacheInsert(self: *Resolver, name: []const u8, shape: Shape, results: []const dns.LookupResult, ttl: u32, now: Timestamp) void {
+    fn cacheInsert(self: *Resolver, name: []const u8, shape: Shape, results: []const dns.LookupResult, truncated: bool, ttl: u32, now: Timestamp) void {
         var key: CacheKey = undefined;
         CacheKey.init(&key, name, self.hash_seed, shape);
 
-        if (results.len == 0 or results.len > max_cached_addrs) {
+        if (results.len == 0 or truncated or results.len > max_cached_addrs) {
             self.lock.lockUncancelable();
             defer self.lock.unlock();
             self.cache.expire(&key);
@@ -564,7 +571,14 @@ fn makeFqdn(buf: *[256]u8, name: []const u8, suffix: ?[]const u8) ?[]u8 {
     return buf[0..total];
 }
 
-const QueryResult = struct { count: usize, ttl: u32, canonical_name_len: usize = 0 };
+const QueryResult = struct {
+    count: usize,
+    ttl: u32,
+    canonical_name_len: usize = 0,
+    // True when a family had more records than max_addrs_per_family; the
+    // result is incomplete and must not be cached.
+    truncated: bool = false,
+};
 
 /// Per-family state tracked across the attempts × servers loop of one batched
 /// query. A query is `done` once it reaches a terminal state (records found or
@@ -578,6 +592,7 @@ const FamilyQuery = struct {
     answered: bool = false, // got a response this send-round (for recv accounting)
     addrs: [max_addrs_per_family]net.IpAddress = undefined,
     count: usize = 0,
+    overflow: bool = false, // the answer had more records than `addrs` holds
     ttl: u32 = 0,
 };
 
@@ -718,6 +733,7 @@ fn queryBatch(
                             const c = @min(result.count, parse_addrs.len);
                             @memcpy(q.addrs[0..c], parse_addrs[0..c]);
                             q.count = c;
+                            q.overflow = result.count > parse_addrs.len;
                             q.ttl = result.ttl;
                             q.found = c > 0;
                             q.done = true;
@@ -766,6 +782,7 @@ fn queryBatch(
                     const c = @min(result.count, parse_addrs.len);
                     @memcpy(q.addrs[0..c], parse_addrs[0..c]);
                     q.count = c;
+                    q.overflow = result.count > parse_addrs.len;
                     q.ttl = result.ttl;
                     q.found = c > 0;
                     if (q.found and canonical_name_len == 0 and result.canonical_name_len > 0) {
@@ -798,6 +815,7 @@ fn queryBatch(
     var total: usize = 0;
     var min_ttl: u32 = 0;
     var any_found = false;
+    var any_overflow = false;
     var all_done = true;
     for (qs) |*q| {
         if (q.found) {
@@ -808,12 +826,13 @@ fn queryBatch(
             }
             min_ttl = if (!any_found) q.ttl else @min(min_ttl, q.ttl);
             any_found = true;
+            if (q.overflow) any_overflow = true;
         }
         if (!q.done) all_done = false;
     }
 
     if (any_found) {
-        return .{ .count = total, .ttl = min_ttl, .canonical_name_len = canonical_name_len };
+        return .{ .count = total, .ttl = min_ttl, .canonical_name_len = canonical_name_len, .truncated = any_overflow };
     }
     if (all_done) {
         // Every family answered definitively with no records → advance candidate.
@@ -908,4 +927,122 @@ fn loadResolvConf(allocator: std.mem.Allocator, mtime_out: *i64) ResolvConf {
         log.warn("dns: failed to parse /etc/resolv.conf: {}", .{err});
         return .{ .arena = .init(allocator), .servers = &.{}, .search = &.{}, .parse_error = true };
     };
+}
+
+// -- Tests --------------------------------------------------------------------
+
+const Runtime = @import("../../runtime.zig").Runtime;
+
+/// Builds a DNS response for `query` with `num_answers` records of `qtype`,
+/// each answer's name a compression pointer to the question. Addresses are
+/// distinct: 10.0.x.x for A, 2001::x for AAAA.
+fn buildTestResponse(out: []u8, query: []const u8, num_answers: u16, qtype: message.QType) usize {
+    // Find the end of the question section (QNAME + QTYPE + QCLASS).
+    var p: usize = 12;
+    while (query[p] != 0) p += query[p] + 1;
+    p += 1 + 4;
+    const qend = p;
+
+    @memcpy(out[0..2], query[0..2]); // id
+    std.mem.writeInt(u16, out[2..4], 0x8180, .big); // QR + RD + RA, NOERROR
+    std.mem.writeInt(u16, out[4..6], 1, .big); // QDCOUNT
+    std.mem.writeInt(u16, out[6..8], num_answers, .big); // ANCOUNT
+    std.mem.writeInt(u16, out[8..10], 0, .big); // NSCOUNT
+    std.mem.writeInt(u16, out[10..12], 0, .big); // ARCOUNT
+    @memcpy(out[12..qend], query[12..qend]);
+
+    var w: usize = qend;
+    for (0..num_answers) |i| {
+        std.mem.writeInt(u16, out[w..][0..2], 0xC00C, .big); // name: ptr to question
+        std.mem.writeInt(u16, out[w + 2 ..][0..2], @intFromEnum(qtype), .big);
+        std.mem.writeInt(u16, out[w + 4 ..][0..2], 1, .big); // class IN
+        std.mem.writeInt(u32, out[w + 6 ..][0..4], 60, .big); // ttl
+        w += 10;
+        switch (qtype) {
+            .a => {
+                std.mem.writeInt(u16, out[w..][0..2], 4, .big);
+                out[w + 2] = 10;
+                out[w + 3] = 0;
+                out[w + 4] = @intCast((i >> 8) & 0xff);
+                out[w + 5] = @intCast(i & 0xff);
+                w += 6;
+            },
+            .aaaa => {
+                std.mem.writeInt(u16, out[w..][0..2], 16, .big);
+                @memset(out[w + 2 ..][0..16], 0);
+                out[w + 2] = 0x20;
+                out[w + 3] = 0x01;
+                out[w + 16] = @intCast((i >> 8) & 0xff);
+                out[w + 17] = @intCast(i & 0xff);
+                w += 18;
+            },
+            _ => unreachable,
+        }
+    }
+    return w;
+}
+
+/// Serves `num_queries` DNS queries on `sock`, answering A queries with
+/// `num_a` records and AAAA queries with `num_aaaa`.
+const TestDnsServer = struct {
+    fn run(sock: net.Socket, num_a: u16, num_aaaa: u16, num_queries: usize) !void {
+        var qbuf: [512]u8 = undefined;
+        var rbuf: [4096]u8 = undefined;
+        var served: usize = 0;
+        while (served < num_queries) : (served += 1) {
+            const r = try sock.receiveFrom(&qbuf, .none);
+            var p: usize = 12;
+            while (qbuf[p] != 0) p += qbuf[p] + 1;
+            const qtype: message.QType = @enumFromInt(std.mem.readInt(u16, qbuf[p + 1 ..][0..2], .big));
+            const n = if (qtype == .a) num_a else num_aaaa;
+            const len = buildTestResponse(&rbuf, qbuf[0..r.len], n, qtype);
+            _ = try sock.sendTo(r.from, rbuf[0..len], .none);
+        }
+    }
+};
+
+test "queryBatch: answer beyond the family buffer is capped and flagged, not an error" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const bind_addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    const sock = try bind_addr.bind(.{});
+    defer sock.close();
+
+    var server_task = try rt.spawn(TestDnsServer.run, .{ sock, 80, 0, 1 });
+    defer server_task.cancel();
+
+    var resolver = Resolver.init(std.testing.allocator);
+    defer resolver.deinit();
+
+    var storage: [2 * max_addrs_per_family]dns.LookupResult = undefined;
+    const servers = [_]net.IpAddress{sock.address.ip};
+    const r = try queryBatch(&resolver, storage[0..], .{ .name = "big.test", .port = 80 }, "big.test.", .ipv4, &servers, 1, .fromSeconds(5));
+
+    try std.testing.expectEqual(max_addrs_per_family, r.count);
+    try std.testing.expect(r.truncated);
+    try server_task.join();
+}
+
+test "queryBatch: answer within the family buffer is complete and unflagged" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const bind_addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    const sock = try bind_addr.bind(.{});
+    defer sock.close();
+
+    var server_task = try rt.spawn(TestDnsServer.run, .{ sock, 12, 0, 1 });
+    defer server_task.cancel();
+
+    var resolver = Resolver.init(std.testing.allocator);
+    defer resolver.deinit();
+
+    var storage: [2 * max_addrs_per_family]dns.LookupResult = undefined;
+    const servers = [_]net.IpAddress{sock.address.ip};
+    const r = try queryBatch(&resolver, storage[0..], .{ .name = "big.test", .port = 80 }, "big.test.", .ipv4, &servers, 1, .fromSeconds(5));
+
+    try std.testing.expectEqual(12, r.count);
+    try std.testing.expect(!r.truncated);
+    try server_task.join();
 }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -31,9 +31,7 @@ const max_search_domain_len = 254;
 
 const Cache = @import("cache.zig").Cache;
 const CacheKey = @import("cache.zig").CacheKey;
-const CacheEntry = @import("cache.zig").CacheEntry;
 const Shape = @import("cache.zig").Shape;
-const max_cached_addrs = @import("cache.zig").max_cached_addrs;
 
 // Maximum addresses parsed/returned per family within one batched query.
 const max_addrs_per_family = dns.max_addrs_per_family;
@@ -108,7 +106,7 @@ pub const Resolver = struct {
             .conf_mtime = conf_mtime,
             .conf_next_check = .init(next_check_s),
             .conf_reloading = .init(false),
-            .cache = std.mem.zeroes(Cache),
+            .cache = .init(),
             .hash_seed = hash_seed,
             .prng_mutex = .init,
             .prng = prng,
@@ -260,16 +258,15 @@ pub const Resolver = struct {
         {
             try self.lock.lockShared();
             defer self.lock.unlockShared();
-            if (self.cache.get(&key, now)) |entry| {
-                var i: usize = 0;
-                for (entry.addrs[0..entry.count]) |addr_in| {
-                    if (i >= storage.len) break;
+            var cached: [2 * max_addrs_per_family]net.IpAddress = undefined;
+            if (self.cache.get(&key, now, cached[0..])) |n| {
+                const c = @min(n, storage.len);
+                for (cached[0..c], storage[0..c]) |addr_in, *out| {
                     var addr = addr_in;
                     addr.setPort(options.port);
-                    storage[i] = .{ .address = addr };
-                    i += 1;
+                    out.* = .{ .address = addr };
                 }
-                if (i > 0) return .{ .count = i, .canonical_name_len = 0 };
+                return .{ .count = c, .canonical_name_len = 0 };
             }
         }
 
@@ -476,7 +473,7 @@ pub const Resolver = struct {
         var key: CacheKey = undefined;
         CacheKey.init(&key, name, self.hash_seed, shape);
 
-        if (results.len == 0 or truncated or results.len > max_cached_addrs) {
+        if (results.len == 0 or truncated) {
             self.lock.lockUncancelable();
             defer self.lock.unlock();
             self.cache.expire(&key);
@@ -484,19 +481,15 @@ pub const Resolver = struct {
         }
 
         const ttl_secs = std.math.clamp(ttl, cache_ttl_min, cache_ttl_max);
-        var entry: CacheEntry = .{
-            .addrs = undefined,
-            .count = @intCast(results.len),
-            .expiry = now.addDuration(.fromSeconds(ttl_secs)),
-        };
-        for (results, 0..) |r, i| {
-            entry.addrs[i] = r.address;
-            entry.addrs[i].setPort(0);
+        var addrs: [2 * max_addrs_per_family]net.IpAddress = undefined;
+        for (results, addrs[0..results.len]) |r, *out| {
+            out.* = r.address;
+            out.setPort(0);
         }
 
         self.lock.lockUncancelable();
         defer self.lock.unlock();
-        self.cache.put(&key, entry, now);
+        self.cache.put(&key, addrs[0..results.len], now.addDuration(.fromSeconds(ttl_secs)), now);
     }
 
     fn maybeReloadHosts(self: *Resolver, now: Timestamp) void {

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -811,24 +811,45 @@ fn queryBatch(
         if (!resolved) q.done = false;
     }
 
-    // Assemble the union of all families that found records.
-    var total: usize = 0;
+    // Assemble the union of all families that found records, interleaved
+    // IPv6-first (RFC 6724 preference), so a caller whose buffer is smaller
+    // than the answer still sees both families. This runs before caching, so
+    // a cache hit and a fresh lookup return the same order.
     var min_ttl: u32 = 0;
     var any_found = false;
     var any_overflow = false;
     var all_done = true;
+    var v6: ?*FamilyQuery = null;
+    var v4: ?*FamilyQuery = null;
     for (qs) |*q| {
         if (q.found) {
-            for (q.addrs[0..q.count]) |a| {
-                if (total >= storage.len) break;
-                storage[total] = .{ .address = a };
-                total += 1;
-            }
+            if (q.qtype == .aaaa) v6 = q else v4 = q;
             min_ttl = if (!any_found) q.ttl else @min(min_ttl, q.ttl);
             any_found = true;
             if (q.overflow) any_overflow = true;
         }
         if (!q.done) all_done = false;
+    }
+
+    var total: usize = 0;
+    var next6: usize = 0;
+    var next4: usize = 0;
+    var take6 = true;
+    while (total < storage.len) {
+        const rem6 = if (v6) |q| q.count - next6 else 0;
+        const rem4 = if (v4) |q| q.count - next4 else 0;
+        if (rem6 == 0 and rem4 == 0) break;
+        // Alternate; once one family is exhausted, continue with the other.
+        const use6 = if (rem6 == 0) false else if (rem4 == 0) true else take6;
+        if (use6) {
+            storage[total] = .{ .address = v6.?.addrs[next6] };
+            next6 += 1;
+        } else {
+            storage[total] = .{ .address = v4.?.addrs[next4] };
+            next4 += 1;
+        }
+        total += 1;
+        take6 = !take6;
     }
 
     if (any_found) {
@@ -1044,5 +1065,31 @@ test "queryBatch: answer within the family buffer is complete and unflagged" {
 
     try std.testing.expectEqual(12, r.count);
     try std.testing.expect(!r.truncated);
+    try server_task.join();
+}
+
+test "queryBatch: dual-stack answers interleave IPv6-first" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const bind_addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    const sock = try bind_addr.bind(.{});
+    defer sock.close();
+
+    var server_task = try rt.spawn(TestDnsServer.run, .{ sock, 3, 2, 2 });
+    defer server_task.cancel();
+
+    var resolver = Resolver.init(std.testing.allocator);
+    defer resolver.deinit();
+
+    var storage: [2 * max_addrs_per_family]dns.LookupResult = undefined;
+    const servers = [_]net.IpAddress{sock.address.ip};
+    const r = try queryBatch(&resolver, storage[0..], .{ .name = "dual.test", .port = 80 }, "dual.test.", .both, &servers, 1, .fromSeconds(5));
+
+    try std.testing.expectEqual(5, r.count);
+    const expected_families = [_]net.IpAddress.Family{ .ipv6, .ipv4, .ipv6, .ipv4, .ipv4 };
+    for (storage[0..r.count], expected_families) |entry, family| {
+        try std.testing.expectEqual(family, entry.address.getFamily());
+    }
     try server_task.join();
 }

--- a/src/dns/resolver/resolver.zig
+++ b/src/dns/resolver/resolver.zig
@@ -32,6 +32,7 @@ const max_search_domain_len = 254;
 const Cache = @import("cache.zig").Cache;
 const CacheKey = @import("cache.zig").CacheKey;
 const Shape = @import("cache.zig").Shape;
+const max_entry_addrs = @import("cache.zig").max_entry_addrs;
 
 // Maximum addresses parsed/returned per family within one batched query.
 const max_addrs_per_family = dns.max_addrs_per_family;
@@ -258,7 +259,7 @@ pub const Resolver = struct {
         {
             try self.lock.lockShared();
             defer self.lock.unlockShared();
-            var cached: [2 * max_addrs_per_family]net.IpAddress = undefined;
+            var cached: [max_entry_addrs]net.IpAddress = undefined;
             if (self.cache.get(&key, now, cached[0..])) |n| {
                 const c = @min(n, storage.len);
                 for (cached[0..c], storage[0..c]) |addr_in, *out| {
@@ -318,7 +319,7 @@ pub const Resolver = struct {
         // Always resolve into an internal buffer sized for the full answer, so
         // what gets cached never depends on the caller's buffer; the caller
         // receives whatever prefix fits.
-        var tmp: [2 * max_addrs_per_family]dns.LookupResult = undefined;
+        var tmp: [max_entry_addrs]dns.LookupResult = undefined;
         const result = self.lookupDnsBatched(tmp[0..], opts, shape);
 
         if (result) |r| {
@@ -481,7 +482,7 @@ pub const Resolver = struct {
         }
 
         const ttl_secs = std.math.clamp(ttl, cache_ttl_min, cache_ttl_max);
-        var addrs: [2 * max_addrs_per_family]net.IpAddress = undefined;
+        var addrs: [max_entry_addrs]net.IpAddress = undefined;
         for (results, addrs[0..results.len]) |r, *out| {
             out.* = r.address;
             out.setPort(0);

--- a/src/dns/root.zig
+++ b/src/dns/root.zig
@@ -9,6 +9,13 @@ const runtime = @import("../runtime.zig");
 pub const IpAddress = net.IpAddress;
 pub const HostName = net.HostName;
 
+/// Maximum addresses the built-in resolver keeps per address family in one
+/// lookup. Records beyond this are silently dropped; results are never
+/// truncated below this limit by the resolver itself, only by the caller's
+/// buffer. A dual-stack lookup can thus return up to `2 * max_addrs_per_family`
+/// addresses (plus one canonical-name entry when requested).
+pub const max_addrs_per_family = 64;
+
 pub const LookupOptions = struct {
     name: []const u8,
     port: u16,
@@ -35,7 +42,6 @@ pub const LookupError = error{
     Canceled,
     RuntimeShutdown,
     NoThreadPool,
-    TooManyAddresses,
 };
 
 /// Extended error set used internally by Resolver/NoResolver. Includes
@@ -53,6 +59,10 @@ else if (builtin.os.tag.isDarwin() and backend.backend == .kqueue)
 else
     @import("posix.zig");
 
+/// Resolves a hostname, filling `storage` with up to `storage.len` results and
+/// returning the number of entries written. Addresses that do not fit are
+/// dropped without error — a full buffer may therefore mean the answer was
+/// truncated.
 pub fn lookup(
     storage: []LookupResult,
     options: LookupOptions,

--- a/src/dns/test.zig
+++ b/src/dns/test.zig
@@ -177,7 +177,7 @@ test "HostName: lookup with no storage" {
 
     const host = try HostName.init("localhost");
     var storage: [0]HostName.LookupResult = undefined;
-    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 80 }));
+    try std.testing.expectEqual(0, try host.lookup(&storage, .{ .port = 80 }));
 }
 
 test "HostName: lookup localhost" {
@@ -225,7 +225,7 @@ test "HostName: lookup numeric IPv4 with no storage" {
 
     const host = try HostName.init("127.0.0.1");
     var storage: [0]HostName.LookupResult = undefined;
-    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 8080 }));
+    try std.testing.expectEqual(0, try host.lookup(&storage, .{ .port = 8080 }));
 }
 
 test "HostName: lookup numeric IPv6 with no storage" {
@@ -234,7 +234,7 @@ test "HostName: lookup numeric IPv6 with no storage" {
 
     const host = try HostName.init("::1");
     var storage: [0]HostName.LookupResult = undefined;
-    try std.testing.expectError(error.TooManyAddresses, host.lookup(&storage, .{ .port = 8080 }));
+    try std.testing.expectEqual(0, try host.lookup(&storage, .{ .port = 8080 }));
 }
 
 test "HostName: lookup numeric IPv4 wrong family" {

--- a/src/dns/windows.zig
+++ b/src/dns/windows.zig
@@ -130,7 +130,7 @@ fn fillBuffers(
     while (current) |info| : (current = info.ai_next) {
         const addr = info.ai_addr orelse continue;
         if (addr.family != os_net.AF.INET and addr.family != os_net.AF.INET6) continue;
-        if (i >= storage.len) return error.TooManyAddresses;
+        if (i >= storage.len) break;
         storage[i] = .{ .address = dns.IpAddress.initPosix(@ptrCast(addr), @intCast(info.ai_addrlen)) };
         i += 1;
     }

--- a/src/io.zig
+++ b/src/io.zig
@@ -2527,7 +2527,9 @@ fn netLookupImpl(
     const io = fromRuntime(rt);
     defer resolved.close(io);
 
-    var storage: [32]zio_dns.LookupResult = undefined;
+    // Sized for the largest answer the resolver can return: both families
+    // plus one canonical-name entry.
+    var storage: [2 * zio_dns.max_addrs_per_family + 1]zio_dns.LookupResult = undefined;
     const count = zio_dns.lookup(&storage, .{
         .name = host_name.bytes,
         .port = options.port,
@@ -2536,10 +2538,7 @@ fn netLookupImpl(
             .ip6 => .ipv6,
         } else null,
         .canonical_name_buffer = options.canonical_name_buffer,
-    }) catch |err| switch (err) {
-        error.TooManyAddresses => storage.len,
-        else => return dnsLookupErrToStdErr(err),
-    };
+    }) catch |err| return dnsLookupErrToStdErr(err);
 
     for (storage[0..count]) |entry| switch (entry) {
         .address => |addr| {
@@ -2567,7 +2566,6 @@ fn dnsLookupErrToStdErr(err: zio_dns.LookupError) Io.net.HostName.LookupError {
         error.ProcessFdQuotaExceeded => error.ProcessFdQuotaExceeded,
         error.SystemResources, error.OutOfMemory => error.SystemResources,
         error.Canceled => error.Canceled,
-        error.TooManyAddresses => unreachable, // handled before calling this function
         error.Unexpected, error.ServiceUnavailable, error.NoThreadPool, error.RuntimeShutdown => error.Unexpected,
     };
 }

--- a/src/net.zig
+++ b/src/net.zig
@@ -154,7 +154,8 @@ pub const HostName = struct {
 
     /// Resolves the hostname to IP addresses.
     /// Fills `storage` with up to `storage.len` results.
-    /// Returns the number of entries written.
+    /// Returns the number of entries written. Addresses that do not fit are
+    /// dropped without error — a full buffer may mean the answer was truncated.
     pub fn lookup(
         self: HostName,
         storage: []LookupResult,
@@ -171,10 +172,7 @@ pub const HostName = struct {
     /// Resolves the hostname and connects to the first successful address.
     pub fn connect(self: HostName, port: u16, options: IpAddress.ConnectOptions) !Stream {
         var storage: [32]LookupResult = undefined;
-        const count = self.lookup(&storage, .{ .port = port }) catch |err| switch (err) {
-            error.TooManyAddresses => storage.len,
-            else => return err,
-        };
+        const count = try self.lookup(&storage, .{ .port = port });
 
         var last_err: ?anyerror = null;
         for (storage[0..count]) |entry| {


### PR DESCRIPTION
Fixes #626. Closes #625 by removing the error it is about.

## What changes

**The per-family cap goes from 8 to 64, and truncation is no longer an error.** Lookups always resolve into an internal buffer holding 64 addresses per family; the caller receives whatever prefix fits and the returned count says how much was written. `error.TooManyAddresses` is removed from `LookupError` — a breaking change, but both internal consumers (`netLookup`, `HostName.connect`) already caught it and converted it to exactly these fill-and-stop semantics, and std's `LookupError` has no such member either. This also fixes #625 structurally: with no aliasing of the caller's buffer, there is no path that can error out with the buffer in a path-dependent state.

**What gets cached never depends on the caller's buffer.** An answer that overflows the internal buffer is returned capped and never cached (`parseResponse` already reports the true record count; the flag now propagates through both the UDP and TCP paths instead of being discarded by `@min`).

**Dual-stack results interleave IPv6-first** (RFC 6724 preference) before caching, so a caller with a small buffer sees both families, and a cache hit returns the same order as a fresh lookup. Note this deliberately differs from getaddrinfo's grouped sort; the previous custom-resolver order was IPv4-first.

**The cache stores addresses in pooled 4-address chunks** linked by u16 index (1024 nodes shared across 1024 slots). The old inline entries held at most 6 addresses, so anything larger — including a 4+4 dual-stack answer — was never cached at all; inline storage at the new maximum would cost 3.6 MB. The pool caches everything up to the 128-address maximum and shrinks the cache from 221 KB to a measured 168 KB. `put` is infallible (rotating-cursor eviction; a comptime assert keeps the pool at least one maximal entry large, so a full sweep always frees enough). Indices rather than pointers keep `Resolver` safely movable by value, which is also why `std.mem.zeroes(Cache)` gave way to `Cache.init()`.

## Testing

- `zig build test`: 595/595 on Linux x86_64 (Debug, io_uring backend).
- New `queryBatch` tests against an in-process fake UDP DNS server: an 80-record answer yields 64 addresses with the truncated flag and no error (fails on the old code, which returned 8); a 12-record answer round-trips unflagged; a 3×A/2×AAAA answer interleaves v6,v4,v6,v4,v4.
- New cache unit tests: node conservation across expire/overwrite/eviction under a 4096-put pool-exhaustion loop, probe-window survival after a sweep, maximal 128-address round-trip, output-buffer truncation.
- `x86_64-windows-gnu` and `aarch64-macos` cross-compile clean; not run.

## Not covered

- End-to-end `lookup()` cache-interaction tests: the resolver reads `/etc/resolv.conf`/`/etc/hosts` from fixed paths, so testing the full path would need injection plumbing this PR doesn't add.
- Zero-length storage now returns 0 instead of erroring, including from `/etc/hosts` entries (a matched hosts name answers immediately rather than falling through to DNS).
- The 64-per-family cap is a policy choice (musl uses 48); it is documented on `max_addrs_per_family` and callers can detect possible truncation by a full buffer.
