### PR TITLE
runtime: scheduler event counters and a metrics monitor thread

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,12 +24,15 @@ pub fn build(b: *std.Build) void {
 
     const task_migration = b.option(bool, "task-migration", "Compile in task migration / work-stealing support. When false, tasks are pinned to their home executor and the scheduler can drop the machinery it needs (default true)") orelse true;
 
+    const scheduler_metrics = b.option(bool, "scheduler-metrics", "Count scheduler events (parks, steals, wake batches) in per-executor counters readable via Runtime.schedulerMetrics (default true; the counters sit on executor-local paths and cost one plain increment per event)") orelse true;
+
     // Create options for backend selection
     var options = b.addOptions();
     options.addOption(?[]const u8, "backend", backend);
     options.addOption(ResolveBeneathMode, "resolve_beneath_mode", resolve_beneath_mode);
     options.addOption(bool, "no_hacks", no_hacks);
     options.addOption(bool, "task_migration", task_migration);
+    options.addOption(bool, "scheduler_metrics", scheduler_metrics);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),

--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build) void {
 
     const task_migration = b.option(bool, "task-migration", "Compile in task migration / work-stealing support. When false, tasks are pinned to their home executor and the scheduler can drop the machinery it needs (default true)") orelse true;
 
-    const scheduler_metrics = b.option(bool, "scheduler-metrics", "Count scheduler events (parks, steals, wake batches) in per-executor counters readable via Runtime.schedulerMetrics (default true; the counters sit on executor-local paths and cost one plain increment per event)") orelse true;
+    const scheduler_metrics = b.option(bool, "scheduler_metrics", "Count scheduler events (parks, steals, wake batches) in per-executor counters readable via Runtime.schedulerMetrics (default true; the counters sit on executor-local paths and cost one plain increment per event)") orelse true;
 
     // Create options for backend selection
     var options = b.addOptions();

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added scheduler event counters, readable as a summed snapshot via
+  `Runtime.schedulerMetrics()`: parks (doze and full), searcher elections, steal
+  attempts/hits and hint hits, dispatched-wake batches and their sizes, batched wake
+  claims, and load-shed wakes. Compiled in by default (each event is one plain
+  increment on an executor-local counter); `-Dscheduler-metrics=false` strips them.
+
 - When an executor with queued work wakes an idle one to help, the wake now carries a
   hint saying whose queue is loaded, and the woken executor starts stealing there
   instead of probing executors in random order. The work itself stays in the waker's

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
   attempts/hits and hint hits, dispatched-wake batches and their sizes, batched wake
   claims, and load-shed wakes. Compiled in by default (each event is one plain
   increment on an executor-local counter); `-Dscheduler-metrics=false` strips them.
+  The new `metrics_log_interval` runtime option starts a monitor thread that logs
+  the counters' per-interval deltas at that cadence; being its own thread, it keeps
+  reporting even when every executor is busy or parked.
 
 - When an executor with queued work wakes an idle one to help, the wake now carries a
   hint saying whose queue is loaded, and the woken executor starts stealing there

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
   `Runtime.schedulerMetrics()`: parks (doze and full), searcher elections, steal
   attempts/hits and hint hits, dispatched-wake batches and their sizes, batched wake
   claims, and load-shed wakes. Compiled in by default (each event is one plain
-  increment on an executor-local counter); `-Dscheduler-metrics=false` strips them.
+  increment on an executor-local counter); `-Dscheduler_metrics=false` strips them.
   The new `metrics_log_interval` runtime option starts a monitor thread that logs
   the counters' per-interval deltas at that cadence; being its own thread, it keeps
   reporting even when every executor is busy or parked.

--- a/src/os/root.zig
+++ b/src/os/root.zig
@@ -15,6 +15,7 @@ pub const syscall_cancel = @import("syscall_cancel.zig");
 pub const Mutex = thread.Mutex;
 pub const Condition = thread.Condition;
 pub const ResetEvent = thread.ResetEvent;
