### PR TITLE
test: tolerate a leaked working directory in the setCurrentDir test

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -2759,6 +2759,11 @@ test "io: processSetCurrentPath and processSetCurrentDir move the working direct
     var original_buf: [std.fs.max_path_bytes]u8 = undefined;
     const original = original_buf[0..try std.process.currentPath(io, &original_buf)];
 
+    // A previous run may have leaked the directory: the deferred cleanup below
+    // swallows errors, and on Windows CI a just-used directory can transiently
+    // resist deletion (e.g. an external scanner holds it open). Start from a
+    // clean slate so the test self-heals instead of failing on PathAlreadyExists.
+    dir.deleteDir(io, sub_path) catch {};
     try dir.createDir(io, sub_path, .default_dir);
     defer dir.deleteDir(io, sub_path) catch {};
 


### PR DESCRIPTION
## What

Pre-clean the `test_io_set_current_dir` leftover before `createDir` in the `processSetCurrentPath`/`processSetCurrentDir` test, so the test self-heals instead of failing with `PathAlreadyExists`.

## Why

The deferred `deleteDir ... catch {}` swallows errors, and on Windows CI a just-used directory can transiently resist deletion (e.g. an external scanner holding it open), leaking it for the next run. Seen on PR #605's Windows debug job: the iocp pass ran the test fine but leaked the directory, and the poll pass in the same job then failed `createDir` 95 seconds later.

## Test

Reproduced locally: with a planted `test_io_set_current_dir` directory, the unfixed test fails with the exact CI error; with the fix it passes and cleans up.