### PR TITLE
runtime: steal hints and batched I/O wakes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- When an executor with queued work wakes an idle one to help, the wake now carries a
+  hint saying whose queue is loaded, and the woken executor starts stealing there
+  instead of probing executors in random order. The work itself stays in the waker's
+  queue until it is actually stolen, so a task the waker gets to promptly still runs
+  where it was woken. This mainly speeds up fan-out patterns (one task waking many)
+  on multi-threaded runtimes.
+
 - **BREAKING**: Reworked coroutine stack allocation. On 64-bit POSIX targets, stacks
   are now carved from larger slab reservations (one syscall per cold stack instead of
   three, and no syscalls at all to release and reuse one), which sped up workloads

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file.
   where it was woken. This mainly speeds up fan-out patterns (one task waking many)
   on multi-threaded runtimes.
 
+- Tasks woken by I/O completions are now scheduled as one batch per event loop poll,
+  with a single wake decision for the whole batch (waking several idle executors at
+  once for a large batch), instead of one announcement per completion. This mainly
+  helps servers with many connections completing I/O together (~10% more throughput
+  in the 1000-connection echo benchmark). In the low-level `ev` API, setting a
+  completion's `callback` to null now delivers it through `nextDispatched()` instead
+  of invoking anything, the per-completion form of `do_not_call_callbacks`.
+
 - **BREAKING**: Reworked coroutine stack allocation. On 64-bit POSIX targets, stacks
   are now carved from larger slab reservations (one syscall per cold stack instead of
   three, and no syscalls at all to release and reuse one), which sped up workloads

