### PR TITLE
coro: slab-allocate coroutine stacks with a decaying demand watermark

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,12 +24,15 @@ pub fn build(b: *std.Build) void {
 
     const task_migration = b.option(bool, "task-migration", "Compile in task migration / work-stealing support. When false, tasks are pinned to their home executor and the scheduler can drop the machinery it needs (default true)") orelse true;
 
+    const stack_slab_slots = b.option(usize, "stack-slab-slots", "Coroutine stack slots carved from one slab address-space reservation; 0 disables slab allocation and maps every stack separately (default 64, only used on 64-bit POSIX targets)") orelse 64;
+
     // Create options for backend selection
     var options = b.addOptions();
     options.addOption(?[]const u8, "backend", backend);
     options.addOption(ResolveBeneathMode, "resolve_beneath_mode", resolve_beneath_mode);
     options.addOption(bool, "no_hacks", no_hacks);
     options.addOption(bool, "task_migration", task_migration);
+    options.addOption(usize, "stack_slab_slots", stack_slab_slots);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),

--- a/build.zig
+++ b/build.zig
@@ -24,15 +24,12 @@ pub fn build(b: *std.Build) void {
 
     const task_migration = b.option(bool, "task-migration", "Compile in task migration / work-stealing support. When false, tasks are pinned to their home executor and the scheduler can drop the machinery it needs (default true)") orelse true;
 
-    const stack_slab_slots = b.option(usize, "stack-slab-slots", "Coroutine stack slots carved from one slab address-space reservation; 0 disables slab allocation and maps every stack separately (default 64, only used on 64-bit POSIX targets)") orelse 64;
-
     // Create options for backend selection
     var options = b.addOptions();
     options.addOption(?[]const u8, "backend", backend);
     options.addOption(ResolveBeneathMode, "resolve_beneath_mode", resolve_beneath_mode);
     options.addOption(bool, "no_hacks", no_hacks);
     options.addOption(bool, "task_migration", task_migration);
-    options.addOption(usize, "stack_slab_slots", stack_slab_slots);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,14 +15,16 @@ All notable changes to this project will be documented in this file.
   at startup so an early spawn burst skips stack allocation entirely.
 
 - **BREAKING**: The stack pool's `max_unused_stacks` and `max_age` settings are gone,
-  replaced by a demand watermark. The pool tracks the peak number of stacks
-  simultaneously in use over each `stack_pool.shrink_interval` (default 60 seconds,
-  `.zero` disables shrinking), and a periodic pass returns free capacity beyond that
-  watermark to the OS, unmapping whole empty slabs first and then individually mapped
-  stacks. Prewarmed slots act as a floor and are never shrunk away. Compared to the
-  old count cap and age limit, memory now follows what the workload actually needed
-  recently: a burst decays one interval after it stops repeating, and a steady load
-  keeps its stacks indefinitely without periodic reallocation.
+  replaced by a decaying demand watermark. The pool keeps a retain target that jumps
+  to the peak number of stacks simultaneously in use whenever demand grows and halves
+  per `stack_pool.shrink_interval` (default 60 seconds, `.zero` disables shrinking) on
+  the way down. A periodic pass returns free capacity beyond the target to the OS,
+  unmapping whole empty slabs first (a bounded number per pass, so a single pass never
+  stalls an executor) and then individually mapped stacks. Prewarmed slots act as a
+  floor and are never shrunk away. Compared to the old count cap and age limit, memory
+  follows what the workload actually needed recently: a burst's capacity drains with a
+  half-life of one interval, a repeat burst re-inflates it instantly, and a steady
+  load keeps its stacks indefinitely without periodic reallocation.
 
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local
   tasks. A freshly idle executor now gives its own event loop a short grace window first

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,8 +19,8 @@ All notable changes to this project will be documented in this file.
   to the peak number of stacks simultaneously in use whenever demand grows and halves
   per `stack_pool.shrink_interval` (default 60 seconds, `.zero` disables shrinking) on
   the way down. A periodic pass returns free capacity beyond the target to the OS,
-  unmapping whole empty slabs first (a bounded number per pass, so a single pass never
-  stalls an executor) and then individually mapped stacks. Prewarmed slots act as a
+  unmapping whole empty slabs first (at most half of them per pass, matching the decay
+  shape) and then individually mapped stacks. Prewarmed slots act as a
   floor and are never shrunk away. Compared to the old count cap and age limit, memory
   follows what the workload actually needed recently: a burst's capacity drains with a
   half-life of one interval, a repeat burst re-inflates it instantly, and a steady

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,9 +11,9 @@ All notable changes to this project will be documented in this file.
   by ~10%. The pool's `max_unused_stacks` and `max_age` settings are gone, replaced
   by a decaying demand watermark: a periodic pass returns capacity beyond the recent
   peak usage to the OS, with a half-life of one `stack_pool.shrink_interval` (default
-  60s, `.zero` disables shrinking). The slots-per-slab count is a build option
-  (`-Dstack-slab-slots`, 0 restores the per-stack allocator), and the new
-  `stack_pool.prewarm` option commits that many slots at startup and floors the
+  60s, `.zero` disables shrinking). The slots-per-slab count is a runtime option
+  (`stack_pool.slab_slots`, default 64; 0 restores the per-stack allocator), and the
+  new `stack_pool.prewarm` option commits that many slots at startup and floors the
   watermark. (#436)
 
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Coroutine stacks are now carved out of larger slab reservations instead of each
+  getting its own mmap (on 64-bit POSIX targets; Windows and OpenBSD keep the previous
+  allocator). A cold stack costs one page-protection syscall instead of three mapping
+  syscalls, and a released stack is kept and reused with no syscalls at all, with no
+  cap and no age eviction. This mainly helps workloads holding many coroutines alive
+  at once: 10k concurrently sleeping tasks got about 25% faster, large fan-out about
+  10%. Note the memory trade-off: slab-backed stacks are only returned to the OS at
+  runtime shutdown, so resident memory tracks the high-water mark of concurrently
+  live coroutine stacks. The slots-per-slab count is a build option
+  (`-Dstack-slab-slots=N`, default 64; 0 restores the per-stack allocator), and the
+  new `stack_pool.prewarm` runtime option commits that many slots at startup so an
+  early spawn burst skips stack allocation entirely.
+
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local
   tasks. A freshly idle executor now gives its own event loop a short grace window first
   (a non-blocking probe, then a park capped at 100us), since completions usually re-ready

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   60s, `.zero` disables shrinking). The slots-per-slab count is a build option
   (`-Dstack-slab-slots`, 0 restores the per-stack allocator), and the new
   `stack_pool.prewarm` option commits that many slots at startup and floors the
