### PR TITLE
runtime: doze before stealing (give the idle executor's own loop a grace window)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Multi-threaded runtimes no longer steal work the moment an executor runs out of local
+  tasks. A freshly idle executor now gives its own event loop a short grace window first
+  (a non-blocking probe, then a park capped at 100us), since completions usually re-ready
+  the very tasks that just ran there. Stealing, which also migrates a task's pending I/O
+  to another loop, only starts once that window produces nothing, and an executor with
+  excess work still wakes an idle one immediately through the searcher protocol. This
+  removes speculative cross-executor task migration from the steady-state I/O path.
+
+- **BREAKING**: `Loop.run(mode)` and `ev.RunMode` are gone from the low-level event loop
+  API. Use `loop.poll(max_wait)` for a single pass, where `.zero` never blocks (the old
+  `.no_wait`), `.max` waits for the next event (the old `.once`), and anything in between
+  caps the wait. The parameterless `loop.run()` keeps the old `.until_done` behavior.
+
 - Fixed a deadlock in the io_uring backend when many operations were cancelled at once,
   for example when a burst of operation timeouts expired together. A full submission
   queue made the backend drop cancel requests with a "Failed to get io_uring SQE for

--- a/examples/ev_demo.zig
+++ b/examples/ev_demo.zig
@@ -10,7 +10,7 @@
 //! The low-level API is useful when you need:
 //! - Callback-based async instead of coroutines
 //! - Building a custom scheduler/runtime on top of zio.ev
-//! - Embedding in a game loop (call loop.run(.no_wait) each frame)
+//! - Embedding in a game loop (call loop.poll(.zero) each frame)
 
 const std = @import("std");
 const zio = @import("zio");
@@ -72,7 +72,7 @@ pub fn main() !void {
     slow_timer.start(&loop);
 
     // Run until all completions are done
-    try loop.run(.until_done);
+    try loop.run();
 
     std.log.info("", .{});
     std.log.info("[main] event loop finished", .{});

--- a/src/ev/README.md
+++ b/src/ev/README.md
@@ -33,7 +33,7 @@ pub fn main() !void {
     timer.c.callback = timerCallback;
     loop.add(&timer.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 fn timerCallback(loop: *ev.Loop, c: *ev.Completion) void {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -137,12 +137,6 @@ pub const LoopGroup = struct {
     shared: Backend.SharedState = .{},
 };
 
-pub const RunMode = enum {
-    no_wait,
-    once,
-    until_done,
-};
-
 fn timerDeadlineLess(_: void, a: *Timer, b: *Timer) bool {
     return a.deadline.value < b.deadline.value;
 }
@@ -821,15 +815,12 @@ pub const Loop = struct {
         }
     }
 
-    pub fn run(self: *Loop, mode: RunMode) !void {
+    /// Run the loop until every completion it owns has finished (or the loop
+    /// is stopped).
+    pub fn run(self: *Loop) !void {
         std.debug.assert(self.state.initialized);
-        if (self.state.stopped) return;
-        switch (mode) {
-            .no_wait => try self.tick(false),
-            .once => try self.tick(true),
-            .until_done => while (!self.done()) {
-                try self.tick(true);
-            },
+        while (!self.done()) {
+            try self.poll(.max);
         }
     }
 
@@ -1024,7 +1015,7 @@ pub const Loop = struct {
 
         // Each wall-clock domain has its own heap, compared against `now` in
         // that clock. The earliest remaining across all domains becomes the
-        // poll timeout; `tick`'s caller caps it at `max_wait`, which bounds how
+        // poll timeout; `poll` caps it at `max_wait`, which bounds how
         // far a boot/real timer can oversleep after a suspend or clock step
         // (the re-read of `now(clock)` on the next scan corrects it).
         for (0..wall_clock_count) |idx| {
@@ -1422,9 +1413,18 @@ pub const Loop = struct {
         self.state.markCompleted(&op.c);
     }
 
-    pub fn tick(self: *Loop, wait: bool) !void {
+    /// Process one batch of events: expire timers, poll the backend for
+    /// completions, run callbacks. `wait_cap` bounds how long the backend poll
+    /// may block: `.zero` never blocks (and skips the poll syscall entirely
+    /// when nothing is in flight), `.max` waits for the next event, anything
+    /// in between caps the wait at that duration (the executor's idle doze).
+    /// Timer deadlines, pending completions, and the loop's `max_wait` option
+    /// can all shorten the wait; they never lengthen it.
+    pub fn poll(self: *Loop, wait_cap: Duration) !void {
+        std.debug.assert(self.state.initialized);
         if (self.done()) return;
 
+        const wait = wait_cap.value != 0;
         const timer_result = self.checkTimers();
 
         // Re-send SIGURG to any worker still blocked in a canceled syscall.
@@ -1447,9 +1447,12 @@ pub const Loop = struct {
             if (self.state.cancel_resend != null and timeout.value > resend_interval.value) {
                 timeout = resend_interval;
             }
+            if (wait_cap.value < timeout.value) {
+                timeout = wait_cap;
+            }
         }
 
-        // Skip backend poll in no_wait mode if there's nothing to retrieve.
+        // Skip the backend poll when not waiting and there's nothing to retrieve.
         // This avoids syscall overhead for pure CPU-bound workloads.
         const should_poll = wait or self.backend.hasInflight();
         const wake_flags = self.state.wake_requested.swap(0, .acq_rel);

--- a/src/ev/root.zig
+++ b/src/ev/root.zig
@@ -16,7 +16,6 @@ pub const Backend = @import("backend.zig").Backend;
 
 pub const Loop = @import("loop.zig").Loop;
 pub const LoopGroup = @import("loop.zig").LoopGroup;
-pub const RunMode = @import("loop.zig").RunMode;
 pub const ThreadPool = @import("thread_pool.zig").ThreadPool;
 
 pub const ReadBuf = @import("buf.zig").ReadBuf;

--- a/src/ev/test/async_stress.zig
+++ b/src/ev/test/async_stress.zig
@@ -94,7 +94,7 @@ test "Async: cross-thread notify storm with rearm never strands work" {
 
     // Join before propagating a loop error: the producers publish into
     // stack-local state that must not be unwound under them.
-    const run_result = loop.run(.until_done);
+    const run_result = loop.run();
     for (threads) |t| t.join();
     try run_result;
 
@@ -170,7 +170,7 @@ test "Async: notify racing the rearm re-add is never lost" {
 
     // On a loop error the producer would spin forever waiting for progress;
     // signal it before joining, and only then propagate.
-    const run_result = loop.run(.until_done);
+    const run_result = loop.run();
     ctx.abort.store(true, .release);
     t.join();
     try run_result;

--- a/src/ev/test/cancel.zig
+++ b/src/ev/test/cancel.zig
@@ -28,7 +28,7 @@ test "cancel: timer with loop.cancel()" {
     loop.cancel(&timer.c);
 
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed_ms = wall_timer.read().toMilliseconds();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -48,7 +48,7 @@ test "cancel: double cancel is idempotent" {
     loop.cancel(&timer.c);
     loop.cancel(&timer.c);
 
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectError(error.Canceled, timer.getResult());
 }
 
@@ -61,7 +61,7 @@ test "cancel: cancel completed operation is no-op" {
     loop.add(&timer.c);
 
     // Wait for timer to complete
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try timer.getResult();
 
@@ -82,7 +82,7 @@ test "cancel: cancel not-started operation marks for cancel on add" {
 
     // Now add - should immediately fail with Canceled
     loop.add(&timer.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectError(error.Canceled, timer.getResult());
 }
 
@@ -96,7 +96,7 @@ test "cancel: async handle with loop.cancel()" {
 
     loop.cancel(&async_handle.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try std.testing.expectError(error.Canceled, async_handle.getResult());
@@ -110,7 +110,7 @@ test "cancel: net_accept with loop.cancel()" {
     // Create and bind server socket
     var server_open: NetOpen = .init(.ipv4, .stream, .ip, .{ .nonblocking = true });
     loop.add(&server_open.c);
-    try loop.run(.until_done);
+    try loop.run();
     const server_sock = try server_open.getResult();
 
     var addr = net.sockaddr.in{
@@ -122,26 +122,26 @@ test "cancel: net_accept with loop.cancel()" {
     var addr_len: net.socklen_t = @sizeOf(@TypeOf(addr));
     var server_bind: NetBind = .init(server_sock, @ptrCast(&addr), &addr_len);
     loop.add(&server_bind.c);
-    try loop.run(.until_done);
+    try loop.run();
     try server_bind.getResult();
 
     // Listen
     var server_listen: NetListen = .init(server_sock, 1);
     loop.add(&server_listen.c);
-    try loop.run(.until_done);
+    try loop.run();
     try server_listen.getResult();
 
     // Start accept
     var accept_comp: NetAccept = .init(server_sock, null, null);
     loop.add(&accept_comp.c);
 
-    try loop.run(.no_wait);
+    try loop.poll(.zero);
     try std.testing.expectEqual(.running, accept_comp.c.loadState().phase);
 
     // Cancel with loop.cancel()
     loop.cancel(&accept_comp.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, accept_comp.c.loadState().phase);
     try std.testing.expectError(error.Canceled, accept_comp.getResult());
@@ -149,7 +149,7 @@ test "cancel: net_accept with loop.cancel()" {
     // Close server socket
     var close_server: NetClose = .init(server_sock);
     loop.add(&close_server.c);
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "cancel: net_recv with loop.cancel()" {
@@ -160,7 +160,7 @@ test "cancel: net_recv with loop.cancel()" {
     // Create socket pair
     var server_open: NetOpen = .init(.ipv4, .stream, .ip, .{ .nonblocking = true });
     loop.add(&server_open.c);
-    try loop.run(.until_done);
+    try loop.run();
     const server_sock = try server_open.getResult();
 
     var addr = net.sockaddr.in{
@@ -172,12 +172,12 @@ test "cancel: net_recv with loop.cancel()" {
     var addr_len: net.socklen_t = @sizeOf(@TypeOf(addr));
     var server_bind: NetBind = .init(server_sock, @ptrCast(&addr), &addr_len);
     loop.add(&server_bind.c);
-    try loop.run(.until_done);
+    try loop.run();
     try server_bind.getResult();
 
     var server_listen: NetListen = .init(server_sock, 1);
     loop.add(&server_listen.c);
-    try loop.run(.until_done);
+    try loop.run();
     try server_listen.getResult();
 
     // Get bound address
@@ -186,7 +186,7 @@ test "cancel: net_recv with loop.cancel()" {
     // Connect client
     var client_open: NetOpen = .init(.ipv4, .stream, .ip, .{ .nonblocking = true });
     loop.add(&client_open.c);
-    try loop.run(.until_done);
+    try loop.run();
     const client_sock = try client_open.getResult();
 
     var client_conn = ev.NetConnect.init(client_sock, @ptrCast(&addr), addr_len);
@@ -196,7 +196,7 @@ test "cancel: net_recv with loop.cancel()" {
     var accept: NetAccept = .init(server_sock, null, null);
     loop.add(&accept.c);
 
-    try loop.run(.until_done);
+    try loop.run();
     try client_conn.getResult();
     const accepted_sock = try accept.getResult();
 
@@ -206,13 +206,13 @@ test "cancel: net_recv with loop.cancel()" {
     var recv: NetRecv = .init(accepted_sock, .fromSlice(&buf, &read_iov), .{});
     loop.add(&recv.c);
 
-    try loop.run(.no_wait);
+    try loop.poll(.zero);
     try std.testing.expectEqual(.running, recv.c.loadState().phase);
 
     // Cancel with loop.cancel()
     loop.cancel(&recv.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, recv.c.loadState().phase);
     try std.testing.expectError(error.Canceled, recv.getResult());
@@ -224,7 +224,7 @@ test "cancel: net_recv with loop.cancel()" {
     loop.add(&close1.c);
     loop.add(&close2.c);
     loop.add(&close3.c);
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "cancel: cancel_requested flag is set on completion" {
@@ -241,7 +241,7 @@ test "cancel: cancel_requested flag is set on completion" {
 
     try std.testing.expect(timer.c.loadState().cancel_requested);
 
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "cancel: callback is invoked on canceled operation" {
@@ -268,7 +268,7 @@ test "cancel: callback is invoked on canceled operation" {
     loop.add(&timer.c);
 
     loop.cancel(&timer.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expect(ctx.called);
     try std.testing.expect(ctx.was_canceled);
@@ -285,7 +285,7 @@ test "cancel: race - operation completes before cancel" {
     loop.add(&timer.c);
 
     // Wait for it to complete
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try timer.getResult(); // Should succeed
 
@@ -309,7 +309,7 @@ test "cancel: multiple timers, cancel one" {
     // Cancel middle timer
     loop.cancel(&timer2.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // timer1 and timer3 should complete normally
     try timer1.getResult();
@@ -348,7 +348,7 @@ test "cancel: work after completion is no-op" {
     loop.add(&work.c);
 
     // Wait for work to complete
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try work.getResult();
     try std.testing.expect(test_fn.called);
@@ -418,7 +418,7 @@ test "cancel: work before run" {
     // Unblock the first work so the loop can complete
     blocker_event.set();
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try std.testing.expectError(error.Canceled, work.getResult());
@@ -487,7 +487,7 @@ test "cancel: work double cancel is idempotent" {
     // Unblock the first work so the loop can complete
     blocker_event.set();
 
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectError(error.Canceled, work.getResult());
     try std.testing.expect(!test_fn.called);
 }
@@ -593,7 +593,7 @@ test "cancel: cross-thread cancellation" {
     // Run loop1 until completion (should be cancelled quickly)
     var wall_timer = time.Stopwatch.start();
     while (!completed.load(.acquire)) {
-        try loop1.run(.once);
+        try loop1.poll(.max);
         if (wall_timer.read().toSeconds() > 1) {
             return error.TestTimeout;
         }

--- a/src/ev/test/dgram_server.zig
+++ b/src/ev/test/dgram_server.zig
@@ -371,7 +371,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     // Run loop until server reaches receiving state
     var iterations: usize = 0;
     while (server.state != .receiving and server.state != .failed) {
-        try loop.run(.once);
+        try loop.poll(.max);
         iterations += 1;
         if (iterations > 100) {
             return error.Timeout;
@@ -394,7 +394,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     client.start();
 
     // Run until both are done
-    try loop.run(.until_done);
+    try loop.run();
 
     // Verify results
     try std.testing.expectEqual(.done, server.state);

--- a/src/ev/test/dgram_server_msg.zig
+++ b/src/ev/test/dgram_server_msg.zig
@@ -420,7 +420,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     // Run loop until server reaches receiving state
     var iterations: usize = 0;
     while (server.state != .receiving and server.state != .failed) {
-        try loop.run(.once);
+        try loop.poll(.max);
         iterations += 1;
         if (iterations > 100) {
             return error.Timeout;
@@ -443,7 +443,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     client.start();
 
     // Run until both are done
-    try loop.run(.until_done);
+    try loop.run();
 
     // Verify results
     try std.testing.expectEqual(.done, server.state);

--- a/src/ev/test/fs.zig
+++ b/src/ev/test/fs.zig
@@ -20,7 +20,7 @@ test "File: open/close" {
     var file_create = ev.FileCreate.init(cwd, "test-file", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, file_create.c.loadState().phase);
     try std.testing.expectEqual(true, file_create.c.has_result);
@@ -37,7 +37,7 @@ test "File: open/close" {
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_write.c.loadState().phase);
     try std.testing.expectEqual(true, file_write.c.has_result);
     const bytes_written = try file_write.getResult();
@@ -46,7 +46,7 @@ test "File: open/close" {
     // Sync file (full sync)
     var file_sync1 = ev.FileSync.init(fd, .{ .only_data = false });
     loop.add(&file_sync1.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_sync1.c.loadState().phase);
     try std.testing.expectEqual(true, file_sync1.c.has_result);
     try file_sync1.getResult();
@@ -56,7 +56,7 @@ test "File: open/close" {
     var read_iov: [1]os.iovec = undefined;
     var file_read = ev.FileRead.init(fd, .fromSlice(&read_buffer, &read_iov), 0);
     loop.add(&file_read.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_read.c.loadState().phase);
     try std.testing.expectEqual(true, file_read.c.has_result);
     const bytes_read = try file_read.getResult();
@@ -66,7 +66,7 @@ test "File: open/close" {
     // Sync file (data only)
     var file_sync2 = ev.FileSync.init(fd, .{ .only_data = true });
     loop.add(&file_sync2.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_sync2.c.loadState().phase);
     try std.testing.expectEqual(true, file_sync2.c.has_result);
     try file_sync2.getResult();
@@ -74,7 +74,7 @@ test "File: open/close" {
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, file_close.c.loadState().phase);
     try std.testing.expectEqual(true, file_close.c.has_result);
@@ -99,7 +99,7 @@ test "File: rename/delete" {
     // Create a test file
     var file_create = ev.FileCreate.init(cwd, "test-rename-src", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_create.c.loadState().phase);
     const fd = (try file_create.getResult()).fd;
 
@@ -108,19 +108,19 @@ test "File: rename/delete" {
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_write.c.loadState().phase);
 
     // Close the file
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_close.c.loadState().phase);
 
     // Rename the file
     var file_rename = ev.DirRename.init(cwd, "test-rename-src", cwd, "test-rename-dst");
     loop.add(&file_rename.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_rename.c.loadState().phase);
     try std.testing.expectEqual(true, file_rename.c.has_result);
     try file_rename.getResult();
@@ -128,7 +128,7 @@ test "File: rename/delete" {
     // Verify the renamed file exists by opening it
     var file_open = ev.FileOpen.init(cwd, "test-rename-dst", .{ .mode = .read_only });
     loop.add(&file_open.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_open.c.loadState().phase);
     const fd2 = (try file_open.getResult()).fd;
 
@@ -137,7 +137,7 @@ test "File: rename/delete" {
     var read_iov2: [1]os.iovec = undefined;
     var file_read = ev.FileRead.init(fd2, .fromSlice(&read_buffer, &read_iov2), 0);
     loop.add(&file_read.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_read.c.loadState().phase);
     const bytes_read = try file_read.getResult();
     try std.testing.expectEqual(write_data.len, bytes_read);
@@ -146,13 +146,13 @@ test "File: rename/delete" {
     // Close the file
     var file_close2 = ev.FileClose.init(fd2);
     loop.add(&file_close2.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_close2.c.loadState().phase);
 
     // Delete the file
     var file_delete = ev.DirDeleteFile.init(cwd, "test-rename-dst");
     loop.add(&file_delete.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_delete.c.loadState().phase);
     try std.testing.expectEqual(true, file_delete.c.has_result);
     try file_delete.getResult();
@@ -160,7 +160,7 @@ test "File: rename/delete" {
     // Verify the file no longer exists
     var file_open_fail = ev.FileOpen.init(cwd, "test-rename-dst", .{ .mode = .read_only });
     loop.add(&file_open_fail.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_open_fail.c.loadState().phase);
     try std.testing.expectError(error.FileNotFound, file_open_fail.getResult());
 }
@@ -182,14 +182,14 @@ test "File: read EOF" {
     // Create and write a small file
     var file_create = ev.FileCreate.init(cwd, "test-eof", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
-    try loop.run(.until_done);
+    try loop.run();
     const fd = (try file_create.getResult()).fd;
 
     const write_data = "Hello";
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(write_data.len, try file_write.getResult());
 
     // Read all data
@@ -197,7 +197,7 @@ test "File: read EOF" {
     var read_iov1: [1]os.iovec = undefined;
     var file_read1 = ev.FileRead.init(fd, .fromSlice(&read_buffer1, &read_iov1), 0);
     loop.add(&file_read1.c);
-    try loop.run(.until_done);
+    try loop.run();
     const bytes_read1 = try file_read1.getResult();
     try std.testing.expectEqual(write_data.len, bytes_read1);
     try std.testing.expectEqualStrings(write_data, read_buffer1[0..bytes_read1]);
@@ -207,7 +207,7 @@ test "File: read EOF" {
     var read_iov2: [1]os.iovec = undefined;
     var file_read2 = ev.FileRead.init(fd, .fromSlice(&read_buffer2, &read_iov2), write_data.len);
     loop.add(&file_read2.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_read2.c.loadState().phase);
     try std.testing.expectEqual(true, file_read2.c.has_result);
     const bytes_read2 = try file_read2.getResult();
@@ -216,12 +216,12 @@ test "File: read EOF" {
     // Close and delete
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_close.getResult();
 
     var file_delete = ev.DirDeleteFile.init(cwd, "test-eof");
     loop.add(&file_delete.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_delete.getResult();
 }
 
@@ -242,13 +242,13 @@ test "File: size" {
     // Create a file
     var file_create = ev.FileCreate.init(cwd, "test-size", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
-    try loop.run(.until_done);
+    try loop.run();
     const fd = (try file_create.getResult()).fd;
 
     // Check size of empty file
     var file_size1 = ev.FileSize.init(fd);
     loop.add(&file_size1.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_size1.c.loadState().phase);
     try std.testing.expectEqual(true, file_size1.c.has_result);
     const size1 = try file_size1.getResult();
@@ -259,13 +259,13 @@ test "File: size" {
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(write_data.len, try file_write.getResult());
 
     // Check size after write
     var file_size2 = ev.FileSize.init(fd);
     loop.add(&file_size2.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_size2.c.loadState().phase);
     try std.testing.expectEqual(true, file_size2.c.has_result);
     const size2 = try file_size2.getResult();
@@ -276,25 +276,25 @@ test "File: size" {
     var write_iov2: [1]os.iovec_const = undefined;
     var file_write2 = ev.FileWrite.init(fd, .fromSlice(more_data, &write_iov2), write_data.len);
     loop.add(&file_write2.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(more_data.len, try file_write2.getResult());
 
     // Check final size
     var file_size3 = ev.FileSize.init(fd);
     loop.add(&file_size3.c);
-    try loop.run(.until_done);
+    try loop.run();
     const size3 = try file_size3.getResult();
     try std.testing.expectEqual(write_data.len + more_data.len, size3);
 
     // Close and delete
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_close.getResult();
 
     var file_delete = ev.DirDeleteFile.init(cwd, "test-size");
     loop.add(&file_delete.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_delete.getResult();
 }
 
@@ -315,13 +315,13 @@ test "File: stat" {
     // Create a file
     var file_create = ev.FileCreate.init(cwd, "test-stat", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
-    try loop.run(.until_done);
+    try loop.run();
     const fd = (try file_create.getResult()).fd;
 
     // Stat empty file (by fd - path is null)
     var file_stat1 = ev.FileStat.init(fd, null, .{});
     loop.add(&file_stat1.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_stat1.c.loadState().phase);
     try std.testing.expectEqual(true, file_stat1.c.has_result);
     const stat1 = try file_stat1.getResult();
@@ -334,13 +334,13 @@ test "File: stat" {
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(write_data.len, try file_write.getResult());
 
     // Stat after write (by fd - path is null)
     var file_stat2 = ev.FileStat.init(fd, null, .{});
     loop.add(&file_stat2.c);
-    try loop.run(.until_done);
+    try loop.run();
     const stat2 = try file_stat2.getResult();
     try std.testing.expectEqual(write_data.len, stat2.size);
     try std.testing.expectEqual(.file, stat2.kind);
@@ -350,12 +350,12 @@ test "File: stat" {
     // Close and delete
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_close.getResult();
 
     var file_delete = ev.DirDeleteFile.init(cwd, "test-stat");
     loop.add(&file_delete.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_delete.getResult();
 }
 
@@ -376,7 +376,7 @@ test "File: stat_path" {
     // Create a file
     var file_create = ev.FileCreate.init(cwd, "test-stat-path", .{ .read = true, .truncate = true, .mode = 0o664 });
     loop.add(&file_create.c);
-    try loop.run(.until_done);
+    try loop.run();
     const fd = (try file_create.getResult()).fd;
 
     // Write some data
@@ -384,19 +384,19 @@ test "File: stat_path" {
     var write_iov: [1]os.iovec_const = undefined;
     var file_write = ev.FileWrite.init(fd, .fromSlice(write_data, &write_iov), 0);
     loop.add(&file_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(write_data.len, try file_write.getResult());
 
     // Close file so we can stat by path
     var file_close = ev.FileClose.init(fd);
     loop.add(&file_close.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_close.getResult();
 
     // Stat by path (using FileStat with non-null path)
     var file_stat = ev.FileStat.init(cwd, "test-stat-path", .{});
     loop.add(&file_stat.c);
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, file_stat.c.loadState().phase);
     try std.testing.expectEqual(true, file_stat.c.has_result);
     const stat = try file_stat.getResult();
@@ -407,6 +407,6 @@ test "File: stat_path" {
     // Delete the file
     var file_delete = ev.DirDeleteFile.init(cwd, "test-stat-path");
     loop.add(&file_delete.c);
-    try loop.run(.until_done);
+    try loop.run();
     try file_delete.getResult();
 }

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -17,7 +17,7 @@ test "group: empty group completes immediately" {
     var group: Group = .init(.gather);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, group.c.loadState().phase);
     try group.getResult();
@@ -34,7 +34,7 @@ test "group: single completion" {
     group.add(&timer.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expectEqual(.dead, group.c.loadState().phase);
@@ -57,7 +57,7 @@ test "group: multiple completions" {
     group.add(&timer3.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, timer1.c.loadState().phase);
     try std.testing.expectEqual(.dead, timer2.c.loadState().phase);
@@ -118,7 +118,7 @@ test "group: callback invoked when all complete" {
     group.add(&timer2.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // Group callback should be called after both timer callbacks
     try std.testing.expect(ctx.group_callback_order > ctx.timer1_callback_order);
@@ -162,7 +162,7 @@ test "group: gather member freed by the group callback is not used-after-free (#
     group.add(&member.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expect(ctx.completed);
 }
@@ -185,7 +185,7 @@ test "group: cancel cancels all children" {
     // Cancel the group
     loop.cancel(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // All children should be canceled
     try std.testing.expectError(error.Canceled, timer1.getResult());
@@ -212,7 +212,7 @@ test "group: child error does not affect group result" {
     // Cancel just timer2, not the group
     loop.cancel(&timer2.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // timer1 should succeed
     try timer1.getResult();
@@ -240,7 +240,7 @@ test "group: mixed completion types" {
     // Notify async immediately
     async_handle.notify();
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
@@ -264,7 +264,7 @@ test "group: race mode first completer wins" {
     group.add(&slow_timer.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // Fast timer should complete successfully
     try fast_timer.getResult();
@@ -291,7 +291,7 @@ test "group: race mode cancels siblings" {
     group.add(&timer3.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // timer1 should complete successfully (it fires first)
     try timer1.getResult();
@@ -315,7 +315,7 @@ test "group: race mode with single child" {
     group.add(&timer.c);
     loop.add(&group.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     // Timer should complete successfully
     try timer.getResult();
@@ -347,7 +347,7 @@ test "group: nested gather inside race (timeout pattern) - ops complete first" {
     race.add(&ops.c);
 
     loop.add(&race.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     // Operations should complete successfully
     try op1.getResult();
@@ -384,7 +384,7 @@ test "group: nested gather inside race (timeout pattern) - timeout fires first" 
     race.add(&ops.c);
 
     loop.add(&race.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     // Timeout should complete successfully (it won the race)
     try timeout.getResult();
@@ -418,7 +418,7 @@ test "group: nested gather inside gather" {
     outer.add(&op3.c);
 
     loop.add(&outer.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     // All should complete successfully
     try op1.getResult();
@@ -449,7 +449,7 @@ test "group: nested race inside gather" {
     outer.add(&op.c);
 
     loop.add(&outer.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     // Fast wins inner race, slow is canceled
     try fast.getResult();
@@ -485,7 +485,7 @@ test "group: large batch exceeding queue size exercises deferred pending list" {
     var create_group: Group = .init(.gather);
     for (creates) |*pc| create_group.add(&pc.c);
     loop.add(&create_group.c);
-    try loop.run(.until_done);
+    try loop.run();
     try create_group.getResult();
 
     // Collect all fds from the created pipe pairs
@@ -507,7 +507,7 @@ test "group: large batch exceeding queue size exercises deferred pending list" {
     var close_group: Group = .init(.gather);
     for (closes) |*pc| close_group.add(&pc.c);
     loop.add(&close_group.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     for (closes) |*pc| try pc.getResult();
     try close_group.getResult();

--- a/src/ev/test/poll_server.zig
+++ b/src/ev/test/poll_server.zig
@@ -540,7 +540,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     // Run loop until server reaches accepting state
     var iterations: usize = 0;
     while (server.state != .accepting and server.state != .failed) {
-        try loop.run(.once);
+        try loop.poll(.max);
         iterations += 1;
         if (iterations > 100) {
             return error.Timeout;
@@ -557,7 +557,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     client.start();
 
     // Run until both are done
-    try loop.run(.until_done);
+    try loop.run();
 
     // Verify results
     try std.testing.expectEqual(.done, server.state);

--- a/src/ev/test/process_wait.zig
+++ b/src/ev/test/process_wait.zig
@@ -36,7 +36,7 @@ test "ProcessWait: wait for child process exit code 0" {
 
     var wait = ProcessWait.init(child.id.?);
     loop.add(&wait.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     const result = try wait.getResult();
     child.id = null;
@@ -61,7 +61,7 @@ test "ProcessWait: wait for child process exit code 1" {
 
     var wait = ProcessWait.init(child.id.?);
     loop.add(&wait.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     const result = try wait.getResult();
     child.id = null;
@@ -86,7 +86,7 @@ test "ProcessWait: wait for child process killed by signal" {
 
     var wait = ProcessWait.init(child.id.?);
     loop.add(&wait.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     const result = try wait.getResult();
     child.id = null;

--- a/src/ev/test/stream_server.zig
+++ b/src/ev/test/stream_server.zig
@@ -468,7 +468,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     // Run loop until server reaches accepting state
     var iterations: usize = 0;
     while (server.state != .accepting and server.state != .failed) {
-        try loop.run(.once);
+        try loop.poll(.max);
         iterations += 1;
         if (iterations > 100) {
             return error.Timeout;
@@ -485,7 +485,7 @@ fn testEcho(comptime domain: net.Domain, comptime sockaddr: type) !void {
     client.start();
 
     // Run until both are done
-    try loop.run(.until_done);
+    try loop.run();
 
     // Verify results
     try std.testing.expectEqual(.done, server.state);

--- a/src/ev/test/thread_pool.zig
+++ b/src/ev/test/thread_pool.zig
@@ -34,7 +34,7 @@ test "ev.ThreadPool: one task" {
 
     loop.add(&work.c);
 
-    try loop.run(.until_done);
+    try loop.run();
 
     try std.testing.expectEqual(.dead, work.c.loadState().phase);
     try std.testing.expectEqual(1, test_fn.called);

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -237,7 +237,7 @@ test "clearTimer racing a firing timer (cross-thread)" {
             defer {
                 // Deinit belongs to this thread, but must not race the main
                 // thread's final wake(): a stale wake from the last clearTimer
-                // can pop run(.once) before that wake() is issued.
+                // can pop poll(.max) before that wake() is issued.
                 while (!w.load(.acquire)) std.Thread.yield() catch {};
                 l.deinit();
             }

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -15,7 +15,7 @@ test "setTimer and clearTimer basic" {
     try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -41,7 +41,7 @@ test "clearTimer before expiration" {
 
     // Run the loop - should complete immediately with no active timers
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.once);
+    try loop.poll(.max);
     const elapsed = wall_timer.read();
 
     // Should be very fast since there's nothing to wait for
@@ -71,7 +71,7 @@ test "clearTimer reports a callback it could not stop" {
     }.cb;
 
     loop.setTimer(&timer, .{ .duration = .zero });
-    try loop.run(.once);
+    try loop.poll(.max);
     try std.testing.expect(!fired);
 
     try std.testing.expect(!loop.clearTimer(&timer));
@@ -103,7 +103,7 @@ test "setTimer multiple times" {
 
     // Should complete after ~10ms, not 2000ms
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -129,7 +129,7 @@ test "clearTimer and reuse timer" {
     try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -147,7 +147,7 @@ test "timer with zero duration completes immediately" {
 
     var wall_timer = time.Stopwatch.start();
     loop.add(&timer.c);
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -166,7 +166,7 @@ test "timer with explicit deadline" {
 
     var wall_timer = time.Stopwatch.start();
     loop.add(&timer.c);
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -185,7 +185,7 @@ test "timer on boot clock fires (duration)" {
     try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -207,7 +207,7 @@ test "timer on real clock fires (absolute deadline)" {
 
     var wall_timer = time.Stopwatch.start();
     loop.add(&timer.c);
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -243,7 +243,7 @@ test "clearTimer racing a firing timer (cross-thread)" {
             }
             r.store(true, .release);
             while (!s.load(.acquire)) {
-                l.run(.once) catch return;
+                l.poll(.max) catch return;
             }
         }
     }.run, .{ &loop, &ready, &stop, &wake_done });

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -37,7 +37,7 @@ test "Loop: empty run(.no_wait)" {
     try loop.init(.{});
     defer loop.deinit();
 
-    try loop.run(.no_wait);
+    try loop.poll(.zero);
 }
 
 test "Loop: empty run(.once)" {
@@ -45,7 +45,7 @@ test "Loop: empty run(.once)" {
     try loop.init(.{});
     defer loop.deinit();
 
-    try loop.run(.once);
+    try loop.poll(.max);
 }
 
 test "Loop: empty run(.until_done)" {
@@ -53,7 +53,7 @@ test "Loop: empty run(.until_done)" {
     try loop.init(.{});
     defer loop.deinit();
 
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "Loop: timer basic" {
@@ -66,7 +66,7 @@ test "Loop: timer basic" {
     loop.add(&timer.c);
 
     var wall_timer = time.Stopwatch.start();
-    try loop.run(.until_done);
+    try loop.run();
     const elapsed = wall_timer.read();
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
@@ -83,13 +83,13 @@ test "Loop: close" {
     // Create a socket first
     var open: NetOpen = .init(.ipv4, .stream, .ip, .{ .nonblocking = true });
     loop.add(&open.c);
-    try loop.run(.until_done);
+    try loop.run();
     const sock = try open.c.getResult(.net_open);
 
     // Now close it
     var close: NetClose = .init(sock);
     loop.add(&close.c);
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "Loop: socket create and bind" {
@@ -100,7 +100,7 @@ test "Loop: socket create and bind" {
     // Create socket
     var open: NetOpen = .init(.ipv4, .stream, .ip, .{ .nonblocking = true });
     loop.add(&open.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     const sock = try open.c.getResult(.net_open);
 
@@ -114,14 +114,14 @@ test "Loop: socket create and bind" {
     var addr_len: net.socklen_t = @sizeOf(@TypeOf(addr));
     var bind: NetBind = .init(sock, @ptrCast(&addr), &addr_len);
     loop.add(&bind.c);
-    try loop.run(.until_done);
+    try loop.run();
 
     try bind.c.getResult(.net_bind);
 
     // Close socket
     var close: NetClose = .init(sock);
     loop.add(&close.c);
-    try loop.run(.until_done);
+    try loop.run();
 }
 
 test "Loop: async notification - same thread" {
@@ -136,7 +136,7 @@ test "Loop: async notification - same thread" {
     async_handle.notify();
 
     // Run loop - async should complete
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try async_handle.c.getResult(.async);
 }
@@ -163,7 +163,7 @@ test "Loop: async notification - cross-thread" {
     }.notifyThread, .{&ctx});
 
     // Run loop - should block until notified
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
     try async_handle.c.getResult(.async);
 
@@ -189,7 +189,7 @@ test "Loop: async notification - multiple handles" {
     async3.notify();
 
     // Run loop - all should complete
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, async1.c.loadState().phase);
     try std.testing.expectEqual(.dead, async2.c.loadState().phase);
     try std.testing.expectEqual(.dead, async3.c.loadState().phase);
@@ -205,14 +205,14 @@ test "Loop: async notification - re-arm" {
     // First notification cycle
     loop.add(&async_handle.c);
     async_handle.notify();
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
 
     // Re-arm for second notification
     async_handle = .init();
     loop.add(&async_handle.c);
     async_handle.notify();
-    try loop.run(.until_done);
+    try loop.run();
     try std.testing.expectEqual(.dead, async_handle.c.loadState().phase);
 }
 
@@ -235,7 +235,7 @@ test "Pipe: write and read" {
     var stream_write: FileWriteStreaming = .init(pipefd[1], write_buf);
     stream_write.pollable = true;
     loop.add(&stream_write.c);
-    try loop.run(.until_done);
+    try loop.run();
     const written = try stream_write.getResult();
     try std.testing.expectEqual(write_data.len, written);
 
@@ -246,7 +246,7 @@ test "Pipe: write and read" {
     var stream_read: FileReadStreaming = .init(pipefd[0], read_buf);
     stream_read.pollable = true;
     loop.add(&stream_read.c);
-    try loop.run(.until_done);
+    try loop.run();
     const read_len = try stream_read.getResult();
     try std.testing.expectEqual(write_data.len, read_len);
     try std.testing.expectEqualStrings(write_data, read_data[0..read_len]);
@@ -271,7 +271,7 @@ test "Pipe: poll for readability" {
     // Poll for readability
     var stream_poll: PipePoll = .init(pipefd[0], .read);
     loop.add(&stream_poll.c);
-    try loop.run(.until_done);
+    try loop.run();
     try stream_poll.getResult();
 
     // Verify we can read the data

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -32,7 +32,7 @@ test {
     _ = @import("test/async_stress.zig");
 }
 
-test "Loop: empty run(.no_wait)" {
+test "Loop: empty poll(.zero)" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();
@@ -40,7 +40,7 @@ test "Loop: empty run(.no_wait)" {
     try loop.poll(.zero);
 }
 
-test "Loop: empty run(.once)" {
+test "Loop: empty poll(.max)" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();
@@ -48,7 +48,7 @@ test "Loop: empty run(.once)" {
     try loop.poll(.max);
 }
 
-test "Loop: empty run(.until_done)" {
+test "Loop: empty run()" {
     var loop: Loop = undefined;
     try loop.init(.{});
     defer loop.deinit();

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -642,6 +642,13 @@ pub const Executor = struct {
                 self.processCleanup();
             }
 
+            // Quanta spent this cycle mean tasks ran here, which re-arms the
+            // doze grace window (see parkAndSearch). Same bookkeeping family
+            // as the tick budget, but consulted here rather than in the
+            // retune below: the park decision runs between the two, and it
+            // must see the fresh value.
+            if (self.tick_task_count > 0) self.dozed = false;
+
             // Exit if loop is stopped
             if (self.loop.stopped()) {
                 if (mode == .until_stopped) {
@@ -652,7 +659,6 @@ pub const Executor = struct {
 
             const has_work = self.checkLocalWork(check_ready);
             if (has_work) {
-                self.dozed = false;
                 try self.loop.poll(.zero);
             } else {
                 try self.parkAndSearch(check_ready);

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -395,6 +395,11 @@ pub const Executor = struct {
     // average (see scheduleTaskLocal).
     shed_quota: u32 = 0,
 
+    // Whether this executor has already spent its doze (the steal-free grace
+    // park, see parkAndSearch) since it last had local work. Reset by any
+    // local work; while set, empty passes go straight to the full park.
+    dozed: bool = false,
+
     // Deferred cleanup for the task that just yielded away from this executor.
     // Processed by the next coroutine to run (at landing sites: startFn, yield resume, run loop).
     pending_cleanup: TaskCleanup = .none,
@@ -542,6 +547,15 @@ pub const Executor = struct {
     /// workloads; also tokio's max tasks per global-queue interval.
     const checkpoint_interval = 127;
 
+    /// How long the first idle park (the "doze") waits before this executor
+    /// concludes it is genuinely idle and stealing is worth the churn. An I/O
+    /// completion typically re-readies the very tasks that just ran here (their
+    /// ops are homed on this loop), so the loop gets this long to produce local
+    /// work before any task is dragged to another executor. The idle bit is set
+    /// while dozing, so a searcher wake still cuts the doze short — excess work
+    /// elsewhere reaches this executor within a wake, not within doze_wait.
+    const doze_wait: Duration = .fromMicroseconds(100);
+
     /// True while the current tick may keep spending quanta without polling.
     inline fn tickBudgetLeft(self: *const Executor) bool {
         return self.tick_task_count < self.tick_task_budget and !self.tick_expired;
@@ -604,6 +618,10 @@ pub const Executor = struct {
         // Process deferred cleanup (e.g. main task's park/reschedule)
         self.processCleanup();
 
+        // Entering the run loop means the main task just ran (or this executor
+        // just started): that was productive work, a fresh doze is due.
+        self.dozed = false;
+
         // When entered with the tick budget already spent (e.g. the main task
         // yielded because its slice ran out), ready tasks must get one
         // fresh-budget batch after the next poll before control can return to
@@ -632,8 +650,13 @@ pub const Executor = struct {
                 @panic("event loop stopped while the main task was yielding");
             }
 
-            const has_work = self.checkAboutForWork(check_ready, true);
-            if (has_work) try self.loop.run(.no_wait) else try self.parkAndSearch(check_ready);
+            const has_work = self.checkLocalWork(check_ready);
+            if (has_work) {
+                self.dozed = false;
+                try self.loop.poll(.zero);
+            } else {
+                try self.parkAndSearch(check_ready);
+            }
 
             // Retune the tick budget from this batch. Skipped when we may have
             // slept in parkAndSearch — sleep time would poison the estimate.
@@ -696,7 +719,53 @@ pub const Executor = struct {
         }
     }
 
+    /// One idle step per call; the run loop re-checks stopped/main-ready/local
+    /// work between calls and resets `dozed` whenever any of those produce
+    /// work.
+    ///
+    /// The first empty pass after productive work probes the loop with a
+    /// non-blocking poll and, if that yields nothing, dozes: a park capped at
+    /// doze_wait whose work check is local-only. Together they give this
+    /// executor's own event loop a grace window to hand back the tasks that
+    /// just ran here before any stealing churn is paid. Every later pass
+    /// parks indefinitely with stealing folded into the pre-park check — by
+    /// then idleness is proven and the steal is also what makes the park's
+    /// wake protocol sound (see park).
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
+        if (!self.dozed) {
+            self.dozed = true;
+            // With nobody to steal from (or to) the probe and doze would only
+            // delay the real park; skip both.
+            if (self.runtime.stealingActive()) {
+                // Probe: one non-blocking poll before publishing any idleness.
+                // Completions that already arrived (the common case right
+                // after a drain) put this executor straight back on the busy
+                // path without touching idle_mask or inviting a spurious
+                // searcher election.
+                try self.loop.poll(.zero);
+                if (self.checkLocalWork(check_ready)) return;
+                return self.park(check_ready, doze_wait, .local_only);
+            }
+        }
+        return self.park(check_ready, .max, .steal);
+    }
+
+    const ParkSearch = enum { local_only, steal };
+
+    /// One park episode: publish the idle bit, give the event loop one poll
+    /// bounded by `wait_cap`, withdraw the bit. If armSearcher elected this
+    /// executor as the searcher meanwhile, run the searcher-token protocol:
+    /// consume the token by finding work, or release it and steal on the
+    /// pusher's behalf.
+    ///
+    /// With `search == .steal` the pre-park work check extends to the other
+    /// executors' rings. That is what makes an indefinite park sound: the bit
+    /// is published before the check while a pusher publishes its task before
+    /// reading idle_mask (both seq_cst), so either the pusher sees the bit and
+    /// wakes us, or this check sees the pushed task — including one sitting in
+    /// the pusher's own ring. A `.local_only` check (the doze) reopens that
+    /// window, but only for doze_wait: the cap itself is the rescue.
+    fn park(self: *Executor, check_ready: bool, wait_cap: Duration, search: ParkSearch) !void {
         const my_bit = @as(usize, 1) << self.id;
         // seq_cst: pairs with armSearcher's idle_mask load (see there). The bit
         // must be globally visible before the work check below, or a concurrent
@@ -709,8 +778,9 @@ pub const Executor = struct {
             }
         }
 
-        const found_work = self.checkAboutForWork(check_ready, true);
-        try self.loop.run(if (found_work) .no_wait else .once);
+        var found_work = self.checkLocalWork(check_ready);
+        if (!found_work and search == .steal) found_work = self.stealWork();
+        try self.loop.poll(if (found_work) .zero else wait_cap);
 
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 
@@ -743,12 +813,17 @@ pub const Executor = struct {
             // push missed by this recheck - a dropped wake with no retry.
             _ = self.runtime.searchers.cmpxchgStrong(1, 0, .seq_cst, .monotonic);
             if (self.stealWork()) return;
-            if (self.checkAboutForWork(check_ready, false)) self.runtime.armSearcher();
+            // No main-ready here: only queued (stealable) work justifies
+            // arming a fresh searcher.
+            if (self.checkLocalWork(false)) self.runtime.armSearcher();
         }
     }
 
-    fn checkAboutForWork(self: *Executor, check_ready: bool, include_main_ready: bool) bool {
-        const main_ready = include_main_ready and check_ready and self.main_task.state.load(.acquire).tag == .ready;
+    /// Local work check: the main task (when `check_main_ready`), the ring,
+    /// and a refill from the overflow queue. Deliberately never steals — see
+    /// parkAndSearch for when remote work is taken.
+    fn checkLocalWork(self: *Executor, check_main_ready: bool) bool {
+        const main_ready = check_main_ready and self.main_task.state.load(.acquire).tag == .ready;
         // Overflow work counts too: if the ring is empty but the overflow queue
         // still holds tasks (e.g. a local ring spill, which doesn't wake the
         // loop), don't block — return promptly and refill from it below.
@@ -768,10 +843,14 @@ pub const Executor = struct {
             self.run_queue.refill(batch);
             has_work = !self.run_queue.isEmpty();
         }
-        if (!has_work) has_work = self.stealWork();
         return has_work;
     }
 
+    /// Steal half of a random victim's ring into ours. Reached only from
+    /// park() — the indefinite park's pre-check and the searcher-token path —
+    /// never while this executor still has plausible local work and never
+    /// before the doze has elapsed, since migrating a task also re-homes its
+    /// I/O and the home loop usually hands work back within doze_wait.
     fn stealWork(self: *Executor) bool {
         if (!self.runtime.stealingActive()) return false;
         const executors = self.runtime.executors.items;


### PR DESCRIPTION
## What

An executor that drains its run queue no longer attempts a steal immediately. The idle path is now a ladder, one step per empty pass of the run loop:

1. **probe**: one non-blocking poll, without touching `idle_mask`, so the common case (completions already arrived) goes straight back to the busy loop with no idle-machinery traffic;
2. **doze**: a park capped at 100us with the idle bit published and a local-only work check, so a searcher election still cuts it short;
3. **full park**: indefinite, with `stealWork` folded into the pre-park check, re-stealing on every wake that finds nothing local.

Rationale: an I/O completion typically re-readies exactly the tasks that just ran on this executor, and stealing a task also re-homes its pending I/O, so stealing before the loop had a chance to answer is speculative migration churn. Same gating idea as ClickHouse Silk's idle-budgeted steal loop, adapted to the existing searcher/idle-mask protocol. Stealing stays exceptional; the searcher wake path (a pusher with excess work electing a parked executor) is unchanged and still immediate.

## Protocol note (the subtle bit)

Stealing inside the indefinite park's pre-check, after the idle bit is published, is **load-bearing**: the seq_cst pairing with `armSearcher` only prevents lost wakes if the parker's final check can see a task sitting in the pusher's own ring. An earlier draft checked only local queues and reliably hung the Mutex churn test on epoll: a dropped announce stranded a ready task behind a non-yielding task on another executor, with no rescue on any later timeout wake. The doze is exempt from this requirement because its wait cap bounds a missed announce to 100us. This is documented in `park()`.

## Loop API change (breaking, low-level)

The capped park needed a wait bound, so `Loop.run(RunMode)` and `RunMode` are folded into one knob:

- `loop.poll(max_wait)`: one pass; `.zero` = old `.no_wait` (still skips the syscall when nothing is in flight), `.max` = old `.once`, anything in between caps the wait. Timer deadlines, pending completions and the loop's `max_wait` option shorten the wait as before; the cap only tightens.
- `loop.run()` (parameterless) = old `.until_done`.

## Testing

- Full suite on io_uring, epoll, poll; Windows/iocp under Wine; kqueue cross-compiles; examples build.
- Mutex cancellation-churn test 10x on epoll (the test that caught the protocol bug).

## Benchmarks (zio-benchmarks, interleaved A/B vs main, isolated caches)

Neutral (within the +-5% box noise): ping-pong (1/100 pairs, st+mt), spawn/sleep 10k tasks, worker_pool CPU-bound, tcp lat/pipe, http c128, and all single-threaded cases. Regressions, consistent across reruns: worker_pool light fan-in/fan-out (~4-8%) and tcp `many` (1000 conns x 100 x 64B) on io_uring-mt (~5-6%), i.e. burst-distribution shapes with no or cold I/O. A 10us doze measures the same, so the cost is the single-token searcher serialization (already known from #562), not the doze length; the planned searching/parking rewrite is the fix for that axis.