### PR TITLE
ev: fix flaky Windows blocking-sockets test (poll before socket ops)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed blocking-path socket operations on Windows failing with `error.WouldBlock`
+  when the socket was in nonblocking mode, seen as a flaky CI failure in the blocking
+  sockets test. Accepted sockets are nonblocking by default (`NetAccept`'s flags), but
+  the Windows blocking executor called recv/send/accept once assuming blocking mode,
+  so a receive racing the peer's send surfaced `WouldBlock` instead of waiting.
+  Windows now uses the same poll-and-retry loop as the other platforms, which handles
+  both socket modes.
+
 - When an executor with queued work wakes an idle one to help, the wake now carries a
   hint saying whose queue is loaded, and the woken executor starts stealing there
   instead of probing executors in random order. The work itself stays in the waker's

--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -271,17 +271,9 @@ fn handleNetShutdown(c: *Completion) void {
 fn handleNetRecv(c: *Completion) void {
     const data = c.cast(NetRecv);
 
-    // Windows: blocking recv, no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.recv(data.handle, data.buffers.iovecs, data.flags)) |bytes_read| {
-            c.setResult(.net_recv, bytes_read);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+recv loop to handle race if multiple threads access same socket
+    // Poll+recv loop: the socket may be nonblocking (NetAccept hands out
+    // nonblocking sockets by default), and multiple threads may race on the
+    // same socket; poll readiness and retry on WouldBlock either way.
     while (true) {
         pollForReady(data.handle, os.net.POLL.IN) catch |err| {
             c.setError(err);
@@ -305,17 +297,7 @@ fn handleNetRecv(c: *Completion) void {
 fn handleNetSend(c: *Completion) void {
     const data = c.cast(NetSend);
 
-    // Windows: blocking send, no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.send(data.handle, data.buffer.iovecs, data.flags)) |bytes_written| {
-            c.setResult(.net_send, bytes_written);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+send loop to handle race if multiple threads access same socket
+    // Poll+send loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.OUT) catch |err| {
             c.setError(err);
@@ -339,17 +321,7 @@ fn handleNetSend(c: *Completion) void {
 fn handleNetRecvFrom(c: *Completion) void {
     const data = c.cast(NetRecvFrom);
 
-    // Windows: blocking recvfrom, no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.recvfrom(data.handle, data.buffer.iovecs, data.flags, data.addr, data.addr_len)) |bytes_read| {
-            c.setResult(.net_recvfrom, bytes_read);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+recvfrom loop to handle race if multiple threads access same socket
+    // Poll+recvfrom loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.IN) catch |err| {
             c.setError(err);
@@ -373,17 +345,7 @@ fn handleNetRecvFrom(c: *Completion) void {
 fn handleNetSendTo(c: *Completion) void {
     const data = c.cast(NetSendTo);
 
-    // Windows: blocking sendto, no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.sendto(data.handle, data.buffer.iovecs, data.flags, data.addr, data.addr_len)) |bytes_written| {
-            c.setResult(.net_sendto, bytes_written);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+sendto loop to handle race if multiple threads access same socket
+    // Poll+sendto loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.OUT) catch |err| {
             c.setError(err);
@@ -407,17 +369,7 @@ fn handleNetSendTo(c: *Completion) void {
 fn handleNetRecvMsg(c: *Completion) void {
     const data = c.cast(NetRecvMsg);
 
-    // Windows: blocking recvmsg (emulated in net layer), no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.recvmsg(data.handle, data.data.iovecs, data.flags, data.addr, data.addr_len, data.control)) |result| {
-            c.setResult(.net_recvmsg, result);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+recvmsg loop to handle race if multiple threads access same socket
+    // Poll+recvmsg loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.IN) catch |err| {
             c.setError(err);
@@ -441,17 +393,7 @@ fn handleNetRecvMsg(c: *Completion) void {
 fn handleNetSendMsg(c: *Completion) void {
     const data = c.cast(NetSendMsg);
 
-    // Windows: blocking sendmsg (emulated in net layer), no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.sendmsg(data.handle, data.data.iovecs, data.flags, data.addr, data.addr_len, data.control)) |bytes_written| {
-            c.setResult(.net_sendmsg, bytes_written);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+sendmsg loop to handle race if multiple threads access same socket
+    // Poll+sendmsg loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.OUT) catch |err| {
             c.setError(err);
@@ -513,17 +455,7 @@ fn handleNetConnect(c: *Completion) void {
 fn handleNetAccept(c: *Completion) void {
     const data = c.cast(NetAccept);
 
-    // Windows: blocking accept, no poll needed
-    if (builtin.os.tag == .windows) {
-        if (os.net.accept(data.handle, data.addr, data.addr_len, data.flags)) |new_handle| {
-            c.setResult(.net_accept, new_handle);
-        } else |err| {
-            c.setError(err);
-        }
-        return;
-    }
-
-    // POSIX: poll+accept loop to handle race if multiple threads access same socket
+    // Poll+accept loop; see handleNetRecv for why polling is unconditional.
     while (true) {
         pollForReady(data.handle, os.net.POLL.IN) catch |err| {
             c.setError(err);

--- a/src/ev/test/blocking_sockets.zig
+++ b/src/ev/test/blocking_sockets.zig
@@ -157,3 +157,84 @@ test "Blocking sockets: basic smoke test" {
     try std.testing.expectEqual(null, state.server_err);
     try std.testing.expectEqual(null, state.client_err);
 }
+
+test "Blocking sockets: recv on a nonblocking socket waits for data" {
+    // NetAccept hands back a nonblocking socket by default (the event loop
+    // wants that), so the blocking executor cannot assume its handles are in
+    // blocking mode: a recv that arrives before the peer's send must poll
+    // and wait, not surface WouldBlock. The ordering here is deterministic:
+    // the sender only transmits after the receiver is already parked in
+    // executeBlocking.
+    net.ensureWSAInitialized();
+
+    const alloc = std.testing.allocator;
+
+    // Listener, blocking mode, on an ephemeral loopback port.
+    var addr = net.sockaddr.in{
+        .family = net.AF.INET,
+        .port = 0,
+        .addr = @bitCast([4]u8{ 127, 0, 0, 1 }),
+        .zero = @splat(0),
+    };
+    var addr_len: net.socklen_t = @sizeOf(net.sockaddr.in);
+
+    var open = ev.NetOpen.init(.ipv4, .stream, .ip, .{ .nonblocking = false });
+    blocking.executeBlocking(&open.c, alloc);
+    const listener = try open.c.getResult(.net_open);
+    defer {
+        var close = ev.NetClose.init(listener);
+        blocking.executeBlocking(&close.c, alloc);
+        _ = close.c.getResult(.net_close) catch {};
+    }
+
+    var bind = ev.NetBind.init(listener, @ptrCast(&addr), &addr_len);
+    blocking.executeBlocking(&bind.c, alloc);
+    try bind.c.getResult(.net_bind);
+
+    var listen = ev.NetListen.init(listener, 1);
+    blocking.executeBlocking(&listen.c, alloc);
+    try listen.c.getResult(.net_listen);
+
+    // Client connects; loopback connect completes without an accept.
+    var copen = ev.NetOpen.init(.ipv4, .stream, .ip, .{ .nonblocking = false });
+    blocking.executeBlocking(&copen.c, alloc);
+    const client = try copen.c.getResult(.net_open);
+    defer {
+        var close = ev.NetClose.init(client);
+        blocking.executeBlocking(&close.c, alloc);
+        _ = close.c.getResult(.net_close) catch {};
+    }
+
+    var connect = ev.NetConnect.init(client, @ptrCast(&addr), addr_len);
+    blocking.executeBlocking(&connect.c, alloc);
+    try connect.getResult();
+
+    // Accept with the default flags: the accepted socket is nonblocking.
+    var accept = ev.NetAccept.init(listener, null, null);
+    blocking.executeBlocking(&accept.c, alloc);
+    const accepted = try accept.getResult();
+    defer {
+        var close = ev.NetClose.init(accepted);
+        blocking.executeBlocking(&close.c, alloc);
+        _ = close.c.getResult(.net_close) catch {};
+    }
+
+    // The send happens strictly after this thread is inside the recv.
+    const sender = try std.Thread.spawn(.{}, struct {
+        fn sendLate(sock: net.fd_t) void {
+            os.time.sleep(.fromMilliseconds(50));
+            var iov: [1]os.iovec_const = undefined;
+            var send = ev.NetSend.init(sock, .fromSlice("late data", &iov), .{});
+            blocking.executeBlocking(&send.c, std.testing.allocator);
+            _ = send.getResult() catch {};
+        }
+    }.sendLate, .{client});
+    defer sender.join();
+
+    var buf: [32]u8 = undefined;
+    var iov: [1]os.iovec = undefined;
+    var recv = ev.NetRecv.init(accepted, .fromSlice(&buf, &iov), .{});
+    blocking.executeBlocking(&recv.c, alloc);
+    const n = try recv.getResult();
+    try std.testing.expectEqualStrings("late data", buf[0..n]);
+}


### PR DESCRIPTION
Fixes the flaky `Blocking sockets: basic smoke test` failure on Windows CI (`expected null, found error.WouldBlock`).

## Root cause

The blocking executor's Windows socket handlers called recv/send/accept **once**, with comments assuming the socket is in blocking mode ("Windows: blocking recv, no poll needed"). The assumption is false: `NetAccept`'s flags default to `.nonblocking = true` (correct for the event loop, which is the main consumer), so the accepted socket in the smoke test is nonblocking. The server's single-shot recv then races the client's loopback send:

- send lands first → recv finds data → pass
- server reaches recv first → `WSAEWOULDBLOCK` → the flake

Every other platform was immune because the POSIX handlers poll for readiness and retry on `WouldBlock` regardless of socket mode — which is why this only ever struck the Windows job, randomly, at the mercy of thread scheduling.

## Fix

Delete the seven Windows special-case branches; all platforms now use the same poll+retry loop (`os.net.poll` is `WSAPoll` on Windows). The loop is correct for both socket modes: a blocking socket just blocks in the call after poll, a nonblocking one retries on the next readiness.

## Proof

New deterministic regression test, `recv on a nonblocking socket waits for data`: accepts with default flags (nonblocking socket), parks in `executeBlocking` recv, and only then does a helper thread send, 50ms later — the exact ordering that made the smoke test flake. Before the fix it fails under Wine with `WouldBlock` on every run; after, it passes, along with the full Wine suite (518/518) and the native suite.