--- a/src/common.zig
+++ b/src/common.zig
@@ -330,11 +330,9 @@ pub const Waiter = struct {
 pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
-    // Null callback: the loop delivers the finished completion through its
-    // dispatched queue instead of calling anything, and the executor signals
-    // the waiter when it drains the queue after the poll — the whole poll's
-    // worth of task wakes becomes one batch with one wake decision, instead
-    // of an announce per completion (see Executor.drainDispatched).
+    // Null callback: the loop hands the finished completion out through its
+    // dispatched queue, and the executor signals the waiter when it drains
+    // the queue (see Executor.drainDispatched).
     c.callback = null;
     c.flags = .{ .defer_callback = false }; // single-shot wait: no rearm either
 
@@ -384,7 +382,7 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
 pub fn waitForIoUncancelable(c: *ev.Completion) void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
-    c.callback = null; // batch-delivered via the dispatched queue, see waitForIo
+    c.callback = null; // dispatched-queue delivery, see waitForIo
     c.flags = .{ .defer_callback = false };
 
     defer if (std.debug.runtime_safety) {

--- a/src/common.zig
+++ b/src/common.zig
@@ -330,13 +330,15 @@ pub const Waiter = struct {
 pub fn waitForIo(c: *ev.Completion) Cancelable!void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
-    c.callback = Waiter.callback;
-    // The callback only wakes the parked task — nothing that needs the
-    // deferred-finish safety net, and the hot path skips the queue round trip.
+    // Null callback: the loop delivers the finished completion through its
+    // dispatched queue instead of calling anything, and the executor signals
+    // the waiter when it drains the queue after the poll — the whole poll's
+    // worth of task wakes becomes one batch with one wake decision, instead
+    // of an announce per completion (see Executor.drainDispatched).
+    c.callback = null;
     c.flags = .{ .defer_callback = false }; // single-shot wait: no rearm either
 
     defer if (std.debug.runtime_safety) {
-        c.callback = null;
         c.userdata = null;
     };
 
@@ -382,11 +384,10 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
 pub fn waitForIoUncancelable(c: *ev.Completion) void {
     var waiter = Waiter.init();
     c.userdata = &waiter;
-    c.callback = Waiter.callback;
+    c.callback = null; // batch-delivered via the dispatched queue, see waitForIo
     c.flags = .{ .defer_callback = false };
 
     defer if (std.debug.runtime_safety) {
-        c.callback = null;
         c.userdata = null;
     };
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -353,11 +353,9 @@ pub const LoopState = struct {
         // queue link is free to reuse. Rearm/group completions fall through and
         // run inline, since their machinery must stay synchronous.
         //
-        // A null callback opts a single completion into the same delivery: it
-        // is handed out through `nextDispatched` instead of being invoked.
-        // This is how the runtime's task wakes travel — the executor drains
-        // them after each poll and wakes the whole batch at once, instead of
-        // one announce per completion (see Executor.drainDispatched).
+        // A null callback opts a single completion into the same delivery:
+        // it is handed out through `nextDispatched` instead of being invoked.
+        // Task wakes travel this way (see Executor.drainDispatched).
         if ((self.loop.do_not_call_callbacks or completion.callback == null) and !was_rearm and owner_callback == null) {
             self.dispatched.push(completion);
             return;
@@ -574,8 +572,7 @@ pub const Loop = struct {
     /// dispatch: every finished completion when the loop was created with
     /// `do_not_call_callbacks`, and completions with a null callback always.
     /// Returns null when drained; the caller invokes `completion.call(loop)`
-    /// (or interprets the completion itself, as the runtime does for task
-    /// wakes).
+    /// or interprets the completion itself.
     pub fn nextDispatched(self: *Loop) ?*Completion {
         return self.state.dispatched.pop();
     }

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -352,7 +352,13 @@ pub const LoopState = struct {
         // invoked here. `completion` was just popped from `completions`, so its
         // queue link is free to reuse. Rearm/group completions fall through and
         // run inline, since their machinery must stay synchronous.
-        if (self.loop.do_not_call_callbacks and !was_rearm and owner_callback == null) {
+        //
+        // A null callback opts a single completion into the same delivery: it
+        // is handed out through `nextDispatched` instead of being invoked.
+        // This is how the runtime's task wakes travel — the executor drains
+        // them after each poll and wakes the whole batch at once, instead of
+        // one announce per completion (see Executor.drainDispatched).
+        if ((self.loop.do_not_call_callbacks or completion.callback == null) and !was_rearm and owner_callback == null) {
             self.dispatched.push(completion);
             return;
         }
@@ -565,8 +571,11 @@ pub const Loop = struct {
     }
 
     /// Pop the next finished standalone completion awaiting user-callback
-    /// dispatch (only populated when created with `do_not_call_callbacks`).
-    /// Returns null when drained; the caller invokes `completion.call(loop)`.
+    /// dispatch: every finished completion when the loop was created with
+    /// `do_not_call_callbacks`, and completions with a null callback always.
+    /// Returns null when drained; the caller invokes `completion.call(loop)`
+    /// (or interprets the completion itself, as the runtime does for task
+    /// wakes).
     pub fn nextDispatched(self: *Loop) ?*Completion {
         return self.state.dispatched.pop();
     }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -340,6 +340,8 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
 pub const Executor = struct {
     pub const max_executors = std.math.maxInt(ExecutorId) + 1;
 
+    const no_steal_hint = std.math.maxInt(u32);
+
     id: ExecutorId,
     loop: ev.Loop,
 
@@ -397,6 +399,14 @@ pub const Executor = struct {
     // park, see parkAndSearch) since it last had local work. Reset by any
     // local work; while set, empty passes go straight to the full park.
     dozed: bool = false,
+
+    // Where the pusher that elected this executor as searcher has surplus
+    // work (armSearcher writes it just before the wake; stealWork consumes
+    // it). The elected searcher starts its victim scan there instead of at a
+    // random executor, turning the wake into an invitation with directions:
+    // the work stays in the pusher's ring, and the usual wake-to-pop race
+    // still decides whether it migrates at all. `no_steal_hint` means none.
+    steal_hint: std.atomic.Value(u32) = .init(no_steal_hint),
 
     // Deferred cleanup for the task that just yielded away from this executor.
     // Processed by the next coroutine to run (at landing sites: startFn, yield resume, run loop).
@@ -807,7 +817,7 @@ pub const Executor = struct {
                 self.run_queue.refill(batch);
                 if (!self.run_queue.isEmpty()) {
                     _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
-                    if (!self.run_queue.overflow.isEmpty()) self.runtime.armSearcher();
+                    if (!self.run_queue.overflow.isEmpty()) self.runtime.armSearcher(null);
                     return;
                 }
             }
@@ -823,7 +833,7 @@ pub const Executor = struct {
             if (self.stealWork()) return;
             // No main-ready here: only queued (stealable) work justifies
             // arming a fresh searcher.
-            if (self.checkLocalWork(false)) self.runtime.armSearcher();
+            if (self.checkLocalWork(false)) self.runtime.armSearcher(self.id);
         }
     }
 
@@ -864,7 +874,14 @@ pub const Executor = struct {
         const executors = self.runtime.executors.items;
         if (executors.len <= 1) return false;
 
-        const start = self.steal_prng.random().uintLessThan(usize, executors.len);
+        // A pending hint from the electing pusher points at the loaded ring;
+        // start the scan there and fall back to the circular sweep, so a
+        // stale hint degrades to exactly the old behavior.
+        const hinted = self.steal_hint.swap(no_steal_hint, .acquire);
+        const start = if (hinted != no_steal_hint and hinted < executors.len)
+            hinted
+        else
+            self.steal_prng.random().uintLessThan(usize, executors.len);
         for (0..executors.len) |i| {
             const victim = executors[(start + i) % executors.len];
             if (victim == self) continue;
@@ -875,7 +892,9 @@ pub const Executor = struct {
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
                 _ = self.run_queue.push(node);
-                self.runtime.armSearcher();
+                // Propagation: the rest of the loaded ring is still at the
+                // victim; point the next searcher straight at it.
+                self.runtime.armSearcher(victim.id);
                 return true;
             }
         }
@@ -924,7 +943,7 @@ pub const Executor = struct {
         if (self.shed_quota > 0) {
             self.shed_quota -= 1;
             self.run_queue.overflow.push(&task.awaitable.wait_node);
-            self.runtime.armSearcher();
+            self.runtime.armSearcher(null);
             return;
         }
 
@@ -936,7 +955,7 @@ pub const Executor = struct {
         // still announce, since the waker may keep the executor busy.
         const was_empty = self.run_queue.push(&task.awaitable.wait_node);
         if (!was_empty or self.current_task != null) {
-            self.runtime.armSearcher();
+            self.runtime.armSearcher(self.id);
         }
     }
 
@@ -949,7 +968,7 @@ pub const Executor = struct {
 
         self.run_queue.overflow.push(&task.awaitable.wait_node);
         self.loop.wake();
-        self.runtime.armSearcher();
+        self.runtime.armSearcher(null);
     }
 
     /// Schedule a task for execution.
@@ -1509,7 +1528,7 @@ pub const Runtime = struct {
         return zio_options.task_migration and self.options.enable_task_migration and self.executors_stealable.load(.acquire);
     }
 
-    fn armSearcher(self: *Runtime) void {
+    fn armSearcher(self: *Runtime, hint: ?ExecutorId) void {
         // The two early-return loads pair with the parker: an executor sets its
         // idle bit (seq_cst RMW) and only then makes its final work check, while
         // a pusher publishes the task and only then reads idle_mask/searchers
@@ -1528,7 +1547,11 @@ pub const Runtime = struct {
             const bit = @as(usize, 1) << id;
             const previous_mask = self.idle_mask.fetchAnd(~bit, .acq_rel);
             if (previous_mask & bit != 0) {
-                self.executors.items[id].loop.wake();
+                const target = self.executors.items[id];
+                // Deliver (or clear) the hint before the wake; the wake edge
+                // publishes it. Exclusive: only the bit winner writes.
+                target.steal_hint.store(hint orelse Executor.no_steal_hint, .release);
+                target.loop.wake();
                 return;
             }
             candidates &= ~bit;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -400,6 +400,11 @@ pub const Executor = struct {
     // local work; while set, empty passes go straight to the full park.
     dozed: bool = false,
 
+    // True while drainDispatched signals a poll's worth of task wakes:
+    // scheduleTaskLocal skips the per-push announce, and one batched wake
+    // decision covers the whole drain afterwards.
+    draining_wakes: bool = false,
+
     // Where the pusher that elected this executor as searcher has surplus
     // work (armSearcher writes it just before the wake; stealWork consumes
     // it). The elected searcher starts its victim scan there instead of at a
@@ -761,6 +766,7 @@ pub const Executor = struct {
                 // path without touching idle_mask or inviting a spurious
                 // searcher election.
                 try self.loop.poll(.zero);
+                self.drainDispatched();
                 if (self.checkLocalWork(check_ready)) return;
                 return self.park(check_ready, doze_wait, .local_only);
             }
@@ -799,6 +805,10 @@ pub const Executor = struct {
         var found_work = self.checkLocalWork(check_ready);
         if (!found_work and search == .steal) found_work = self.stealWork();
         try self.loop.poll(if (found_work) .zero else wait_cap);
+        // Drain before withdrawing the bit: the wake batch lands in the ring
+        // first, so the post-park work checks below see it, and the batched
+        // announce can already offer the surplus to other sleepers.
+        self.drainDispatched();
 
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 
@@ -841,6 +851,12 @@ pub const Executor = struct {
     /// and a refill from the overflow queue. Deliberately never steals — see
     /// parkAndSearch for when remote work is taken.
     fn checkLocalWork(self: *Executor, check_main_ready: bool) bool {
+        // Task wakes can enter the dispatched queue outside any poll: an
+        // operation that completes inline during loop.add (a socket open, an
+        // already-ready recv) finishes on this thread before its task parks.
+        // Every work check must see those, or a pre-park check can miss the
+        // only work in existence and sleep on it.
+        self.drainDispatched();
         const main_ready = check_main_ready and self.main_task.state.load(.acquire).tag == .ready;
         // Overflow work counts too: if the ring is empty but the overflow queue
         // still holds tasks (e.g. a local ring spill, which doesn't wake the
@@ -954,8 +970,42 @@ pub const Executor = struct {
         // home) to another executor for nothing. Wakes from a running task
         // still announce, since the waker may keep the executor busy.
         const was_empty = self.run_queue.push(&task.awaitable.wait_node);
+        if (self.draining_wakes) return; // one batched announce after the drain
         if (!was_empty or self.current_task != null) {
             self.runtime.armSearcher(self.id);
+        }
+    }
+
+    /// Drain the loop's dispatched queue: completions the loop handed out
+    /// instead of calling, which for this runtime means task wakes (waitForIo
+    /// sets a null callback; see finishCompletion). Signals every waiter with
+    /// per-push announces suppressed, then makes one batched wake decision
+    /// for the whole poll's worth of newly ready tasks. Runs after every
+    /// poll, before any work check that could decide to park.
+    fn drainDispatched(self: *Executor) void {
+        var first = self.loop.nextDispatched() orelse return;
+
+        self.draining_wakes = true;
+        var count: usize = 0;
+        while (true) {
+            const c = first;
+            if (c.callback != null) {
+                // Not a task wake (executors never set do_not_call_callbacks,
+                // but stay correct if a completion with a real callback ever
+                // lands here).
+                @branchHint(.unlikely);
+                c.call(&self.loop);
+            } else {
+                const waiter: *Waiter = @ptrCast(@alignCast(c.userdata.?));
+                waiter.signal();
+                count += 1;
+            }
+            first = self.loop.nextDispatched() orelse break;
+        }
+        self.draining_wakes = false;
+
+        if (count > 0) {
+            self.runtime.batchWakeSleepers(self.run_queue.len(), self.id);
         }
     }
 
@@ -1541,7 +1591,18 @@ pub const Runtime = struct {
         if (!self.stealingActive() or (self.idle_mask.load(.seq_cst) == 0) or (self.searchers.load(.seq_cst) != 0)) return;
         if (self.searchers.cmpxchgStrong(0, 1, .seq_cst, .monotonic)) |_| return;
 
+        if (!self.claimAndWake(hint, null)) {
+            _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+        }
+    }
+
+    /// Claim one parked executor from the idle mask (skipping `exclude`),
+    /// deliver the hint, and wake it. The bit-clear is the claim: exactly one
+    /// caller wins a given bit, and only the winner writes the hint. Returns
+    /// false if no executor could be claimed.
+    fn claimAndWake(self: *Runtime, hint: ?ExecutorId, exclude: ?ExecutorId) bool {
         var candidates = self.idle_mask.load(.acquire);
+        if (exclude) |id| candidates &= ~(@as(usize, 1) << id);
         while (candidates != 0) {
             const id: ExecutorId = @intCast(@ctz(candidates));
             const bit = @as(usize, 1) << id;
@@ -1552,11 +1613,35 @@ pub const Runtime = struct {
                 // publishes it. Exclusive: only the bit winner writes.
                 target.steal_hint.store(hint orelse Executor.no_steal_hint, .release);
                 target.loop.wake();
-                return;
+                return true;
             }
             candidates &= ~bit;
         }
-        _ = self.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
+        return false;
+    }
+
+    /// Wake several sleepers at once for a batch of `ready` freshly woken
+    /// tasks sitting in the calling executor's ring - the analog of Go's
+    /// injectglist, which starts min(batch, idle) threads because batch
+    /// arrival deserves batch wakeup. Bypasses the single-searcher token:
+    /// the token throttles speculative announces, and a counted batch is not
+    /// speculation. Since every claimed searcher steals half of what remains,
+    /// log2(ready) searchers cover the batch; more would just race.
+    ///
+    /// A claimed searcher's park exit releases the token it never took; that
+    /// cmpxchg(1,0) only fires if a concurrent single announce holds the
+    /// token, and prematurely releasing it merely allows one extra election.
+    /// Wasteful in the rarest case, never a lost wake.
+    fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) void {
+        if (!self.stealingActive() or ready < 2) return;
+        if (self.idle_mask.load(.seq_cst) == 0) return;
+
+        var wakes: usize = 0;
+        var covered: usize = 2; // one searcher covers half of 2+
+        while (covered < ready) : (covered *= 2) wakes += 1;
+        while (wakes > 0) : (wakes -= 1) {
+            if (!self.claimAndWake(hint, hint)) return;
+        }
     }
 
     // Convenience methods that operate on the current coroutine context

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -400,17 +400,14 @@ pub const Executor = struct {
     // local work; while set, empty passes go straight to the full park.
     dozed: bool = false,
 
-    // True while drainDispatched signals a poll's worth of task wakes:
-    // scheduleTaskLocal skips the per-push announce, and one batched wake
-    // decision covers the whole drain afterwards.
+    // True while drainDispatched signals a batch of task wakes:
+    // scheduleTaskLocal skips the per-push announce, the drain announces
+    // once at the end.
     draining_wakes: bool = false,
 
     // Where the pusher that elected this executor as searcher has surplus
-    // work (armSearcher writes it just before the wake; stealWork consumes
-    // it). The elected searcher starts its victim scan there instead of at a
-    // random executor, turning the wake into an invitation with directions:
-    // the work stays in the pusher's ring, and the usual wake-to-pop race
-    // still decides whether it migrates at all. `no_steal_hint` means none.
+    // work; armSearcher writes it just before the wake, stealWork consumes
+    // it as the scan's starting victim. `no_steal_hint` means none.
     steal_hint: std.atomic.Value(u32) = .init(no_steal_hint),
 
     // Deferred cleanup for the task that just yielded away from this executor.
@@ -805,9 +802,8 @@ pub const Executor = struct {
         var found_work = self.checkLocalWork(check_ready);
         if (!found_work and search == .steal) found_work = self.stealWork();
         try self.loop.poll(if (found_work) .zero else wait_cap);
-        // Drain before withdrawing the bit: the wake batch lands in the ring
-        // first, so the post-park work checks below see it, and the batched
-        // announce can already offer the surplus to other sleepers.
+        // Drain before withdrawing the bit, so the post-park work checks
+        // below see the woken batch.
         self.drainDispatched();
 
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
@@ -852,10 +848,9 @@ pub const Executor = struct {
     /// parkAndSearch for when remote work is taken.
     fn checkLocalWork(self: *Executor, check_main_ready: bool) bool {
         // Task wakes can enter the dispatched queue outside any poll: an
-        // operation that completes inline during loop.add (a socket open, an
-        // already-ready recv) finishes on this thread before its task parks.
-        // Every work check must see those, or a pre-park check can miss the
-        // only work in existence and sleep on it.
+        // operation that completes inline during loop.add finishes on this
+        // thread before its task parks. Every work check must see those, or
+        // a pre-park check can sleep on the only work in existence.
         self.drainDispatched();
         const main_ready = check_main_ready and self.main_task.state.load(.acquire).tag == .ready;
         // Overflow work counts too: if the ring is empty but the overflow queue
@@ -890,9 +885,9 @@ pub const Executor = struct {
         const executors = self.runtime.executors.items;
         if (executors.len <= 1) return false;
 
-        // A pending hint from the electing pusher points at the loaded ring;
-        // start the scan there and fall back to the circular sweep, so a
-        // stale hint degrades to exactly the old behavior.
+        // A pending hint points at the electing pusher's loaded ring; start
+        // the scan there. Stale hints are harmless: the circular sweep just
+        // continues past them.
         const hinted = self.steal_hint.swap(no_steal_hint, .acquire);
         const start = if (hinted != no_steal_hint and hinted < executors.len)
             hinted
@@ -908,8 +903,8 @@ pub const Executor = struct {
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
                 _ = self.run_queue.push(node);
-                // Propagation: the rest of the loaded ring is still at the
-                // victim; point the next searcher straight at it.
+                // The rest of the loaded ring is still at the victim; point
+                // the next searcher straight at it.
                 self.runtime.armSearcher(victim.id);
                 return true;
             }
@@ -976,12 +971,11 @@ pub const Executor = struct {
         }
     }
 
-    /// Drain the loop's dispatched queue: completions the loop handed out
-    /// instead of calling, which for this runtime means task wakes (waitForIo
-    /// sets a null callback; see finishCompletion). Signals every waiter with
-    /// per-push announces suppressed, then makes one batched wake decision
-    /// for the whole poll's worth of newly ready tasks. Runs after every
-    /// poll, before any work check that could decide to park.
+    /// Drain the completions the loop handed out instead of calling (null
+    /// callback, see finishCompletion): signal every waiter with per-push
+    /// announces suppressed, then wake sleepers once for the whole batch.
+    /// Runs after every poll and from checkLocalWork, so no park decision
+    /// can miss a pending wake.
     fn drainDispatched(self: *Executor) void {
         var first = self.loop.nextDispatched() orelse return;
 
@@ -990,9 +984,8 @@ pub const Executor = struct {
         while (true) {
             const c = first;
             if (c.callback != null) {
-                // Not a task wake (executors never set do_not_call_callbacks,
-                // but stay correct if a completion with a real callback ever
-                // lands here).
+                // Not a task wake: a completion with a real callback, only
+                // possible under do_not_call_callbacks.
                 @branchHint(.unlikely);
                 c.call(&self.loop);
             } else {
@@ -1620,24 +1613,21 @@ pub const Runtime = struct {
         return false;
     }
 
-    /// Wake several sleepers at once for a batch of `ready` freshly woken
-    /// tasks sitting in the calling executor's ring - the analog of Go's
-    /// injectglist, which starts min(batch, idle) threads because batch
-    /// arrival deserves batch wakeup. Bypasses the single-searcher token:
-    /// the token throttles speculative announces, and a counted batch is not
-    /// speculation. Since every claimed searcher steals half of what remains,
-    /// log2(ready) searchers cover the batch; more would just race.
+    /// Wake several sleepers at once for `ready` freshly woken tasks in the
+    /// calling executor's ring (Go's injectglist). Bypasses the
+    /// single-searcher token: the token throttles speculative announces, and
+    /// a counted batch is not speculative. Each claimed searcher steals half
+    /// of what remains, so log2(ready) searchers cover the batch; more would
+    /// just race.
     ///
-    /// A claimed searcher's park exit releases the token it never took; that
-    /// cmpxchg(1,0) only fires if a concurrent single announce holds the
-    /// token, and prematurely releasing it merely allows one extra election.
-    /// Wasteful in the rarest case, never a lost wake.
+    /// A claimed searcher's park exit may release a token it never took;
+    /// that lets one extra election through, it never loses a wake.
     fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) void {
         if (!self.stealingActive() or ready < 2) return;
         if (self.idle_mask.load(.seq_cst) == 0) return;
 
         var wakes: usize = 0;
-        var covered: usize = 2; // one searcher covers half of 2+
+        var covered: usize = 2; // wakes = ceil(log2(ready))
         while (covered < ready) : (covered *= 2) wakes += 1;
         while (wakes > 0) : (wakes -= 1) {
             if (!self.claimAndWake(hint, hint)) return;


### PR DESCRIPTION
Two commits, one story: wakes get smarter about where work is and how much of it there is.

## Commit 1: steal hints

`armSearcher` records the pusher's executor id in the elected searcher's `steal_hint` just before the wake (exclusive by construction: only the winner of the idle-bit claim writes, and the wake edge publishes the store). `stealWork` consumes the hint as its scan start and falls back to the usual random circular sweep, so a stale hint degrades to exactly the old behavior. The wake becomes an invitation with directions instead of a blind search warrant: the elected searcher skips the random victim probing, while the work stays in the waker's ring until actually stolen -- the wake-to-pop race still decides whether anything migrates. Hint sources: local announce passes the pusher's id; shed/remote wakes pass none (their work is in the shared overflow queue, checked first anyway); a successful steal propagates by pointing the next searcher at the same victim's remainder.

## Commit 2: batched I/O wakes (Go's injectglist, zio-shaped)

Task-wake completions (`waitForIo`) now set a **null callback**, which the loop routes into the dispatched queue instead of invoking anything -- a null callback is the per-completion form of `do_not_call_callbacks`, and `nextDispatched()` serves both. The executor drains the queue after every poll, signaling each waiter with per-push announces suppressed, then makes **one batched wake decision** for the whole poll's worth of newly ready tasks: wake log2(ready) sleepers hinted at this executor (each steals half of what remains, so log2 covers the batch). Batches bypass the single-searcher token -- the token throttles speculative announces, and a counted batch is not speculation; Go draws the same line (`wakep` single-flights, `injectglist` starts min(batch, idle) threads).

Rationale: early per-completion wakes bought nothing locally -- a task woken mid-poll cannot run until the poll returns anyway, so immediate callbacks only enabled per-completion announce traffic and mid-poll steals, the churny kind. This also removes the last per-completion indirect call.

The subtle requirement (found via a hanging TCP handshake test): an operation that completes **inline during `loop.add`** (a socket open) enters the dispatched queue outside any poll, on the very thread about to park. `checkLocalWork` therefore drains the queue first, making pending wakes visible to every work check including the pre-park one.

## Alternatives probed and rejected

- Raising the searcher token cap: fan workloads ~11% worse (thieves racing CAS on one victim's ring head). Targeting, not more pullers.
- Mailbox handoff (push-side batch delivery to a claimed sleeper): beat main on fan-in by ~15% but commits migration at push time -- shedding without a trigger -- and needed three new protocol invariants. Kept as a local reference branch.
- Gating hints on ring depth >= 2: no measurable effect.

## Benchmarks (interleaved, rotated order, isolated caches; dev box with +-5% noise -- please rerun on the Xeon box)

- **tcp many (1000 conns): +11% vs main** -- the completion-burst shape the batching targets, the strongest result on that benchmark from any of this week's scheduler work.
- ping_pong 1 pair: -7..10% (reproduced every session; hints).
- lat / pipe / sleep / spawn / ping_pong 100p: neutral. worker_pool fan wakes are task-to-task (not completions), so the batch path doesn't run there; observed deltas did not reproduce across sessions.
- Known micro-trade: ops that complete inline during `loop.add` (socket open) lose the completed-inline fast path and pay one park/unpark round trip; where that class is most frequent (tcp many) the net is still +11%. Recovery exists if ever needed (self-drain after `add`).

## Testing

Native 601/601, epoll 601/601, poll suite, Windows/iocp under Wine 518/518, kqueue cross-compiles, Mutex churn stress clean, all under verbose per-test-timeout runs. Rebased on main (includes #632/#634/#635).
