### PR TITLE
io_uring: flush a full submission queue instead of dropping SQEs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed a deadlock in the io_uring backend when many operations were cancelled at once,
+  for example when a burst of operation timeouts expired together. A full submission
+  queue made the backend drop cancel requests with a "Failed to get io_uring SQE for
+  cancel" log line, leaving the cancelled operations running and the tasks awaiting them
+  blocked forever. The submission queue is now flushed to the kernel and the submission
+  retried whenever it fills up, for cancels and regular operations alike.
+
 - Added `withTimeout(timeout, func, args)`, the scoped form of `AutoCancel`: it arms the
   timer, runs `func`, and turns the `error.Canceled` the timeout produced back into
   `error.Timeout`. The result type is `func`'s own, with `error.Timeout` added to its

--- a/src/ev/backends/io_uring.zig
+++ b/src/ev/backends/io_uring.zig
@@ -329,11 +329,12 @@ pub fn wake(self: *Self, state: *LoopState) void {
 }
 
 /// Arm the multishot poll on the waker eventfd if needed. Returns false only
-/// when a rearm was needed but the SQ was full (caller must not block).
-/// Normally a no-op: the poll is armed once and the kernel keeps it armed.
+/// when a rearm was needed but the ring refused the SQE (caller must not
+/// block). Normally a no-op: the poll is armed once and the kernel keeps it
+/// armed.
 fn armWaker(self: *Self) bool {
     if (!self.waker_needs_rearm) return true;
-    const sqe = self.ring.get_sqe() catch return false;
+    const sqe = self.getSqe() orelse return false;
     sqe.prep_poll_add(self.waker_eventfd, linux.POLL.IN);
     sqe.len = linux.IORING_POLL_ADD_MULTI;
     sqe.user_data = specialUd(.waker, 0);
@@ -863,9 +864,14 @@ pub fn cancel(self: *Self, _: *LoopState, target: *Completion) void {
             // In poll(), we:
             // - Skip cancel CQEs with user_data=USER_DATA_CANCEL
             // - Process target CQE and mark target complete with error.Canceled (or natural result)
-            const sqe = self.ring.get_sqe() catch {
-                log.err("Failed to get io_uring SQE for cancel", .{});
-                // Cancel SQE failed - do nothing, let target complete naturally
+            // A dropped cancel is not benign: a cancel is submitted precisely
+            // because the target is not expected to complete on its own (e.g.
+            // a recv on a silent peer whose timeout just fired), so dropping
+            // it leaves the completion running and the awaiting task blocked
+            // forever. getSqe() flushes a full SQ and retries, so this only
+            // fails if the kernel refuses submissions outright.
+            const sqe = self.getSqe() orelse {
+                log.err("dropping cancel SQE, kernel refused submission; target may never complete", .{});
                 return;
             };
             sqe.prep_cancel(@intFromPtr(target), 0);
@@ -879,10 +885,29 @@ pub fn cancel(self: *Self, _: *LoopState, target: *Completion) void {
     }
 }
 
-/// Get an SQE or defer the completion to the pending list if the SQ is full.
-/// Returns null if deferred (caller should return immediately).
+/// Get an SQE, flushing the submission queue to the kernel if it is full.
+/// A full SQ consists entirely of entries the kernel has not been told about
+/// yet, so one non-blocking submit frees the whole ring and the retry
+/// succeeds. The flush is retried on signal interruption. Returns null only
+/// if the kernel refuses submissions outright (e.g. CQ overcommit); every
+/// caller needs a fallback for that case.
+fn getSqe(self: *Self) ?*linux.io_uring_sqe {
+    if (self.ring.get_sqe()) |sqe| return sqe else |_| {}
+    while (true) {
+        _ = self.ring.submit() catch |err| switch (err) {
+            error.SignalInterrupt => continue,
+            else => return null,
+        };
+        break;
+    }
+    return self.ring.get_sqe() catch null;
+}
+
+/// Get an SQE or defer the completion to the pending list if the ring will
+/// not accept one even after a flush. Returns null if deferred (caller should
+/// return immediately).
 fn getSqeOrDefer(self: *Self, c: *Completion) ?*linux.io_uring_sqe {
-    return self.ring.get_sqe() catch {
+    return self.getSqe() orelse {
         self.pending.push(c);
         return null;
     };
@@ -903,16 +928,17 @@ pub fn syncWallTimer(self: *Self, clock: Clock, deadline: ?u64) bool {
 
     // Remove the existing timeout (if any) before re-arming. The removed
     // timeout's CQE and the remove op's CQE are both ignored in poll(). If the
-    // SQ is full, leave wall_armed unchanged (old timeout stays valid) and
-    // report failure so the loop folds this clock into the capped poll timeout.
+    // ring refuses the SQE, leave wall_armed unchanged (old timeout stays
+    // valid) and report failure so the loop folds this clock into the capped
+    // poll timeout.
     if (self.wall_armed[idx] != null) {
-        const sqe = self.ring.get_sqe() catch return false;
+        const sqe = self.getSqe() orelse return false;
         sqe.prep_timeout_remove(specialUd(wallKind(idx), self.wall_generation[idx]), 0);
         sqe.user_data = specialUd(.cancel, 0);
     }
 
     if (deadline) |d| {
-        const sqe = self.ring.get_sqe() catch {
+        const sqe = self.getSqe() orelse {
             // Remove was queued but we can't arm the new timeout now. Forget it
             // (the next scan re-arms) and report failure so the loop folds.
             self.wall_armed[idx] = null;


### PR DESCRIPTION
Fixes #623.

## Problem

When more operation timeouts expired together than the SQ could absorb, `cancel` dropped its SQE with a `Failed to get io_uring SQE for cancel` log line, assuming the target would complete naturally. It does not: a cancel is submitted precisely because the target is not expected to finish on its own (a `recv` on a silent peer whose timeout just fired). The completion stayed `.running` forever, the race group in `timedWaitForIo` never resolved, and the awaiting tasks blocked permanently.

## Fix

A full SQ consists entirely of entries the kernel has not been told about yet, so a plain non-blocking `submit()` frees the whole ring. The new `getSqe()` helper flushes and retries (retrying the flush on EINTR), and every SQE acquisition now goes through it, not just cancel:

- `getSqeOrDefer` keeps the pending-list deferral, but only as the fallback for the kernel refusing submissions outright (EBUSY/EAGAIN). This also removes the latency wart where a deferred op sat unsubmitted through the next poll's wait.
- `cancel` logs and drops only in that same near-unreachable refusal case, with an honest message.
- `armWaker` and `syncWallTimer` keep their existing fold-back paths for it too.

The cancel target cannot ride the existing `pending` list: `drainPending` treats entries as awaiting submission, and both of its branches are wrong for a target already running in the kernel (early `ECANCELED` completion while the kernel still owns the buffers, or a double submission).

There are no linked SQE chains and no SQPOLL in this backend, so a mid-stream flush is safe at every call site.

The flush-and-retry approach for `cancel` follows the patch @floatdrop published on their fork (zoxy-io/zio, `fix/cancel-sqe-exhaustion`); this PR extends it to all submissions and retries the flush on EINTR.

## Verification

Built the issue's reproduction against baseline and patched trees (ReleaseSafe, 25s watchdog):

| | N=6000 | N=10000 |
|---|---|---|
| baseline (5e75fbe9) | hung 5/8 runs, 16-31 dropped cancels per hang | not run |
| patched | 0/8 hung, 0 dropped | 0/3 hung, 0 dropped |

`./check.sh`: 588/588 tests pass, plus a changelog entry.