### PR TITLE
ev: fix flaky realtime timer test (measure in its own clock domain)

### DIFF
--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -202,13 +202,21 @@ test "timer on real clock fires (absolute deadline)" {
     // Absolute realtime deadline 100ms in the future. The deadline lives in the
     // realtime epoch (ns since 1970), so it must be compared against now(real),
     // not the monotonic clock.
-    const deadline = time.Timestamp.now(.real).addDuration(.fromMilliseconds(100));
+    const start = time.Timestamp.now(.real);
+    const deadline = start.addDuration(.fromMilliseconds(100));
     var timer: Timer = .initClock(.{ .deadline = deadline }, .real);
 
-    var wall_timer = time.Stopwatch.start();
     loop.add(&timer.c);
     try loop.run();
-    const elapsed = wall_timer.read();
+
+    // Measure elapsed on the realtime clock too, not a monotonic stopwatch: a
+    // realtime timer fires when the wall clock crosses the deadline, and the
+    // kernel re-evaluates it across clock steps. CI machines (macOS VMs
+    // especially) step the wall clock while tests run, which moves the firing
+    // moment in monotonic terms and made this test flaky; in the timer's own
+    // clock domain a step moves "now" and the crossing together, so the
+    // elapsed time stays ~100ms plus firing latency either way.
+    const elapsed = start.durationTo(time.Timestamp.now(.real));
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
     try std.testing.expect(elapsed.toMilliseconds() >= 90);


### PR DESCRIPTION
The `timer on real clock fires (absolute deadline)` test arms an absolute deadline in the realtime epoch but asserted elapsed time on a monotonic stopwatch. A realtime timer fires when the wall clock crosses the deadline, and the kernel deliberately re-evaluates it across clock steps (`NOTE_ABSOLUTE` on Darwin, `TFD_TIMER_ABSTIME` on Linux) — so a wall-clock step during the 100ms window moves the firing moment in monotonic terms: a forward step trips the `>= 90ms` bound, a backward step (plus load) the `<= 250ms` one.

That's why it flaked specifically on macOS CI: the macOS runner VMs drift and `timed` corrects them by stepping, often several times early in a job, while Linux runners mostly slew. The timer behaves correctly in both cases; the test was measuring it with the wrong clock.

Fix: measure elapsed with `now(.real)` before and after. In the timer's own clock domain, a step moves the current time and the deadline crossing together, so elapsed stays ~100ms plus firing latency regardless of steps in either direction. The bounds keep their existing meaning (no early fire, bounded latency) without the false coupling to wall-clock corrections.