+pub const Futex = thread.Futex;
 
 /// Fill `buffer` with cryptographically secure random bytes from the OS.
 /// Blocking primitive (raw syscall on the calling thread).

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -132,10 +132,12 @@ pub const RuntimeOptions = struct {
         .maximum_size = 8 * 1024 * 1024,
         .committed_size = 256 * 1024,
     },
-    /// When non-zero and scheduler metrics are compiled in, a monitor thread
-    /// logs the counters' per-interval deltas at this cadence. A dedicated
-    /// thread rather than an executor timer, so it keeps reporting even when
-    /// every executor is wedged or asleep.
+    /// When non-zero, a monitor thread logs the scheduler counters'
+    /// per-interval deltas at this cadence. A dedicated thread rather than
+    /// an executor timer, so it keeps reporting even when every executor is
+    /// wedged or asleep. Requires the counters compiled in (build option
+    /// `scheduler_metrics`) and a multi-threaded build; warns and stays off
+    /// otherwise.
     metrics_log_interval: Duration = .zero,
 
     /// Total number of executors to run.
@@ -343,12 +345,13 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
 }
 
 /// Whether scheduler event counters are compiled in (build option
-/// `scheduler-metrics`).
+/// `scheduler_metrics`).
 pub const metrics_enabled = zio_options.scheduler_metrics;
 
 /// Counts of scheduler events, kept per executor (plain increments on the
-/// owning thread) and summed by `Runtime.schedulerMetrics`. All zeros when
-/// `metrics_enabled` is false.
+/// owning thread) and summed by `Runtime.schedulerMetrics`. With
+/// `metrics_enabled` false the per-executor storage is zero-bit and the
+/// summed snapshot is all zeros.
 pub const SchedulerMetrics = struct {
     /// Parks with the doze cap (the steal-free grace park).
     parks_doze: u64 = 0,
@@ -381,6 +384,9 @@ pub const SchedulerMetrics = struct {
         }
     }
 };
