### PR TITLE
runtime: restore SIGPIPE protection lost in the Zig 0.16 migration

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -43,6 +43,19 @@ const ExecutorId = switch (@sizeOf(usize)) {
     8 => u6,
     else => @compileError("Unsupported architecture"),
 };
+
+// SIGPIPE protection. Zig 0.15's start code ignored SIGPIPE process-wide, but
+// Zig 0.16 moved that into std.Io.Threaded.init, which zio replaces — so
+// without this, a write to a peer-closed socket or pipe kills the process
+// instead of failing with EPIPE. (Zig's test runner creates its own
+// std.Io.Threaded, which is why tests never see the crash.) A do-nothing
+// handler rather than SIG_IGN so the disposition is not inherited across
+// execve into child processes, mirroring std.Io.Threaded.
+const have_sig_pipe = builtin.os.tag != .windows and @hasField(os.posix.SIG, "PIPE");
+
+// Only referenced when have_sig_pipe, so the posix types are never analyzed
+// on Windows.
+fn doNothingSignalHandler(_: os.posix.SIG) callconv(.c) void {}
 const mod = @This();
 
 /// Number of executor threads to run (including main).
@@ -1112,6 +1125,13 @@ pub const Runtime = struct {
     teardown: os.ResetEvent = .init(),
     own_self: bool = false,
 
+    /// Previous SIGPIPE disposition, restored in deinit. Only valid while
+    /// `sig_pipe_installed`; never installed when an embedder already changed
+    /// the disposition away from SIG_DFL (e.g. a host language runtime that
+    /// manages SIGPIPE itself).
+    old_sig_pipe: if (have_sig_pipe) os.posix.Sigaction else void = undefined,
+    sig_pipe_installed: bool = false,
+
     resolver: ?dns.Resolver = null,
 
     const Worker = struct {
@@ -1149,6 +1169,24 @@ pub const Runtime = struct {
             .resolver = if (options.dns.custom_resolver) dns.Resolver.init(allocator) else null,
         };
         errdefer if (self.resolver) |*r| r.deinit();
+
+        if (comptime have_sig_pipe) {
+            var old: os.posix.Sigaction = undefined;
+            os.posix.sigaction(os.posix.SIG.PIPE, null, &old);
+            if (old.handler.handler == os.posix.SIG.DFL) {
+                const act: os.posix.Sigaction = .{
+                    .handler = .{ .handler = doNothingSignalHandler },
+                    .mask = os.posix.sigemptyset(),
+                    .flags = 0,
+                };
+                os.posix.sigaction(os.posix.SIG.PIPE, &act, null);
+                self.old_sig_pipe = old;
+                self.sig_pipe_installed = true;
+            }
+        }
+        errdefer if (comptime have_sig_pipe) {
+            if (self.sig_pipe_installed) os.posix.sigaction(os.posix.SIG.PIPE, &self.old_sig_pipe, null);
+        };
 
         try self.thread_pool.init(allocator, options.thread_pool);
         errdefer self.thread_pool.deinit();
@@ -1253,6 +1291,10 @@ pub const Runtime = struct {
         self.task_pool.deinit();
 
         if (self.resolver) |*r| r.deinit();
+
+        if (comptime have_sig_pipe) {
+            if (self.sig_pipe_installed) os.posix.sigaction(os.posix.SIG.PIPE, &self.old_sig_pipe, null);
+        }
 
         // Free the Runtime allocation
         if (self.own_self) {
@@ -1958,4 +2000,50 @@ test "runtime: disable main executor" {
     var handle = try runtime.spawn(compute, .{21});
     const result = handle.join();
     try std.testing.expectEqual(42, result);
+}
+
+test "runtime: installs a SIGPIPE handler while the disposition is default" {
+    if (comptime !have_sig_pipe) return error.SkipZigTest;
+
+    // The test runner's std.Io.Threaded already owns SIGPIPE, so stash its
+    // disposition, run the whole test from SIG_DFL, and restore at the end.
+    var saved: os.posix.Sigaction = undefined;
+    os.posix.sigaction(os.posix.SIG.PIPE, null, &saved);
+    defer os.posix.sigaction(os.posix.SIG.PIPE, &saved, null);
+
+    const dfl: os.posix.Sigaction = .{
+        .handler = .{ .handler = os.posix.SIG.DFL },
+        .mask = os.posix.sigemptyset(),
+        .flags = 0,
+    };
+    os.posix.sigaction(os.posix.SIG.PIPE, &dfl, null);
+
+    var current: os.posix.Sigaction = undefined;
+    {
+        const runtime = try Runtime.init(std.testing.allocator, .{});
+        defer runtime.deinit();
+
+        // The runtime replaced SIG_DFL with its do-nothing handler.
+        os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
+        try std.testing.expect(current.handler.handler != os.posix.SIG.DFL);
+
+        // The proof: without the handler this write kills the test process.
+        const fds = try os.fs.pipe();
+        os.fs.close(fds[0]) catch {};
+        defer os.fs.close(fds[1]) catch {};
+        try std.testing.expectError(error.BrokenPipe, os.fs.write(fds[1], "x"));
+    }
+
+    // deinit restored SIG_DFL.
+    os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
+    try std.testing.expect(current.handler.handler == os.posix.SIG.DFL);
+
+    // A second runtime must leave a non-default (embedder-owned) disposition
+    // alone.
+    os.posix.sigaction(os.posix.SIG.PIPE, &saved, null);
+    {
+        const runtime = try Runtime.init(std.testing.allocator, .{});
+        defer runtime.deinit();
+        try std.testing.expect(!runtime.sig_pipe_installed);
+    }
 }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -53,9 +53,47 @@ const ExecutorId = switch (@sizeOf(usize)) {
 // execve into child processes, mirroring std.Io.Threaded.
 const have_sig_pipe = builtin.os.tag != .windows and @hasField(os.posix.SIG, "PIPE");
 
-// Only referenced when have_sig_pipe, so the posix types are never analyzed
-// on Windows.
-fn doNothingSignalHandler(_: os.posix.SIG) callconv(.c) void {}
+// The disposition is process-global while Runtime instances may overlap, so
+// ownership is refcounted at module scope: the first acquire installs (only
+// when the disposition is still SIG_DFL — embedders that manage SIGPIPE
+// themselves, e.g. a host language runtime, are left alone), and only the
+// last release restores what the install replaced. Only referenced when
+// have_sig_pipe, so the posix types are never analyzed on Windows.
+const sig_pipe_guard = struct {
+    var mutex: os.Mutex = .init();
+    var refcount: usize = 0;
+    var installed: bool = false;
+    var old: os.posix.Sigaction = undefined;
+
+    fn doNothingSignalHandler(_: os.posix.SIG) callconv(.c) void {}
+
+    fn acquire() void {
+        mutex.lock();
+        defer mutex.unlock();
+        refcount += 1;
+        if (refcount > 1) return;
+        os.posix.sigaction(os.posix.SIG.PIPE, null, &old);
+        if (old.handler.handler == os.posix.SIG.DFL) {
+            const act: os.posix.Sigaction = .{
+                .handler = .{ .handler = doNothingSignalHandler },
+                .mask = os.posix.sigemptyset(),
+                .flags = 0,
+            };
+            os.posix.sigaction(os.posix.SIG.PIPE, &act, null);
+            installed = true;
+        }
+    }
+
+    fn release() void {
+        mutex.lock();
+        defer mutex.unlock();
+        refcount -= 1;
+        if (refcount == 0 and installed) {
+            os.posix.sigaction(os.posix.SIG.PIPE, &old, null);
+            installed = false;
+        }
+    }
+};
 const mod = @This();
 
 /// Number of executor threads to run (including main).
@@ -1125,13 +1163,6 @@ pub const Runtime = struct {
     teardown: os.ResetEvent = .init(),
     own_self: bool = false,
 
-    /// Previous SIGPIPE disposition, restored in deinit. Only valid while
-    /// `sig_pipe_installed`; never installed when an embedder already changed
-    /// the disposition away from SIG_DFL (e.g. a host language runtime that
-    /// manages SIGPIPE itself).
-    old_sig_pipe: if (have_sig_pipe) os.posix.Sigaction else void = undefined,
-    sig_pipe_installed: bool = false,
-
     resolver: ?dns.Resolver = null,
 
     const Worker = struct {
@@ -1170,23 +1201,8 @@ pub const Runtime = struct {
         };
         errdefer if (self.resolver) |*r| r.deinit();
 
-        if (comptime have_sig_pipe) {
-            var old: os.posix.Sigaction = undefined;
-            os.posix.sigaction(os.posix.SIG.PIPE, null, &old);
-            if (old.handler.handler == os.posix.SIG.DFL) {
-                const act: os.posix.Sigaction = .{
-                    .handler = .{ .handler = doNothingSignalHandler },
-                    .mask = os.posix.sigemptyset(),
-                    .flags = 0,
-                };
-                os.posix.sigaction(os.posix.SIG.PIPE, &act, null);
-                self.old_sig_pipe = old;
-                self.sig_pipe_installed = true;
-            }
-        }
-        errdefer if (comptime have_sig_pipe) {
-            if (self.sig_pipe_installed) os.posix.sigaction(os.posix.SIG.PIPE, &self.old_sig_pipe, null);
-        };
+        if (comptime have_sig_pipe) sig_pipe_guard.acquire();
+        errdefer if (comptime have_sig_pipe) sig_pipe_guard.release();
 
         try self.thread_pool.init(allocator, options.thread_pool);
         errdefer self.thread_pool.deinit();
@@ -1292,9 +1308,7 @@ pub const Runtime = struct {
 
         if (self.resolver) |*r| r.deinit();
 
-        if (comptime have_sig_pipe) {
-            if (self.sig_pipe_installed) os.posix.sigaction(os.posix.SIG.PIPE, &self.old_sig_pipe, null);
-        }
+        if (comptime have_sig_pipe) sig_pipe_guard.release();
 
         // Free the Runtime allocation
         if (self.own_self) {
@@ -2038,12 +2052,28 @@ test "runtime: installs a SIGPIPE handler while the disposition is default" {
     os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
     try std.testing.expect(current.handler.handler == os.posix.SIG.DFL);
 
-    // A second runtime must leave a non-default (embedder-owned) disposition
-    // alone.
+    // Overlapping lifetimes: the disposition is owned by the group of live
+    // runtimes, so the first deinit must not strip protection from the second.
+    // Worker-thread executors only — two main executors cannot share the test
+    // thread (loop thread-affinity).
+    if (!builtin.single_threaded) {
+        const opts: RuntimeOptions = .{ .executors = .exact(1), .enable_main_executor = false };
+        const a = try Runtime.init(std.testing.allocator, opts);
+        const b = try Runtime.init(std.testing.allocator, opts);
+        a.deinit();
+        os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
+        try std.testing.expect(current.handler.handler != os.posix.SIG.DFL);
+        b.deinit();
+        os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
+        try std.testing.expect(current.handler.handler == os.posix.SIG.DFL);
+    }
+
+    // A non-default (embedder-owned) disposition must be left alone.
     os.posix.sigaction(os.posix.SIG.PIPE, &saved, null);
     {
         const runtime = try Runtime.init(std.testing.allocator, .{});
         defer runtime.deinit();
-        try std.testing.expect(!runtime.sig_pipe_installed);
+        os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
+        try std.testing.expect(current.handler.handler == saved.handler.handler);
     }
 }


### PR DESCRIPTION
## What

Install a do-nothing SIGPIPE handler in `Runtime.initStatic` (restored in `deinit`), so writes to peer-closed sockets and pipes fail with `EPIPE`/`BrokenPipe` instead of killing the process. The handler is only installed while the current disposition is `SIG_DFL`, so embedders that manage SIGPIPE themselves (e.g. CPython, which blazio embeds into) are left alone; a do-nothing handler rather than `SIG_IGN` so the disposition is not inherited across `execve` into child processes. Mirrors `std.Io.Threaded`.

## Why

Zig 0.15's start code ignored SIGPIPE process-wide for every executable (`maybeIgnoreSigpipe`, opt-out via `std.options.keep_sigpipe`). Zig 0.16 removed that and moved the behavior into `std.Io.Threaded.init` — which zio replaces with its own runtime. Since the 0.16 migration, any zio application writing to a broken pipe dies of SIGPIPE where it previously got a clean error. `MSG_NOSIGNAL` covers socket sends, but `write(2)` has no such flag (pipe writes, stdout into a closed pager), and neither does FreeBSD's `sendfile(2)` (the native path from #605).

CI never caught this because the Zig test runner creates its own `std.Io.Threaded`, which installs the handler and shields the entire test binary — verified: a plain Zig 0.16 executable performing the same broken-pipe write dies with exit 141.

This protection was actually implemented once before, on the zig-0.16 porting branch (`3a5c94d2`, "Zig 0.16 removed automatic signal ignoring from start()"), but was dropped when the migration landed on main via a different path. This restores the SIGPIPE half; the SIGIO half of that commit was legitimately superseded by the SIGURG-based syscall_cancel machinery.

## Test

New test resets the disposition to `SIG_DFL` (undoing the test runner's shield), creates a Runtime, and performs a write to a closed pipe — a write that kills the test process if the handler is missing. Also asserts install, restore-on-deinit, and that a non-default disposition is left untouched.