### PR TITLE
runtime: stop the load-shed oscillation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Load shedding no longer oscillates on evenly loaded runtimes. The imbalance
+  threshold now scales with the load average (12.5% over it, at least 2), and
+  shedding is evaluated every few milliseconds instead of every scheduler tick, so
+  momentary op-count jitter no longer reads as imbalance. On a steady 64-connection
+  pipelined echo workload this cut shed traffic from ~50k to under 1k migrations per
+  second with unchanged throughput, and steal hints hit their target much more often
+  once connections stopped circulating.
+
 - When an executor with queued work wakes an idle one to help, the wake now carries a
   hint saying whose queue is loaded, and the woken executor starts stealing there
   instead of probing executors in random order. The work itself stays in the waker's

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -395,6 +395,9 @@ pub const Executor = struct {
     // average (see scheduleTaskLocal).
     shed_quota: u32 = 0,
 
+    // Ticks until the next shed evaluation (see recomputeShedQuota).
+    shed_cooldown: u32 = 0,
+
     // Whether this executor has already spent its doze (the steal-free grace
     // park, see parkAndSearch) since it last had local work. Reset by any
     // local work; while set, empty passes go straight to the full park.
@@ -716,6 +719,10 @@ pub const Executor = struct {
     /// queue into the primary scheduling path.
     const max_shed_per_tick = 4;
 
+    /// Ticks between shed evaluations; at the ~100us tick target this
+    /// samples load roughly every 6ms.
+    const shed_eval_interval = 64;
+
     /// Once per tick, compare this executor's resident load (active ops
     /// submitted on this loop, mostly tasks parked on I/O) against the
     /// runtime average; the excess becomes this tick's shed quota (see
@@ -725,6 +732,19 @@ pub const Executor = struct {
     fn recomputeShedQuota(self: *Executor) void {
         self.shed_quota = 0;
         if (!self.runtime.stealingActive()) return;
+
+        // Shedding corrects sustained imbalance, so it only needs to look
+        // every few milliseconds. Evaluating every tick lets instantaneous
+        // op-count spread (ops complete and resubmit continuously, so
+        // executors' loadActive counts scatter around the average at any
+        // given moment) grant a fresh quota tens of thousands of times per
+        // second, circulating connections through the global queue with no
+        // lasting rebalancing effect.
+        if (self.shed_cooldown > 0) {
+            self.shed_cooldown -= 1;
+            return;
+        }
+        self.shed_cooldown = shed_eval_interval;
 
         const executors = self.runtime.executors.items;
         const mine = self.loop.state.loadActive();

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -732,9 +732,14 @@ pub const Executor = struct {
         var total: usize = 0;
         for (executors) |e| total += e.loop.state.loadActive();
         const avg = total / executors.len;
-        // The +1 keeps neighbors one apart from trading the same task back
-        // and forth forever.
-        if (mine > avg + 1) {
+        // The margin scales with the average so that integer division and
+        // moment-to-moment op jitter never read as imbalance; connections
+        // that cannot divide evenly across executors would otherwise
+        // circulate through the global queue forever (a steady 64-connection
+        // pipeline measured ~50k sheds/s under a flat margin of 1). Shedding
+        // starts at ~12.5% over average, and no less than 2 above it.
+        const margin = @max(2, avg / 8);
+        if (mine > avg + margin) {
             self.shed_quota = @intCast(@min(mine - avg, max_shed_per_tick));
         }
     }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -744,7 +744,7 @@ pub const Executor = struct {
             self.shed_cooldown -= 1;
             return;
         }
-        self.shed_cooldown = shed_eval_interval;
+        self.shed_cooldown = shed_eval_interval - 1;
 
         const executors = self.runtime.executors.items;
         const mine = self.loop.state.loadActive();
@@ -757,7 +757,8 @@ pub const Executor = struct {
         // that cannot divide evenly across executors would otherwise
         // circulate through the global queue forever (a steady 64-connection
         // pipeline measured ~50k sheds/s under a flat margin of 1). Shedding
-        // starts at ~12.5% over average, and no less than 2 above it.
+        // starts strictly beyond the margin: past ~12.5% over the average,
+        // and never for an excess of 2 or less.
         const margin = @max(2, avg / 8);
         if (mine > avg + margin) {
             self.shed_quota = @intCast(@min(mine - avg, max_shed_per_tick));


### PR DESCRIPTION
First change driven end-to-end by the scheduler counters (#636): they revealed that load shedding runs a permanent oscillation on evenly loaded runtimes, and they verify the fix.

## The finding

On a steady 64-connection pipelined echo workload (8 executors, io_uring), the counters showed **~50,000 sheds per second** — each one a global-queue round trip, a wake, and a connection re-homing — on a workload with nothing to rebalance. Two causes compounding:

- the flat `avg + 1` threshold: connections that cannot divide evenly across executors always leave someone 1-2 above average;
- per-tick evaluation: ops complete and resubmit continuously, so executors' `loadActive` counts scatter around the average at any instant, and re-granting a shed quota every ~100us tick turns that scatter into tens of thousands of migrations per second.

Measured to be net-benign for median throughput on this box (disabling the machinery entirely changed pipe by -1.8%), but it is unintended behavior, its cost on epoll/kqueue (where migration means cross-loop servicing) is unmeasured, and the global-queue mutex traffic grows with scale.

## The fix

Two commits: the threshold scales with the load average (12.5% over it, at least 2), and shedding is evaluated every 64 ticks (~6ms at the tick target) instead of every tick. The margin alone was measured insufficient (still ~33k/s — instantaneous spread exceeds any static margin); the cadence is what bounds the rate structurally. Shedding still corrects sustained skew at scheduler timescales.

## Counter-verified results (1s monitor intervals)

| workload | sheds/s before | sheds/s after | throughput |
|---|---|---|---|
| pipe (64 conns, p16) | ~50,000 | **~800** | +4.9% (noise band) |
| many (1000 conns) | ~78,000 | **~550** | -2.4% (noise band) |
| lat (1 conn) | ~5 | ~0 | -1.7% (noise band) |

Side effects visible in the counters once connections stop circulating: on `many`, the steal-hint hit rate rose from ~43% to ~73% and completion drain batches grew from ~6 to ~10 tasks — work staying put makes both hints and batching more effective.

## Testing

Full native suite; the change is two small modifications to `recomputeShedQuota` plus one countdown field.