### PR TITLE
process: reliably kill children on NetBSD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,22 @@ jobs:
       fail-fast: false
       matrix:
         zig_version: ['0.16.0']
-        # Diagnostic PR: iterate quickly on the NetBSD childKill investigation.
-        mode: [debug]
+        mode: [debug, release]
         config:
+          - { os: ubuntu-24.04, target: native, backends: 'io_uring epoll poll' }
+          - { os: ubuntu-24.04-arm, target: native, backends: 'io_uring epoll poll' }
+          - { os: macos-latest, target: native, backends: 'kqueue poll' }
+          - { os: macos-15-intel, target: native, backends: 'kqueue poll' }
+          - { os: windows-latest, target: native, backends: 'iocp poll' }
+          - { os: ubuntu-latest, target: arm-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: thumb-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: riscv32-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: riscv64-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: loongarch64-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: powerpc64le-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: x86_64-freebsd, vm: freebsd, backends: 'kqueue poll' }
           - { os: ubuntu-latest, target: x86_64-netbsd, vm: netbsd, backends: 'kqueue poll' }
+          - { os: ubuntu-latest, target: x86_64-openbsd, vm: openbsd, backends: 'kqueue poll' }
 
     runs-on: ${{ matrix.config.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         zig_version: ['0.16.0']
-        mode: [debug, release]
+        # Diagnostic PR: iterate quickly on the NetBSD childKill investigation.
+        mode: [debug]
         config:
-          - { os: ubuntu-24.04, target: native, backends: 'io_uring epoll poll' }
-          - { os: ubuntu-24.04-arm, target: native, backends: 'io_uring epoll poll' }
-          - { os: macos-latest, target: native, backends: 'kqueue poll' }
-          - { os: macos-15-intel, target: native, backends: 'kqueue poll' }
-          - { os: windows-latest, target: native, backends: 'iocp poll' }
-          - { os: ubuntu-latest, target: arm-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: thumb-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv32-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: loongarch64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: powerpc64le-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: x86_64-freebsd, vm: freebsd, backends: 'kqueue poll' }
           - { os: ubuntu-latest, target: x86_64-netbsd, vm: netbsd, backends: 'kqueue poll' }
-          - { os: ubuntu-latest, target: x86_64-openbsd, vm: openbsd, backends: 'kqueue poll' }
 
     runs-on: ${{ matrix.config.os }}
 

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -34,7 +34,9 @@ pub const NetHandle = net.fd_t;
 const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
 
 pub const capabilities: BackendCapabilities = .{
-    .process_wait = true,
+    // NetBSD cannot reliably attach EVFILT_PROC after a child exits
+    // (kern/60358). Use the blocking-pool waitpid path instead.
+    .process_wait = builtin.os.tag != .netbsd,
     // Only Darwin has usable absolute wall-clock EVFILT_TIMER semantics
     // (NOTE_ABSOLUTE = gettimeofday, NOTE_MACH_CONTINUOUS_TIME = suspend-aware).
     // The BSDs' EVFILT_TIMER absolute clock is monotonic-only and underspecified

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -1005,12 +1005,6 @@ pub fn checkCompletion(comp: *Completion, event: *const std.c.Kevent) CheckResul
             return .completed;
         },
         .process_wait => {
-            if (builtin.os.tag == .netbsd) {
-                std.debug.print(
-                    "NETBSD processWait: kevent ident={} flags=0x{x} fflags=0x{x} data={}\n",
-                    .{ event.ident, event.flags, event.fflags, event.data },
-                );
-            }
             // Process exited - call waitpid to get exit status and reap zombie
             // Following libuv pattern: kevent just notifies us, waitpid gets the status
             const data = comp.cast(ProcessWait);

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -1005,6 +1005,12 @@ pub fn checkCompletion(comp: *Completion, event: *const std.c.Kevent) CheckResul
             return .completed;
         },
         .process_wait => {
+            if (builtin.os.tag == .netbsd) {
+                std.debug.print(
+                    "NETBSD processWait: kevent ident={} flags=0x{x} fflags=0x{x} data={}\n",
+                    .{ event.ident, event.flags, event.fflags, event.data },
+                );
+            }
             // Process exited - call waitpid to get exit status and reap zombie
             // Following libuv pattern: kevent just notifies us, waitpid gets the status
             const data = comp.cast(ProcessWait);

--- a/src/process.zig
+++ b/src/process.zig
@@ -29,7 +29,7 @@ pub fn childWait(child: *std.process.Child) std.process.Child.WaitError!std.proc
 }
 
 pub fn childKill(child: *std.process.Child) void {
-    sendTermSignal(child.id.?);
+    terminateProcess(child.id.?);
     var op = ev.ProcessWait.init(child.id.?);
     waitForIoUncancelable(&op.c);
     childCleanup(child);
@@ -42,49 +42,15 @@ fn exitStatusToTerm(status: ev.ProcessWait.ExitStatus) std.process.Child.Term {
     return .{ .exited = status.code };
 }
 
-fn sendTermSignal(handle: ProcessHandle) void {
+fn terminateProcess(handle: ProcessHandle) void {
     if (builtin.os.tag == .windows) {
         _ = std.os.windows.ntdll.NtTerminateProcess(handle, @enumFromInt(1));
     } else {
-        const rc = std.posix.system.kill(handle, .TERM);
-        if (builtin.os.tag == .netbsd) {
-            std.debug.print("NETBSD childKill: kill(pid={}, SIGTERM) rc={} errno={}\n", .{
-                handle,
-                rc,
-                std.posix.errno(rc),
-            });
-        }
+        // NetBSD 10 and older can discard a pending signal during execve,
+        // making an immediate SIGTERM after spawn unreliable (kern/58091).
+        const signal: std.posix.SIG = if (builtin.os.tag == .netbsd) .KILL else .TERM;
+        _ = std.posix.system.kill(handle, signal);
     }
-}
-
-fn sendKillSignal(handle: ProcessHandle) void {
-    const rc = std.posix.system.kill(handle, .KILL);
-    std.debug.print("NETBSD childKill: kill(pid={}, SIGKILL) rc={} errno={}\n", .{
-        handle,
-        rc,
-        std.posix.errno(rc),
-    });
-}
-
-fn dumpTermSignalState() void {
-    if (builtin.os.tag != .netbsd) return;
-
-    var action: std.posix.Sigaction = undefined;
-    std.posix.sigaction(.TERM, null, &action);
-    var mask: std.posix.sigset_t = undefined;
-    std.posix.sigprocmask(std.posix.SIG.SETMASK, null, &mask);
-
-    const handler = action.handler.handler;
-    std.debug.print(
-        "NETBSD childKill: parent SIGTERM handler=0x{x} (DFL=0x{x}, IGN=0x{x}) blocked={} flags=0x{x}\n",
-        .{
-            if (handler) |h| @intFromPtr(h) else 0,
-            0,
-            1,
-            std.posix.sigismember(&mask, .TERM),
-            action.flags,
-        },
-    );
 }
 
 fn childCleanup(child: *std.process.Child) void {
@@ -120,14 +86,9 @@ else
     &.{"false"};
 
 const argv_sleep: []const []const u8 = if (builtin.os.tag == .windows)
-    &.{ "cmd.exe", "/c", "timeout /t 5 /nobreak" }
+    &.{ "cmd.exe", "/c", "timeout /t 100 /nobreak" }
 else
-    &.{ "sleep", "5" };
-
-const argv_sleep_short: []const []const u8 = if (builtin.os.tag == .windows)
-    &.{ "cmd.exe", "/c", "timeout /t 1 /nobreak" }
-else
-    &.{ "sleep", "1" };
+    &.{ "sleep", "100" };
 
 test "childWait: exit code 0" {
     const rt = try Runtime.init(std.testing.allocator, .{});
@@ -151,63 +112,9 @@ test "childKill: terminates process" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    dumpTermSignalState();
     var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
     childKill(&child);
     try std.testing.expect(child.id == null);
-}
-
-test "childKill: NetBSD child exits before process wait registration" {
-    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
-
-    const rt = try Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
-    std.debug.print("NETBSD delayed childKill: spawned pid={}\n", .{child.id.?});
-    sendTermSignal(child.id.?);
-    os.time.sleep(.fromMilliseconds(100));
-    std.debug.print("NETBSD delayed childKill: registering ProcessWait after 100ms\n", .{});
-    var op = ev.ProcessWait.init(child.id.?);
-    waitForIoUncancelable(&op.c);
-    childCleanup(&child);
-    try std.testing.expect(child.id == null);
-}
-
-test "childKill: NetBSD repeated immediate SIGKILL" {
-    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
-
-    const rt = try Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    for (0..20) |iteration| {
-        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
-        std.debug.print("NETBSD immediate SIGKILL: iteration={} pid={}\n", .{ iteration, child.id.? });
-        sendKillSignal(child.id.?);
-        var op = ev.ProcessWait.init(child.id.?);
-        waitForIoUncancelable(&op.c);
-        childCleanup(&child);
-        try std.testing.expect(child.id == null);
-    }
-}
-
-test "childKill: NetBSD repeated SIGTERM after 10ms" {
-    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
-
-    const rt = try Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    for (0..20) |iteration| {
-        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
-        std.debug.print("NETBSD repeated SIGTERM: iteration={} pid={}\n", .{ iteration, child.id.? });
-        sendTermSignal(child.id.?);
-        os.time.sleep(.fromMilliseconds(10));
-        sendTermSignal(child.id.?);
-        var op = ev.ProcessWait.init(child.id.?);
-        waitForIoUncancelable(&op.c);
-        childCleanup(&child);
-        try std.testing.expect(child.id == null);
-    }
 }
 
 test "childWait: spawn nonexistent binary returns FileNotFound" {

--- a/src/process.zig
+++ b/src/process.zig
@@ -111,9 +111,14 @@ else
     &.{"false"};
 
 const argv_sleep: []const []const u8 = if (builtin.os.tag == .windows)
-    &.{ "cmd.exe", "/c", "timeout /t 5 /nobreak" }
+    &.{ "cmd.exe", "/c", "timeout /t 100 /nobreak" }
 else
-    &.{ "sleep", "5" };
+    &.{ "sleep", "100" };
+
+const argv_sleep_short: []const []const u8 = if (builtin.os.tag == .windows)
+    &.{ "cmd.exe", "/c", "timeout /t 1 /nobreak" }
+else
+    &.{ "sleep", "1" };
 
 test "childWait: exit code 0" {
     const rt = try Runtime.init(std.testing.allocator, .{});
@@ -139,9 +144,6 @@ test "childKill: terminates process" {
 
     dumpTermSignalState();
     var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
-    if (builtin.os.tag == .netbsd) {
-        std.debug.print("NETBSD childKill: spawned pid={}\n", .{child.id.?});
-    }
     childKill(&child);
     try std.testing.expect(child.id == null);
 }
@@ -152,7 +154,7 @@ test "childKill: NetBSD child exits before process wait registration" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
+    var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
     std.debug.print("NETBSD delayed childKill: spawned pid={}\n", .{child.id.?});
     sendTermSignal(child.id.?);
     os.time.sleep(.fromMilliseconds(100));
@@ -170,8 +172,10 @@ test "childKill: NetBSD repeated immediate termination" {
     defer rt.deinit();
 
     for (0..100) |iteration| {
-        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
-        std.debug.print("NETBSD repeated childKill: iteration={} pid={}\n", .{ iteration, child.id.? });
+        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
+        if (iteration % 10 == 0) {
+            std.debug.print("NETBSD repeated childKill: iteration={} pid={}\n", .{ iteration, child.id.? });
+        }
         childKill(&child);
         try std.testing.expect(child.id == null);
     }

--- a/src/process.zig
+++ b/src/process.zig
@@ -46,8 +46,36 @@ fn sendTermSignal(handle: ProcessHandle) void {
     if (builtin.os.tag == .windows) {
         _ = std.os.windows.ntdll.NtTerminateProcess(handle, @enumFromInt(1));
     } else {
-        _ = std.posix.system.kill(handle, .TERM);
+        const rc = std.posix.system.kill(handle, .TERM);
+        if (builtin.os.tag == .netbsd) {
+            std.debug.print("NETBSD childKill: kill(pid={}, SIGTERM) rc={} errno={}\n", .{
+                handle,
+                rc,
+                std.posix.errno(rc),
+            });
+        }
     }
+}
+
+fn dumpTermSignalState() void {
+    if (builtin.os.tag != .netbsd) return;
+
+    var action: std.posix.Sigaction = undefined;
+    std.posix.sigaction(.TERM, null, &action);
+    var mask: std.posix.sigset_t = undefined;
+    std.posix.sigprocmask(std.posix.SIG.SETMASK, null, &mask);
+
+    const handler = action.handler.handler;
+    std.debug.print(
+        "NETBSD childKill: parent SIGTERM handler=0x{x} (DFL=0x{x}, IGN=0x{x}) blocked={} flags=0x{x}\n",
+        .{
+            if (handler) |h| @intFromPtr(h) else 0,
+            0,
+            1,
+            std.posix.sigismember(&mask, .TERM),
+            action.flags,
+        },
+    );
 }
 
 fn childCleanup(child: *std.process.Child) void {
@@ -83,9 +111,9 @@ else
     &.{"false"};
 
 const argv_sleep: []const []const u8 = if (builtin.os.tag == .windows)
-    &.{ "cmd.exe", "/c", "timeout /t 100 /nobreak" }
+    &.{ "cmd.exe", "/c", "timeout /t 5 /nobreak" }
 else
-    &.{ "sleep", "100" };
+    &.{ "sleep", "5" };
 
 test "childWait: exit code 0" {
     const rt = try Runtime.init(std.testing.allocator, .{});
@@ -109,7 +137,11 @@ test "childKill: terminates process" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
+    dumpTermSignalState();
     var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
+    if (builtin.os.tag == .netbsd) {
+        std.debug.print("NETBSD childKill: spawned pid={}\n", .{child.id.?});
+    }
     childKill(&child);
     try std.testing.expect(child.id == null);
 }

--- a/src/process.zig
+++ b/src/process.zig
@@ -45,11 +45,14 @@ fn exitStatusToTerm(status: ev.ProcessWait.ExitStatus) std.process.Child.Term {
 fn terminateProcess(handle: ProcessHandle) void {
     if (builtin.os.tag == .windows) {
         _ = std.os.windows.ntdll.NtTerminateProcess(handle, @enumFromInt(1));
+    } else if (builtin.os.tag == .netbsd) {
+        // NetBSD 10 and older can discard a pending signal during execve
+        // (kern/58091). Retry after the exec window with an uncatchable signal.
+        _ = std.posix.system.kill(handle, .KILL);
+        os.time.sleep(.fromMilliseconds(10));
+        _ = std.posix.system.kill(handle, .KILL);
     } else {
-        // NetBSD 10 and older can discard a pending signal during execve,
-        // making an immediate SIGTERM after spawn unreliable (kern/58091).
-        const signal: std.posix.SIG = if (builtin.os.tag == .netbsd) .KILL else .TERM;
-        _ = std.posix.system.kill(handle, signal);
+        _ = std.posix.system.kill(handle, .TERM);
     }
 }
 

--- a/src/process.zig
+++ b/src/process.zig
@@ -146,6 +146,37 @@ test "childKill: terminates process" {
     try std.testing.expect(child.id == null);
 }
 
+test "childKill: NetBSD child exits before process wait registration" {
+    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
+    std.debug.print("NETBSD delayed childKill: spawned pid={}\n", .{child.id.?});
+    sendTermSignal(child.id.?);
+    os.time.sleep(.fromMilliseconds(100));
+    std.debug.print("NETBSD delayed childKill: registering ProcessWait after 100ms\n", .{});
+    var op = ev.ProcessWait.init(child.id.?);
+    waitForIoUncancelable(&op.c);
+    childCleanup(&child);
+    try std.testing.expect(child.id == null);
+}
+
+test "childKill: NetBSD repeated immediate termination" {
+    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    for (0..100) |iteration| {
+        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep });
+        std.debug.print("NETBSD repeated childKill: iteration={} pid={}\n", .{ iteration, child.id.? });
+        childKill(&child);
+        try std.testing.expect(child.id == null);
+    }
+}
+
 test "childWait: spawn nonexistent binary returns FileNotFound" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();

--- a/src/process.zig
+++ b/src/process.zig
@@ -57,6 +57,15 @@ fn sendTermSignal(handle: ProcessHandle) void {
     }
 }
 
+fn sendKillSignal(handle: ProcessHandle) void {
+    const rc = std.posix.system.kill(handle, .KILL);
+    std.debug.print("NETBSD childKill: kill(pid={}, SIGKILL) rc={} errno={}\n", .{
+        handle,
+        rc,
+        std.posix.errno(rc),
+    });
+}
+
 fn dumpTermSignalState() void {
     if (builtin.os.tag != .netbsd) return;
 
@@ -111,9 +120,9 @@ else
     &.{"false"};
 
 const argv_sleep: []const []const u8 = if (builtin.os.tag == .windows)
-    &.{ "cmd.exe", "/c", "timeout /t 100 /nobreak" }
+    &.{ "cmd.exe", "/c", "timeout /t 5 /nobreak" }
 else
-    &.{ "sleep", "100" };
+    &.{ "sleep", "5" };
 
 const argv_sleep_short: []const []const u8 = if (builtin.os.tag == .windows)
     &.{ "cmd.exe", "/c", "timeout /t 1 /nobreak" }
@@ -165,18 +174,38 @@ test "childKill: NetBSD child exits before process wait registration" {
     try std.testing.expect(child.id == null);
 }
 
-test "childKill: NetBSD repeated immediate termination" {
+test "childKill: NetBSD repeated immediate SIGKILL" {
     if (builtin.os.tag != .netbsd) return error.SkipZigTest;
 
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
-    for (0..100) |iteration| {
+    for (0..20) |iteration| {
         var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
-        if (iteration % 10 == 0) {
-            std.debug.print("NETBSD repeated childKill: iteration={} pid={}\n", .{ iteration, child.id.? });
-        }
-        childKill(&child);
+        std.debug.print("NETBSD immediate SIGKILL: iteration={} pid={}\n", .{ iteration, child.id.? });
+        sendKillSignal(child.id.?);
+        var op = ev.ProcessWait.init(child.id.?);
+        waitForIoUncancelable(&op.c);
+        childCleanup(&child);
+        try std.testing.expect(child.id == null);
+    }
+}
+
+test "childKill: NetBSD repeated SIGTERM after 10ms" {
+    if (builtin.os.tag != .netbsd) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    for (0..20) |iteration| {
+        var child = try std.process.spawn(rt.io(), .{ .argv = argv_sleep_short });
+        std.debug.print("NETBSD repeated SIGTERM: iteration={} pid={}\n", .{ iteration, child.id.? });
+        sendTermSignal(child.id.?);
+        os.time.sleep(.fromMilliseconds(10));
+        sendTermSignal(child.id.?);
+        var op = ev.ProcessWait.init(child.id.?);
+        waitForIoUncancelable(&op.c);
+        childCleanup(&child);
         try std.testing.expect(child.id == null);
     }
 }


### PR DESCRIPTION
## Summary

Make `childKill` reliable on NetBSD while leaving other platforms unchanged:

- Send `SIGKILL` on NetBSD, wait 10ms, and send it again after the vulnerable exec window.
- Route NetBSD process waits through the blocking-pool `waitpid` path instead of `EVFILT_PROC`.
- Other POSIX platforms retain `SIGTERM`; Windows is unchanged.

## Why

NetBSD 10.1 CI consistently took the full `sleep 100` duration even though `kill(pid, SIGTERM)` returned success. Diagnostic runs established two NetBSD kernel issues:

1. [kern/58091](https://gnats.netbsd.org/58091): a signal sent immediately after spawn can be discarded while the child is completing `execve`. This can affect the first SIGKILL too, so the NetBSD workaround retries after 10ms.
2. [kern/60358](https://gnats.netbsd.org/60358): `EVFILT_PROC` cannot reliably attach after the child has already exited. Delegating process waits to blocking `waitpid` avoids that registration race.

Both issues are NetBSD-specific. Temporary tracing and stress tests were removed from the final diff.

## Verification

NetBSD 10.1 VM CI passes in debug and ReleaseSafe for both kqueue and poll. The formerly 100-second test now takes:

- Debug kqueue: 22.22ms
- Debug poll: 20.89ms
- ReleaseSafe kqueue: 15.27ms
- ReleaseSafe poll: 17.24ms

Local verification:

- `./check.sh --filter "childKill: terminates process" --backend poll`
- NetBSD kqueue cross-build with the same test filter