-  watermark.
+  watermark. (#436)
 
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local
   tasks. A freshly idle executor now gives its own event loop a short grace window first

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,27 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Coroutine stacks are now carved out of larger slab reservations instead of each
-  getting its own mmap (on 64-bit POSIX targets; Windows and OpenBSD keep the previous
-  allocator). A cold stack costs one page-protection syscall instead of three mapping
-  syscalls, and releasing and reusing stacks never makes a syscall at all. This mainly
-  helps workloads holding many coroutines alive at once: 10k concurrently sleeping
-  tasks got about 25% faster, large fan-out about 10%. The slots-per-slab count is a
-  build option (`-Dstack-slab-slots=N`, default 64; 0 restores the per-stack
-  allocator), and the new `stack_pool.prewarm` runtime option commits that many slots
-  at startup so an early spawn burst skips stack allocation entirely.
-
-- **BREAKING**: The stack pool's `max_unused_stacks` and `max_age` settings are gone,
-  replaced by a decaying demand watermark. The pool keeps a retain target that jumps
-  to the peak number of stacks simultaneously in use whenever demand grows and halves
-  per `stack_pool.shrink_interval` (default 60 seconds, `.zero` disables shrinking) on
-  the way down. A periodic pass returns free capacity beyond the target to the OS,
-  unmapping whole empty slabs first (at most half of them per pass, matching the decay
-  shape) and then individually mapped stacks. Prewarmed slots act as a
-  floor and are never shrunk away. Compared to the old count cap and age limit, memory
-  follows what the workload actually needed recently: a burst's capacity drains with a
-  half-life of one interval, a repeat burst re-inflates it instantly, and a steady
-  load keeps its stacks indefinitely without periodic reallocation.
+- **BREAKING**: Reworked coroutine stack allocation. On 64-bit POSIX targets, stacks
+  are now carved from larger slab reservations (one syscall per cold stack instead of
+  three, and no syscalls at all to release and reuse one), which sped up workloads
+  with many live coroutines: 10k concurrently sleeping tasks by ~25%, large fan-out
+  by ~10%. The pool's `max_unused_stacks` and `max_age` settings are gone, replaced
+  by a decaying demand watermark: a periodic pass returns capacity beyond the recent
+  peak usage to the OS, with a half-life of one `stack_pool.shrink_interval` (default
+  60s, `.zero` disables shrinking). The slots-per-slab count is a build option
+  (`-Dstack-slab-slots`, 0 restores the per-stack allocator), and the new
+  `stack_pool.prewarm` option commits that many slots at startup and floors the
+  watermark.
 
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local
   tasks. A freshly idle executor now gives its own event loop a short grace window first

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,15 +7,22 @@ All notable changes to this project will be documented in this file.
 - Coroutine stacks are now carved out of larger slab reservations instead of each
   getting its own mmap (on 64-bit POSIX targets; Windows and OpenBSD keep the previous
   allocator). A cold stack costs one page-protection syscall instead of three mapping
-  syscalls, and a released stack is kept and reused with no syscalls at all, with no
-  cap and no age eviction. This mainly helps workloads holding many coroutines alive
-  at once: 10k concurrently sleeping tasks got about 25% faster, large fan-out about
-  10%. Note the memory trade-off: slab-backed stacks are only returned to the OS at
-  runtime shutdown, so resident memory tracks the high-water mark of concurrently
-  live coroutine stacks. The slots-per-slab count is a build option
-  (`-Dstack-slab-slots=N`, default 64; 0 restores the per-stack allocator), and the
-  new `stack_pool.prewarm` runtime option commits that many slots at startup so an
-  early spawn burst skips stack allocation entirely.
+  syscalls, and releasing and reusing stacks never makes a syscall at all. This mainly
+  helps workloads holding many coroutines alive at once: 10k concurrently sleeping
+  tasks got about 25% faster, large fan-out about 10%. The slots-per-slab count is a
+  build option (`-Dstack-slab-slots=N`, default 64; 0 restores the per-stack
+  allocator), and the new `stack_pool.prewarm` runtime option commits that many slots
+  at startup so an early spawn burst skips stack allocation entirely.
+
+- **BREAKING**: The stack pool's `max_unused_stacks` and `max_age` settings are gone,
+  replaced by a demand watermark. The pool tracks the peak number of stacks
+  simultaneously in use over each `stack_pool.shrink_interval` (default 60 seconds,
+  `.zero` disables shrinking), and a periodic pass returns free capacity beyond that
+  watermark to the OS, unmapping whole empty slabs first and then individually mapped
+  stacks. Prewarmed slots act as a floor and are never shrunk away. Compared to the
+  old count cap and age limit, memory now follows what the workload actually needed
+  recently: a burst decays one interval after it stops repeating, and a steady load
+  keeps its stacks indefinitely without periodic reallocation.
 
 - Multi-threaded runtimes no longer steal work the moment an executor runs out of local
   tasks. A freshly idle executor now gives its own event loop a short grace window first

--- a/src/coro/stack.zig
+++ b/src/coro/stack.zig
@@ -88,8 +88,10 @@ fn stackAllocPosix(info: *StackInfo, maximum_size: usize, committed_size: usize)
 
     // Guard page stays as PROT_NONE (first page)
 
-    // Round committed size up to page boundary
-    const commit_size = std.mem.alignForward(usize, committed_size, page_size);
+    // Round committed size up to page boundary; commit at least one page so
+    // the owner-tag word below and the pool's FreeNode always have committed
+    // memory to live in.
+    const commit_size = @max(std.mem.alignForward(usize, committed_size, page_size), page_size);
 
     // Validate that committed size doesn't exceed available space (minus guard page)
     if (commit_size > size - page_size) {
@@ -109,13 +111,34 @@ fn stackAllocPosix(info: *StackInfo, maximum_size: usize, committed_size: usize)
     // Stack layout (grows downward from high to low addresses):
     // [guard_page (PROT_NONE)][uncommitted (PROT_NONE)][committed (READ|WRITE)]
     // ^                                                ^                       ^
-    // allocation_ptr                                   limit                   base (allocation_ptr + allocation_len)
+    // allocation_ptr                                   limit                   base (top - tag reserve)
+    // The topmost 16 bytes above base hold the pool's owner tag (see
+    // stackWriteOwnerTag); an individually mapped stack tags itself 0.
     info.* = .{
         .allocation_ptr = allocation.ptr,
-        .base = stack_top,
+        .base = stack_top - owner_tag_reserve,
         .limit = initial_commit_start,
         .allocation_len = allocation.len,
     };
+    stackWriteOwnerTag(info.*, 0);
+}
+
+/// Bytes reserved above `base` at the very top of every POSIX stack for the
+/// pool's owner tag (the slab a slot was carved from, or 0 for an individual
+/// mapping). The coroutine's stack pointer starts at `base` and grows down,
+/// so the tag survives the coroutine's whole lifetime, and 16 bytes keeps
+/// `base` 16-byte aligned. Lets the pool find a released stack's slab with
+/// one read instead of scanning the slab chain.
+pub const owner_tag_reserve = 16;
+
+pub fn stackWriteOwnerTag(info: StackInfo, tag: usize) void {
+    const tag_ptr: *usize = @ptrFromInt(@intFromPtr(info.allocation_ptr) + info.allocation_len - 8);
+    tag_ptr.* = tag;
+}
+
+pub fn stackReadOwnerTag(info: StackInfo) usize {
+    const tag_ptr: *const usize = @ptrFromInt(@intFromPtr(info.allocation_ptr) + info.allocation_len - 8);
+    return tag_ptr.*;
 }
 
 /// Allocate a coroutine stack on OpenBSD.
@@ -211,7 +234,7 @@ pub fn slabFree(mem: []align(page_size) u8) void {
 /// exactly the layout stackAllocPosix produces, so growth, overflow
 /// detection, and pooling treat both kinds identically. One mprotect per
 /// cold slot; a recycled slot pays no syscalls at all.
-pub fn stackInitSlot(info: *StackInfo, slot: []align(page_size) u8, committed_size: usize) error{OutOfMemory}!void {
+pub fn stackInitSlot(info: *StackInfo, slot: []align(page_size) u8, committed_size: usize, owner_tag: usize) error{OutOfMemory}!void {
     // Commit at least one page so the pool's FreeNode always fits.
     const commit_size = @max(std.mem.alignForward(usize, committed_size, page_size), page_size);
     if (commit_size > slot.len - page_size) {
@@ -229,10 +252,11 @@ pub fn stackInitSlot(info: *StackInfo, slot: []align(page_size) u8, committed_si
 
     info.* = .{
         .allocation_ptr = slot.ptr,
-        .base = stack_top,
+        .base = stack_top - owner_tag_reserve,
         .limit = initial_commit_start,
         .allocation_len = slot.len,
     };
+    stackWriteOwnerTag(info.*, owner_tag);
 
     if (builtin.mode == .Debug and builtin.valgrind_support) {
         const stack_slice: [*]u8 = @ptrFromInt(info.limit);
@@ -643,11 +667,12 @@ test "Stack: alloc/free" {
     // Verify base is at the top (high address)
     try std.testing.expect(stack.base > stack.limit);
 
-    // Verify at least the requested amount was committed
+    // Verify at least the requested amount was committed (minus the owner
+    // tag reserve, which lives in committed memory above `base` on POSIX).
     // Note: RtlCreateUserStack on Windows may commit more than requested
     const commit_size_rounded = std.mem.alignForward(usize, committed_size, page_size);
     const actual_committed = stack.base - stack.limit;
-    try std.testing.expect(actual_committed >= commit_size_rounded);
+    try std.testing.expect(actual_committed + owner_tag_reserve >= commit_size_rounded);
 
     // Verify base is at the top of the allocation
     try std.testing.expect(stack.base >= @intFromPtr(stack.allocation_ptr));

--- a/src/coro/stack.zig
+++ b/src/coro/stack.zig
@@ -169,6 +169,77 @@ fn stackAllocOpenBSD(info: *StackInfo, size: usize) error{OutOfMemory}!void {
     };
 }
 
+/// Reserve one slab arena: a PROT_NONE address-space reservation that stack
+/// slots are carved out of, with its first page committed for the slab
+/// header. Pages between and below slots stay PROT_NONE, so guard pages cost
+/// nothing extra. POSIX-only (the slab pool is comptime-disabled elsewhere);
+/// OpenBSD is excluded because MAP_STACK cannot start as PROT_NONE.
+pub fn slabReserve(len: usize) error{OutOfMemory}![]align(page_size) u8 {
+    const prot_flags = posix.PROT.NONE | posix.PROT.MAX(posix.PROT.READ | posix.PROT.WRITE);
+    var map_flags = posix.MAP.PRIVATE | posix.MAP.ANONYMOUS;
+    if (builtin.os.tag == .linux or builtin.os.tag == .netbsd) {
+        map_flags |= posix.MAP.STACK;
+    }
+
+    const allocation = posix.mmap(null, len, prot_flags, map_flags, -1, 0) catch |err| {
+        log.err("Failed to mmap stack slab (size={d}): {}", .{ len, err });
+        return error.OutOfMemory;
+    };
+    errdefer posix.munmap(allocation) catch {};
+
+    // One madvise for the whole slab instead of one per stack.
+    if (@hasDecl(posix.MADV, "NOHUGEPAGE")) {
+        posix.madvise(allocation, posix.MADV.NOHUGEPAGE) catch {};
+    }
+
+    // Commit the header page for the slab bookkeeping.
+    posix.mprotect(allocation.ptr[0..page_size], posix.PROT.READ | posix.PROT.WRITE) catch |err| {
+        log.err("Failed to commit stack slab header page: {}", .{err});
+        return error.OutOfMemory;
+    };
+
+    return allocation;
+}
+
+pub fn slabFree(mem: []align(page_size) u8) void {
+    posix.munmap(mem) catch {};
+}
+
+/// Initialize a stack inside a slab slot: commit the initial region at the
+/// top and leave everything below it (including the slot's first page, the
+/// guard) as the slab's PROT_NONE reservation. The resulting StackInfo has
+/// exactly the layout stackAllocPosix produces, so growth, overflow
+/// detection, and pooling treat both kinds identically. One mprotect per
+/// cold slot; a recycled slot pays no syscalls at all.
+pub fn stackInitSlot(info: *StackInfo, slot: []align(page_size) u8, committed_size: usize) error{OutOfMemory}!void {
+    // Commit at least one page so the pool's FreeNode always fits.
+    const commit_size = @max(std.mem.alignForward(usize, committed_size, page_size), page_size);
+    if (commit_size > slot.len - page_size) {
+        log.err("Committed size ({d}) exceeds slab slot size ({d})", .{ commit_size, slot.len });
+        return error.OutOfMemory;
+    }
+
+    const stack_top = @intFromPtr(slot.ptr) + slot.len;
+    const initial_commit_start = stack_top - commit_size;
+    const initial_region: [*]align(page_size) u8 = @ptrFromInt(initial_commit_start);
+    posix.mprotect(initial_region[0..commit_size], posix.PROT.READ | posix.PROT.WRITE) catch |err| {
+        log.err("Failed to commit slab stack slot (commit_size={d}): {}", .{ commit_size, err });
+        return error.OutOfMemory;
+    };
+
+    info.* = .{
+        .allocation_ptr = slot.ptr,
+        .base = stack_top,
+        .limit = initial_commit_start,
+        .allocation_len = slot.len,
+    };
+
+    if (builtin.mode == .Debug and builtin.valgrind_support) {
+        const stack_slice: [*]u8 = @ptrFromInt(info.limit);
+        info.valgrind_stack_id = std.valgrind.stackRegister(stack_slice[0 .. info.base - info.limit]);
+    }
+}
+
 pub fn stackFree(info: StackInfo) void {
     if (builtin.mode == .Debug and builtin.valgrind_support) {
         if (info.valgrind_stack_id != 0) {

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -252,13 +252,6 @@ pub const StackPool = struct {
         self.mutex.unlock();
     }
 
-    /// Bounds on work per shrink pass, so a pass after a large burst does
-    /// not stall an executor's timer callback on hundreds of munmaps. The
-    /// decay curve already spreads reclamation over multiple intervals;
-    /// these bound the worst single pass.
-    const max_stack_frees_per_shrink = 64;
-    const max_slab_frees_per_shrink = 16;
-
     /// Periodic shrink pass: rate-limited to `shrink_interval` internally,
     /// so any executor's timer may drive it. Frees the committed capacity
     /// that the demand watermark says was not needed since the previous
@@ -293,25 +286,34 @@ pub const StackPool = struct {
             // Committed capacity = live stacks + everything parked on free
             // lists. Anything beyond the retain target is up for release.
             var free_capacity: usize = self.pool_size;
+            var slab_count: usize = 0;
             var slab = self.slabs;
             while (slab) |s| : (slab = s.next) {
                 free_capacity += s.carved - s.in_use;
+                slab_count += 1;
             }
             var excess = (self.in_use + free_capacity) -| self.retain_target;
+
+            // Per-pass work bounds are relative (half of what is currently
+            // there, rounded up), matching the decay curve's own shape: the
+            // worst pass after a burst scales with the burst, halves every
+            // interval after that, and never turns the exponential drain
+            // into a linear one the way an absolute cap would.
+            var slab_budget = (slab_count + 1) / 2;
+            var stack_budget = (self.pool_size + 1) / 2;
 
             // Unmap empty slabs first: one syscall retires a whole arena.
             // Strictly within the excess, so capacity never dips below the
             // target (a mostly-empty slab bigger than the excess stays).
             if (slab_enabled) {
-                var freed_slabs: usize = 0;
                 var prev: ?*Slab = null;
                 var cur = self.slabs;
                 while (cur) |s| {
                     const next = s.next;
-                    if (s.in_use == 0 and s.carved <= excess and freed_slabs < max_slab_frees_per_shrink) {
+                    if (s.in_use == 0 and s.carved <= excess and slab_budget > 0) {
                         if (prev) |p| p.next = next else self.slabs = next;
                         excess -= s.carved;
-                        freed_slabs += 1;
+                        slab_budget -= 1;
                         s.next = slabs_to_free;
                         slabs_to_free = s;
                     } else {
@@ -322,14 +324,13 @@ pub const StackPool = struct {
             }
 
             // Then individually mapped stacks, oldest first.
-            var freed: usize = 0;
-            while (excess > 0 and freed < max_stack_frees_per_shrink) {
+            while (excess > 0 and stack_budget > 0) {
                 const node = self.head orelse break;
                 self.removeNode(node);
                 node.next = stacks_to_free;
                 stacks_to_free = node;
                 excess -= 1;
-                freed += 1;
+                stack_budget -= 1;
             }
         }
 

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -10,12 +10,11 @@ const Timestamp = @import("../time.zig").Timestamp;
 const Duration = @import("../time.zig").Duration;
 const os = @import("../os/root.zig");
 
-/// A node in the free list, stored at the base of an unused stack.
+/// A node in a free list, stored at the base of an unused stack.
 const FreeNode = struct {
     prev: ?*FreeNode,
     next: ?*FreeNode,
     stack_info: StackInfo,
-    timestamp: Timestamp,
 };
 
 /// Number of stack slots carved from one slab reservation (build option
@@ -39,7 +38,12 @@ pub const slab_enabled = slab_slots > 0 and @sizeOf(usize) == 8 and switch (buil
 const Slab = struct {
     next: ?*Slab,
     memory: []align(stack.page_size) u8,
+    /// Slots handed out at least once. Only the newest slab still carves.
     carved: usize,
+    /// Slots currently acquired by live coroutines.
+    in_use: usize,
+    /// Released slots of this slab (LIFO). carved - in_use entries.
+    free: ?*FreeNode,
 };
 
 pub const Config = struct {
@@ -51,37 +55,45 @@ pub const Config = struct {
     /// This is the amount of physical memory initially committed.
     committed_size: usize,
 
-    /// Maximum number of unused stacks to keep in the pool.
-    /// When this limit is exceeded, the oldest stack is freed.
-    max_unused_stacks: usize = 16,
-
-    /// Maximum age of an unused stack.
-    /// Stacks older than this will be freed on the next release() call.
-    /// .zero means no age limit.
-    /// Only applies to individually mapped stacks; slab slots are never
-    /// evicted or decommitted (recycling was measured too expensive).
-    max_age: Duration = .zero,
+    /// How often the pool re-evaluates its size against recent demand.
+    ///
+    /// The pool tracks a demand watermark: the peak number of stacks
+    /// simultaneously in use since the previous evaluation (but never below
+    /// `prewarm`). On each evaluation, free capacity beyond that watermark is
+    /// returned to the OS: whole slabs whose every slot is unused are
+    /// unmapped first, then individually mapped stacks, oldest first.
+    /// Between evaluations, releasing and reusing stacks never makes a
+    /// syscall. `.zero` disables shrinking entirely; the pool then holds its
+    /// high-water mark until deinit.
+    shrink_interval: Duration = .fromSeconds(60),
 
     /// Number of slab slots to carve and commit up front (at runtime init),
-    /// so that a burst of early spawns skips the cold-allocation cost.
-    /// Ignored when slab allocation is compiled out.
+    /// so that a burst of early spawns skips the cold-allocation cost. Also
+    /// acts as the floor for the demand watermark, so prewarmed capacity is
+    /// never shrunk away. Ignored when slab allocation is compiled out.
     prewarm: usize = 0,
 };
 
 pub const StackPool = struct {
     config: Config,
     mutex: os.Mutex,
+    /// Individually mapped stacks (fallback path): doubly linked, oldest at
+    /// the head, so shrinking frees the longest-idle ones first.
     head: ?*FreeNode,
     tail: ?*FreeNode,
     pool_size: usize,
-    // Slab state: chain of arenas (newest first; only the newest still has
-    // uncarved slots) and a LIFO of released slab slots. Slab slots bypass
-    // the max_unused_stacks/max_age policy entirely: releasing one is a
-    // pointer push, reusing one costs no syscalls, and the memory is only
-    // returned at deinit.
+    /// Slab chain, newest first. Acquire prefers the first slab with a free
+    /// slot, so load concentrates at the head and older slabs drain toward
+    /// empty, where the shrink pass can unmap them wholesale.
     slabs: ?*Slab,
-    arena_free: ?*FreeNode,
     slot_size: usize,
+    /// Stacks currently acquired (both kinds).
+    in_use: usize,
+    /// Peak of `in_use` since the last shrink evaluation: the demand
+    /// watermark that decides how much free capacity the next evaluation
+    /// keeps.
+    epoch_peak: usize,
+    last_shrink: Timestamp,
 
     pub fn init(config: Config) StackPool {
         // Same slot layout as stackAllocPosix: usable size rounded to pages,
@@ -94,8 +106,10 @@ pub const StackPool = struct {
             .tail = null,
             .pool_size = 0,
             .slabs = null,
-            .arena_free = null,
             .slot_size = @max(aligned_max + stack.page_size, stack.page_size * 2),
+            .in_use = 0,
+            .epoch_peak = 0,
+            .last_shrink = .zero,
         };
     }
 
@@ -103,7 +117,7 @@ pub const StackPool = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        // Free all stacks in the pool
+        // Free all individually mapped stacks in the pool
         var current = self.head;
         while (current) |node| {
             const next = node.next;
@@ -123,7 +137,6 @@ pub const StackPool = struct {
             slab = next;
         }
         self.slabs = null;
-        self.arena_free = null;
     }
 
     /// Acquires a stack from the pool, or allocates a new one if the pool is empty.
@@ -135,17 +148,24 @@ pub const StackPool = struct {
             defer self.mutex.unlock();
 
             if (slab_enabled) {
-                // Released slab slots first: LIFO, still committed, still
-                // cache-warm, zero syscalls.
-                if (self.arena_free) |node| {
-                    self.arena_free = node.next;
-                    return node.stack_info;
+                // Released slab slots first: still committed, still
+                // cache-warm, zero syscalls. First slab with a free slot
+                // wins, concentrating load near the head of the chain.
+                var slab = self.slabs;
+                while (slab) |s| : (slab = s.next) {
+                    if (s.free) |node| {
+                        s.free = node.next;
+                        s.in_use += 1;
+                        self.noteAcquireLocked();
+                        return node.stack_info;
+                    }
                 }
             }
 
             if (self.head) |node| {
                 const stack_info = node.stack_info;
                 self.removeNode(node);
+                self.noteAcquireLocked();
                 return stack_info;
             }
 
@@ -154,6 +174,7 @@ pub const StackPool = struct {
                 // new slab if the current one is exhausted. Done under the
                 // lock — carving is rare and the bookkeeping needs it anyway.
                 if (self.carveSlotLocked()) |stack_info| {
+                    self.noteAcquireLocked();
                     return stack_info;
                 }
                 // Slab reservation failed (address space exhausted?); fall
@@ -164,12 +185,155 @@ pub const StackPool = struct {
         // Pool was empty, allocate new stack outside the lock
         var stack_info: StackInfo = undefined;
         try stack.stackAlloc(&stack_info, self.config.maximum_size, self.config.committed_size);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.noteAcquireLocked();
         return stack_info;
+    }
+
+    fn noteAcquireLocked(self: *StackPool) void {
+        self.in_use += 1;
+        self.epoch_peak = @max(self.epoch_peak, self.in_use);
+    }
+
+    /// Releases a stack back to the pool. Never makes a syscall: slab slots
+    /// are pushed onto their slab's free list and individually mapped stacks
+    /// onto the pool's list. Returning memory to the OS happens only in the
+    /// periodic shrink pass.
+    pub fn release(self: *StackPool, stack_info: StackInfo) void {
+        // The FreeNode is stored at the base of the stack (aligned backward)
+        const node_addr = std.mem.alignBackward(usize, stack_info.base - @sizeOf(FreeNode), @alignOf(FreeNode));
+
+        self.mutex.lock();
+
+        if (slab_enabled) {
+            if (self.slabOfLocked(stack_info.allocation_ptr)) |slab| {
+                // Slab slots always commit at least one page, so the node fits.
+                std.debug.assert(node_addr >= stack_info.limit);
+                const node: *FreeNode = @ptrFromInt(node_addr);
+                node.* = .{
+                    .prev = null,
+                    .next = slab.free,
+                    .stack_info = stack_info,
+                };
+                slab.free = node;
+                slab.in_use -= 1;
+                self.in_use -= 1;
+                self.mutex.unlock();
+                return;
+            }
+        }
+
+        self.in_use -= 1;
+
+        // Verify the FreeNode fits within the committed region (between limit and base)
+        if (node_addr < stack_info.limit) {
+            // Stack is too small to hold the FreeNode, free it instead of pooling
+            self.mutex.unlock();
+            stack.stackFree(stack_info);
+            return;
+        }
+
+        const node: *FreeNode = @ptrFromInt(node_addr);
+        node.* = .{
+            .prev = null,
+            .next = null,
+            .stack_info = stack_info,
+        };
+        self.addNode(node);
+        self.mutex.unlock();
+    }
+
+    /// Bound on individually mapped stacks freed per shrink pass, so a pass
+    /// after a large burst does not stall an executor on thousands of
+    /// munmaps. Whole-slab frees are not bounded; there are few slabs and
+    /// each unmap retires many slots at once.
+    const max_stack_frees_per_shrink = 64;
+
+    /// Periodic shrink pass: rate-limited to `shrink_interval` internally,
+    /// so any executor's timer may drive it. Frees the committed capacity
+    /// that the demand watermark says was not needed since the previous
+    /// pass; see Config.shrink_interval.
+    pub fn shrink(self: *StackPool, now: Timestamp) void {
+        if (self.config.shrink_interval.value == 0) return;
+
+        var slabs_to_free: ?*Slab = null;
+        var stacks_to_free: ?*FreeNode = null;
+
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            if (self.last_shrink.value != 0 and
+                self.last_shrink.durationTo(now).value < self.config.shrink_interval.value)
+            {
+                return;
+            }
+            self.last_shrink = now;
+
+            const floor = @max(self.epoch_peak, if (slab_enabled) self.config.prewarm else 0);
+            self.epoch_peak = self.in_use;
+
+            // Committed capacity = live stacks + everything parked on free
+            // lists. Anything beyond the watermark is up for release.
+            var free_capacity: usize = self.pool_size;
+            var slab = self.slabs;
+            while (slab) |s| : (slab = s.next) {
+                free_capacity += s.carved - s.in_use;
+            }
+            var excess = (self.in_use + free_capacity) -| floor;
+
+            // Unmap empty slabs first: one syscall retires a whole arena.
+            // Strictly within the excess, so capacity never dips below the
+            // watermark (a mostly-empty slab bigger than the excess stays).
+            if (slab_enabled) {
+                var prev: ?*Slab = null;
+                var cur = self.slabs;
+                while (cur) |s| {
+                    const next = s.next;
+                    if (s.in_use == 0 and s.carved <= excess) {
+                        if (prev) |p| p.next = next else self.slabs = next;
+                        excess -= s.carved;
+                        s.next = slabs_to_free;
+                        slabs_to_free = s;
+                    } else {
+                        prev = s;
+                    }
+                    cur = next;
+                }
+            }
+
+            // Then individually mapped stacks, oldest first.
+            var freed: usize = 0;
+            while (excess > 0 and freed < max_stack_frees_per_shrink) {
+                const node = self.head orelse break;
+                self.removeNode(node);
+                node.next = stacks_to_free;
+                stacks_to_free = node;
+                excess -= 1;
+                freed += 1;
+            }
+        }
+
+        // Return memory to the OS outside the lock.
+        while (slabs_to_free) |s| {
+            const next = s.next;
+            stack.slabFree(s.memory);
+            slabs_to_free = next;
+        }
+        while (stacks_to_free) |node| {
+            const next = node.next;
+            stack.stackFree(node.stack_info);
+            stacks_to_free = next;
+        }
     }
 
     /// Carve and commit the next slot out of the newest slab, growing the
     /// slab chain when needed. Returns null if reservation or commit fails
     /// (the caller falls back to individual mappings). Must run under mutex.
+    /// The new slot is counted as in use on its slab; the caller accounts
+    /// the pool-wide acquire.
     fn carveSlotLocked(self: *StackPool) ?StackInfo {
         const slab = blk: {
             if (self.slabs) |s| {
@@ -178,7 +342,7 @@ pub const StackPool = struct {
             const len = stack.page_size + slab_slots * self.slot_size;
             const mem = stack.slabReserve(len) catch return null;
             const s: *Slab = @ptrCast(@alignCast(mem.ptr));
-            s.* = .{ .next = self.slabs, .memory = mem, .carved = 0 };
+            s.* = .{ .next = self.slabs, .memory = mem, .carved = 0, .in_use = 0, .free = null };
             self.slabs = s;
             break :blk s;
         };
@@ -188,19 +352,21 @@ pub const StackPool = struct {
         var stack_info: StackInfo = undefined;
         stack.stackInitSlot(&stack_info, slot, self.config.committed_size) catch return null;
         slab.carved += 1;
+        slab.in_use += 1;
         return stack_info;
     }
 
-    /// Whether this allocation is a slab slot. Must run under mutex (the
-    /// slab chain is mutated by carveSlotLocked).
-    fn inArenaLocked(self: *StackPool, ptr: [*]align(stack.page_size) u8) bool {
+    /// The slab this allocation was carved from, or null for an individually
+    /// mapped stack. Must run under mutex (the chain is mutated by carving
+    /// and shrinking).
+    fn slabOfLocked(self: *StackPool, ptr: [*]align(stack.page_size) u8) ?*Slab {
         const addr = @intFromPtr(ptr);
         var slab = self.slabs;
         while (slab) |s| : (slab = s.next) {
             const base = @intFromPtr(s.memory.ptr);
-            if (addr >= base and addr < base + s.memory.len) return true;
+            if (addr >= base and addr < base + s.memory.len) return s;
         }
-        return false;
+        return null;
     }
 
     /// Carve and commit `config.prewarm` slots up front. Called once from
@@ -216,140 +382,9 @@ pub const StackPool = struct {
                 self.mutex.unlock();
                 return error.OutOfMemory;
             };
+            self.in_use += 1;
             self.mutex.unlock();
-            self.release(stack_info, .zero);
-        }
-    }
-
-    /// Releases a stack back to the pool.
-    /// Expired stacks are removed before adding the new stack to avoid depleting the pool.
-    /// If the pool is full, frees the oldest stack and adds this one.
-    /// If the stack's committed region is too small to store the FreeNode, the stack is freed instead.
-    pub fn release(self: *StackPool, stack_info: StackInfo, timestamp: Timestamp) void {
-        // Check if the stack has enough committed space to store the FreeNode
-        // The FreeNode is stored at the base of the stack (aligned backward)
-        const node_addr = std.mem.alignBackward(usize, stack_info.base - @sizeOf(FreeNode), @alignOf(FreeNode));
-
-        if (slab_enabled) {
-            self.mutex.lock();
-            if (self.inArenaLocked(stack_info.allocation_ptr)) {
-                // Slab slots always commit at least one page, so the node fits.
-                std.debug.assert(node_addr >= stack_info.limit);
-                const node: *FreeNode = @ptrFromInt(node_addr);
-                node.* = .{
-                    .prev = null,
-                    .next = self.arena_free,
-                    .stack_info = stack_info,
-                    .timestamp = timestamp,
-                };
-                self.arena_free = node;
-                self.mutex.unlock();
-                return;
-            }
-            self.mutex.unlock();
-        }
-
-        // Verify the FreeNode fits within the committed region (between limit and base)
-        if (node_addr < stack_info.limit) {
-            // Stack is too small to hold the FreeNode, free it instead of pooling
-            stack.stackFree(stack_info);
-            return;
-        }
-
-        // Recycle the stack memory (MADV_FREE on POSIX) - no lock needed
-        // NOTE: this turns out to be tooo expensive to be worth it
-        // stack.stackRecycle(stack_info);
-
-        // Store the FreeNode at the base of the stack
-        const node = @as(*FreeNode, @ptrFromInt(node_addr));
-        node.* = .{
-            .prev = null,
-            .next = null,
-            .stack_info = stack_info,
-            .timestamp = timestamp,
-        };
-
-        // Collect stacks to free in a temporary singly-linked list
-        // Limit how many we free per call to bound latency
-        const max_free_per_release = 4;
-        var to_free_head: ?*FreeNode = null;
-        var to_free_count: usize = 0;
-
-        {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-
-            // Remove expired stacks from the front of the list (up to limit)
-            // Do this before adding the new stack to avoid the situation where we'd
-            // remove all stacks (including the one we're about to add) and end up with an empty pool
-            if (self.config.max_age.value > 0) {
-                while (self.head) |expired| {
-                    if (to_free_count >= max_free_per_release) break;
-                    const age = expired.timestamp.durationTo(timestamp);
-                    if (age.value > self.config.max_age.value) {
-                        self.removeNode(expired);
-                        expired.next = to_free_head;
-                        to_free_head = expired;
-                        to_free_count += 1;
-                    } else {
-                        // List is ordered by timestamp, so we can stop
-                        break;
-                    }
-                }
-            }
-
-            // If pool is at capacity and under limit, remove the oldest stack
-            if (self.pool_size >= self.config.max_unused_stacks and to_free_count < max_free_per_release) {
-                if (self.head) |oldest| {
-                    self.removeNode(oldest);
-                    oldest.next = to_free_head;
-                    to_free_head = oldest;
-                    to_free_count += 1;
-                }
-            }
-
-            // Add to the tail of the list (most recently released)
-            self.addNode(node);
-        }
-
-        // Free collected stacks - no lock held
-        while (to_free_head) |free_node| {
-            const next = free_node.next;
-            stack.stackFree(free_node.stack_info);
-            to_free_head = next;
-        }
-    }
-
-    /// Evicts up to `limit` expired stacks from the pool.
-    /// Intended to be called periodically from a timer to reclaim idle stacks.
-    pub fn cleanup(self: *StackPool, now: Timestamp, limit: usize) void {
-        if (self.config.max_age.value == 0) return;
-
-        var to_free_head: ?*FreeNode = null;
-        var to_free_count: usize = 0;
-
-        {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-
-            while (self.head) |node| {
-                if (to_free_count >= limit) break;
-                const age = node.timestamp.durationTo(now);
-                if (age.value > self.config.max_age.value) {
-                    self.removeNode(node);
-                    node.next = to_free_head;
-                    to_free_head = node;
-                    to_free_count += 1;
-                } else {
-                    break;
-                }
-            }
-        }
-
-        while (to_free_head) |free_node| {
-            const next = free_node.next;
-            stack.stackFree(free_node.stack_info);
-            to_free_head = next;
+            self.release(stack_info);
         }
     }
 
@@ -393,7 +428,6 @@ test "StackPool basic acquire and release" {
     var pool = StackPool.init(.{
         .maximum_size = 1024 * 1024,
         .committed_size = 64 * 1024,
-        .max_unused_stacks = 4,
     });
     defer pool.deinit();
 
@@ -401,15 +435,17 @@ test "StackPool basic acquire and release" {
     const stack1 = try pool.acquire();
     try std.testing.expect(stack1.base != 0);
     try std.testing.expect(stack1.base > stack1.limit); // Stack grows downward
+    try std.testing.expectEqual(1, pool.in_use);
 
     // Release it back, acquire again - should reuse the same stack
-    pool.release(stack1, .zero);
+    pool.release(stack1);
+    try std.testing.expectEqual(0, pool.in_use);
     const stack2 = try pool.acquire();
     try std.testing.expectEqual(stack1.base, stack2.base);
 
     // Return it so pool.deinit() reclaims it (slab slots must not be
     // stackFree'd individually).
-    pool.release(stack2, .zero);
+    pool.release(stack2);
 }
 
 test "StackPool slab: carving spans slabs and slots are distinct" {
@@ -431,7 +467,7 @@ test "StackPool slab: carving spans slabs and slots are distinct" {
         // Every slot must be arena-backed while slabs have room.
         pool.mutex.lock();
         defer pool.mutex.unlock();
-        try std.testing.expect(pool.inArenaLocked(info.allocation_ptr));
+        try std.testing.expect(pool.slabOfLocked(info.allocation_ptr) != null);
     }
 
     // All distinct, all writable at base, guard layout intact.
@@ -448,105 +484,127 @@ test "StackPool slab: carving spans slabs and slots are distinct" {
     try std.testing.expect(pool.slabs != null);
     try std.testing.expect(pool.slabs.?.next != null);
 
-    // Release everything; re-acquire returns the same slots (LIFO) with no
-    // new carving.
-    for (infos) |info| pool.release(info, .zero);
+    // Release everything; re-acquire returns slab slots with no new carving.
+    for (infos) |info| pool.release(info);
     const carved_before = pool.slabs.?.carved;
     for (0..total) |_| {
         const info = try pool.acquire();
-        pool.release(info, .zero);
+        pool.release(info);
     }
     try std.testing.expectEqual(carved_before, pool.slabs.?.carved);
 }
 
-test "StackPool slab: prewarm fills the arena freelist" {
+test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {
     if (!slab_enabled) return error.SkipZigTest;
 
     var pool = StackPool.init(.{
         .maximum_size = 256 * 1024,
         .committed_size = 16 * 1024,
+        .shrink_interval = .fromSeconds(1),
+    });
+    defer pool.deinit();
+
+    // Two slabs' worth of concurrent stacks, then all released.
+    const total = slab_slots + 2;
+    const infos = try std.testing.allocator.alloc(StackInfo, total);
+    defer std.testing.allocator.free(infos);
+    for (infos) |*info| info.* = try pool.acquire();
+    for (infos) |info| pool.release(info);
+
+    // First pass: the epoch peak still covers the burst, nothing is freed.
+    pool.shrink(.fromSeconds(10));
+    try std.testing.expect(pool.slabs != null);
+    try std.testing.expect(pool.slabs.?.next != null);
+
+    // Second pass: peak has decayed to the current demand (zero), so every
+    // empty slab goes back to the OS.
+    pool.shrink(.fromSeconds(20));
+    try std.testing.expect(pool.slabs == null);
+
+    // A pass inside the rate-limit window is a no-op even with demand at
+    // zero (nothing left to free here, but the guard must hold).
+    pool.shrink(.fromSeconds(20));
+}
+
+test "StackPool slab: watermark keeps capacity for live stacks" {
+    if (!slab_enabled) return error.SkipZigTest;
+
+    var pool = StackPool.init(.{
+        .maximum_size = 256 * 1024,
+        .committed_size = 16 * 1024,
+        .shrink_interval = .fromSeconds(1),
+    });
+    defer pool.deinit();
+
+    // Keep one stack live; burst and release the rest of the slab.
+    const held = try pool.acquire();
+    const burst = try std.testing.allocator.alloc(StackInfo, 8);
+    defer std.testing.allocator.free(burst);
+    for (burst) |*info| info.* = try pool.acquire();
+    for (burst) |info| pool.release(info);
+
+    // Two decayed passes: the slab holds a live slot, so it must survive.
+    pool.shrink(.fromSeconds(10));
+    pool.shrink(.fromSeconds(20));
+    pool.shrink(.fromSeconds(30));
+    try std.testing.expect(pool.slabs != null);
+    try std.testing.expectEqual(1, pool.in_use);
+
+    pool.release(held);
+}
+
+test "StackPool slab: prewarm fills the freelist and floors the watermark" {
+    if (!slab_enabled) return error.SkipZigTest;
+
+    var pool = StackPool.init(.{
+        .maximum_size = 256 * 1024,
+        .committed_size = 16 * 1024,
+        .shrink_interval = .fromSeconds(1),
         .prewarm = 8,
     });
     defer pool.deinit();
 
     try pool.prewarm();
-    try std.testing.expect(pool.arena_free != null);
+    try std.testing.expect(pool.slabs != null);
     try std.testing.expectEqual(8, pool.slabs.?.carved);
+    try std.testing.expectEqual(0, pool.in_use);
 
     // Acquires are served from the prewarmed slots without carving more.
     const s1 = try pool.acquire();
     try std.testing.expectEqual(8, pool.slabs.?.carved);
-    pool.release(s1, .zero);
+    pool.release(s1);
+
+    // The prewarm floor keeps the slab alive through decayed shrink passes.
+    pool.shrink(.fromSeconds(10));
+    pool.shrink(.fromSeconds(20));
+    pool.shrink(.fromSeconds(30));
+    try std.testing.expect(pool.slabs != null);
 }
 
-test "StackPool respects max_unused_stacks" {
-    // Policy applies to individually mapped stacks only.
+test "StackPool fallback: shrink frees idle stacks beyond the watermark" {
+    // The individually-mapped path backs every stack when slabs are
+    // compiled out; with slabs enabled it only serves failure fallbacks, so
+    // exercise it directly here.
     if (slab_enabled) return error.SkipZigTest;
+
     var pool = StackPool.init(.{
         .maximum_size = 1024 * 1024,
         .committed_size = 64 * 1024,
-        .max_unused_stacks = 2,
+        .shrink_interval = .fromSeconds(1),
     });
     defer pool.deinit();
 
-    // Acquire and release 3 stacks
     const stack1 = try pool.acquire();
     const stack2 = try pool.acquire();
     const stack3 = try pool.acquire();
+    pool.release(stack1);
+    pool.release(stack2);
+    pool.release(stack3);
+    try std.testing.expectEqual(3, pool.pool_size);
 
-    pool.release(stack1, .zero);
-    try std.testing.expectEqual(1, pool.pool_size);
-
-    pool.release(stack2, .zero);
-    try std.testing.expectEqual(2, pool.pool_size);
-
-    // Releasing the third should evict the first (oldest)
-    pool.release(stack3, .zero);
-    try std.testing.expectEqual(2, pool.pool_size);
-
-    // Verify that stack1 is not in the pool (stack2 and stack3 should be)
-    const reused1 = try pool.acquire();
-    const reused2 = try pool.acquire();
-
-    try std.testing.expect(reused1.base == stack2.base or reused1.base == stack3.base);
-    try std.testing.expect(reused2.base == stack2.base or reused2.base == stack3.base);
-    try std.testing.expect(reused1.base != reused2.base);
-
-    // Clean up
-    stack.stackFree(reused1);
-    stack.stackFree(reused2);
-}
-
-test "StackPool age-based expiration" {
-    // Policy applies to individually mapped stacks only.
-    if (slab_enabled) return error.SkipZigTest;
-
-    const max_age: Duration = .fromMilliseconds(100);
-
-    var pool = StackPool.init(.{
-        .maximum_size = 1024 * 1024,
-        .committed_size = 64 * 1024,
-        .max_unused_stacks = 4,
-        .max_age = max_age,
-    });
-    defer pool.deinit();
-
-    // Acquire and release a stack at timestamp 0
-    const stack1 = try pool.acquire();
-    pool.release(stack1, .zero);
-    try std.testing.expectEqual(1, pool.pool_size);
-
-    // Acquire a new stack and release it with timestamp past expiration
-    // This triggers expiration check and should evict stack1
-    const stack2 = try pool.acquire();
+    // Peak covers the burst on the first pass; decays on the second.
+    pool.shrink(.fromSeconds(10));
+    try std.testing.expectEqual(3, pool.pool_size);
+    pool.shrink(.fromSeconds(20));
     try std.testing.expectEqual(0, pool.pool_size);
-    pool.release(stack2, .fromMilliseconds(101));
-    try std.testing.expectEqual(1, pool.pool_size);
-
-    // Verify the pool contains stack2 (stack1 was expired)
-    const reused = try pool.acquire();
-    try std.testing.expectEqual(stack2.base, reused.base);
-
-    // Clean up
-    stack.stackFree(reused);
 }

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -40,6 +40,11 @@ const Slab = struct {
     in_use: usize,
     /// Released slots of this slab (LIFO). carved - in_use entries.
     free: ?*FreeNode,
+    /// Links in the pool's partial list: the slabs with at least one free
+    /// slot, so acquire finds one in O(1) instead of scanning the chain.
+    /// A slab is linked exactly when `free != null`.
+    partial_prev: ?*Slab,
+    partial_next: ?*Slab,
 };
 
 pub const Config = struct {
@@ -87,10 +92,14 @@ pub const StackPool = struct {
     head: ?*FreeNode,
     tail: ?*FreeNode,
     pool_size: usize,
-    /// Slab chain, newest first. Acquire prefers the first slab with a free
-    /// slot, so load concentrates at the head and older slabs drain toward
-    /// empty, where the shrink pass can unmap them wholesale.
+    /// Slab chain, newest first: every slab, walked only by carving (head
+    /// slab), the shrink pass, and deinit.
     slabs: ?*Slab,
+    /// Head of the partial list: slabs with free slots, most recently
+    /// released-to first. Acquire pops here in O(1); the LIFO order keeps
+    /// load concentrated on recently active slabs, so the rest drain toward
+    /// empty, where the shrink pass can unmap them wholesale.
+    partial: ?*Slab,
     slot_size: usize,
     /// Stacks currently acquired (both kinds).
     in_use: usize,
@@ -113,6 +122,7 @@ pub const StackPool = struct {
             .tail = null,
             .pool_size = 0,
             .slabs = null,
+            .partial = null,
             .slot_size = @max(aligned_max + stack.page_size, stack.page_size * 2),
             .in_use = 0,
             .epoch_peak = 0,
@@ -146,6 +156,7 @@ pub const StackPool = struct {
                 slab = next;
             }
             self.slabs = null;
+            self.partial = null;
         }
     }
 
@@ -159,16 +170,15 @@ pub const StackPool = struct {
 
             if (slab_supported) {
                 // Released slab slots first: still committed, still
-                // cache-warm, zero syscalls. First slab with a free slot
-                // wins, concentrating load near the head of the chain.
-                var slab = self.slabs;
-                while (slab) |s| : (slab = s.next) {
-                    if (s.free) |node| {
-                        s.free = node.next;
-                        s.in_use += 1;
-                        self.noteAcquireLocked();
-                        return node.stack_info;
-                    }
+                // cache-warm, zero syscalls. The partial list's head has one
+                // by definition.
+                if (self.partial) |s| {
+                    const node = s.free.?;
+                    s.free = node.next;
+                    if (s.free == null) self.unlinkPartial(s);
+                    s.in_use += 1;
+                    self.noteAcquireLocked();
+                    return node.stack_info;
                 }
             }
 
@@ -215,10 +225,20 @@ pub const StackPool = struct {
         // The FreeNode is stored at the base of the stack (aligned backward)
         const node_addr = std.mem.alignBackward(usize, stack_info.base - @sizeOf(FreeNode), @alignOf(FreeNode));
 
-        self.mutex.lock();
-
         if (slab_supported) {
-            if (self.slabOfLocked(stack_info.allocation_ptr)) |slab| {
+            // The owner tag at the top of the stack names the slab this slot
+            // was carved from (0 for an individually mapped stack): one read
+            // instead of scanning the slab chain.
+            const tag = stack.stackReadOwnerTag(stack_info);
+            if (tag != 0) {
+                const slab: *Slab = @ptrFromInt(tag);
+                // Stack overflow into the tag word is impossible (it sits
+                // above base), but cheap paranoia in safe builds: the slab
+                // must contain this slot.
+                self.mutex.lock();
+                if (builtin.mode == .Debug) {
+                    std.debug.assert(self.slabOfLocked(stack_info.allocation_ptr) == slab);
+                }
                 // Slab slots always commit at least one page, so the node fits.
                 std.debug.assert(node_addr >= stack_info.limit);
                 const node: *FreeNode = @ptrFromInt(node_addr);
@@ -227,6 +247,7 @@ pub const StackPool = struct {
                     .next = slab.free,
                     .stack_info = stack_info,
                 };
+                if (slab.free == null) self.linkPartial(slab);
                 slab.free = node;
                 slab.in_use -= 1;
                 self.in_use -= 1;
@@ -235,6 +256,7 @@ pub const StackPool = struct {
             }
         }
 
+        self.mutex.lock();
         self.in_use -= 1;
 
         // Verify the FreeNode fits within the committed region (between limit and base)
@@ -320,6 +342,7 @@ pub const StackPool = struct {
                     const next = s.next;
                     if (s.in_use == 0 and s.carved <= excess and slab_budget > 0) {
                         if (prev) |p| p.next = next else self.slabs = next;
+                        if (s.free != null) self.unlinkPartial(s);
                         excess -= s.carved;
                         slab_budget -= 1;
                         s.next = slabs_to_free;
@@ -370,7 +393,7 @@ pub const StackPool = struct {
             const len = stack.page_size + self.config.slab_slots * self.slot_size;
             const mem = stack.slabReserve(len) catch return null;
             const s: *Slab = @ptrCast(@alignCast(mem.ptr));
-            s.* = .{ .next = self.slabs, .memory = mem, .carved = 0, .in_use = 0, .free = null };
+            s.* = .{ .next = self.slabs, .memory = mem, .carved = 0, .in_use = 0, .free = null, .partial_prev = null, .partial_next = null };
             self.slabs = s;
             break :blk s;
         };
@@ -378,10 +401,26 @@ pub const StackPool = struct {
         const offset = stack.page_size + slab.carved * self.slot_size;
         const slot: []align(stack.page_size) u8 = @alignCast(slab.memory[offset .. offset + self.slot_size]);
         var stack_info: StackInfo = undefined;
-        stack.stackInitSlot(&stack_info, slot, self.config.committed_size) catch return null;
+        stack.stackInitSlot(&stack_info, slot, self.config.committed_size, @intFromPtr(slab)) catch return null;
         slab.carved += 1;
         slab.in_use += 1;
         return stack_info;
+    }
+
+    /// Link a slab at the head of the partial list. Must run under mutex.
+    fn linkPartial(self: *StackPool, s: *Slab) void {
+        std.debug.assert(s.partial_prev == null and s.partial_next == null and self.partial != s);
+        s.partial_next = self.partial;
+        if (self.partial) |head| head.partial_prev = s;
+        self.partial = s;
+    }
+
+    /// Unlink a slab from the partial list. Must run under mutex.
+    fn unlinkPartial(self: *StackPool, s: *Slab) void {
+        if (s.partial_prev) |prev| prev.partial_next = s.partial_next else self.partial = s.partial_next;
+        if (s.partial_next) |next| next.partial_prev = s.partial_prev;
+        s.partial_prev = null;
+        s.partial_next = null;
     }
 
     /// The slab this allocation was carved from, or null for an individually
@@ -520,6 +559,32 @@ test "StackPool slab: carving spans slabs and slots are distinct" {
         pool.release(info);
     }
     try std.testing.expectEqual(carved_before, pool.slabs.?.carved);
+}
+
+test "StackPool slab: releases route acquires to their slab via the partial list" {
+    if (!slab_supported) return error.SkipZigTest;
+
+    var pool = StackPool.init(.{
+        .maximum_size = 256 * 1024,
+        .committed_size = 16 * 1024,
+    });
+    defer pool.deinit();
+
+    // Fill two slabs; infos[0] was carved from the older slab.
+    const total = pool.config.slab_slots + 2;
+    const infos = try std.testing.allocator.alloc(StackInfo, total);
+    defer std.testing.allocator.free(infos);
+    for (infos) |*info| info.* = try pool.acquire();
+
+    // Release a single slot from the older slab: its slab becomes the
+    // partial head, and the next acquire must return exactly that slot,
+    // without scanning or carving.
+    pool.release(infos[0]);
+    const reused = try pool.acquire();
+    try std.testing.expectEqual(infos[0].allocation_ptr, reused.allocation_ptr);
+    infos[0] = reused;
+
+    for (infos) |info| pool.release(info);
 }
 
 test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -269,6 +269,11 @@ pub const StackPool = struct {
             self.mutex.lock();
             defer self.mutex.unlock();
 
+            // durationTo saturates to zero when `now` lags behind
+            // last_shrink (timestamps come from different loops' caches, and
+            // a loop's cached now can be stale), so a backwards timestamp
+            // lands in this early return and skips the pass: staleness can
+            // only delay shrinking, never speed it up.
             if (self.last_shrink.value != 0 and
                 self.last_shrink.durationTo(now).value < self.config.shrink_interval.value)
             {

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -57,13 +57,17 @@ pub const Config = struct {
 
     /// How often the pool re-evaluates its size against recent demand.
     ///
-    /// The pool tracks a demand watermark: the peak number of stacks
-    /// simultaneously in use since the previous evaluation (but never below
-    /// `prewarm`). On each evaluation, free capacity beyond that watermark is
-    /// returned to the OS: whole slabs whose every slot is unused are
-    /// unmapped first, then individually mapped stacks, oldest first.
-    /// Between evaluations, releasing and reusing stacks never makes a
-    /// syscall. `.zero` disables shrinking entirely; the pool then holds its
+    /// The pool keeps a retain target that follows demand with a decay
+    /// curve: every interval it becomes the larger of the peak number of
+    /// stacks simultaneously in use since the previous evaluation and half
+    /// of the previous target (but never below `prewarm`). Free capacity
+    /// beyond the target is returned to the OS: whole slabs whose every
+    /// slot is unused are unmapped first (a bounded number per pass), then
+    /// individually mapped stacks, oldest first. A burst therefore
+    /// re-inflates the target instantly, while its capacity drains with a
+    /// half-life of one interval instead of falling off a cliff. Between
+    /// evaluations, releasing and reusing stacks never makes a syscall.
+    /// `.zero` disables shrinking entirely; the pool then holds its
     /// high-water mark until deinit.
     shrink_interval: Duration = .fromSeconds(60),
 
@@ -89,10 +93,12 @@ pub const StackPool = struct {
     slot_size: usize,
     /// Stacks currently acquired (both kinds).
     in_use: usize,
-    /// Peak of `in_use` since the last shrink evaluation: the demand
-    /// watermark that decides how much free capacity the next evaluation
-    /// keeps.
+    /// Peak of `in_use` since the last shrink evaluation.
     epoch_peak: usize,
+    /// The decayed demand watermark: how much total capacity the shrink
+    /// pass keeps. Ratchets up to every epoch's peak instantly and halves
+    /// per interval on the way down (see Config.shrink_interval).
+    retain_target: usize,
     last_shrink: Timestamp,
 
     pub fn init(config: Config) StackPool {
@@ -109,6 +115,7 @@ pub const StackPool = struct {
             .slot_size = @max(aligned_max + stack.page_size, stack.page_size * 2),
             .in_use = 0,
             .epoch_peak = 0,
+            .retain_target = 0,
             .last_shrink = .zero,
         };
     }
@@ -245,11 +252,12 @@ pub const StackPool = struct {
         self.mutex.unlock();
     }
 
-    /// Bound on individually mapped stacks freed per shrink pass, so a pass
-    /// after a large burst does not stall an executor on thousands of
-    /// munmaps. Whole-slab frees are not bounded; there are few slabs and
-    /// each unmap retires many slots at once.
+    /// Bounds on work per shrink pass, so a pass after a large burst does
+    /// not stall an executor's timer callback on hundreds of munmaps. The
+    /// decay curve already spreads reclamation over multiple intervals;
+    /// these bound the worst single pass.
     const max_stack_frees_per_shrink = 64;
+    const max_slab_frees_per_shrink = 16;
 
     /// Periodic shrink pass: rate-limited to `shrink_interval` internally,
     /// so any executor's timer may drive it. Frees the committed capacity
@@ -272,29 +280,38 @@ pub const StackPool = struct {
             }
             self.last_shrink = now;
 
-            const floor = @max(self.epoch_peak, if (slab_enabled) self.config.prewarm else 0);
+            // Decay curve: ratchet up to this epoch's peak immediately, halve
+            // per interval on the way down, never below the prewarm floor. A
+            // burst's capacity drains with a half-life of one interval
+            // instead of vanishing the moment one quiet epoch passes.
+            self.retain_target = @max(
+                @max(self.epoch_peak, self.retain_target / 2),
+                if (slab_enabled) self.config.prewarm else 0,
+            );
             self.epoch_peak = self.in_use;
 
             // Committed capacity = live stacks + everything parked on free
-            // lists. Anything beyond the watermark is up for release.
+            // lists. Anything beyond the retain target is up for release.
             var free_capacity: usize = self.pool_size;
             var slab = self.slabs;
             while (slab) |s| : (slab = s.next) {
                 free_capacity += s.carved - s.in_use;
             }
-            var excess = (self.in_use + free_capacity) -| floor;
+            var excess = (self.in_use + free_capacity) -| self.retain_target;
 
             // Unmap empty slabs first: one syscall retires a whole arena.
             // Strictly within the excess, so capacity never dips below the
-            // watermark (a mostly-empty slab bigger than the excess stays).
+            // target (a mostly-empty slab bigger than the excess stays).
             if (slab_enabled) {
+                var freed_slabs: usize = 0;
                 var prev: ?*Slab = null;
                 var cur = self.slabs;
                 while (cur) |s| {
                     const next = s.next;
-                    if (s.in_use == 0 and s.carved <= excess) {
+                    if (s.in_use == 0 and s.carved <= excess and freed_slabs < max_slab_frees_per_shrink) {
                         if (prev) |p| p.next = next else self.slabs = next;
                         excess -= s.carved;
+                        freed_slabs += 1;
                         s.next = slabs_to_free;
                         slabs_to_free = s;
                     } else {
@@ -516,14 +533,28 @@ test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {
     try std.testing.expect(pool.slabs != null);
     try std.testing.expect(pool.slabs.?.next != null);
 
-    // Second pass: peak has decayed to the current demand (zero), so every
-    // empty slab goes back to the OS.
+    // Second pass: the retain target halves, which releases the small
+    // second slab but keeps the full one (its carved count exceeds the
+    // excess) - the decay curve, not a cliff.
     pool.shrink(.fromSeconds(20));
-    try std.testing.expect(pool.slabs == null);
+    try std.testing.expect(pool.slabs != null);
+    try std.testing.expect(pool.slabs.?.next == null);
 
-    // A pass inside the rate-limit window is a no-op even with demand at
-    // zero (nothing left to free here, but the guard must hold).
+    // A pass inside the rate-limit window is a no-op.
     pool.shrink(.fromSeconds(20));
+    try std.testing.expect(pool.slabs != null);
+
+    // With demand at zero the target halves each interval and reaches zero,
+    // at which point the last slab goes back to the OS too.
+    var t: u64 = 30;
+    var passes: usize = 0;
+    while (pool.slabs != null and passes < 16) : ({
+        t += 10;
+        passes += 1;
+    }) {
+        pool.shrink(.fromSeconds(t));
+    }
+    try std.testing.expect(pool.slabs == null);
 }
 
 test "StackPool slab: watermark keeps capacity for live stacks" {
@@ -602,9 +633,12 @@ test "StackPool fallback: shrink frees idle stacks beyond the watermark" {
     pool.release(stack3);
     try std.testing.expectEqual(3, pool.pool_size);
 
-    // Peak covers the burst on the first pass; decays on the second.
+    // Peak covers the burst on the first pass; then the target halves per
+    // interval (3 -> 1 -> 0), draining the pool over two more passes.
     pool.shrink(.fromSeconds(10));
     try std.testing.expectEqual(3, pool.pool_size);
     pool.shrink(.fromSeconds(20));
+    try std.testing.expectEqual(1, pool.pool_size);
+    pool.shrink(.fromSeconds(30));
     try std.testing.expectEqual(0, pool.pool_size);
 }

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const builtin = @import("builtin");
+const zio_options = @import("zio_options");
 const stack = @import("stack.zig");
 const StackInfo = stack.StackInfo;
 const Timestamp = @import("../time.zig").Timestamp;
@@ -14,6 +16,30 @@ const FreeNode = struct {
     next: ?*FreeNode,
     stack_info: StackInfo,
     timestamp: Timestamp,
+};
+
+/// Number of stack slots carved from one slab reservation (build option
+/// `stack-slab-slots`; 0 disables slab allocation and every stack gets its
+/// own mapping as before).
+pub const slab_slots: usize = zio_options.stack_slab_slots;
+
+/// Slab allocation reserves slab_slots * (maximum_size + guard) of address
+/// space per slab, which is only affordable on 64-bit targets. Windows keeps
+/// RtlCreateUserStack (TEB integration), and OpenBSD requires MAP_STACK
+/// mappings that cannot start as PROT_NONE reservations.
+pub const slab_enabled = slab_slots > 0 and @sizeOf(usize) == 8 and switch (builtin.os.tag) {
+    .windows, .openbsd, .freestanding, .wasi => false,
+    else => true,
+};
+
+/// Slab header, stored in the committed first page of the arena itself.
+/// Slots follow the header page back to back; each slot's first page is
+/// never committed and acts as its guard page, exactly mirroring the layout
+/// of a standalone stack mapping.
+const Slab = struct {
+    next: ?*Slab,
+    memory: []align(stack.page_size) u8,
+    carved: usize,
 };
 
 pub const Config = struct {
@@ -32,7 +58,14 @@ pub const Config = struct {
     /// Maximum age of an unused stack.
     /// Stacks older than this will be freed on the next release() call.
     /// .zero means no age limit.
+    /// Only applies to individually mapped stacks; slab slots are never
+    /// evicted or decommitted (recycling was measured too expensive).
     max_age: Duration = .zero,
+
+    /// Number of slab slots to carve and commit up front (at runtime init),
+    /// so that a burst of early spawns skips the cold-allocation cost.
+    /// Ignored when slab allocation is compiled out.
+    prewarm: usize = 0,
 };
 
 pub const StackPool = struct {
@@ -41,14 +74,28 @@ pub const StackPool = struct {
     head: ?*FreeNode,
     tail: ?*FreeNode,
     pool_size: usize,
+    // Slab state: chain of arenas (newest first; only the newest still has
+    // uncarved slots) and a LIFO of released slab slots. Slab slots bypass
+    // the max_unused_stacks/max_age policy entirely: releasing one is a
+    // pointer push, reusing one costs no syscalls, and the memory is only
+    // returned at deinit.
+    slabs: ?*Slab,
+    arena_free: ?*FreeNode,
+    slot_size: usize,
 
     pub fn init(config: Config) StackPool {
+        // Same slot layout as stackAllocPosix: usable size rounded to pages,
+        // plus the (never committed) guard page, at least two pages total.
+        const aligned_max = std.mem.alignForward(usize, config.maximum_size, stack.page_size);
         return .{
             .config = config,
             .mutex = .init(),
             .head = null,
             .tail = null,
             .pool_size = 0,
+            .slabs = null,
+            .arena_free = null,
+            .slot_size = @max(aligned_max + stack.page_size, stack.page_size * 2),
         };
     }
 
@@ -67,6 +114,16 @@ pub const StackPool = struct {
         self.head = null;
         self.tail = null;
         self.pool_size = 0;
+
+        // Free whole slab arenas; their FreeNodes and headers live inside.
+        var slab = self.slabs;
+        while (slab) |s| {
+            const next = s.next;
+            stack.slabFree(s.memory);
+            slab = next;
+        }
+        self.slabs = null;
+        self.arena_free = null;
     }
 
     /// Acquires a stack from the pool, or allocates a new one if the pool is empty.
@@ -77,10 +134,30 @@ pub const StackPool = struct {
             self.mutex.lock();
             defer self.mutex.unlock();
 
+            if (slab_enabled) {
+                // Released slab slots first: LIFO, still committed, still
+                // cache-warm, zero syscalls.
+                if (self.arena_free) |node| {
+                    self.arena_free = node.next;
+                    return node.stack_info;
+                }
+            }
+
             if (self.head) |node| {
                 const stack_info = node.stack_info;
                 self.removeNode(node);
                 return stack_info;
+            }
+
+            if (slab_enabled) {
+                // Cold path: carve a fresh slot (one mprotect), creating a
+                // new slab if the current one is exhausted. Done under the
+                // lock — carving is rare and the bookkeeping needs it anyway.
+                if (self.carveSlotLocked()) |stack_info| {
+                    return stack_info;
+                }
+                // Slab reservation failed (address space exhausted?); fall
+                // through to an individual mapping.
             }
         }
 
@@ -88,6 +165,60 @@ pub const StackPool = struct {
         var stack_info: StackInfo = undefined;
         try stack.stackAlloc(&stack_info, self.config.maximum_size, self.config.committed_size);
         return stack_info;
+    }
+
+    /// Carve and commit the next slot out of the newest slab, growing the
+    /// slab chain when needed. Returns null if reservation or commit fails
+    /// (the caller falls back to individual mappings). Must run under mutex.
+    fn carveSlotLocked(self: *StackPool) ?StackInfo {
+        const slab = blk: {
+            if (self.slabs) |s| {
+                if (s.carved < slab_slots) break :blk s;
+            }
+            const len = stack.page_size + slab_slots * self.slot_size;
+            const mem = stack.slabReserve(len) catch return null;
+            const s: *Slab = @ptrCast(@alignCast(mem.ptr));
+            s.* = .{ .next = self.slabs, .memory = mem, .carved = 0 };
+            self.slabs = s;
+            break :blk s;
+        };
+
+        const offset = stack.page_size + slab.carved * self.slot_size;
+        const slot: []align(stack.page_size) u8 = @alignCast(slab.memory[offset .. offset + self.slot_size]);
+        var stack_info: StackInfo = undefined;
+        stack.stackInitSlot(&stack_info, slot, self.config.committed_size) catch return null;
+        slab.carved += 1;
+        return stack_info;
+    }
+
+    /// Whether this allocation is a slab slot. Must run under mutex (the
+    /// slab chain is mutated by carveSlotLocked).
+    fn inArenaLocked(self: *StackPool, ptr: [*]align(stack.page_size) u8) bool {
+        const addr = @intFromPtr(ptr);
+        var slab = self.slabs;
+        while (slab) |s| : (slab = s.next) {
+            const base = @intFromPtr(s.memory.ptr);
+            if (addr >= base and addr < base + s.memory.len) return true;
+        }
+        return false;
+    }
+
+    /// Carve and commit `config.prewarm` slots up front. Called once from
+    /// runtime init so that an early spawn burst finds warm slots instead of
+    /// paying the cold-allocation cost inside the workload.
+    pub fn prewarm(self: *StackPool) error{OutOfMemory}!void {
+        if (!slab_enabled) return;
+
+        var i: usize = 0;
+        while (i < self.config.prewarm) : (i += 1) {
+            self.mutex.lock();
+            const stack_info = self.carveSlotLocked() orelse {
+                self.mutex.unlock();
+                return error.OutOfMemory;
+            };
+            self.mutex.unlock();
+            self.release(stack_info, .zero);
+        }
     }
 
     /// Releases a stack back to the pool.
@@ -98,6 +229,25 @@ pub const StackPool = struct {
         // Check if the stack has enough committed space to store the FreeNode
         // The FreeNode is stored at the base of the stack (aligned backward)
         const node_addr = std.mem.alignBackward(usize, stack_info.base - @sizeOf(FreeNode), @alignOf(FreeNode));
+
+        if (slab_enabled) {
+            self.mutex.lock();
+            if (self.inArenaLocked(stack_info.allocation_ptr)) {
+                // Slab slots always commit at least one page, so the node fits.
+                std.debug.assert(node_addr >= stack_info.limit);
+                const node: *FreeNode = @ptrFromInt(node_addr);
+                node.* = .{
+                    .prev = null,
+                    .next = self.arena_free,
+                    .stack_info = stack_info,
+                    .timestamp = timestamp,
+                };
+                self.arena_free = node;
+                self.mutex.unlock();
+                return;
+            }
+            self.mutex.unlock();
+        }
 
         // Verify the FreeNode fits within the committed region (between limit and base)
         if (node_addr < stack_info.limit) {
@@ -252,20 +402,86 @@ test "StackPool basic acquire and release" {
     try std.testing.expect(stack1.base != 0);
     try std.testing.expect(stack1.base > stack1.limit); // Stack grows downward
 
-    // Release it back
+    // Release it back, acquire again - should reuse the same stack
     pool.release(stack1, .zero);
-    try std.testing.expectEqual(1, pool.pool_size);
-
-    // Acquire again - should reuse the same stack
     const stack2 = try pool.acquire();
     try std.testing.expectEqual(stack1.base, stack2.base);
-    try std.testing.expectEqual(0, pool.pool_size);
 
-    // Clean up
-    stack.stackFree(stack2);
+    // Return it so pool.deinit() reclaims it (slab slots must not be
+    // stackFree'd individually).
+    pool.release(stack2, .zero);
+}
+
+test "StackPool slab: carving spans slabs and slots are distinct" {
+    if (!slab_enabled) return error.SkipZigTest;
+
+    var pool = StackPool.init(.{
+        .maximum_size = 256 * 1024,
+        .committed_size = 16 * 1024,
+    });
+    defer pool.deinit();
+
+    // Acquire more slots than one slab holds to force a second slab.
+    const total = slab_slots + 2;
+    const infos = try std.testing.allocator.alloc(StackInfo, total);
+    defer std.testing.allocator.free(infos);
+
+    for (infos) |*info| {
+        info.* = try pool.acquire();
+        // Every slot must be arena-backed while slabs have room.
+        pool.mutex.lock();
+        defer pool.mutex.unlock();
+        try std.testing.expect(pool.inArenaLocked(info.allocation_ptr));
+    }
+
+    // All distinct, all writable at base, guard layout intact.
+    for (infos, 0..) |a, i| {
+        for (infos[i + 1 ..]) |b| {
+            try std.testing.expect(a.allocation_ptr != b.allocation_ptr);
+        }
+        const mem: [*]u8 = @ptrFromInt(a.limit);
+        mem[0] = 0xAA;
+        mem[a.base - a.limit - 1] = 0xBB;
+    }
+
+    // Two slabs exist now.
+    try std.testing.expect(pool.slabs != null);
+    try std.testing.expect(pool.slabs.?.next != null);
+
+    // Release everything; re-acquire returns the same slots (LIFO) with no
+    // new carving.
+    for (infos) |info| pool.release(info, .zero);
+    const carved_before = pool.slabs.?.carved;
+    for (0..total) |_| {
+        const info = try pool.acquire();
+        pool.release(info, .zero);
+    }
+    try std.testing.expectEqual(carved_before, pool.slabs.?.carved);
+}
+
+test "StackPool slab: prewarm fills the arena freelist" {
+    if (!slab_enabled) return error.SkipZigTest;
+
+    var pool = StackPool.init(.{
+        .maximum_size = 256 * 1024,
+        .committed_size = 16 * 1024,
+        .prewarm = 8,
+    });
+    defer pool.deinit();
+
+    try pool.prewarm();
+    try std.testing.expect(pool.arena_free != null);
+    try std.testing.expectEqual(8, pool.slabs.?.carved);
+
+    // Acquires are served from the prewarmed slots without carving more.
+    const s1 = try pool.acquire();
+    try std.testing.expectEqual(8, pool.slabs.?.carved);
+    pool.release(s1, .zero);
 }
 
 test "StackPool respects max_unused_stacks" {
+    // Policy applies to individually mapped stacks only.
+    if (slab_enabled) return error.SkipZigTest;
     var pool = StackPool.init(.{
         .maximum_size = 1024 * 1024,
         .committed_size = 64 * 1024,
@@ -302,6 +518,9 @@ test "StackPool respects max_unused_stacks" {
 }
 
 test "StackPool age-based expiration" {
+    // Policy applies to individually mapped stacks only.
+    if (slab_enabled) return error.SkipZigTest;
+
     const max_age: Duration = .fromMilliseconds(100);
 
     var pool = StackPool.init(.{

--- a/src/coro/stack_pool.zig
+++ b/src/coro/stack_pool.zig
@@ -3,7 +3,6 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const zio_options = @import("zio_options");
 const stack = @import("stack.zig");
 const StackInfo = stack.StackInfo;
 const Timestamp = @import("../time.zig").Timestamp;
@@ -17,16 +16,13 @@ const FreeNode = struct {
     stack_info: StackInfo,
 };
 
-/// Number of stack slots carved from one slab reservation (build option
-/// `stack-slab-slots`; 0 disables slab allocation and every stack gets its
-/// own mapping as before).
-pub const slab_slots: usize = zio_options.stack_slab_slots;
-
-/// Slab allocation reserves slab_slots * (maximum_size + guard) of address
-/// space per slab, which is only affordable on 64-bit targets. Windows keeps
-/// RtlCreateUserStack (TEB integration), and OpenBSD requires MAP_STACK
-/// mappings that cannot start as PROT_NONE reservations.
-pub const slab_enabled = slab_slots > 0 and @sizeOf(usize) == 8 and switch (builtin.os.tag) {
+/// Whether this target can back stacks with slab reservations. Slabs reserve
+/// slab_slots * (maximum_size + guard) of address space each, which is only
+/// affordable on 64-bit targets. Windows keeps RtlCreateUserStack (TEB
+/// integration), and OpenBSD requires MAP_STACK mappings that cannot start
+/// as PROT_NONE reservations. Whether slabs are actually used is a runtime
+/// choice (Config.slab_slots).
+pub const slab_supported = @sizeOf(usize) == 8 and switch (builtin.os.tag) {
     .windows, .openbsd, .freestanding, .wasi => false,
     else => true,
 };
@@ -70,6 +66,11 @@ pub const Config = struct {
     /// `.zero` disables shrinking entirely; the pool then holds its
     /// high-water mark until deinit.
     shrink_interval: Duration = .fromSeconds(60),
+
+    /// Number of stack slots carved from one slab reservation. 0 disables
+    /// slab allocation and every stack gets its own mapping; ignored on
+    /// targets without slab support (see slab_supported).
+    slab_slots: usize = 64,
 
     /// Number of slab slots to carve and commit up front (at runtime init),
     /// so that a burst of early spawns skips the cold-allocation cost. Also
@@ -137,13 +138,15 @@ pub const StackPool = struct {
         self.pool_size = 0;
 
         // Free whole slab arenas; their FreeNodes and headers live inside.
-        var slab = self.slabs;
-        while (slab) |s| {
-            const next = s.next;
-            stack.slabFree(s.memory);
-            slab = next;
+        if (slab_supported) {
+            var slab = self.slabs;
+            while (slab) |s| {
+                const next = s.next;
+                stack.slabFree(s.memory);
+                slab = next;
+            }
+            self.slabs = null;
         }
-        self.slabs = null;
     }
 
     /// Acquires a stack from the pool, or allocates a new one if the pool is empty.
@@ -154,7 +157,7 @@ pub const StackPool = struct {
             self.mutex.lock();
             defer self.mutex.unlock();
 
-            if (slab_enabled) {
+            if (slab_supported) {
                 // Released slab slots first: still committed, still
                 // cache-warm, zero syscalls. First slab with a free slot
                 // wins, concentrating load near the head of the chain.
@@ -176,7 +179,7 @@ pub const StackPool = struct {
                 return stack_info;
             }
 
-            if (slab_enabled) {
+            if (slab_supported and self.config.slab_slots > 0) {
                 // Cold path: carve a fresh slot (one mprotect), creating a
                 // new slab if the current one is exhausted. Done under the
                 // lock — carving is rare and the bookkeeping needs it anyway.
@@ -214,7 +217,7 @@ pub const StackPool = struct {
 
         self.mutex.lock();
 
-        if (slab_enabled) {
+        if (slab_supported) {
             if (self.slabOfLocked(stack_info.allocation_ptr)) |slab| {
                 // Slab slots always commit at least one page, so the node fits.
                 std.debug.assert(node_addr >= stack_info.limit);
@@ -279,7 +282,7 @@ pub const StackPool = struct {
             // instead of vanishing the moment one quiet epoch passes.
             self.retain_target = @max(
                 @max(self.epoch_peak, self.retain_target / 2),
-                if (slab_enabled) self.config.prewarm else 0,
+                if (slab_supported) self.config.prewarm else 0,
             );
             self.epoch_peak = self.in_use;
 
@@ -305,7 +308,7 @@ pub const StackPool = struct {
             // Unmap empty slabs first: one syscall retires a whole arena.
             // Strictly within the excess, so capacity never dips below the
             // target (a mostly-empty slab bigger than the excess stays).
-            if (slab_enabled) {
+            if (slab_supported) {
                 var prev: ?*Slab = null;
                 var cur = self.slabs;
                 while (cur) |s| {
@@ -335,10 +338,12 @@ pub const StackPool = struct {
         }
 
         // Return memory to the OS outside the lock.
-        while (slabs_to_free) |s| {
-            const next = s.next;
-            stack.slabFree(s.memory);
-            slabs_to_free = next;
+        if (slab_supported) {
+            while (slabs_to_free) |s| {
+                const next = s.next;
+                stack.slabFree(s.memory);
+                slabs_to_free = next;
+            }
         }
         while (stacks_to_free) |node| {
             const next = node.next;
@@ -355,9 +360,9 @@ pub const StackPool = struct {
     fn carveSlotLocked(self: *StackPool) ?StackInfo {
         const slab = blk: {
             if (self.slabs) |s| {
-                if (s.carved < slab_slots) break :blk s;
+                if (s.carved < self.config.slab_slots) break :blk s;
             }
-            const len = stack.page_size + slab_slots * self.slot_size;
+            const len = stack.page_size + self.config.slab_slots * self.slot_size;
             const mem = stack.slabReserve(len) catch return null;
             const s: *Slab = @ptrCast(@alignCast(mem.ptr));
             s.* = .{ .next = self.slabs, .memory = mem, .carved = 0, .in_use = 0, .free = null };
@@ -391,7 +396,7 @@ pub const StackPool = struct {
     /// runtime init so that an early spawn burst finds warm slots instead of
     /// paying the cold-allocation cost inside the workload.
     pub fn prewarm(self: *StackPool) error{OutOfMemory}!void {
-        if (!slab_enabled) return;
+        if (!slab_supported or self.config.slab_slots == 0) return;
 
         var i: usize = 0;
         while (i < self.config.prewarm) : (i += 1) {
@@ -467,7 +472,7 @@ test "StackPool basic acquire and release" {
 }
 
 test "StackPool slab: carving spans slabs and slots are distinct" {
-    if (!slab_enabled) return error.SkipZigTest;
+    if (!slab_supported) return error.SkipZigTest;
 
     var pool = StackPool.init(.{
         .maximum_size = 256 * 1024,
@@ -476,7 +481,7 @@ test "StackPool slab: carving spans slabs and slots are distinct" {
     defer pool.deinit();
 
     // Acquire more slots than one slab holds to force a second slab.
-    const total = slab_slots + 2;
+    const total = pool.config.slab_slots + 2;
     const infos = try std.testing.allocator.alloc(StackInfo, total);
     defer std.testing.allocator.free(infos);
 
@@ -513,7 +518,7 @@ test "StackPool slab: carving spans slabs and slots are distinct" {
 }
 
 test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {
-    if (!slab_enabled) return error.SkipZigTest;
+    if (!slab_supported) return error.SkipZigTest;
 
     var pool = StackPool.init(.{
         .maximum_size = 256 * 1024,
@@ -523,7 +528,7 @@ test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {
     defer pool.deinit();
 
     // Two slabs' worth of concurrent stacks, then all released.
-    const total = slab_slots + 2;
+    const total = pool.config.slab_slots + 2;
     const infos = try std.testing.allocator.alloc(StackInfo, total);
     defer std.testing.allocator.free(infos);
     for (infos) |*info| info.* = try pool.acquire();
@@ -559,7 +564,7 @@ test "StackPool slab: shrink unmaps empty slabs beyond the watermark" {
 }
 
 test "StackPool slab: watermark keeps capacity for live stacks" {
-    if (!slab_enabled) return error.SkipZigTest;
+    if (!slab_supported) return error.SkipZigTest;
 
     var pool = StackPool.init(.{
         .maximum_size = 256 * 1024,
@@ -586,7 +591,7 @@ test "StackPool slab: watermark keeps capacity for live stacks" {
 }
 
 test "StackPool slab: prewarm fills the freelist and floors the watermark" {
-    if (!slab_enabled) return error.SkipZigTest;
+    if (!slab_supported) return error.SkipZigTest;
 
     var pool = StackPool.init(.{
         .maximum_size = 256 * 1024,
@@ -614,15 +619,13 @@ test "StackPool slab: prewarm fills the freelist and floors the watermark" {
 }
 
 test "StackPool fallback: shrink frees idle stacks beyond the watermark" {
-    // The individually-mapped path backs every stack when slabs are
-    // compiled out; with slabs enabled it only serves failure fallbacks, so
-    // exercise it directly here.
-    if (slab_enabled) return error.SkipZigTest;
-
+    // Disable slabs so the individually-mapped path backs every stack; on
+    // targets without slab support this is the only path anyway.
     var pool = StackPool.init(.{
         .maximum_size = 1024 * 1024,
         .committed_size = 64 * 1024,
         .shrink_interval = .fromSeconds(1),
+        .slab_slots = 0,
     });
     defer pool.deinit();
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1286,6 +1286,11 @@ pub const Runtime = struct {
         };
         errdefer if (self.resolver) |*r| r.deinit();
 
+        // Carve the requested number of stack slots up front (no-op when
+        // prewarm is 0 or slab allocation is compiled out).
+        try self.stack_pool.prewarm();
+        errdefer self.stack_pool.deinit();
+
         if (comptime have_sig_pipe) sig_pipe_guard.acquire();
         errdefer if (comptime have_sig_pipe) sig_pipe_guard.release();
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1289,9 +1289,11 @@ pub const Runtime = struct {
         errdefer if (self.resolver) |*r| r.deinit();
 
         // Carve the requested number of stack slots up front (no-op when
-        // prewarm is 0 or slab allocation is compiled out).
-        try self.stack_pool.prewarm();
+        // prewarm is 0 or slab allocation is compiled out). The errdefer
+        // comes first: a mid-loop failure in prewarm itself must unmap the
+        // slabs it already reserved.
         errdefer self.stack_pool.deinit();
+        try self.stack_pool.prewarm();
 
         if (comptime have_sig_pipe) sig_pipe_guard.acquire();
         errdefer if (comptime have_sig_pipe) sig_pipe_guard.release();

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -131,8 +131,6 @@ pub const RuntimeOptions = struct {
     stack_pool: StackPoolConfig = .{
         .maximum_size = 8 * 1024 * 1024,
         .committed_size = 256 * 1024,
-        .max_unused_stacks = 1000,
-        .max_age = .fromSeconds(60),
     },
     /// Total number of executors to run.
     /// When enable_main_executor is true (default), this includes the main executor on the calling thread.
@@ -417,8 +415,9 @@ pub const Executor = struct {
     // When notified, it calls loop.stop() to exit the event loop.
     shutdown: ev.Async = ev.Async.init(),
 
-    // Periodic timer for evicting idle stacks from the shared stack pool.
-    stack_pool_eviction_timer: ev.Timer = ev.Timer.init(.{ .duration = .fromSeconds(60) }),
+    // Periodic timer driving the stack pool's watermark shrink pass. The
+    // pool rate-limits itself, so every executor may carry this timer.
+    stack_pool_shrink_timer: ev.Timer = ev.Timer.init(.{ .duration = .fromSeconds(60) }),
 
     // The task currently executing on this executor, or null when we are running
     // scheduler code (the run loop, a context switch, a completion callback) rather
@@ -500,11 +499,14 @@ pub const Executor = struct {
         self.shutdown.c.callback = shutdownCallback;
         self.loop.add(&self.shutdown.c);
 
-        // Register periodic stack pool eviction timer (skipped when max_age is zero)
-        if (self.runtime.options.stack_pool.max_age.value > 0) {
-            self.stack_pool_eviction_timer.c.callback = stackPoolEvictionCallback;
-            self.stack_pool_eviction_timer.c.flags.rearm = true;
-            self.loop.add(&self.stack_pool_eviction_timer.c);
+        // Register the periodic stack pool shrink timer (skipped when
+        // shrinking is disabled).
+        const shrink_interval = self.runtime.options.stack_pool.shrink_interval;
+        if (shrink_interval.value > 0) {
+            self.stack_pool_shrink_timer = ev.Timer.init(.{ .duration = shrink_interval });
+            self.stack_pool_shrink_timer.c.callback = stackPoolShrinkCallback;
+            self.stack_pool_shrink_timer.c.flags.rearm = true;
+            self.loop.add(&self.stack_pool_shrink_timer.c);
         }
 
         self.main_task.coro.setCurrent();
@@ -525,10 +527,10 @@ pub const Executor = struct {
         loop.stop();
     }
 
-    fn stackPoolEvictionCallback(loop: *ev.Loop, c: *ev.Completion) void {
+    fn stackPoolShrinkCallback(loop: *ev.Loop, c: *ev.Completion) void {
         const timer = c.cast(ev.Timer);
-        const self: *Executor = @alignCast(@fieldParentPtr("stack_pool_eviction_timer", timer));
-        self.runtime.stack_pool.cleanup(loop.now(), 16);
+        const self: *Executor = @alignCast(@fieldParentPtr("stack_pool_shrink_timer", timer));
+        self.runtime.stack_pool.shrink(loop.now());
     }
 
     pub const YieldCancelMode = enum { allow_cancel, no_cancel };
@@ -1066,7 +1068,7 @@ pub const Executor = struct {
             .finish => |task| {
                 self.pending_cleanup = .none;
                 task.state.store(.{ .tag = .finished }, .release);
-                task.releaseCoro(self.runtime, self.loop.now());
+                task.releaseCoro(self.runtime);
                 finishTask(self.runtime, &task.awaitable);
             },
         }

--- a/src/task.zig
+++ b/src/task.zig
@@ -470,16 +470,16 @@ pub const AnyTask = struct {
     /// once control has left the coroutine's stack. `destroy` calls it again
     /// for tasks that were created but never ran. Idempotent, with a zeroed
     /// `allocation_len` marking the resources as already released.
-    pub fn releaseCoro(self: *AnyTask, rt: *Runtime, now: Timestamp) void {
+    pub fn releaseCoro(self: *AnyTask, rt: *Runtime) void {
         if (self.coro.context.stack_info.allocation_len == 0) return;
-        rt.stack_pool.release(self.coro.context.stack_info, now);
+        rt.stack_pool.release(self.coro.context.stack_info);
         self.coro.context.stack_info.allocation_len = 0;
         self.coro.deinit();
     }
 
     pub fn destroy(self: *AnyTask) void {
         const rt = self.getRuntime();
-        self.releaseCoro(rt, rt.now());
+        self.releaseCoro(rt);
 
         self.closure.free(AnyTask, rt, self);
     }


### PR DESCRIPTION
Closes #436.

## What

Coroutine stacks on 64-bit POSIX targets are now carved from slab reservations instead of each getting its own mapping, and the stack pool's retention policy is a decaying demand watermark instead of the old count cap and age limit.

**Allocation.** A slab is one `mmap(PROT_NONE)` reservation holding `-Dstack-slab-slots` slots (build option, default 64; 0 restores the per-stack allocator), with the slab header in the arena's first committed page and `NOHUGEPAGE` advised once per slab. Each slot has the exact layout of a standalone stack mapping (its first page is never-committed reservation, acting as the guard page), so the SIGSEGV growth handler, overflow detection, valgrind registration, and the pool's FreeNode-in-stack trick all work unchanged. A cold stack costs one `mprotect` instead of mmap+madvise+mprotect (#436 measured those at ~68ms per 10k tasks); releasing and reusing a stack costs no syscalls on any path.

**Retention.** `max_unused_stacks` and `max_age` are gone (**BREAKING** for direct `StackPool.Config` users). The pool keeps a retain target that ratchets up to each epoch's peak in-use count instantly and halves per `shrink_interval` (default 60s, `.zero` disables shrinking) on the way down — jemalloc-decay-style rather than a cliff. A periodic pass (driven by the existing per-executor timer; the pool rate-limits itself) frees capacity beyond the target: whole empty slabs first, then individually mapped stacks oldest-first, each pass bounded to half of what is currently there so the worst pass scales with the burst and halves every interval. Slabs keep per-slab freelists and in-use counts, and acquire prefers the first slab with a free slot, so load concentrates and older slabs drain toward empty where one munmap retires 64 slots. `stack_pool.prewarm` commits N slots at init and floors the watermark.

Burst-then-idle example: a 10k-task burst holds its capacity for one full interval (repeat bursts pay nothing), then drains 10k → 5k → 2.5k → … to the steady-state demand over ~10 minutes; a trickle load keeps one warm slab forever; total silence for an interval releases everything.

## Platform matrix

| platform | allocator |
|---|---|
| 64-bit POSIX (Linux, macOS, FreeBSD, NetBSD, illumos) | slab slots |
| 32-bit targets | per-stack mmap (slabs can't afford the contiguous VA) |
| Windows | per-stack `RtlCreateUserStack` (TEB/PAGE_GUARD integration) |
| OpenBSD | per-stack `MAP_STACK`, fully committed (can't start as PROT_NONE) |

The slab path also falls back to per-stack mapping at runtime if a reservation fails. The watermark policy applies uniformly; only the reclamation unit differs.

## Deviations from #436's proposal

- Chained fixed-size slabs instead of one giant N-stack reservation: same syscall economics, but reclaimable piecewise by the watermark instead of all-or-nothing.
- No `MADV_FREE` on release: that path was measured too expensive back when `stackRecycle` was disabled, and it's the motivation for keeping release syscall-free and batching all reclamation into the periodic pass.

## Benchmarks

Interleaved A/B vs main (dev box), zio-benchmarks: **sleep 10ms x 10k tasks -25% st / -23% mt** (the README's known weak case), fan-out light -5% st / -11% mt, spawn -7%, fan-in and ping-pong neutral-to-better. Confirmed after the watermark/decay commits landed. Motivating decomposition: ~75% of the fan-out-vs-Go gap was this fixed per-stack cost, not scheduling.

## Testing

Full suite on io_uring, epoll (599/599); arm32 cross-compiles (gate degrades to the per-stack path); watermark semantics pinned by deterministic tests driving `shrink()` with synthetic timestamps (burst protection for one epoch, halving decay, live-slot pinning, prewarm floor, rate-limit guard). riscv64-under-QEMU has one pre-existing failure (`clearTimer racing a firing timer`) that reproduces identically on clean main.