+
+const MetricsStorage = if (metrics_enabled) SchedulerMetrics else void;
+const metrics_storage_init: MetricsStorage = if (metrics_enabled) .{} else {};
 
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
@@ -447,7 +453,7 @@ pub const Executor = struct {
     dozed: bool = false,
 
     // Scheduler event counters; written only by this executor's thread.
-    metrics: SchedulerMetrics = .{},
+    metrics: MetricsStorage = metrics_storage_init,
 
     // True while drainDispatched signals a batch of task wakes:
     // scheduleTaskLocal skips the per-push announce, the drain announces
@@ -1468,10 +1474,12 @@ pub const Runtime = struct {
         }
 
         if (options.metrics_log_interval.value > 0) {
-            if (metrics_enabled and !builtin.single_threaded) {
-                self.metrics_monitor = try std.Thread.spawn(.{}, runMetricsMonitor, .{self});
-            } else {
+            if (comptime !metrics_enabled) {
                 log.warn("metrics_log_interval set, but scheduler metrics are compiled out", .{});
+            } else if (comptime builtin.single_threaded) {
+                log.warn("metrics_log_interval set, but a single-threaded build cannot start the monitor thread", .{});
+            } else {
+                self.metrics_monitor = try std.Thread.spawn(.{}, runMetricsMonitor, .{self});
             }
         }
     }
@@ -1682,8 +1690,10 @@ pub const Runtime = struct {
     /// they are quiesced. All zeros when `metrics_enabled` is false.
     pub fn schedulerMetrics(self: *Runtime) SchedulerMetrics {
         var total: SchedulerMetrics = .{};
-        for (self.executors.items) |executor| {
-            total.add(executor.metrics);
+        if (comptime metrics_enabled) {
+            for (self.executors.items) |executor| {
+                total.add(executor.metrics);
+            }
         }
         return total;
     }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -132,6 +132,12 @@ pub const RuntimeOptions = struct {
         .maximum_size = 8 * 1024 * 1024,
         .committed_size = 256 * 1024,
     },
+    /// When non-zero and scheduler metrics are compiled in, a monitor thread
+    /// logs the counters' per-interval deltas at this cadence. A dedicated
+    /// thread rather than an executor timer, so it keeps reporting even when
+    /// every executor is wedged or asleep.
+    metrics_log_interval: Duration = .zero,
+
     /// Total number of executors to run.
     /// When enable_main_executor is true (default), this includes the main executor on the calling thread.
     /// When enable_main_executor is false, all executors run as background worker threads.
@@ -366,6 +372,12 @@ pub const SchedulerMetrics = struct {
     pub fn add(self: *SchedulerMetrics, other: SchedulerMetrics) void {
         inline for (@typeInfo(SchedulerMetrics).@"struct".fields) |field| {
             @field(self, field.name) += @field(other, field.name);
+        }
+    }
+
+    pub fn sub(self: *SchedulerMetrics, other: SchedulerMetrics) void {
+        inline for (@typeInfo(SchedulerMetrics).@"struct".fields) |field| {
+            @field(self, field.name) -= @field(other, field.name);
         }
     }
 };
@@ -1362,6 +1374,8 @@ pub const Runtime = struct {
     // so a worker cannot close its waker fds while a notifier is still using
     // them. See the wait in runWorker().
     teardown: os.ResetEvent = .init(),
+    metrics_monitor: ?std.Thread = null,
+    metrics_stop: std.atomic.Value(u32) = .init(0),
     own_self: bool = false,
 
     resolver: ?dns.Resolver = null,
@@ -1452,6 +1466,41 @@ pub const Runtime = struct {
             // false lets single-executor runtimes skip the steal machinery.
             if (num_workers > 0) self.executors_stealable.store(true, .release);
         }
+
+        if (options.metrics_log_interval.value > 0) {
+            if (metrics_enabled and !builtin.single_threaded) {
+                self.metrics_monitor = try std.Thread.spawn(.{}, runMetricsMonitor, .{self});
+            } else {
+                log.warn("metrics_log_interval set, but scheduler metrics are compiled out", .{});
+            }
+        }
+    }
+
+    /// Logs scheduler counter deltas every metrics_log_interval until deinit
+    /// sets metrics_stop.
+    fn runMetricsMonitor(self: *Runtime) void {
+        const interval = self.options.metrics_log_interval;
+        var last: SchedulerMetrics = .{};
+        while (self.metrics_stop.load(.acquire) == 0) {
+            os.Futex.timedWait(&self.metrics_stop, 0, interval) catch {
+                const total = self.schedulerMetrics();
+                var delta = total;
+                delta.sub(last);
+                last = total;
+                log.info("scheduler: parks doze={d} full={d} elections={d} steals={d}/{d} hint_hits={d} drains={d} woken={d} batch_claims={d} sheds={d}", .{
+                    delta.parks_doze,
+                    delta.parks_full,
+                    delta.park_elections,
+                    delta.steal_hits,
+                    delta.steal_attempts,
+                    delta.steal_hint_hits,
+                    delta.drain_batches,
+                    delta.drain_woken,
+                    delta.batch_wake_claims,
+                    delta.sheds,
+                });
+            };
+        }
     }
 
     /// Stop worker executors and join threads. Used by deinit() and init() error path.
@@ -1482,6 +1531,15 @@ pub const Runtime = struct {
 
         // Set shutting_down flag to prevent new spawns
         self.shutting_down.store(true, .release);
+
+        // The monitor reads executor state, so it must go before any of the
+        // teardown below.
+        if (self.metrics_monitor) |monitor| {
+            self.metrics_stop.store(1, .release);
+            os.Futex.wake(&self.metrics_stop, .one);
+            monitor.join();
+            self.metrics_monitor = null;
+        }
 
         // Stop and join the thread pool first, while all executor loops are
         // still alive. Thread-pool completion callbacks wake the owning loop
@@ -1789,6 +1847,18 @@ test "Runtime: scheduler metrics count parks and drained wakes" {
     try std.testing.expect(m.drain_woken >= 1);
     try std.testing.expect(m.drain_batches >= 1);
     try std.testing.expect(m.parks_doze + m.parks_full >= 1);
+}
+
+test "Runtime: metrics monitor thread starts and stops" {
+    if (!metrics_enabled or builtin.single_threaded) return error.SkipZigTest;
+
+    const runtime = try Runtime.init(std.testing.allocator, .{
+        .metrics_log_interval = .fromMilliseconds(5),
+    });
+    defer runtime.deinit();
+
+    // Long enough for a couple of monitor reports.
+    try runtime.sleep(.fromMilliseconds(15));
 }
 
 test "runtime: spawnBlocking smoke test" {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1478,6 +1478,8 @@ pub const Runtime = struct {
                 log.warn("metrics_log_interval set, but scheduler metrics are compiled out", .{});
             } else if (comptime builtin.single_threaded) {
                 log.warn("metrics_log_interval set, but a single-threaded build cannot start the monitor thread", .{});
+            } else if (comptime os.Futex == void) {
+                log.warn("metrics_log_interval set, but this target has no futex for the monitor thread", .{});
             } else {
                 self.metrics_monitor = try std.Thread.spawn(.{}, runMetricsMonitor, .{self});
             }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -336,6 +336,40 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
     return rt.executors.items[index % rt.executors.items.len];
 }
 
+/// Whether scheduler event counters are compiled in (build option
+/// `scheduler-metrics`).
+pub const metrics_enabled = zio_options.scheduler_metrics;
+
+/// Counts of scheduler events, kept per executor (plain increments on the
+/// owning thread) and summed by `Runtime.schedulerMetrics`. All zeros when
+/// `metrics_enabled` is false.
+pub const SchedulerMetrics = struct {
+    /// Parks with the doze cap (the steal-free grace park).
+    parks_doze: u64 = 0,
+    /// Indefinite parks.
+    parks_full: u64 = 0,
+    /// Park exits where a pusher had claimed this executor's idle bit.
+    park_elections: u64 = 0,
+    /// stealWork scans that ran / that took work.
+    steal_attempts: u64 = 0,
+    steal_hits: u64 = 0,
+    /// Steals satisfied by the hinted victim on the first probe.
+    steal_hint_hits: u64 = 0,
+    /// Dispatched-queue drains that woke at least one task / tasks woken.
+    drain_batches: u64 = 0,
+    drain_woken: u64 = 0,
+    /// Sleepers woken by batched wake decisions.
+    batch_wake_claims: u64 = 0,
+    /// Wakes routed to the global queue by load shedding.
+    sheds: u64 = 0,
+
+    pub fn add(self: *SchedulerMetrics, other: SchedulerMetrics) void {
+        inline for (@typeInfo(SchedulerMetrics).@"struct".fields) |field| {
+            @field(self, field.name) += @field(other, field.name);
+        }
+    }
+};
+
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
     pub const max_executors = std.math.maxInt(ExecutorId) + 1;
@@ -399,6 +433,9 @@ pub const Executor = struct {
     // park, see parkAndSearch) since it last had local work. Reset by any
     // local work; while set, empty passes go straight to the full park.
     dozed: bool = false,
+
+    // Scheduler event counters; written only by this executor's thread.
+    metrics: SchedulerMetrics = .{},
 
     // True while drainDispatched signals a batch of task wakes:
     // scheduleTaskLocal skips the per-push announce, the drain announces
@@ -546,6 +583,10 @@ pub const Executor = struct {
     }
 
     pub const YieldCancelMode = enum { allow_cancel, no_cancel };
+
+    inline fn bump(self: *Executor, comptime field: []const u8, n: u64) void {
+        if (comptime metrics_enabled) @field(self.metrics, field) += n;
+    }
 
     /// Aim to poll I/O roughly this often while running tasks back-to-back.
     const tick_target_ns = 100_000;
@@ -765,9 +806,11 @@ pub const Executor = struct {
                 try self.loop.poll(.zero);
                 self.drainDispatched();
                 if (self.checkLocalWork(check_ready)) return;
+                self.bump("parks_doze", 1);
                 return self.park(check_ready, doze_wait, .local_only);
             }
         }
+        self.bump("parks_full", 1);
         return self.park(check_ready, .max, .steal);
     }
 
@@ -809,6 +852,7 @@ pub const Executor = struct {
         const previous_bit = self.runtime.idle_mask.fetchAnd(~my_bit, .acq_rel);
 
         if (previous_bit & my_bit == 0) {
+            self.bump("park_elections", 1);
             if (found_work or (check_ready and self.main_task.state.load(.acquire).tag == .ready) or !self.run_queue.isEmpty()) {
                 _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
                 return;
@@ -889,10 +933,12 @@ pub const Executor = struct {
         // the scan there. Stale hints are harmless: the circular sweep just
         // continues past them.
         const hinted = self.steal_hint.swap(no_steal_hint, .acquire);
-        const start = if (hinted != no_steal_hint and hinted < executors.len)
+        const hint_start = hinted != no_steal_hint and hinted < executors.len;
+        const start = if (hint_start)
             hinted
         else
             self.steal_prng.random().uintLessThan(usize, executors.len);
+        self.bump("steal_attempts", 1);
         for (0..executors.len) |i| {
             const victim = executors[(start + i) % executors.len];
             if (victim == self) continue;
@@ -903,6 +949,8 @@ pub const Executor = struct {
 
             if (self.run_queue.steal(&victim.run_queue)) |node| {
                 _ = self.run_queue.push(node);
+                self.bump("steal_hits", 1);
+                if (hint_start and i == 0) self.bump("steal_hint_hits", 1);
                 // The rest of the loaded ring is still at the victim; point
                 // the next searcher straight at it.
                 self.runtime.armSearcher(victim.id);
@@ -953,6 +1001,7 @@ pub const Executor = struct {
         // pull from it, and a shed task's I/O re-homes wherever it runs next.
         if (self.shed_quota > 0) {
             self.shed_quota -= 1;
+            self.bump("sheds", 1);
             self.run_queue.overflow.push(&task.awaitable.wait_node);
             self.runtime.armSearcher(null);
             return;
@@ -998,7 +1047,10 @@ pub const Executor = struct {
         self.draining_wakes = false;
 
         if (count > 0) {
-            self.runtime.batchWakeSleepers(self.run_queue.len(), self.id);
+            self.bump("drain_batches", 1);
+            self.bump("drain_woken", count);
+            const claims = self.runtime.batchWakeSleepers(self.run_queue.len(), self.id);
+            self.bump("batch_wake_claims", claims);
         }
     }
 
@@ -1566,6 +1618,18 @@ pub const Runtime = struct {
         }
     }
 
+    /// Sum of all executors' scheduler event counters. The counters are
+    /// written without atomics by their owning threads, so this is an
+    /// approximate snapshot while executors are running; it is exact once
+    /// they are quiesced. All zeros when `metrics_enabled` is false.
+    pub fn schedulerMetrics(self: *Runtime) SchedulerMetrics {
+        var total: SchedulerMetrics = .{};
+        for (self.executors.items) |executor| {
+            total.add(executor.metrics);
+        }
+        return total;
+    }
+
     /// Whether other executors can currently steal from this runtime's queues.
     pub inline fn stealingActive(self: *Runtime) bool {
         return zio_options.task_migration and self.options.enable_task_migration and self.executors_stealable.load(.acquire);
@@ -1622,16 +1686,20 @@ pub const Runtime = struct {
     ///
     /// A claimed searcher's park exit may release a token it never took;
     /// that lets one extra election through, it never loses a wake.
-    fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) void {
-        if (!self.stealingActive() or ready < 2) return;
-        if (self.idle_mask.load(.seq_cst) == 0) return;
+    /// Returns the number of sleepers actually woken.
+    fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) u64 {
+        if (!self.stealingActive() or ready < 2) return 0;
+        if (self.idle_mask.load(.seq_cst) == 0) return 0;
 
         var wakes: usize = 0;
         var covered: usize = 2; // wakes = ceil(log2(ready))
         while (covered < ready) : (covered *= 2) wakes += 1;
+        var woken: u64 = 0;
         while (wakes > 0) : (wakes -= 1) {
-            if (!self.claimAndWake(hint, hint)) return;
+            if (!self.claimAndWake(hint, hint)) break;
+            woken += 1;
         }
+        return woken;
     }
 
     // Convenience methods that operate on the current coroutine context
@@ -1691,6 +1759,37 @@ pub const Runtime = struct {
         return @import("io.zig").toRuntime(value);
     }
 };
+
+test "Runtime: scheduler metrics count parks and drained wakes" {
+    if (!metrics_enabled) return error.SkipZigTest;
+
+    const runtime = try Runtime.init(std.testing.allocator, .{
+        .executors = .exact(2),
+    });
+    defer runtime.deinit();
+
+    // An Async wait goes through waitForIo, so its wake is delivered through
+    // the dispatched queue whether it completes inline or after parking.
+    const waitForIo = @import("common.zig").waitForIo;
+    const Ctx = struct {
+        handle: ev.Async = ev.Async.init(),
+        fn wait(ctx: *@This()) void {
+            waitForIo(&ctx.handle.c) catch {};
+        }
+    };
+    var ctx: Ctx = .{};
+    var handle = try runtime.spawn(Ctx.wait, .{&ctx});
+    defer handle.cancel();
+
+    try runtime.sleep(.fromMilliseconds(1));
+    ctx.handle.notify();
+    handle.join();
+
+    const m = runtime.schedulerMetrics();
+    try std.testing.expect(m.drain_woken >= 1);
+    try std.testing.expect(m.drain_batches >= 1);
+    try std.testing.expect(m.parks_doze + m.parks_full >= 1);
+}
 
 test "runtime: spawnBlocking smoke test" {
     const runtime = try Runtime.init(std.testing.allocator, .{


### PR DESCRIPTION
Per-executor counters for the scheduler events every tuning discussion has needed numbers for, plus an optional monitor thread that logs them periodically.

## Counters

`Runtime.schedulerMetrics()` returns a summed snapshot of ten per-executor counters: parks split by doze/full, searcher elections, steal attempts/hits and how often the hint's victim paid off, dispatched wake batches and their sizes, batched wake claims, and load-shed wakes. Writes are plain increments by the owning thread, so the snapshot is approximate while executors run and exact once quiesced.

Counters sit only on cold scheduler paths (a park entry, a steal scan, a drain pass), never on the per-push hot path, so they are compiled in by default; `-Dscheduler_metrics=false` strips them to nothing (the option name is a valid Zig identifier, matching the `zio_options` field; the older hyphenated options will be renamed separately). Ping-pong measures identically with counters on.

## Monitor thread

The `metrics_log_interval` runtime option starts a thread that logs the counters' per-interval deltas at that cadence:

```
info(zio): scheduler: parks doze=182 full=41 elections=37 steals=29/44 hint_hits=25 drains=210 woken=1843 batch_claims=61 sheds=0
```

A dedicated thread rather than an executor timer, so it keeps reporting even when every executor is wedged or asleep, which is when the numbers matter most. Stopped and joined first thing in `deinit` (it reads executor state); the sleep is a futex timed wait on the stop word, so shutdown never waits out an interval. Warns and stays off if the counters are compiled out.

## Testing

Full suite with metrics on (both new tests included: counter assertions through an `ev.Async` wait that provably crosses the dispatched queue, and a monitor lifecycle test at 5ms cadence), 601/601 with `-Dscheduler_metrics=false`, epoll suite, Windows cross-compile.

First intended use: watching steal/drain rates on the tcp pipe workload to chase the ~4% lat/pipe question from #633.