### PR TITLE
ev: add io_uring fallback to epoll

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,17 @@ jobs:
         zig_version: ['0.16.0']
         mode: [debug, release]
         config:
-          - { os: ubuntu-24.04, target: native, backends: 'io_uring epoll poll' }
-          - { os: ubuntu-24.04-arm, target: native, backends: 'io_uring epoll poll' }
+          - { os: ubuntu-24.04, target: native, backends: 'linux io_uring epoll poll' }
+          - { os: ubuntu-24.04-arm, target: native, backends: 'linux io_uring epoll poll' }
           - { os: macos-latest, target: native, backends: 'kqueue poll' }
           - { os: macos-15-intel, target: native, backends: 'kqueue poll' }
           - { os: windows-latest, target: native, backends: 'iocp poll' }
-          - { os: ubuntu-latest, target: arm-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: thumb-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv32-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: riscv64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: loongarch64-linux, qemu: true, backends: 'epoll poll' }
-          - { os: ubuntu-latest, target: powerpc64le-linux, qemu: true, backends: 'epoll poll' }
+          - { os: ubuntu-latest, target: arm-linux, qemu: true, backends: 'linux epoll poll' }
+          - { os: ubuntu-latest, target: thumb-linux, qemu: true, backends: 'linux epoll poll' }
+          - { os: ubuntu-latest, target: riscv32-linux, qemu: true, backends: 'linux epoll poll' }
+          - { os: ubuntu-latest, target: riscv64-linux, qemu: true, backends: 'linux epoll poll' }
+          - { os: ubuntu-latest, target: loongarch64-linux, qemu: true, backends: 'linux epoll poll' }
+          - { os: ubuntu-latest, target: powerpc64le-linux, qemu: true, backends: 'linux epoll poll' }
           - { os: ubuntu-latest, target: x86_64-freebsd, vm: freebsd, backends: 'kqueue poll' }
           - { os: ubuntu-latest, target: x86_64-netbsd, vm: netbsd, backends: 'kqueue poll' }
           - { os: ubuntu-latest, target: x86_64-openbsd, vm: openbsd, backends: 'kqueue poll' }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's similar to [goroutines] in Go, but with the pros and cons of being implemen
 
 ## Features
 
-- Support for Linux (`io_uring`, `epoll`), Windows (`iocp`), macOS/FreeBSD/NetBSD/OpenBSD (`kqueue`), and many other systems (`poll`).
+- Support for Linux (`io_uring` with automatic `epoll` fallback), Windows (`iocp`), macOS/FreeBSD/NetBSD/OpenBSD (`kqueue`), and many other systems (`poll`).
 - User-mode coroutine context switching for `x86_64`, `aarch64`, `arm`, `thumb`, `riscv32`, `riscv64`, `loongarch64` and `powerpc64` architectures.
 - Growable stacks for the coroutines implemented by auto-extending virtual memory reservations.
 - Single-threaded or multi-threaded coroutine scheduler.

--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.Build) void {
     const backend = b.option(
         []const u8,
         "backend",
-        "Override the default event loop backend (io_uring, epoll, kqueue, iocp, poll)",
+        "Override the default event loop backend (linux, io_uring, epoll, kqueue, iocp, poll)",
     );
 
     const ResolveBeneathMode = enum { strict, best_effort };

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Linux now uses one parametric backend that prefers `io_uring` and falls back
+  group-wide to `epoll` when ring setup is unavailable or blocked by policy.
+  Completion storage now separates backend syscall scratch from thread-pool
+  fallback work, with exhaustive compile-time `yes`/`no`/`maybe` capability
+  classification and a recorded runtime route for safe cancellation.
+
 - Load shedding no longer oscillates on evenly loaded runtimes. The imbalance
   threshold now scales with the load average (12.5% over it, at least 2), and
   shedding is evaluated every few milliseconds instead of every scheduler tick, so

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ It's similar to [goroutines](https://en.wikipedia.org/wiki/Go_(programming_langu
 
 ## Features
 
-- Support for Linux (`io_uring`, `epoll`), Windows (`iocp`), macOS (`kqueue`), most BSDs (`kqueue`), and many other systems (`poll`)
+- Support for Linux (`io_uring` with automatic `epoll` fallback), Windows (`iocp`), macOS (`kqueue`), most BSDs (`kqueue`), and many other systems (`poll`)
 - User-mode coroutine context switching for `x86_64`, `aarch64`, `arm`, `thumb`, `riscv32`, `riscv64`, `loongarch64` and `powerpc64` architectures
 - Growable stacks for the coroutines implemented by auto-extending virtual memory reservations
 - Multi-threaded coroutine scheduler

--- a/src/ev/README.md
+++ b/src/ev/README.md
@@ -7,7 +7,7 @@ Callback-based async I/O event loop, similar to [libuv] or [libxev].
 
 ## Features
 
-- Support for Linux (`io_uring`, `epoll`), Windows (`iocp`), macOS (`kqueue`), most BSDs (`kqueue`), and many other systems (`poll`).
+- Support for Linux (`io_uring` with automatic `epoll` fallback), Windows (`iocp`), macOS (`kqueue`), most BSDs (`kqueue`), and many other systems (`poll`).
 - Asynchronous network I/O on all systems.
 - Asynchronous file-system I/O on Linux and Windows, simulated using auxiliary thread pool on other systems.
 - Timers, cross-thread notifications, and thread pool work items.

--- a/src/ev/backend.zig
+++ b/src/ev/backend.zig
@@ -4,6 +4,7 @@ const options = @import("zio_options");
 
 pub const BackendType = enum {
     poll,
+    linux,
     epoll,
     kqueue,
     io_uring,
@@ -12,7 +13,9 @@ pub const BackendType = enum {
 
 pub const backend = blk: {
     if (options.backend) |backend_name| {
-        if (std.mem.eql(u8, backend_name, "epoll")) {
+        if (std.mem.eql(u8, backend_name, "linux")) {
+            break :blk BackendType.linux;
+        } else if (std.mem.eql(u8, backend_name, "epoll")) {
             break :blk BackendType.epoll;
         } else if (std.mem.eql(u8, backend_name, "poll")) {
             break :blk BackendType.poll;
@@ -28,7 +31,7 @@ pub const backend = blk: {
     }
 
     switch (builtin.os.tag) {
-        .linux => break :blk BackendType.io_uring,
+        .linux => break :blk BackendType.linux,
         .macos, .ios, .tvos, .visionos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => break :blk BackendType.kqueue,
         .windows => break :blk BackendType.iocp,
         else => break :blk BackendType.poll,
@@ -37,8 +40,9 @@ pub const backend = blk: {
 
 pub const Backend = switch (backend) {
     .poll => @import("backends/poll.zig"),
-    .epoll => @import("backends/epoll.zig"),
+    .linux => @import("backends/linux.zig").Backend(.auto),
+    .epoll => @import("backends/linux.zig").Backend(.epoll),
     .kqueue => @import("backends/kqueue.zig"),
-    .io_uring => @import("backends/io_uring.zig"),
+    .io_uring => @import("backends/linux.zig").Backend(.io_uring),
     .iocp => @import("backends/iocp.zig"),
 };

--- a/src/ev/backends/common.zig
+++ b/src/ev/backends/common.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Completion = @import("../completion.zig").Completion;
 const Work = @import("../completion.zig").Work;
+const DelegatedWork = @import("../completion.zig").DelegatedWork;
 const NetOpen = @import("../completion.zig").NetOpen;
 const NetBind = @import("../completion.zig").NetBind;
 const NetListen = @import("../completion.zig").NetListen;
@@ -46,6 +47,14 @@ const DeviceIoControl = @import("../completion.zig").DeviceIoControl;
 const ProcessWait = @import("../completion.zig").ProcessWait;
 const net = @import("../../os/net.zig");
 const fs = @import("../../os/fs.zig");
+
+fn delegated(work: *Work) *DelegatedWork {
+    return @fieldParentPtr("work", work);
+}
+
+fn opFromWork(work: *Work, comptime T: type) *T {
+    return delegated(work).linked_context.linked.cast(T);
+}
 
 /// Helper to handle socket open operation
 pub fn handleNetOpen(c: *Completion) void {
@@ -290,15 +299,15 @@ pub fn handleFileSetTimestamps(c: *Completion) void {
 
 /// Work function for FileOpen - performs blocking openat() syscall
 pub fn fileOpenWork(work: *Work) void {
-    const internal: *@FieldType(FileOpen, "internal") = @fieldParentPtr("work", work);
-    const file_open: *FileOpen = @fieldParentPtr("internal", internal);
-    const loop = internal.linked_context.loop;
+    const linked_work = delegated(work);
+    const file_open = opFromWork(work, FileOpen);
+    const loop = linked_work.linked_context.loop;
 
-    if (@TypeOf(loop.backend).capabilities.supportsNonBlockingFileIo()) {
+    if (@TypeOf(loop.backend).supports_nonblocking_file_io) {
         file_open.flags.nonblocking = true;
     }
 
-    handleFileOpen(&file_open.c, file_open.internal.allocator);
+    handleFileOpen(&file_open.c, linked_work.allocator);
 
     // If the operation failed, exit early
     if (file_open.c.err != null) return;
@@ -316,15 +325,15 @@ pub fn fileOpenWork(work: *Work) void {
 
 /// Work function for FileCreate - performs blocking openat() syscall with O_CREAT
 pub fn fileCreateWork(work: *Work) void {
-    const internal: *@FieldType(FileCreate, "internal") = @fieldParentPtr("work", work);
-    const file_create: *FileCreate = @fieldParentPtr("internal", internal);
-    const loop = internal.linked_context.loop;
+    const linked_work = delegated(work);
+    const file_create = opFromWork(work, FileCreate);
+    const loop = linked_work.linked_context.loop;
 
-    if (@TypeOf(loop.backend).capabilities.supportsNonBlockingFileIo()) {
+    if (@TypeOf(loop.backend).supports_nonblocking_file_io) {
         file_create.flags.nonblocking = true;
     }
 
-    handleFileCreate(&file_create.c, file_create.internal.allocator);
+    handleFileCreate(&file_create.c, linked_work.allocator);
 
     // If the operation failed, exit early
     if (file_create.c.err != null) return;
@@ -342,71 +351,61 @@ pub fn fileCreateWork(work: *Work) void {
 
 /// Work function for FileClose - performs blocking close() syscall
 pub fn fileCloseWork(work: *Work) void {
-    const internal: *@FieldType(FileClose, "internal") = @fieldParentPtr("work", work);
-    const file_close: *FileClose = @fieldParentPtr("internal", internal);
+    const file_close = opFromWork(work, FileClose);
     handleFileClose(&file_close.c);
 }
 
 /// Work function for FileRead - performs blocking preadv() syscall
 pub fn fileReadWork(work: *Work) void {
-    const internal: *@FieldType(FileRead, "internal") = @fieldParentPtr("work", work);
-    const file_read: *FileRead = @alignCast(@fieldParentPtr("internal", internal));
+    const file_read = opFromWork(work, FileRead);
     handleFileRead(&file_read.c);
 }
 
 /// Work function for FileWrite - performs blocking pwritev() syscall
 pub fn fileWriteWork(work: *Work) void {
-    const internal: *@FieldType(FileWrite, "internal") = @fieldParentPtr("work", work);
-    const file_write: *FileWrite = @alignCast(@fieldParentPtr("internal", internal));
+    const file_write = opFromWork(work, FileWrite);
     handleFileWrite(&file_write.c);
 }
 
 /// Work function for FileReadStreaming - performs blocking readv() syscall
 pub fn fileReadStreamingWork(work: *Work) void {
-    const internal: *@FieldType(FileReadStreaming, "internal") = @fieldParentPtr("work", work);
-    const file_read: *FileReadStreaming = @alignCast(@fieldParentPtr("internal", internal));
+    const file_read = opFromWork(work, FileReadStreaming);
     handleFileReadStreaming(&file_read.c);
 }
 
 /// Work function for FileWriteStreaming - performs blocking writev() syscall
 pub fn fileWriteStreamingWork(work: *Work) void {
-    const internal: *@FieldType(FileWriteStreaming, "internal") = @fieldParentPtr("work", work);
-    const file_write: *FileWriteStreaming = @alignCast(@fieldParentPtr("internal", internal));
+    const file_write = opFromWork(work, FileWriteStreaming);
     handleFileWriteStreaming(&file_write.c);
 }
 
 /// Work function for FileSync - performs blocking fsync()/fdatasync() syscall
 pub fn fileSyncWork(work: *Work) void {
-    const internal: *@FieldType(FileSync, "internal") = @fieldParentPtr("work", work);
-    const file_sync: *FileSync = @fieldParentPtr("internal", internal);
+    const file_sync = opFromWork(work, FileSync);
     handleFileSync(&file_sync.c);
 }
 
 /// Work function for FileSetSize - performs blocking ftruncate() syscall
 pub fn fileSetSizeWork(work: *Work) void {
-    const internal: *@FieldType(FileSetSize, "internal") = @fieldParentPtr("work", work);
-    const file_set_size: *FileSetSize = @alignCast(@fieldParentPtr("internal", internal));
+    const file_set_size = opFromWork(work, FileSetSize);
     handleFileSetSize(&file_set_size.c);
 }
 
 /// Work function for FileSetPermissions - performs blocking fchmod() syscall
 pub fn fileSetPermissionsWork(work: *Work) void {
-    const internal: *@FieldType(FileSetPermissions, "internal") = @fieldParentPtr("work", work);
-    const file_set_permissions: *FileSetPermissions = @fieldParentPtr("internal", internal);
+    const file_set_permissions = opFromWork(work, FileSetPermissions);
     handleFileSetPermissions(&file_set_permissions.c);
 }
 
 /// Work function for FileSetOwner - performs blocking fchown() syscall
 pub fn fileSetOwnerWork(work: *Work) void {
-    const internal: *@FieldType(FileSetOwner, "internal") = @fieldParentPtr("work", work);
-    const file_set_owner: *FileSetOwner = @fieldParentPtr("internal", internal);
+    const file_set_owner = opFromWork(work, FileSetOwner);
     handleFileSetOwner(&file_set_owner.c);
 }
 
 /// Work function for FileSetTimestamps - performs blocking futimens() syscall
 pub fn fileSetTimestampsWork(work: *Work) void {
-    const internal: *@FieldType(FileSetTimestamps, "internal") = @fieldParentPtr("work", work);
-    const file_set_timestamps: *FileSetTimestamps = @alignCast(@fieldParentPtr("internal", internal));
+    const file_set_timestamps = opFromWork(work, FileSetTimestamps);
     handleFileSetTimestamps(&file_set_timestamps.c);
 }
 
@@ -422,8 +421,7 @@ pub fn handleDirSetPermissions(c: *Completion) void {
 
 /// Work function for DirSetPermissions
 pub fn dirSetPermissionsWork(work: *Work) void {
-    const internal: *@FieldType(DirSetPermissions, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSetPermissions = @fieldParentPtr("internal", internal);
+    const data = opFromWork(work, DirSetPermissions);
     handleDirSetPermissions(&data.c);
 }
 
@@ -439,8 +437,7 @@ pub fn handleDirSetOwner(c: *Completion) void {
 
 /// Work function for DirSetOwner
 pub fn dirSetOwnerWork(work: *Work) void {
-    const internal: *@FieldType(DirSetOwner, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSetOwner = @fieldParentPtr("internal", internal);
+    const data = opFromWork(work, DirSetOwner);
     handleDirSetOwner(&data.c);
 }
 
@@ -456,9 +453,9 @@ pub fn handleDirSetFilePermissions(c: *Completion, allocator: std.mem.Allocator)
 
 /// Work function for DirSetFilePermissions
 pub fn dirSetFilePermissionsWork(work: *Work) void {
-    const internal: *@FieldType(DirSetFilePermissions, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSetFilePermissions = @fieldParentPtr("internal", internal);
-    handleDirSetFilePermissions(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirSetFilePermissions);
+    handleDirSetFilePermissions(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir set file owner operation
@@ -473,9 +470,9 @@ pub fn handleDirSetFileOwner(c: *Completion, allocator: std.mem.Allocator) void 
 
 /// Work function for DirSetFileOwner
 pub fn dirSetFileOwnerWork(work: *Work) void {
-    const internal: *@FieldType(DirSetFileOwner, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSetFileOwner = @fieldParentPtr("internal", internal);
-    handleDirSetFileOwner(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirSetFileOwner);
+    handleDirSetFileOwner(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir set file timestamps operation
@@ -490,9 +487,9 @@ pub fn handleDirSetFileTimestamps(c: *Completion, allocator: std.mem.Allocator) 
 
 /// Work function for DirSetFileTimestamps
 pub fn dirSetFileTimestampsWork(work: *Work) void {
-    const internal: *@FieldType(DirSetFileTimestamps, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSetFileTimestamps = @alignCast(@fieldParentPtr("internal", internal));
-    handleDirSetFileTimestamps(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirSetFileTimestamps);
+    handleDirSetFileTimestamps(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir sym link operation
@@ -507,9 +504,9 @@ pub fn handleDirSymLink(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirSymLink
 pub fn dirSymLinkWork(work: *Work) void {
-    const internal: *@FieldType(DirSymLink, "internal") = @fieldParentPtr("work", work);
-    const data: *DirSymLink = @fieldParentPtr("internal", internal);
-    handleDirSymLink(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirSymLink);
+    handleDirSymLink(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir read link operation
@@ -524,9 +521,9 @@ pub fn handleDirReadLink(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirReadLink
 pub fn dirReadLinkWork(work: *Work) void {
-    const internal: *@FieldType(DirReadLink, "internal") = @fieldParentPtr("work", work);
-    const data: *DirReadLink = @fieldParentPtr("internal", internal);
-    handleDirReadLink(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirReadLink);
+    handleDirReadLink(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir hard link operation
@@ -541,9 +538,9 @@ pub fn handleDirHardLink(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirHardLink
 pub fn dirHardLinkWork(work: *Work) void {
-    const internal: *@FieldType(DirHardLink, "internal") = @fieldParentPtr("work", work);
-    const data: *DirHardLink = @fieldParentPtr("internal", internal);
-    handleDirHardLink(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirHardLink);
+    handleDirHardLink(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir access operation
@@ -558,9 +555,9 @@ pub fn handleDirAccess(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirAccess
 pub fn dirAccessWork(work: *Work) void {
-    const internal: *@FieldType(DirAccess, "internal") = @fieldParentPtr("work", work);
-    const data: *DirAccess = @fieldParentPtr("internal", internal);
-    handleDirAccess(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirAccess);
+    handleDirAccess(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir read operation
@@ -576,8 +573,7 @@ pub fn handleDirRead(c: *Completion) void {
 
 /// Work function for DirRead
 pub fn dirReadWork(work: *Work) void {
-    const internal: *@FieldType(DirRead, "internal") = @fieldParentPtr("work", work);
-    const data: *DirRead = @fieldParentPtr("internal", internal);
+    const data = opFromWork(work, DirRead);
     handleDirRead(&data.c);
 }
 
@@ -593,8 +589,7 @@ pub fn handleDirRealPath(c: *Completion) void {
 
 /// Work function for DirRealPath
 pub fn dirRealPathWork(work: *Work) void {
-    const internal: *@FieldType(DirRealPath, "internal") = @fieldParentPtr("work", work);
-    const data: *DirRealPath = @fieldParentPtr("internal", internal);
+    const data = opFromWork(work, DirRealPath);
     handleDirRealPath(&data.c);
 }
 
@@ -610,9 +605,9 @@ pub fn handleDirRealPathFile(c: *Completion, allocator: std.mem.Allocator) void 
 
 /// Work function for DirRealPathFile
 pub fn dirRealPathFileWork(work: *Work) void {
-    const internal: *@FieldType(DirRealPathFile, "internal") = @fieldParentPtr("work", work);
-    const data: *DirRealPathFile = @fieldParentPtr("internal", internal);
-    handleDirRealPathFile(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, DirRealPathFile);
+    handleDirRealPathFile(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle file real path operation
@@ -627,8 +622,7 @@ pub fn handleFileRealPath(c: *Completion) void {
 
 /// Work function for FileRealPath
 pub fn fileRealPathWork(work: *Work) void {
-    const internal: *@FieldType(FileRealPath, "internal") = @fieldParentPtr("work", work);
-    const data: *FileRealPath = @fieldParentPtr("internal", internal);
+    const data = opFromWork(work, FileRealPath);
     handleFileRealPath(&data.c);
 }
 
@@ -644,9 +638,9 @@ pub fn handleFileHardLink(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for FileHardLink
 pub fn fileHardLinkWork(work: *Work) void {
-    const internal: *@FieldType(FileHardLink, "internal") = @fieldParentPtr("work", work);
-    const data: *FileHardLink = @fieldParentPtr("internal", internal);
-    handleFileHardLink(&data.c, data.internal.allocator);
+    const linked_work = delegated(work);
+    const data = opFromWork(work, FileHardLink);
+    handleFileHardLink(&data.c, linked_work.allocator);
 }
 
 /// Helper to handle dir create dir operation
@@ -701,37 +695,37 @@ pub fn handleDirDeleteDir(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirCreateDir - performs blocking mkdirat() syscall
 pub fn dirCreateDirWork(work: *Work) void {
-    const internal: *@FieldType(DirCreateDir, "internal") = @fieldParentPtr("work", work);
-    const dir_create_dir: *DirCreateDir = @fieldParentPtr("internal", internal);
-    handleDirCreateDir(&dir_create_dir.c, dir_create_dir.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_create_dir = opFromWork(work, DirCreateDir);
+    handleDirCreateDir(&dir_create_dir.c, linked_work.allocator);
 }
 
 /// Work function for DirRename - performs blocking renameat() syscall
 pub fn dirRenameWork(work: *Work) void {
-    const internal: *@FieldType(DirRename, "internal") = @fieldParentPtr("work", work);
-    const dir_rename: *DirRename = @fieldParentPtr("internal", internal);
-    handleDirRename(&dir_rename.c, dir_rename.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_rename = opFromWork(work, DirRename);
+    handleDirRename(&dir_rename.c, linked_work.allocator);
 }
 
 /// Work function for DirRenamePreserve - performs blocking renameat2() syscall with NOREPLACE
 pub fn dirRenamePreserveWork(work: *Work) void {
-    const internal: *@FieldType(DirRenamePreserve, "internal") = @fieldParentPtr("work", work);
-    const dir_rename_preserve: *DirRenamePreserve = @fieldParentPtr("internal", internal);
-    handleDirRenamePreserve(&dir_rename_preserve.c, dir_rename_preserve.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_rename_preserve = opFromWork(work, DirRenamePreserve);
+    handleDirRenamePreserve(&dir_rename_preserve.c, linked_work.allocator);
 }
 
 /// Work function for DirDeleteFile - performs blocking unlinkat() syscall
 pub fn dirDeleteFileWork(work: *Work) void {
-    const internal: *@FieldType(DirDeleteFile, "internal") = @fieldParentPtr("work", work);
-    const dir_delete_file: *DirDeleteFile = @fieldParentPtr("internal", internal);
-    handleDirDeleteFile(&dir_delete_file.c, dir_delete_file.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_delete_file = opFromWork(work, DirDeleteFile);
+    handleDirDeleteFile(&dir_delete_file.c, linked_work.allocator);
 }
 
 /// Work function for DirDeleteDir - performs blocking unlinkat() syscall with AT_REMOVEDIR
 pub fn dirDeleteDirWork(work: *Work) void {
-    const internal: *@FieldType(DirDeleteDir, "internal") = @fieldParentPtr("work", work);
-    const dir_delete_dir: *DirDeleteDir = @fieldParentPtr("internal", internal);
-    handleDirDeleteDir(&dir_delete_dir.c, dir_delete_dir.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_delete_dir = opFromWork(work, DirDeleteDir);
+    handleDirDeleteDir(&dir_delete_dir.c, linked_work.allocator);
 }
 
 /// Helper to handle file size operation
@@ -746,8 +740,7 @@ pub fn handleFileSize(c: *Completion) void {
 
 /// Work function for FileSize - performs blocking fstat() syscall
 pub fn fileSizeWork(work: *Work) void {
-    const internal: *@FieldType(FileSize, "internal") = @fieldParentPtr("work", work);
-    const file_size: *FileSize = @alignCast(@fieldParentPtr("internal", internal));
+    const file_size = opFromWork(work, FileSize);
     handleFileSize(&file_size.c);
 }
 
@@ -770,9 +763,9 @@ pub fn handleFileStat(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for FileStat - performs blocking fstat()/fstatat() syscall
 pub fn fileStatWork(work: *Work) void {
-    const internal: *@FieldType(FileStat, "internal") = @fieldParentPtr("work", work);
-    const file_stat: *FileStat = @alignCast(@fieldParentPtr("internal", internal));
-    handleFileStat(&file_stat.c, file_stat.internal.allocator);
+    const linked_work = delegated(work);
+    const file_stat = opFromWork(work, FileStat);
+    handleFileStat(&file_stat.c, linked_work.allocator);
 }
 
 /// Helper to handle directory open operation
@@ -787,9 +780,9 @@ pub fn handleDirOpen(c: *Completion, allocator: std.mem.Allocator) void {
 
 /// Work function for DirOpen - performs blocking openat() syscall
 pub fn dirOpenWork(work: *Work) void {
-    const internal: *@FieldType(DirOpen, "internal") = @fieldParentPtr("work", work);
-    const dir_open: *DirOpen = @fieldParentPtr("internal", internal);
-    handleDirOpen(&dir_open.c, dir_open.internal.allocator);
+    const linked_work = delegated(work);
+    const dir_open = opFromWork(work, DirOpen);
+    handleDirOpen(&dir_open.c, linked_work.allocator);
 }
 
 /// Helper to handle directory close operation
@@ -804,8 +797,7 @@ pub fn handleDirClose(c: *Completion) void {
 
 /// Work function for DirClose - performs blocking close() syscall
 pub fn dirCloseWork(work: *Work) void {
-    const internal: *@FieldType(DirClose, "internal") = @fieldParentPtr("work", work);
-    const dir_close: *DirClose = @fieldParentPtr("internal", internal);
+    const dir_close = opFromWork(work, DirClose);
     handleDirClose(&dir_close.c);
 }
 
@@ -874,15 +866,13 @@ pub fn handleProcessWait(c: *Completion) void {
 
 /// Work function for ProcessWait - performs blocking wait for process exit
 pub fn processWaitWork(work: *Work) void {
-    const internal: *@FieldType(ProcessWait, "internal") = @fieldParentPtr("work", work);
-    const process_wait: *ProcessWait = @fieldParentPtr("internal", internal);
+    const process_wait = opFromWork(work, ProcessWait);
     handleProcessWait(&process_wait.c);
 }
 
 /// Work function for DeviceIoControl - performs blocking ioctl
 pub fn deviceIoControlWork(work: *Work) void {
-    const internal: *@FieldType(DeviceIoControl, "internal") = @fieldParentPtr("work", work);
-    const device_io_control: *DeviceIoControl = @fieldParentPtr("internal", internal);
+    const device_io_control = opFromWork(work, DeviceIoControl);
     handleDeviceIoControl(&device_io_control.c);
 }
 

--- a/src/ev/backends/common.zig
+++ b/src/ev/backends/common.zig
@@ -125,6 +125,22 @@ pub fn probePollable(handle: fs.fd_t) bool {
     }
 }
 
+/// Resolve and cache whether a streaming operation can use a readiness-based
+/// backend. Unknown Windows handles are deliberately delegated: unlike handles
+/// opened by zio, they are not known to be associated with our IOCP port.
+pub fn resolveStreamingSupport(data: anytype) bool {
+    if (data.pollable) |pollable| return pollable;
+
+    if (builtin.os.tag == .windows) {
+        data.pollable = false;
+        return false;
+    }
+
+    const pollable = probePollable(data.handle);
+    data.pollable = pollable;
+    return pollable;
+}
+
 pub fn handleFileOpen(c: *Completion, allocator: std.mem.Allocator) void {
     const data = c.cast(FileOpen);
     if (fs.openat(allocator, data.dir, data.path, data.flags)) |fd| {

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -236,10 +236,10 @@ pub fn capability(comptime op: Op) Support {
     };
 }
 
-pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+pub fn supports(_: *const Self, comptime op: Op, data: *op.toType()) bool {
     comptime std.debug.assert(capability(op) == .maybe);
     if (comptime op == .file_read_streaming or op == .file_write_streaming) {
-        return data.pollable orelse false;
+        return common.resolveStreamingSupport(data);
     }
     @compileError("unhandled runtime IOCP capability: " ++ @tagName(op));
 }
@@ -697,7 +697,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
         .file_real_path,
         .file_hard_link,
         .device_io_control,
-        => unreachable, // These are handled by thread pool (capabilities = false)
+        => unreachable, // These are handled by thread pool (capability(op) == .no)
 
         .net_send_file => {
             const data = c.cast(NetSendFile);

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -160,23 +160,89 @@ fn loadWinsockExtension(comptime T: type, sock: windows.SOCKET, guid: windows.GU
 
 pub const NetHandle = net.fd_t;
 
-const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
+const Op = @import("../completion.zig").Op;
+const Support = @import("../completion.zig").Support;
 
-pub const capabilities: BackendCapabilities = .{
-    .file_read = true,
-    .file_write = true,
-    // Streaming (positionless) read/write uses overlapped ReadFile/WriteFile
-    // with a zero offset, but only for non-seekable handles (pipes/stdio).
-    // Loop routes pollable fds here; seekable fds go to the thread pool.
-    .file_read_streaming = false,
-    .file_write_streaming = false,
-    .process_wait = true,
-    // Zero-copy file-to-socket transfer via the TransmitFile extension.
-    .net_send_file = true,
-    // Boot/real deadlines are armed via per-loop waitable timers whose
-    // completion-routine APC fires during the alertable poll wait.
-    .native_wall_timers = true,
-};
+// Boot/real deadlines are armed via per-loop waitable timers whose
+// completion-routine APC fires during the alertable poll wait.
+pub const native_wall_timers = true;
+pub const supports_nonblocking_file_io = true;
+
+pub fn capability(comptime op: Op) Support {
+    return switch (op) {
+        // Streaming (positionless) read/write uses overlapped ReadFile/WriteFile
+        // only for non-seekable handles. Seekable handles use the thread pool.
+        .file_read_streaming, .file_write_streaming => .maybe,
+        .file_open,
+        .file_create,
+        .file_close,
+        .file_sync,
+        .file_set_size,
+        .file_set_permissions,
+        .file_set_owner,
+        .file_set_timestamps,
+        .dir_create_dir,
+        .dir_rename,
+        .dir_rename_preserve,
+        .dir_delete_file,
+        .dir_delete_dir,
+        .file_size,
+        .file_stat,
+        .dir_open,
+        .dir_close,
+        .dir_set_permissions,
+        .dir_set_owner,
+        .dir_set_file_permissions,
+        .dir_set_file_owner,
+        .dir_set_file_timestamps,
+        .dir_sym_link,
+        .dir_read_link,
+        .dir_hard_link,
+        .dir_access,
+        .dir_read,
+        .dir_real_path,
+        .dir_real_path_file,
+        .file_real_path,
+        .file_hard_link,
+        .device_io_control,
+        => .no,
+        .group,
+        .timer,
+        .async,
+        .work,
+        .net_open,
+        .net_bind,
+        .net_listen,
+        .net_connect,
+        .net_accept,
+        .net_recv,
+        .net_send,
+        .net_recvfrom,
+        .net_sendto,
+        .net_recvmsg,
+        .net_sendmsg,
+        .net_poll,
+        .net_shutdown,
+        .net_close,
+        .net_send_file,
+        .file_read,
+        .file_write,
+        .pipe_poll,
+        .pipe_create,
+        .pipe_close,
+        .mach_port,
+        .process_wait,
+        => .yes,
+    };
+}
+
+pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+    comptime std.debug.assert(capability(op) == .maybe);
+    if (comptime op == .file_read_streaming or op == .file_write_streaming) {
+        return data.pollable orelse false;
+    }
+    @compileError("unhandled runtime IOCP capability: " ++ @tagName(op));
+}
 
 // Backend-specific data stored in Completion.internal
 pub const CompletionData = struct {

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -109,10 +109,10 @@ pub fn capability(comptime op: Op) Support {
     };
 }
 
-pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+pub fn supports(_: *const Self, comptime op: Op, data: *op.toType()) bool {
     comptime std.debug.assert(capability(op) == .maybe);
     if (comptime op == .file_read_streaming or op == .file_write_streaming) {
-        return data.pollable orelse false;
+        return common.resolveStreamingSupport(data);
     }
     @compileError("unhandled runtime kqueue capability: " ++ @tagName(op));
 }

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -31,23 +31,91 @@ const sockreg = @import("../sockreg.zig");
 
 pub const NetHandle = net.fd_t;
 
-const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
+const Op = @import("../completion.zig").Op;
+const Support = @import("../completion.zig").Support;
 
-pub const capabilities: BackendCapabilities = .{
-    .process_wait = true,
-    // Only Darwin has usable absolute wall-clock EVFILT_TIMER semantics
-    // (NOTE_ABSOLUTE = gettimeofday, NOTE_MACH_CONTINUOUS_TIME = suspend-aware).
-    // The BSDs' EVFILT_TIMER absolute clock is monotonic-only and underspecified
-    // with no CLOCK_REALTIME timer, so they keep the capped poll-timeout fallback.
-    .native_wall_timers = builtin.os.tag.isDarwin(),
-    // FreeBSD only: its sendfile never blocks the caller on disk I/O (the
-    // syscall returns before the reads complete and the kernel fills the
-    // socket asynchronously, in order; documented for ffs), so it is safe to
-    // drive from the loop thread. Darwin's sendfile blocks on disk I/O, so it
-    // deliberately stays on the generic fallback, which reads the file on the
-    // thread pool; the other BSDs have no std.c.sendfile declaration.
-    .net_send_file = builtin.os.tag == .freebsd,
-};
+// Only Darwin has usable absolute wall-clock EVFILT_TIMER semantics
+// (NOTE_ABSOLUTE = gettimeofday, NOTE_MACH_CONTINUOUS_TIME = suspend-aware).
+// The BSDs' EVFILT_TIMER absolute clock is monotonic-only and underspecified
+// with no CLOCK_REALTIME timer, so they keep the capped poll-timeout fallback.
+pub const native_wall_timers = builtin.os.tag.isDarwin();
+pub const supports_nonblocking_file_io = false;
+
+pub fn capability(comptime op: Op) Support {
+    return switch (op) {
+        .file_read_streaming, .file_write_streaming => .maybe,
+        // FreeBSD's sendfile is asynchronous with respect to file reads. The
+        // Darwin implementation can block the loop and deliberately falls back.
+        .net_send_file => if (builtin.os.tag == .freebsd) .yes else .no,
+        .file_open,
+        .file_create,
+        .file_close,
+        .file_read,
+        .file_write,
+        .file_sync,
+        .file_set_size,
+        .file_set_permissions,
+        .file_set_owner,
+        .file_set_timestamps,
+        .dir_create_dir,
+        .dir_rename,
+        .dir_rename_preserve,
+        .dir_delete_file,
+        .dir_delete_dir,
+        .file_size,
+        .file_stat,
+        .dir_open,
+        .dir_close,
+        .dir_set_permissions,
+        .dir_set_owner,
+        .dir_set_file_permissions,
+        .dir_set_file_owner,
+        .dir_set_file_timestamps,
+        .dir_sym_link,
+        .dir_read_link,
+        .dir_hard_link,
+        .dir_access,
+        .dir_read,
+        .dir_real_path,
+        .dir_real_path_file,
+        .file_real_path,
+        .file_hard_link,
+        .device_io_control,
+        => .no,
+        .group,
+        .timer,
+        .async,
+        .work,
+        .net_open,
+        .net_bind,
+        .net_listen,
+        .net_connect,
+        .net_accept,
+        .net_recv,
+        .net_send,
+        .net_recvfrom,
+        .net_sendto,
+        .net_recvmsg,
+        .net_sendmsg,
+        .net_poll,
+        .net_shutdown,
+        .net_close,
+        .pipe_poll,
+        .pipe_create,
+        .pipe_close,
+        .mach_port,
+        .process_wait,
+        => .yes,
+    };
+}
+
+pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+    comptime std.debug.assert(capability(op) == .maybe);
+    if (comptime op == .file_read_streaming or op == .file_write_streaming) {
+        return data.pollable orelse false;
+    }
+    @compileError("unhandled runtime kqueue capability: " ++ @tagName(op));
+}
 
 pub const SharedState = struct {
     /// Backend-internal inflight count: ops accepted by submit() and not yet
@@ -582,7 +650,7 @@ pub fn submit(self: *Self, state: *LoopState, c: *Completion) void {
         .net_send_file => {
             // Driven by Loop's generic read/write fallback on backends
             // without native sendfile, never reaches the backend there.
-            if (comptime !capabilities.net_send_file) unreachable;
+            if (comptime capability(.net_send_file) != .yes) unreachable;
             // Cap the request to the current file size once, so the
             // continuation can treat "remaining == 0" as done and never
             // spins on a writable socket at EOF. Then drive the sendfile
@@ -876,7 +944,7 @@ pub fn checkCompletion(comp: *Completion, event: *const std.c.Kevent) CheckResul
             }
         },
         .net_send_file => {
-            if (comptime !capabilities.net_send_file) unreachable;
+            if (comptime capability(.net_send_file) != .yes) unreachable;
             const data = comp.cast(NetSendFile);
             if (handleKqueueError(event, net.errnoToSendError)) |err| {
                 comp.setError(err);

--- a/src/ev/backends/linux.zig
+++ b/src/ev/backends/linux.zig
@@ -1,0 +1,276 @@
+const std = @import("std");
+
+const IoUring = @import("linux/io_uring.zig");
+const Epoll = @import("linux/epoll.zig");
+const Completion = @import("../completion.zig").Completion;
+const Op = @import("../completion.zig").Op;
+const Support = @import("../completion.zig").Support;
+const LoopState = @import("../loop.zig").LoopState;
+const Duration = @import("../../time.zig").Duration;
+const Clock = @import("../../time.zig").Clock;
+const os = @import("../../os/root.zig");
+
+/// Compile-time Linux backend policy. `auto` prefers io_uring and falls back to
+/// epoll only when ring setup itself is unavailable; explicit engine selections
+/// remain useful for tests and for diagnosing engine-specific behavior.
+pub const Mode = enum {
+    auto,
+    io_uring,
+    epoll,
+};
+
+pub fn Backend(comptime mode: Mode) type {
+    return struct {
+        const Self = @This();
+
+        pub const Engine = enum {
+            io_uring,
+            epoll,
+        };
+
+        const Selection = enum {
+            undecided,
+            io_uring,
+            epoll,
+        };
+
+        pub const NetHandle = IoUring.NetHandle;
+        pub const native_wall_timers = true;
+        // In auto mode a delegated open means epoll was selected; probePollable
+        // applies O_NONBLOCK after opening, matching the old epoll behavior.
+        pub const supports_nonblocking_file_io = mode == .io_uring;
+
+        // io_uring needs these operation-owned syscall arguments to outlive SQE
+        // submission. Epoll has no corresponding per-operation scratch.
+        pub const NetRecvData = if (mode == .epoll) struct {} else IoUring.NetRecvData;
+        pub const NetSendData = if (mode == .epoll) struct {} else IoUring.NetSendData;
+        pub const NetRecvFromData = if (mode == .epoll) struct {} else IoUring.NetRecvFromData;
+        pub const NetSendToData = if (mode == .epoll) struct {} else IoUring.NetSendToData;
+        pub const NetRecvMsgData = if (mode == .epoll) struct {} else IoUring.NetRecvMsgData;
+        pub const NetSendMsgData = if (mode == .epoll) struct {} else IoUring.NetSendMsgData;
+        pub const FileOpenData = IoUring.FileOpenData;
+        pub const FileCreateData = IoUring.FileCreateData;
+        pub const DirCreateDirData = IoUring.DirCreateDirData;
+        pub const DirRenameData = IoUring.DirRenameData;
+        pub const DirRenamePreserveData = IoUring.DirRenamePreserveData;
+        pub const DirDeleteFileData = IoUring.DirDeleteFileData;
+        pub const DirDeleteDirData = IoUring.DirDeleteDirData;
+        pub const FileSizeData = IoUring.FileSizeData;
+        pub const FileStatData = IoUring.FileStatData;
+        pub const DirOpenData = IoUring.DirOpenData;
+        pub const NetSendFileData = IoUring.NetSendFileData;
+        pub const ProcessWaitData = switch (mode) {
+            .auto => struct {
+                siginfo: @FieldType(IoUring.ProcessWaitData, "siginfo") = undefined,
+                pidfd: @FieldType(Epoll.ProcessWaitData, "pidfd") = -1,
+            },
+            .io_uring => IoUring.ProcessWaitData,
+            .epoll => Epoll.ProcessWaitData,
+        };
+
+        pub const SharedState = struct {
+            selection_mutex: os.Mutex = .init(),
+            selection: Selection = .undecided,
+            io_uring: IoUring.SharedState = .{},
+            epoll: Epoll.SharedState = .{},
+        };
+
+        engine: union(Engine) {
+            io_uring: IoUring,
+            epoll: Epoll,
+        },
+
+        pub fn capability(comptime op: Op) Support {
+            return switch (mode) {
+                .io_uring => IoUring.capability(op),
+                .epoll => Epoll.capability(op),
+                .auto => combine(IoUring.capability(op), Epoll.capability(op)),
+            };
+        }
+
+        fn combine(a: Support, b: Support) Support {
+            if (a == b) return a;
+            return .maybe;
+        }
+
+        fn ringUnavailable(err: anyerror) bool {
+            return err == error.SystemOutdated or
+                err == error.PermissionDenied or
+                err == error.ArgumentsInvalid;
+        }
+
+        fn initIoUring(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            queue_size: u16,
+            shared_state: *SharedState,
+        ) !void {
+            var engine: IoUring = undefined;
+            try engine.init(allocator, queue_size, &shared_state.io_uring);
+            self.* = .{ .engine = .{ .io_uring = engine } };
+            shared_state.selection = .io_uring;
+        }
+
+        fn initEpoll(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            queue_size: u16,
+            shared_state: *SharedState,
+        ) !void {
+            var engine: Epoll = undefined;
+            try engine.init(allocator, queue_size, &shared_state.epoll);
+            self.* = .{ .engine = .{ .epoll = engine } };
+            shared_state.selection = .epoll;
+        }
+
+        pub fn init(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            queue_size: u16,
+            shared_state: *SharedState,
+        ) !void {
+            // The decision belongs to the LoopGroup. Holding this mutex through
+            // initialization prevents two first loops from selecting different
+            // engines and also serializes publication of io_uring's master WQ.
+            shared_state.selection_mutex.lock();
+            defer shared_state.selection_mutex.unlock();
+
+            switch (shared_state.selection) {
+                .io_uring => {
+                    std.debug.assert(mode != .epoll);
+                    return self.initIoUring(allocator, queue_size, shared_state);
+                },
+                .epoll => {
+                    std.debug.assert(mode != .io_uring);
+                    return self.initEpoll(allocator, queue_size, shared_state);
+                },
+                .undecided => switch (mode) {
+                    .io_uring => return self.initIoUring(allocator, queue_size, shared_state),
+                    .epoll => return self.initEpoll(allocator, queue_size, shared_state),
+                    .auto => {
+                        self.initIoUring(allocator, queue_size, shared_state) catch |err| {
+                            if (!ringUnavailable(err)) return err;
+                            return self.initEpoll(allocator, queue_size, shared_state);
+                        };
+                    },
+                },
+            }
+        }
+
+        pub fn deinit(self: *Self) void {
+            switch (mode) {
+                .io_uring => self.engine.io_uring.deinit(),
+                .epoll => self.engine.epoll.deinit(),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.deinit(),
+                    .epoll => |*engine| engine.deinit(),
+                },
+            }
+        }
+
+        pub fn selectedEngine(self: *const Self) Engine {
+            return switch (mode) {
+                .io_uring => .io_uring,
+                .epoll => .epoll,
+                .auto => std.meta.activeTag(self.engine),
+            };
+        }
+
+        pub fn supports(self: *const Self, comptime op: Op, data: *const op.toType()) bool {
+            comptime std.debug.assert(capability(op) == .maybe);
+            return switch (mode) {
+                .io_uring => self.engine.io_uring.supports(op, data),
+                .epoll => self.engine.epoll.supports(op, data),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| switch (comptime IoUring.capability(op)) {
+                        .yes => true,
+                        .no => false,
+                        .maybe => engine.supports(op, data),
+                    },
+                    .epoll => |*engine| switch (comptime Epoll.capability(op)) {
+                        .yes => true,
+                        .no => false,
+                        .maybe => engine.supports(op, data),
+                    },
+                },
+            };
+        }
+
+        pub fn wake(self: *Self, state: *LoopState) void {
+            switch (mode) {
+                .io_uring => self.engine.io_uring.wake(state),
+                .epoll => self.engine.epoll.wake(state),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.wake(state),
+                    .epoll => |*engine| engine.wake(state),
+                },
+            }
+        }
+
+        pub fn syncWallTimer(self: *Self, clock: Clock, deadline: ?u64) bool {
+            return switch (mode) {
+                .io_uring => self.engine.io_uring.syncWallTimer(clock, deadline),
+                .epoll => self.engine.epoll.syncWallTimer(clock, deadline),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.syncWallTimer(clock, deadline),
+                    .epoll => |*engine| engine.syncWallTimer(clock, deadline),
+                },
+            };
+        }
+
+        pub fn decrInflight(self: *Self) void {
+            switch (mode) {
+                .io_uring => self.engine.io_uring.decrInflight(),
+                .epoll => self.engine.epoll.decrInflight(),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.decrInflight(),
+                    .epoll => |*engine| engine.decrInflight(),
+                },
+            }
+        }
+
+        pub fn hasInflight(self: *const Self) bool {
+            return switch (mode) {
+                .io_uring => self.engine.io_uring.hasInflight(),
+                .epoll => self.engine.epoll.hasInflight(),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.hasInflight(),
+                    .epoll => |*engine| engine.hasInflight(),
+                },
+            };
+        }
+
+        pub fn submit(self: *Self, state: *LoopState, completion: *Completion) void {
+            switch (mode) {
+                .io_uring => self.engine.io_uring.submit(state, completion),
+                .epoll => self.engine.epoll.submit(state, completion),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.submit(state, completion),
+                    .epoll => |*engine| engine.submit(state, completion),
+                },
+            }
+        }
+
+        pub fn cancel(self: *Self, state: *LoopState, completion: *Completion) void {
+            switch (mode) {
+                .io_uring => self.engine.io_uring.cancel(state, completion),
+                .epoll => self.engine.epoll.cancel(state, completion),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.cancel(state, completion),
+                    .epoll => |*engine| engine.cancel(state, completion),
+                },
+            }
+        }
+
+        pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
+            return switch (mode) {
+                .io_uring => self.engine.io_uring.poll(state, timeout),
+                .epoll => self.engine.epoll.poll(state, timeout),
+                .auto => switch (self.engine) {
+                    .io_uring => |*engine| engine.poll(state, timeout),
+                    .epoll => |*engine| engine.poll(state, timeout),
+                },
+            };
+        }
+    };
+}

--- a/src/ev/backends/linux.zig
+++ b/src/ev/backends/linux.zig
@@ -176,7 +176,7 @@ pub fn Backend(comptime mode: Mode) type {
             };
         }
 
-        pub fn supports(self: *const Self, comptime op: Op, data: *const op.toType()) bool {
+        pub fn supports(self: *const Self, comptime op: Op, data: *op.toType()) bool {
             comptime std.debug.assert(capability(op) == .maybe);
             return switch (mode) {
                 .io_uring => self.engine.io_uring.supports(op, data),

--- a/src/ev/backends/linux/epoll.zig
+++ b/src/ev/backends/linux/epoll.zig
@@ -1,42 +1,114 @@
 const std = @import("std");
-const posix = @import("../../os/posix.zig");
-const net = @import("../../os/net.zig");
-const time = @import("../../os/time.zig");
-const Duration = @import("../../time.zig").Duration;
-const Clock = @import("../../time.zig").Clock;
-const common = @import("common.zig");
+const posix = @import("../../../os/posix.zig");
+const net = @import("../../../os/net.zig");
+const time = @import("../../../os/time.zig");
+const Duration = @import("../../../time.zig").Duration;
+const Clock = @import("../../../time.zig").Clock;
+const common = @import("../common.zig");
 
-const unexpectedError = @import("../../os/base.zig").unexpectedError;
-const LoopState = @import("../loop.zig").LoopState;
-const Completion = @import("../completion.zig").Completion;
-const Op = @import("../completion.zig").Op;
-const Queue = @import("../queue.zig").Queue;
-const NetConnect = @import("../completion.zig").NetConnect;
-const NetAccept = @import("../completion.zig").NetAccept;
-const NetRecv = @import("../completion.zig").NetRecv;
-const NetSend = @import("../completion.zig").NetSend;
-const NetRecvFrom = @import("../completion.zig").NetRecvFrom;
-const NetSendTo = @import("../completion.zig").NetSendTo;
-const NetRecvMsg = @import("../completion.zig").NetRecvMsg;
-const NetSendMsg = @import("../completion.zig").NetSendMsg;
-const NetPoll = @import("../completion.zig").NetPoll;
-const NetClose = @import("../completion.zig").NetClose;
-const PipePoll = @import("../completion.zig").PipePoll;
-const PipeClose = @import("../completion.zig").PipeClose;
-const ProcessWait = @import("../completion.zig").ProcessWait;
-const fs = @import("../../os/fs.zig");
+const unexpectedError = @import("../../../os/base.zig").unexpectedError;
+const LoopState = @import("../../loop.zig").LoopState;
+const Completion = @import("../../completion.zig").Completion;
+const Op = @import("../../completion.zig").Op;
+const Queue = @import("../../queue.zig").Queue;
+const NetConnect = @import("../../completion.zig").NetConnect;
+const NetAccept = @import("../../completion.zig").NetAccept;
+const NetRecv = @import("../../completion.zig").NetRecv;
+const NetSend = @import("../../completion.zig").NetSend;
+const NetRecvFrom = @import("../../completion.zig").NetRecvFrom;
+const NetSendTo = @import("../../completion.zig").NetSendTo;
+const NetRecvMsg = @import("../../completion.zig").NetRecvMsg;
+const NetSendMsg = @import("../../completion.zig").NetSendMsg;
+const NetPoll = @import("../../completion.zig").NetPoll;
+const NetClose = @import("../../completion.zig").NetClose;
+const PipePoll = @import("../../completion.zig").PipePoll;
+const PipeClose = @import("../../completion.zig").PipeClose;
+const ProcessWait = @import("../../completion.zig").ProcessWait;
+const fs = @import("../../../os/fs.zig");
 const linux = std.os.linux;
-const os_linux = @import("../../os/linux.zig");
-const sockreg = @import("../sockreg.zig");
+const os_linux = @import("../../../os/linux.zig");
+const sockreg = @import("../../sockreg.zig");
 
 pub const NetHandle = net.fd_t;
 
-const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
+const Support = @import("../../completion.zig").Support;
 
-pub const capabilities: BackendCapabilities = .{
-    .process_wait = true,
-    .native_wall_timers = true,
-};
+pub const native_wall_timers = true;
+pub const supports_nonblocking_file_io = false;
+
+pub fn capability(comptime op: Op) Support {
+    return switch (op) {
+        .file_read_streaming, .file_write_streaming => .maybe,
+        .net_send_file,
+        .file_open,
+        .file_create,
+        .file_close,
+        .file_read,
+        .file_write,
+        .file_sync,
+        .file_set_size,
+        .file_set_permissions,
+        .file_set_owner,
+        .file_set_timestamps,
+        .dir_create_dir,
+        .dir_rename,
+        .dir_rename_preserve,
+        .dir_delete_file,
+        .dir_delete_dir,
+        .file_size,
+        .file_stat,
+        .dir_open,
+        .dir_close,
+        .dir_set_permissions,
+        .dir_set_owner,
+        .dir_set_file_permissions,
+        .dir_set_file_owner,
+        .dir_set_file_timestamps,
+        .dir_sym_link,
+        .dir_read_link,
+        .dir_hard_link,
+        .dir_access,
+        .dir_read,
+        .dir_real_path,
+        .dir_real_path_file,
+        .file_real_path,
+        .file_hard_link,
+        .device_io_control,
+        => .no,
+        .group,
+        .timer,
+        .async,
+        .work,
+        .net_open,
+        .net_bind,
+        .net_listen,
+        .net_connect,
+        .net_accept,
+        .net_recv,
+        .net_send,
+        .net_recvfrom,
+        .net_sendto,
+        .net_recvmsg,
+        .net_sendmsg,
+        .net_poll,
+        .net_shutdown,
+        .net_close,
+        .pipe_poll,
+        .pipe_create,
+        .pipe_close,
+        .mach_port,
+        .process_wait,
+        => .yes,
+    };
+}
+
+pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+    comptime std.debug.assert(capability(op) == .maybe);
+    if (comptime op == .file_read_streaming or op == .file_write_streaming) {
+        return data.pollable orelse false;
+    }
+    @compileError("unhandled runtime epoll capability: " ++ @tagName(op));
+}
 
 pub const SharedState = struct {
     /// Backend-internal inflight count: ops accepted by submit() and not yet
@@ -105,7 +177,7 @@ const PollEntry = struct {
 
 const Self = @This();
 
-const log = @import("../../common.zig").log;
+const log = @import("../../../common.zig").log;
 
 allocator: std.mem.Allocator,
 poll_queue: std.AutoHashMapUnmanaged(NetHandle, PollEntry) = .empty,

--- a/src/ev/backends/linux/epoll.zig
+++ b/src/ev/backends/linux/epoll.zig
@@ -102,10 +102,10 @@ pub fn capability(comptime op: Op) Support {
     };
 }
 
-pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+pub fn supports(_: *const Self, comptime op: Op, data: *op.toType()) bool {
     comptime std.debug.assert(capability(op) == .maybe);
     if (comptime op == .file_read_streaming or op == .file_write_streaming) {
-        return data.pollable orelse false;
+        return common.resolveStreamingSupport(data);
     }
     @compileError("unhandled runtime epoll capability: " ++ @tagName(op));
 }

--- a/src/ev/backends/linux/io_uring.zig
+++ b/src/ev/backends/linux/io_uring.zig
@@ -1,17 +1,17 @@
 const std = @import("std");
 const linux = std.os.linux;
-const posix = @import("../../os/posix.zig");
-const net = @import("../../os/net.zig");
-const fs = @import("../../os/fs.zig");
-const linux_sys = @import("../../os/system/linux.zig");
-const time = @import("../../os/time.zig");
-const Duration = @import("../../time.zig").Duration;
-const Clock = @import("../../time.zig").Clock;
-const common = @import("common.zig");
-const LoopState = @import("../loop.zig").LoopState;
-const Completion = @import("../completion.zig").Completion;
-const Queue = @import("../queue.zig").Queue;
-const Cancel = @import("../completion.zig").Cancel;
+const posix = @import("../../../os/posix.zig");
+const net = @import("../../../os/net.zig");
+const fs = @import("../../../os/fs.zig");
+const linux_sys = @import("../../../os/system/linux.zig");
+const time = @import("../../../os/time.zig");
+const Duration = @import("../../../time.zig").Duration;
+const Clock = @import("../../../time.zig").Clock;
+const common = @import("../common.zig");
+const LoopState = @import("../../loop.zig").LoopState;
+const Completion = @import("../../completion.zig").Completion;
+const Queue = @import("../../queue.zig").Queue;
+const Cancel = @import("../../completion.zig").Cancel;
 
 // user_data encoding. A *Completion pointer is aligned, so its low bit is 0;
 // internal ops set the low bit and pack a kind (bits 1-2) plus, for the wall
@@ -41,90 +41,130 @@ fn wallKind(idx: usize) SpecialKind {
     return if (idx == 0) .wall_boot else .wall_real;
 }
 
-const NetOpen = @import("../completion.zig").NetOpen;
-const NetConnect = @import("../completion.zig").NetConnect;
-const NetAccept = @import("../completion.zig").NetAccept;
-const NetRecv = @import("../completion.zig").NetRecv;
-const NetSend = @import("../completion.zig").NetSend;
-const NetRecvFrom = @import("../completion.zig").NetRecvFrom;
-const NetSendTo = @import("../completion.zig").NetSendTo;
-const NetRecvMsg = @import("../completion.zig").NetRecvMsg;
-const NetSendMsg = @import("../completion.zig").NetSendMsg;
-const NetSendFile = @import("../completion.zig").NetSendFile;
-const NetPoll = @import("../completion.zig").NetPoll;
-const NetClose = @import("../completion.zig").NetClose;
-const NetShutdown = @import("../completion.zig").NetShutdown;
-const FileOpen = @import("../completion.zig").FileOpen;
-const FileCreate = @import("../completion.zig").FileCreate;
-const DirCreateDir = @import("../completion.zig").DirCreateDir;
-const DirRename = @import("../completion.zig").DirRename;
-const DirRenamePreserve = @import("../completion.zig").DirRenamePreserve;
-const DirDeleteFile = @import("../completion.zig").DirDeleteFile;
-const DirDeleteDir = @import("../completion.zig").DirDeleteDir;
-const FileSize = @import("../completion.zig").FileSize;
-const FileStat = @import("../completion.zig").FileStat;
-const FileClose = @import("../completion.zig").FileClose;
-const FileRead = @import("../completion.zig").FileRead;
-const FileWrite = @import("../completion.zig").FileWrite;
-const FileReadStreaming = @import("../completion.zig").FileReadStreaming;
-const FileWriteStreaming = @import("../completion.zig").FileWriteStreaming;
-const FileSync = @import("../completion.zig").FileSync;
-const FileSetSize = @import("../completion.zig").FileSetSize;
-const DirOpen = @import("../completion.zig").DirOpen;
-const DirClose = @import("../completion.zig").DirClose;
-const PipePoll = @import("../completion.zig").PipePoll;
-const PipeClose = @import("../completion.zig").PipeClose;
-const ProcessWait = @import("../completion.zig").ProcessWait;
+const NetOpen = @import("../../completion.zig").NetOpen;
+const NetConnect = @import("../../completion.zig").NetConnect;
+const NetAccept = @import("../../completion.zig").NetAccept;
+const NetRecv = @import("../../completion.zig").NetRecv;
+const NetSend = @import("../../completion.zig").NetSend;
+const NetRecvFrom = @import("../../completion.zig").NetRecvFrom;
+const NetSendTo = @import("../../completion.zig").NetSendTo;
+const NetRecvMsg = @import("../../completion.zig").NetRecvMsg;
+const NetSendMsg = @import("../../completion.zig").NetSendMsg;
+const NetSendFile = @import("../../completion.zig").NetSendFile;
+const NetPoll = @import("../../completion.zig").NetPoll;
+const NetClose = @import("../../completion.zig").NetClose;
+const NetShutdown = @import("../../completion.zig").NetShutdown;
+const FileOpen = @import("../../completion.zig").FileOpen;
+const FileCreate = @import("../../completion.zig").FileCreate;
+const DirCreateDir = @import("../../completion.zig").DirCreateDir;
+const DirRename = @import("../../completion.zig").DirRename;
+const DirRenamePreserve = @import("../../completion.zig").DirRenamePreserve;
+const DirDeleteFile = @import("../../completion.zig").DirDeleteFile;
+const DirDeleteDir = @import("../../completion.zig").DirDeleteDir;
+const FileSize = @import("../../completion.zig").FileSize;
+const FileStat = @import("../../completion.zig").FileStat;
+const FileClose = @import("../../completion.zig").FileClose;
+const FileRead = @import("../../completion.zig").FileRead;
+const FileWrite = @import("../../completion.zig").FileWrite;
+const FileReadStreaming = @import("../../completion.zig").FileReadStreaming;
+const FileWriteStreaming = @import("../../completion.zig").FileWriteStreaming;
+const FileSync = @import("../../completion.zig").FileSync;
+const FileSetSize = @import("../../completion.zig").FileSetSize;
+const DirOpen = @import("../../completion.zig").DirOpen;
+const DirClose = @import("../../completion.zig").DirClose;
+const PipePoll = @import("../../completion.zig").PipePoll;
+const PipeClose = @import("../../completion.zig").PipeClose;
+const ProcessWait = @import("../../completion.zig").ProcessWait;
 
 pub const NetHandle = net.fd_t;
 
-const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
+const Op = @import("../../completion.zig").Op;
+const Support = @import("../../completion.zig").Support;
 
-pub const capabilities: BackendCapabilities = .{
-    .file_read = true,
-    .file_write = true,
-    .file_read_streaming = true,
-    .file_write_streaming = true,
-    .file_open = true,
-    .file_create = true,
-    .file_close = true,
-    .file_sync = true,
-    // Runtime-dispatched, not statically native: the native IORING_OP_FTRUNCATE
-    // needs Linux >= 6.9. `false` makes the completion carry a DelegatedWork so
-    // the thread-pool path is available; the Loop upgrades to the native SQE at
-    // runtime when `fileSetSizeSupported()` (probed once) says the kernel has it.
-    .file_set_size = false,
-    .dir_create_dir = true,
-    .dir_rename = true,
-    .dir_rename_preserve = true,
-    .dir_delete_file = true,
-    .dir_delete_dir = true,
-    .file_size = true,
-    .file_stat = true,
-    .dir_open = true,
-    .dir_close = true,
-    .process_wait = true,
-    .native_wall_timers = true,
-    // Native zero-copy sendfile via a two-hop splice chain (file -> pipe ->
-    // socket). IORING_OP_SPLICE needs Linux >= 5.7, comfortably below the
-    // >= 6.1 the ring setup flags already require, so no runtime probe.
-    .net_send_file = true,
-};
+pub const native_wall_timers = true;
+pub const supports_nonblocking_file_io = true;
 
-// Tri-state for the once-probed IORING_OP_FTRUNCATE support. `unknown` is treated
-// as `no` at the dispatch site, so a missed/failed probe is always safe (the
-// thread-pool fallback works on every kernel) — never a rejected SQE.
-const ftruncate_unknown: u8 = 0;
-const ftruncate_yes: u8 = 1;
-const ftruncate_no: u8 = 2;
+pub fn capability(comptime op: Op) Support {
+    return switch (op) {
+        // These opcodes postdate the minimum kernel accepted by ring setup and
+        // are resolved from IORING_REGISTER_PROBE at runtime.
+        .file_set_size, .process_wait => .maybe,
+        .file_set_permissions,
+        .file_set_owner,
+        .file_set_timestamps,
+        .dir_set_permissions,
+        .dir_set_owner,
+        .dir_set_file_permissions,
+        .dir_set_file_owner,
+        .dir_set_file_timestamps,
+        .dir_sym_link,
+        .dir_read_link,
+        .dir_hard_link,
+        .dir_access,
+        .dir_read,
+        .dir_real_path,
+        .dir_real_path_file,
+        .file_real_path,
+        .file_hard_link,
+        .device_io_control,
+        => .no,
+        .group,
+        .timer,
+        .async,
+        .work,
+        .net_open,
+        .net_bind,
+        .net_listen,
+        .net_connect,
+        .net_accept,
+        .net_recv,
+        .net_send,
+        .net_recvfrom,
+        .net_sendto,
+        .net_recvmsg,
+        .net_sendmsg,
+        .net_poll,
+        .net_shutdown,
+        .net_close,
+        .net_send_file,
+        .file_open,
+        .file_create,
+        .file_close,
+        .file_read,
+        .file_write,
+        .file_read_streaming,
+        .file_write_streaming,
+        .file_sync,
+        .dir_create_dir,
+        .dir_rename,
+        .dir_rename_preserve,
+        .dir_delete_file,
+        .dir_delete_dir,
+        .file_size,
+        .file_stat,
+        .dir_open,
+        .dir_close,
+        .pipe_poll,
+        .pipe_create,
+        .pipe_close,
+        .mach_port,
+        => .yes,
+    };
+}
+
+const feature_unknown: u8 = 0;
+const feature_yes: u8 = 1;
+const feature_no: u8 = 2;
 
 pub const SharedState = struct {
     master_fd: std.atomic.Value(c_int) = .init(-1),
     refcount: std.atomic.Value(usize) = .init(0),
     /// Whether the running kernel supports IORING_OP_FTRUNCATE (Linux >= 6.9),
-    /// probed exactly once when the master ring is created (see `init`). Read by
-    /// `fileSetSizeSupported()`.
-    ftruncate_support: std.atomic.Value(u8) = .init(ftruncate_unknown),
+    /// probed exactly once when the master ring is created and resolved by
+    /// `supports()` for `.file_set_size`.
+    ftruncate_support: std.atomic.Value(u8) = .init(feature_unknown),
+    /// IORING_OP_WAITID was added after the minimum supported ring setup.
+    waitid_support: std.atomic.Value(u8) = .init(feature_unknown),
 };
 
 pub const NetRecvData = struct {
@@ -240,7 +280,7 @@ const SPLICE_F_MORE: u32 = 4;
 
 const Self = @This();
 
-const log = @import("../../common.zig").log;
+const log = @import("../../../common.zig").log;
 
 allocator: std.mem.Allocator,
 ring: linux.IoUring,
@@ -277,25 +317,19 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
     flags |= linux.IORING_SETUP_DEFER_TASKRUN;
     flags |= linux.IORING_SETUP_COOP_TASKRUN;
 
+    const master_fd = shared_state.master_fd.load(.seq_cst);
+    const is_master = master_fd == -1;
     var ring = blk: {
-        const master_fd = shared_state.master_fd.load(.seq_cst);
-        if (master_fd != -1) {
+        if (!is_master) {
             flags |= linux.IORING_SETUP_ATTACH_WQ;
             break :blk try ringFromMasterFd(master_fd, flags, queue_size);
         } else {
             var ring = try linux.IoUring.init(queue_size, flags);
-            // Probe FTRUNCATE support once, on this fresh ring, and publish the
-            // verdict BEFORE master_fd. Any executor that later attaches sees a
-            // non-negative master_fd (seq_cst) and is thus guaranteed to observe
-            // the stored verdict. Racing creators store the same kernel-global
-            // value, so a redundant store by a CAS loser is harmless.
-            probeAndStoreFtruncate(&ring, shared_state);
-            const old_fd = shared_state.master_fd.cmpxchgStrong(-1, ring.fd, .seq_cst, .seq_cst);
-            if (old_fd != null) {
-                ring.deinit();
-                flags |= linux.IORING_SETUP_ATTACH_WQ;
-                break :blk try ringFromMasterFd(old_fd.?, flags, queue_size);
-            }
+            // The Linux facade serializes group initialization, so this first
+            // ring remains private until every fallible initialization step has
+            // succeeded. This prevents a failed eventfd setup from publishing a
+            // stale master fd that later loops would try to attach to.
+            probeAndStoreFeatures(&ring, shared_state);
             break :blk ring;
         }
     };
@@ -304,6 +338,7 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
     const waker_eventfd = try posix.eventfd(0, posix.EFD.CLOEXEC | posix.EFD.NONBLOCK);
     errdefer _ = linux.close(waker_eventfd);
 
+    if (is_master) shared_state.master_fd.store(ring.fd, .seq_cst);
     _ = shared_state.refcount.fetchAdd(1, .seq_cst);
 
     self.* = .{
@@ -320,23 +355,27 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
     _ = self.armWaker();
 }
 
-/// Probe (once, via IORING_REGISTER_PROBE) whether the kernel knows the
-/// IORING_OP_FTRUNCATE opcode (added in Linux 6.9) and record it in `SharedState`.
-/// A failed probe records "no", so file_set_size takes the always-correct
-/// thread-pool fallback rather than risk a rejected SQE.
-fn probeAndStoreFtruncate(ring: *linux.IoUring, shared_state: *SharedState) void {
-    const supported = blk: {
-        const probe = ring.get_probe() catch break :blk false;
-        break :blk probe.is_supported(.FTRUNCATE);
+/// Probe optional opcodes once. Failure records "no" for every feature so the
+/// Loop takes an always-correct fallback instead of submitting a rejected SQE.
+fn probeAndStoreFeatures(ring: *linux.IoUring, shared_state: *SharedState) void {
+    const probe = ring.get_probe() catch {
+        shared_state.ftruncate_support.store(feature_no, .seq_cst);
+        shared_state.waitid_support.store(feature_no, .seq_cst);
+        return;
     };
-    shared_state.ftruncate_support.store(if (supported) ftruncate_yes else ftruncate_no, .seq_cst);
+    shared_state.ftruncate_support.store(if (probe.is_supported(.FTRUNCATE)) feature_yes else feature_no, .seq_cst);
+    shared_state.waitid_support.store(if (probe.is_supported(.WAITID)) feature_yes else feature_no, .seq_cst);
 }
 
-/// Runtime capability query used by the Loop: may file_set_size use the native
-/// IORING_OP_FTRUNCATE SQE, or must it fall back to the thread pool? Probed once
-/// at ring creation; see `SharedState.ftruncate_support`.
-pub fn fileSetSizeSupported(self: *Self) bool {
-    return self.shared_state.ftruncate_support.load(.seq_cst) == ftruncate_yes;
+pub fn supports(self: *const Self, comptime op: Op, _: *const op.toType()) bool {
+    comptime std.debug.assert(capability(op) == .maybe);
+    if (comptime op == .file_set_size) {
+        return self.shared_state.ftruncate_support.load(.seq_cst) == feature_yes;
+    }
+    if (comptime op == .process_wait) {
+        return self.shared_state.waitid_support.load(.seq_cst) == feature_yes;
+    }
+    @compileError("unhandled runtime io_uring capability: " ++ @tagName(op));
 }
 
 fn ringFromMasterFd(master_fd: i32, flags: u32, queue_size: u16) !linux.IoUring {
@@ -1145,7 +1184,7 @@ pub fn syncWallTimer(self: *Self, clock: Clock, deadline: ?u64) bool {
 }
 
 pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
-    const linux_os = @import("../../os/linux.zig");
+    const linux_os = @import("../../../os/linux.zig");
 
     // The waker poll is normally already armed (a no-op here). It only needs
     // re-arming in the rare case the kernel dropped the multishot; if the SQ is

--- a/src/ev/backends/linux/io_uring.zig
+++ b/src/ev/backends/linux/io_uring.zig
@@ -152,9 +152,11 @@ pub fn capability(comptime op: Op) Support {
     };
 }
 
-const feature_unknown: u8 = 0;
-const feature_yes: u8 = 1;
-const feature_no: u8 = 2;
+const FeatureSupport = enum(u8) {
+    unknown,
+    yes,
+    no,
+};
 
 pub const SharedState = struct {
     master_fd: std.atomic.Value(c_int) = .init(-1),
@@ -162,9 +164,9 @@ pub const SharedState = struct {
     /// Whether the running kernel supports IORING_OP_FTRUNCATE (Linux >= 6.9),
     /// probed exactly once when the master ring is created and resolved by
     /// `supports()` for `.file_set_size`.
-    ftruncate_support: std.atomic.Value(u8) = .init(feature_unknown),
+    ftruncate_support: std.atomic.Value(FeatureSupport) = .init(.unknown),
     /// IORING_OP_WAITID was added after the minimum supported ring setup.
-    waitid_support: std.atomic.Value(u8) = .init(feature_unknown),
+    waitid_support: std.atomic.Value(FeatureSupport) = .init(.unknown),
 };
 
 pub const NetRecvData = struct {
@@ -359,21 +361,21 @@ pub fn init(self: *Self, allocator: std.mem.Allocator, queue_size: u16, shared_s
 /// Loop takes an always-correct fallback instead of submitting a rejected SQE.
 fn probeAndStoreFeatures(ring: *linux.IoUring, shared_state: *SharedState) void {
     const probe = ring.get_probe() catch {
-        shared_state.ftruncate_support.store(feature_no, .seq_cst);
-        shared_state.waitid_support.store(feature_no, .seq_cst);
+        shared_state.ftruncate_support.store(.no, .monotonic);
+        shared_state.waitid_support.store(.no, .monotonic);
         return;
     };
-    shared_state.ftruncate_support.store(if (probe.is_supported(.FTRUNCATE)) feature_yes else feature_no, .seq_cst);
-    shared_state.waitid_support.store(if (probe.is_supported(.WAITID)) feature_yes else feature_no, .seq_cst);
+    shared_state.ftruncate_support.store(if (probe.is_supported(.FTRUNCATE)) .yes else .no, .monotonic);
+    shared_state.waitid_support.store(if (probe.is_supported(.WAITID)) .yes else .no, .monotonic);
 }
 
-pub fn supports(self: *const Self, comptime op: Op, _: *const op.toType()) bool {
+pub fn supports(self: *const Self, comptime op: Op, _: *op.toType()) bool {
     comptime std.debug.assert(capability(op) == .maybe);
     if (comptime op == .file_set_size) {
-        return self.shared_state.ftruncate_support.load(.seq_cst) == feature_yes;
+        return self.shared_state.ftruncate_support.load(.monotonic) == .yes;
     }
     if (comptime op == .process_wait) {
-        return self.shared_state.waitid_support.load(.seq_cst) == feature_yes;
+        return self.shared_state.waitid_support.load(.monotonic) == .yes;
     }
     @compileError("unhandled runtime io_uring capability: " ++ @tagName(op));
 }

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -95,10 +95,10 @@ pub fn capability(comptime op: Op) Support {
     };
 }
 
-pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+pub fn supports(_: *const Self, comptime op: Op, data: *op.toType()) bool {
     comptime std.debug.assert(capability(op) == .maybe);
     if (comptime op == .file_read_streaming or op == .file_write_streaming) {
-        return data.pollable orelse false;
+        return common.resolveStreamingSupport(data);
     }
     @compileError("unhandled runtime poll capability: " ++ @tagName(op));
 }

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -23,10 +23,85 @@ const PipeClose = @import("../completion.zig").PipeClose;
 
 pub const NetHandle = net.fd_t;
 
-const BackendCapabilities = @import("../completion.zig").BackendCapabilities;
+const Support = @import("../completion.zig").Support;
 const fs = @import("../../os/fs.zig");
 
-pub const capabilities: BackendCapabilities = .{};
+pub const native_wall_timers = false;
+pub const supports_nonblocking_file_io = false;
+
+pub fn capability(comptime op: Op) Support {
+    return switch (op) {
+        .file_read_streaming, .file_write_streaming => .maybe,
+        .net_send_file,
+        .file_open,
+        .file_create,
+        .file_close,
+        .file_read,
+        .file_write,
+        .file_sync,
+        .file_set_size,
+        .file_set_permissions,
+        .file_set_owner,
+        .file_set_timestamps,
+        .dir_create_dir,
+        .dir_rename,
+        .dir_rename_preserve,
+        .dir_delete_file,
+        .dir_delete_dir,
+        .file_size,
+        .file_stat,
+        .dir_open,
+        .dir_close,
+        .dir_set_permissions,
+        .dir_set_owner,
+        .dir_set_file_permissions,
+        .dir_set_file_owner,
+        .dir_set_file_timestamps,
+        .dir_sym_link,
+        .dir_read_link,
+        .dir_hard_link,
+        .dir_access,
+        .dir_read,
+        .dir_real_path,
+        .dir_real_path_file,
+        .file_real_path,
+        .file_hard_link,
+        .device_io_control,
+        .process_wait,
+        => .no,
+        .group,
+        .timer,
+        .async,
+        .work,
+        .net_open,
+        .net_bind,
+        .net_listen,
+        .net_connect,
+        .net_accept,
+        .net_recv,
+        .net_send,
+        .net_recvfrom,
+        .net_sendto,
+        .net_recvmsg,
+        .net_sendmsg,
+        .net_poll,
+        .net_shutdown,
+        .net_close,
+        .pipe_poll,
+        .pipe_create,
+        .pipe_close,
+        .mach_port,
+        => .yes,
+    };
+}
+
+pub fn supports(_: *const Self, comptime op: Op, data: *const op.toType()) bool {
+    comptime std.debug.assert(capability(op) == .maybe);
+    if (comptime op == .file_read_streaming or op == .file_write_streaming) {
+        return data.pollable orelse false;
+    }
+    @compileError("unhandled runtime poll capability: " ++ @tagName(op));
+}
 
 pub const SharedState = struct {};
 

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -1274,9 +1274,10 @@ pub const FileReadStreaming = struct {
     handle: fs.fd_t,
     buffer: ReadBuf,
     /// Whether `handle` is pollable (non-seekable). `null` until classified by
-    /// the loop on first submission; backends with a readiness path use the
-    /// poll path when true and the thread pool when false. Callers may seed a
-    /// cached value to skip re-classification, and may read it back afterwards.
+    /// capability resolution on first submission; backends with a readiness
+    /// path use the poll path when true and the thread pool when false. Callers
+    /// may seed a cached value to skip re-classification, and may read it back
+    /// afterwards.
     pollable: ?bool = null,
 
     pub const Error = fs.FileReadError || Cancelable;
@@ -1303,9 +1304,10 @@ pub const FileWriteStreaming = struct {
     handle: fs.fd_t,
     buffer: WriteBuf,
     /// Whether `handle` is pollable (non-seekable). `null` until classified by
-    /// the loop on first submission; backends with a readiness path use the
-    /// poll path when true and the thread pool when false. Callers may seed a
-    /// cached value to skip re-classification, and may read it back afterwards.
+    /// capability resolution on first submission; backends with a readiness
+    /// path use the poll path when true and the thread pool when false. Callers
+    /// may seed a cached value to skip re-classification, and may read it back
+    /// afterwards.
     pollable: ?bool = null,
 
     pub const Error = fs.FileWriteError || Cancelable;

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -14,57 +14,25 @@ const Timestamp = @import("../time.zig").Timestamp;
 const Timeout = @import("../time.zig").Timeout;
 const Clock = @import("../time.zig").Clock;
 
-pub const BackendCapabilities = struct {
-    file_read: bool = false,
-    file_write: bool = false,
-    file_read_streaming: bool = false,
-    file_write_streaming: bool = false,
-    file_open: bool = false,
-    file_create: bool = false,
-    file_close: bool = false,
-    file_sync: bool = false,
-    file_set_size: bool = false,
-    file_set_permissions: bool = false,
-    file_set_owner: bool = false,
-    file_set_timestamps: bool = false,
-    dir_create_dir: bool = false,
-    dir_rename: bool = false,
-    dir_rename_preserve: bool = false,
-    dir_delete_file: bool = false,
-    dir_delete_dir: bool = false,
-    file_size: bool = false,
-    file_stat: bool = false,
-    dir_open: bool = false,
-    dir_close: bool = false,
-    dir_set_permissions: bool = false,
-    dir_set_owner: bool = false,
-    dir_set_file_permissions: bool = false,
-    dir_set_file_owner: bool = false,
-    dir_set_file_timestamps: bool = false,
-    dir_sym_link: bool = false,
-    dir_read_link: bool = false,
-    dir_hard_link: bool = false,
-    dir_access: bool = false,
-    dir_read: bool = false,
-    dir_real_path: bool = false,
-    dir_real_path_file: bool = false,
-    file_real_path: bool = false,
-    file_hard_link: bool = false,
-    /// When true, the backend implements file-to-socket transfer natively
-    /// (e.g. io_uring splice). When false, the loop drives a generic
-    /// read/write callback loop fallback (see NetSendFile).
-    net_send_file: bool = false,
-    device_io_control: bool = false,
-    process_wait: bool = false,
-    /// When true, the backend arms boot/real (wall-clock) timers natively via
-    /// `syncWallTimers`, so the loop must not fold them into the poll timeout.
-    /// When false, the loop falls back to the capped poll-timeout re-evaluation.
-    native_wall_timers: bool = false,
-
-    pub fn supportsNonBlockingFileIo(comptime self: BackendCapabilities) bool {
-        return self.file_read or self.file_write or self.file_read_streaming or self.file_write_streaming;
-    }
+/// Compile-time classification of where an operation can execute. `maybe`
+/// reserves both the backend scratch and fallback state; the Loop resolves the
+/// route against the initialized backend instance when the operation is added.
+pub const Support = enum {
+    yes,
+    no,
+    maybe,
 };
+
+/// The route selected for a `maybe` operation. It is recorded at submission so
+/// cancellation follows the original route rather than repeating a feature or
+/// handle probe whose answer might no longer describe the in-flight work.
+pub const ExecutionRoute = enum {
+    none,
+    backend,
+    fallback,
+};
+
+const NoRoute = enum { none };
 
 pub const Op = enum {
     group,
@@ -931,10 +899,9 @@ pub const NetSendFile = struct {
     /// writer's buffer and the reader's buffer). Unused by native backends.
     bufs: [2][]u8,
 
-    internal: switch (Backend.capabilities.net_send_file) {
-        true => if (@hasDecl(Backend, "NetSendFileData")) Backend.NetSendFileData else struct {},
-        false => Fallback,
-    } = .{},
+    internal: BackendOpData(.net_send_file, "NetSendFileData") = .{},
+    fallback: if (Backend.capability(.net_send_file) != .yes) Fallback else struct {} = .{},
+    route: RouteData(.net_send_file) = .none,
 
     /// State for the generic read/write loop. Unused by native backends.
     pub const Fallback = struct {
@@ -1142,14 +1109,11 @@ pub const FileOpenResult = struct {
     pollable: bool = false,
 };
 
-/// Shared `internal` payload for file/dir ops delegated to the thread pool on
-/// backends without native async support (kqueue/poll). Bundles the pool `Work`,
-/// the loop linkage, an allocator slot (used by path-based ops), and the syscall
-/// cancellation token bound by the worker. The cancel-resend list link lives on
-/// the embedded `work` (see `Work.resend_next`/`resend_key`); `linked_context.linked`
-/// back-points to the owning `Completion` and is used as the work's `resend_key`,
-/// so the loop finds the entry from a completion at finalization without any
-/// per-op-type knowledge.
+/// State for file/dir operations delegated to the thread pool. This is Loop
+/// fallback state, deliberately separate from a backend's `internal` scratch.
+/// `linked_context.linked` back-points to the owning Completion, so worker
+/// callbacks and the cancel-resend machinery need no per-operation container
+/// layout knowledge.
 pub const DelegatedWork = struct {
     work: Work = undefined,
     allocator: std.mem.Allocator = undefined,
@@ -1161,13 +1125,26 @@ pub const DelegatedWork = struct {
     token: os.syscall_cancel.Token = .{},
 };
 
+fn BackendOpData(comptime op: Op, comptime decl_name: []const u8) type {
+    if (Backend.capability(op) == .no) return struct {};
+    if (@hasDecl(Backend, decl_name)) return @field(Backend, decl_name);
+    return struct {};
+}
+
+fn LinkedWorkData(comptime op: Op) type {
+    return if (Backend.capability(op) != .yes) DelegatedWork else struct {};
+}
+
+fn RouteData(comptime op: Op) type {
+    return if (Backend.capability(op) == .maybe) ExecutionRoute else NoRoute;
+}
+
 pub const FileOpen = struct {
     c: Completion,
     result_private_do_not_touch: FileOpenResult = undefined,
-    internal: switch (Backend.capabilities.file_open) {
-        true => if (@hasDecl(Backend, "FileOpenData")) Backend.FileOpenData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_open, "FileOpenData") = .{},
+    linked_work: LinkedWorkData(.file_open) = .{},
+    route: RouteData(.file_open) = .none,
     dir: fs.fd_t,
     path: []const u8,
     flags: fs.FileOpenFlags,
@@ -1191,10 +1168,9 @@ pub const FileOpen = struct {
 pub const FileCreate = struct {
     c: Completion,
     result_private_do_not_touch: FileOpenResult = undefined,
-    internal: switch (Backend.capabilities.file_create) {
-        true => if (@hasDecl(Backend, "FileCreateData")) Backend.FileCreateData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_create, "FileCreateData") = .{},
+    linked_work: LinkedWorkData(.file_create) = .{},
+    route: RouteData(.file_create) = .none,
     dir: fs.fd_t,
     path: []const u8,
     flags: fs.FileCreateFlags,
@@ -1218,10 +1194,9 @@ pub const FileCreate = struct {
 pub const FileClose = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_close) {
-        true => if (@hasDecl(Backend, "FileCloseData")) Backend.FileCloseData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_close, "FileCloseData") = .{},
+    linked_work: LinkedWorkData(.file_close) = .{},
+    route: RouteData(.file_close) = .none,
     handle: fs.fd_t,
 
     pub const Error = fs.FileCloseError || Cancelable;
@@ -1241,10 +1216,9 @@ pub const FileClose = struct {
 pub const FileRead = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.file_read) {
-        true => if (@hasDecl(Backend, "FileReadData")) Backend.FileReadData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_read, "FileReadData") = .{},
+    linked_work: LinkedWorkData(.file_read) = .{},
+    route: RouteData(.file_read) = .none,
     handle: fs.fd_t,
     buffer: ReadBuf,
     offset: u64,
@@ -1268,10 +1242,9 @@ pub const FileRead = struct {
 pub const FileWrite = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.file_write) {
-        true => if (@hasDecl(Backend, "FileWriteData")) Backend.FileWriteData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_write, "FileWriteData") = .{},
+    linked_work: LinkedWorkData(.file_write) = .{},
+    route: RouteData(.file_write) = .none,
     handle: fs.fd_t,
     buffer: WriteBuf,
     offset: u64,
@@ -1295,10 +1268,9 @@ pub const FileWrite = struct {
 pub const FileReadStreaming = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.file_read_streaming) {
-        true => if (@hasDecl(Backend, "FileReadStreamingData")) Backend.FileReadStreamingData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_read_streaming, "FileReadStreamingData") = .{},
+    linked_work: LinkedWorkData(.file_read_streaming) = .{},
+    route: RouteData(.file_read_streaming) = .none,
     handle: fs.fd_t,
     buffer: ReadBuf,
     /// Whether `handle` is pollable (non-seekable). `null` until classified by
@@ -1325,10 +1297,9 @@ pub const FileReadStreaming = struct {
 pub const FileWriteStreaming = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.file_write_streaming) {
-        true => if (@hasDecl(Backend, "FileWriteStreamingData")) Backend.FileWriteStreamingData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_write_streaming, "FileWriteStreamingData") = .{},
+    linked_work: LinkedWorkData(.file_write_streaming) = .{},
+    route: RouteData(.file_write_streaming) = .none,
     handle: fs.fd_t,
     buffer: WriteBuf,
     /// Whether `handle` is pollable (non-seekable). `null` until classified by
@@ -1355,10 +1326,9 @@ pub const FileWriteStreaming = struct {
 pub const FileSync = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_sync) {
-        true => if (@hasDecl(Backend, "FileSyncData")) Backend.FileSyncData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_sync, "FileSyncData") = .{},
+    linked_work: LinkedWorkData(.file_sync) = .{},
+    route: RouteData(.file_sync) = .none,
     handle: fs.fd_t,
     flags: fs.FileSyncFlags,
 
@@ -1380,10 +1350,9 @@ pub const FileSync = struct {
 pub const FileSetSize = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_set_size) {
-        true => if (@hasDecl(Backend, "FileSetSizeData")) Backend.FileSetSizeData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_set_size, "FileSetSizeData") = .{},
+    linked_work: LinkedWorkData(.file_set_size) = .{},
+    route: RouteData(.file_set_size) = .none,
     handle: fs.fd_t,
     length: u64,
 
@@ -1405,10 +1374,9 @@ pub const FileSetSize = struct {
 pub const FileSetPermissions = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_set_permissions) {
-        true => if (@hasDecl(Backend, "FileSetPermissionsData")) Backend.FileSetPermissionsData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_set_permissions, "FileSetPermissionsData") = .{},
+    linked_work: LinkedWorkData(.file_set_permissions) = .{},
+    route: RouteData(.file_set_permissions) = .none,
     handle: fs.fd_t,
     mode: fs.mode_t,
 
@@ -1430,10 +1398,9 @@ pub const FileSetPermissions = struct {
 pub const FileSetOwner = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_set_owner) {
-        true => if (@hasDecl(Backend, "FileSetOwnerData")) Backend.FileSetOwnerData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_set_owner, "FileSetOwnerData") = .{},
+    linked_work: LinkedWorkData(.file_set_owner) = .{},
+    route: RouteData(.file_set_owner) = .none,
     handle: fs.fd_t,
     uid: ?fs.uid_t,
     gid: ?fs.gid_t,
@@ -1457,10 +1424,9 @@ pub const FileSetOwner = struct {
 pub const FileSetTimestamps = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_set_timestamps) {
-        true => if (@hasDecl(Backend, "FileSetTimestampsData")) Backend.FileSetTimestampsData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_set_timestamps, "FileSetTimestampsData") = .{},
+    linked_work: LinkedWorkData(.file_set_timestamps) = .{},
+    route: RouteData(.file_set_timestamps) = .none,
     handle: fs.fd_t,
     timestamps: fs.FileTimestamps,
 
@@ -1482,10 +1448,9 @@ pub const FileSetTimestamps = struct {
 pub const DirSetPermissions = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_set_permissions) {
-        true => if (@hasDecl(Backend, "DirSetPermissionsData")) Backend.DirSetPermissionsData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_set_permissions, "DirSetPermissionsData") = .{},
+    linked_work: LinkedWorkData(.dir_set_permissions) = .{},
+    route: RouteData(.dir_set_permissions) = .none,
     handle: fs.fd_t,
     mode: fs.mode_t,
 
@@ -1507,10 +1472,9 @@ pub const DirSetPermissions = struct {
 pub const DirSetOwner = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_set_owner) {
-        true => if (@hasDecl(Backend, "DirSetOwnerData")) Backend.DirSetOwnerData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_set_owner, "DirSetOwnerData") = .{},
+    linked_work: LinkedWorkData(.dir_set_owner) = .{},
+    route: RouteData(.dir_set_owner) = .none,
     handle: fs.fd_t,
     uid: ?fs.uid_t,
     gid: ?fs.gid_t,
@@ -1534,10 +1498,9 @@ pub const DirSetOwner = struct {
 pub const DirSetFilePermissions = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_set_file_permissions) {
-        true => if (@hasDecl(Backend, "DirSetFilePermissionsData")) Backend.DirSetFilePermissionsData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_set_file_permissions, "DirSetFilePermissionsData") = .{},
+    linked_work: LinkedWorkData(.dir_set_file_permissions) = .{},
+    route: RouteData(.dir_set_file_permissions) = .none,
     dir: fs.fd_t,
     path: []const u8,
     mode: fs.mode_t,
@@ -1563,10 +1526,9 @@ pub const DirSetFilePermissions = struct {
 pub const DirSetFileOwner = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_set_file_owner) {
-        true => if (@hasDecl(Backend, "DirSetFileOwnerData")) Backend.DirSetFileOwnerData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_set_file_owner, "DirSetFileOwnerData") = .{},
+    linked_work: LinkedWorkData(.dir_set_file_owner) = .{},
+    route: RouteData(.dir_set_file_owner) = .none,
     dir: fs.fd_t,
     path: []const u8,
     uid: ?fs.uid_t,
@@ -1594,10 +1556,9 @@ pub const DirSetFileOwner = struct {
 pub const DirSetFileTimestamps = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_set_file_timestamps) {
-        true => if (@hasDecl(Backend, "DirSetFileTimestampsData")) Backend.DirSetFileTimestampsData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_set_file_timestamps, "DirSetFileTimestampsData") = .{},
+    linked_work: LinkedWorkData(.dir_set_file_timestamps) = .{},
+    route: RouteData(.dir_set_file_timestamps) = .none,
     dir: fs.fd_t,
     path: []const u8,
     timestamps: fs.FileTimestamps,
@@ -1623,10 +1584,9 @@ pub const DirSetFileTimestamps = struct {
 pub const DirSymLink = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_sym_link) {
-        true => if (@hasDecl(Backend, "DirSymLinkData")) Backend.DirSymLinkData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_sym_link, "DirSymLinkData") = .{},
+    linked_work: LinkedWorkData(.dir_sym_link) = .{},
+    route: RouteData(.dir_sym_link) = .none,
     dir: fs.fd_t,
     target: []const u8,
     link_path: []const u8,
@@ -1652,10 +1612,9 @@ pub const DirSymLink = struct {
 pub const DirReadLink = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.dir_read_link) {
-        true => if (@hasDecl(Backend, "DirReadLinkData")) Backend.DirReadLinkData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_read_link, "DirReadLinkData") = .{},
+    linked_work: LinkedWorkData(.dir_read_link) = .{},
+    route: RouteData(.dir_read_link) = .none,
     dir: fs.fd_t,
     path: []const u8,
     buffer: []u8,
@@ -1679,10 +1638,9 @@ pub const DirReadLink = struct {
 pub const DirHardLink = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_hard_link) {
-        true => if (@hasDecl(Backend, "DirHardLinkData")) Backend.DirHardLinkData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_hard_link, "DirHardLinkData") = .{},
+    linked_work: LinkedWorkData(.dir_hard_link) = .{},
+    route: RouteData(.dir_hard_link) = .none,
     old_dir: fs.fd_t,
     old_path: []const u8,
     new_dir: fs.fd_t,
@@ -1710,10 +1668,9 @@ pub const DirHardLink = struct {
 pub const DirAccess = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_access) {
-        true => if (@hasDecl(Backend, "DirAccessData")) Backend.DirAccessData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_access, "DirAccessData") = .{},
+    linked_work: LinkedWorkData(.dir_access) = .{},
+    route: RouteData(.dir_access) = .none,
     dir: fs.fd_t,
     path: []const u8,
     flags: fs.AccessFlags,
@@ -1737,10 +1694,9 @@ pub const DirAccess = struct {
 pub const DirRealPath = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.dir_real_path) {
-        true => if (@hasDecl(Backend, "DirRealPathData")) Backend.DirRealPathData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_real_path, "DirRealPathData") = .{},
+    linked_work: LinkedWorkData(.dir_real_path) = .{},
+    route: RouteData(.dir_real_path) = .none,
     fd: fs.fd_t,
     buffer: []u8,
 
@@ -1762,10 +1718,9 @@ pub const DirRealPath = struct {
 pub const DirRealPathFile = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.dir_real_path_file) {
-        true => if (@hasDecl(Backend, "DirRealPathFileData")) Backend.DirRealPathFileData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_real_path_file, "DirRealPathFileData") = .{},
+    linked_work: LinkedWorkData(.dir_real_path_file) = .{},
+    route: RouteData(.dir_real_path_file) = .none,
     dir: fs.fd_t,
     path: []const u8,
     buffer: []u8,
@@ -1789,10 +1744,9 @@ pub const DirRealPathFile = struct {
 pub const FileRealPath = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.file_real_path) {
-        true => if (@hasDecl(Backend, "FileRealPathData")) Backend.FileRealPathData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_real_path, "FileRealPathData") = .{},
+    linked_work: LinkedWorkData(.file_real_path) = .{},
+    route: RouteData(.file_real_path) = .none,
     fd: fs.fd_t,
     buffer: []u8,
 
@@ -1814,10 +1768,9 @@ pub const FileRealPath = struct {
 pub const FileHardLink = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.file_hard_link) {
-        true => if (@hasDecl(Backend, "FileHardLinkData")) Backend.FileHardLinkData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_hard_link, "FileHardLinkData") = .{},
+    linked_work: LinkedWorkData(.file_hard_link) = .{},
+    route: RouteData(.file_hard_link) = .none,
     fd: fs.fd_t,
     new_dir: fs.fd_t,
     new_path: []const u8,
@@ -1843,10 +1796,9 @@ pub const FileHardLink = struct {
 pub const DirCreateDir = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_create_dir) {
-        true => if (@hasDecl(Backend, "DirCreateDirData")) Backend.DirCreateDirData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_create_dir, "DirCreateDirData") = .{},
+    linked_work: LinkedWorkData(.dir_create_dir) = .{},
+    route: RouteData(.dir_create_dir) = .none,
     dir: fs.fd_t,
     path: []const u8,
     mode: fs.mode_t,
@@ -1870,10 +1822,9 @@ pub const DirCreateDir = struct {
 pub const DirRename = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_rename) {
-        true => if (@hasDecl(Backend, "DirRenameData")) Backend.DirRenameData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_rename, "DirRenameData") = .{},
+    linked_work: LinkedWorkData(.dir_rename) = .{},
+    route: RouteData(.dir_rename) = .none,
     old_dir: fs.fd_t,
     old_path: []const u8,
     new_dir: fs.fd_t,
@@ -1899,10 +1850,9 @@ pub const DirRename = struct {
 pub const DirRenamePreserve = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_rename_preserve) {
-        true => if (@hasDecl(Backend, "DirRenamePreserveData")) Backend.DirRenamePreserveData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_rename_preserve, "DirRenamePreserveData") = .{},
+    linked_work: LinkedWorkData(.dir_rename_preserve) = .{},
+    route: RouteData(.dir_rename_preserve) = .none,
     old_dir: fs.fd_t,
     old_path: []const u8,
     new_dir: fs.fd_t,
@@ -1928,10 +1878,9 @@ pub const DirRenamePreserve = struct {
 pub const DirDeleteFile = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_delete_file) {
-        true => if (@hasDecl(Backend, "DirDeleteFileData")) Backend.DirDeleteFileData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_delete_file, "DirDeleteFileData") = .{},
+    linked_work: LinkedWorkData(.dir_delete_file) = .{},
+    route: RouteData(.dir_delete_file) = .none,
     dir: fs.fd_t,
     path: []const u8,
 
@@ -1953,10 +1902,9 @@ pub const DirDeleteFile = struct {
 pub const DirDeleteDir = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_delete_dir) {
-        true => if (@hasDecl(Backend, "DirDeleteDirData")) Backend.DirDeleteDirData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_delete_dir, "DirDeleteDirData") = .{},
+    linked_work: LinkedWorkData(.dir_delete_dir) = .{},
+    route: RouteData(.dir_delete_dir) = .none,
     dir: fs.fd_t,
     path: []const u8,
 
@@ -1978,10 +1926,9 @@ pub const DirDeleteDir = struct {
 pub const FileSize = struct {
     c: Completion,
     result_private_do_not_touch: u64 = undefined,
-    internal: switch (Backend.capabilities.file_size) {
-        true => if (@hasDecl(Backend, "FileSizeData")) Backend.FileSizeData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_size, "FileSizeData") = .{},
+    linked_work: LinkedWorkData(.file_size) = .{},
+    route: RouteData(.file_size) = .none,
     handle: fs.fd_t,
 
     pub const Error = fs.FileSizeError || Cancelable;
@@ -2001,10 +1948,9 @@ pub const FileSize = struct {
 pub const FileStat = struct {
     c: Completion,
     result_private_do_not_touch: fs.FileStatInfo = undefined,
-    internal: switch (Backend.capabilities.file_stat) {
-        true => if (@hasDecl(Backend, "FileStatData")) Backend.FileStatData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.file_stat, "FileStatData") = .{},
+    linked_work: LinkedWorkData(.file_stat) = .{},
+    route: RouteData(.file_stat) = .none,
     handle: fs.fd_t,
     path: ?[]const u8,
     flags: fs.FileStatFlags,
@@ -2031,10 +1977,9 @@ pub const FileStat = struct {
 pub const DirOpen = struct {
     c: Completion,
     result_private_do_not_touch: fs.fd_t = undefined,
-    internal: switch (Backend.capabilities.dir_open) {
-        true => if (@hasDecl(Backend, "DirOpenData")) Backend.DirOpenData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_open, "DirOpenData") = .{},
+    linked_work: LinkedWorkData(.dir_open) = .{},
+    route: RouteData(.dir_open) = .none,
     dir: fs.fd_t,
     path: []const u8,
     flags: fs.DirOpenFlags,
@@ -2058,10 +2003,9 @@ pub const DirOpen = struct {
 pub const DirClose = struct {
     c: Completion,
     result_private_do_not_touch: void = {},
-    internal: switch (Backend.capabilities.dir_close) {
-        true => if (@hasDecl(Backend, "DirCloseData")) Backend.DirCloseData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_close, "DirCloseData") = .{},
+    linked_work: LinkedWorkData(.dir_close) = .{},
+    route: RouteData(.dir_close) = .none,
     handle: fs.fd_t,
 
     pub const Error = Cancelable;
@@ -2081,10 +2025,9 @@ pub const DirClose = struct {
 pub const DirRead = struct {
     c: Completion,
     result_private_do_not_touch: usize = undefined,
-    internal: switch (Backend.capabilities.dir_read) {
-        true => if (@hasDecl(Backend, "DirReadData")) Backend.DirReadData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.dir_read, "DirReadData") = .{},
+    linked_work: LinkedWorkData(.dir_read) = .{},
+    route: RouteData(.dir_read) = .none,
     handle: fs.fd_t,
     buffer: []u8,
     restart: bool,
@@ -2198,7 +2141,9 @@ pub const PipeClose = struct {
 pub const DeviceIoControl = if (builtin.os.tag == .windows) struct {
     c: Completion,
     result_private_do_not_touch: std.os.windows.IO_STATUS_BLOCK = undefined,
-    internal: struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined } = .{},
+    internal: BackendOpData(.device_io_control, "DeviceIoControlData") = .{},
+    linked_work: LinkedWorkData(.device_io_control) = .{},
+    route: RouteData(.device_io_control) = .none,
     handle: fs.fd_t,
     code: std.os.windows.CTL_CODE,
     in: []const u8,
@@ -2223,7 +2168,9 @@ pub const DeviceIoControl = if (builtin.os.tag == .windows) struct {
 } else struct {
     c: Completion,
     result_private_do_not_touch: i32 = undefined,
-    internal: struct { work: Work = undefined, linked_context: Loop.LinkedWorkContext = undefined } = .{},
+    internal: BackendOpData(.device_io_control, "DeviceIoControlData") = .{},
+    linked_work: LinkedWorkData(.device_io_control) = .{},
+    route: RouteData(.device_io_control) = .none,
     handle: fs.fd_t,
     code: u32,
     arg: ?*anyopaque,
@@ -2268,10 +2215,9 @@ pub const ProcessWait = struct {
     c: Completion,
     result_private_do_not_touch: ExitStatus = undefined,
     handle: ProcessHandle,
-    internal: switch (Backend.capabilities.process_wait) {
-        true => if (@hasDecl(Backend, "ProcessWaitData")) Backend.ProcessWaitData else struct {},
-        false => DelegatedWork,
-    } = .{},
+    internal: BackendOpData(.process_wait, "ProcessWaitData") = .{},
+    linked_work: LinkedWorkData(.process_wait) = .{},
+    route: RouteData(.process_wait) = .none,
 
     pub const ProcessHandle = switch (builtin.os.tag) {
         .windows => std.os.windows.HANDLE,

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Backend = @import("backend.zig").Backend;
-const BackendCapabilities = @import("completion.zig").BackendCapabilities;
 const Completion = @import("completion.zig").Completion;
 const Group = @import("completion.zig").Group;
 const Timer = @import("completion.zig").Timer;
@@ -766,58 +765,39 @@ pub const Loop = struct {
             },
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
-                if (comptime Backend.capabilities.net_send_file) {
-                    self.backend.cancel(&self.state, completion);
-                } else {
-                    self.netSendFileCancel(op);
+                switch (comptime Backend.capability(.net_send_file)) {
+                    .yes => self.backend.cancel(&self.state, completion),
+                    .no => self.netSendFileCancel(op),
+                    .maybe => switch (op.route) {
+                        .none => unreachable,
+                        .backend => self.backend.cancel(&self.state, completion),
+                        .fallback => self.netSendFileCancel(op),
+                    },
                 }
             },
 
             inline else => |op| {
-                // File/dir ops that can fallback to thread pool
-                if (@hasField(BackendCapabilities, @tagName(op))) {
-                    if (!@field(Backend.capabilities, @tagName(op))) {
-                        // Pollable streaming ops took the backend poll path, not
-                        // the thread pool, so they must be canceled there. The
-                        // verdict was cached on the op at submission time.
-                        if (comptime (op == .file_read_streaming or op == .file_write_streaming)) {
-                            if (completion.cast(op.toType()).pollable orelse false) {
-                                self.backend.cancel(&self.state, completion);
-                                return;
-                            }
-                        }
-                        // file_set_size may have been submitted natively (the
-                        // FTRUNCATE SQE) when the runtime probe found kernel
-                        // support, so it must be canceled on the backend, not the
-                        // thread pool. The probe verdict is stable for the process,
-                        // so re-querying here agrees with the submission decision.
-                        if (comptime op == .file_set_size and @hasDecl(Backend, "fileSetSizeSupported")) {
-                            if (self.backend.fileSetSizeSupported()) {
-                                self.backend.cancel(&self.state, completion);
-                                return;
-                            }
-                        }
-                        const thread_pool = self.thread_pool orelse unreachable;
-                        const op_data = completion.cast(op.toType());
-                        thread_pool.cancel(&op_data.internal.work);
-                        // If the worker is blocked in the canceled syscall, the
-                        // first SIGURG (sent by cancel above) can be lost in the
-                        // begin()->sleep window. Track it so `tick` re-sends until
-                        // the worker acknowledges. Only DelegatedWork ops have a
-                        // token; the entry is removed when the op finalizes.
-                        if (@hasField(@TypeOf(op_data.internal), "token")) {
-                            if (op_data.internal.token.isCanceling()) {
-                                self.state.addResend(&op_data.internal.work, completion);
-                            }
-                        }
-                    } else {
-                        self.backend.cancel(&self.state, completion);
-                    }
-                } else {
-                    // Backend operations (net_*, etc)
-                    self.backend.cancel(&self.state, completion);
+                const op_data = completion.cast(op.toType());
+                switch (comptime Backend.capability(op)) {
+                    .yes => self.backend.cancel(&self.state, completion),
+                    .no => self.cancelLinkedWork(completion, &op_data.linked_work),
+                    .maybe => switch (op_data.route) {
+                        .none => unreachable,
+                        .backend => self.backend.cancel(&self.state, completion),
+                        .fallback => self.cancelLinkedWork(completion, &op_data.linked_work),
+                    },
                 }
             },
+        }
+    }
+
+    fn cancelLinkedWork(self: *Loop, completion: *Completion, linked_work: *DelegatedWork) void {
+        const thread_pool = self.thread_pool orelse unreachable;
+        thread_pool.cancel(&linked_work.work);
+        // A worker can enter its blocking syscall just after the first SIGURG.
+        // Keep re-sending until it acknowledges or the completion finalizes.
+        if (linked_work.token.isCanceling()) {
+            self.state.addResend(&linked_work.work, completion);
         }
     }
 
@@ -917,29 +897,30 @@ pub const Loop = struct {
             },
             .net_send_file => {
                 const op = completion.cast(NetSendFile);
-                if (comptime Backend.capabilities.net_send_file) {
-                    self.backend.submit(&self.state, completion);
-                } else {
-                    netSendFileStart(self, op);
+                switch (comptime Backend.capability(.net_send_file)) {
+                    .yes => self.backend.submit(&self.state, completion),
+                    .no => netSendFileStart(self, op),
+                    .maybe => {
+                        if (self.backend.supports(.net_send_file, op)) {
+                            op.route = .backend;
+                            self.backend.submit(&self.state, completion);
+                        } else {
+                            op.route = .fallback;
+                            netSendFileStart(self, op);
+                        }
+                    },
                 }
                 return;
             },
             else => {
-                // Streaming reads/writes on a pollable fd (pipe/socket/FIFO/tty)
-                // use the backend readiness poll path instead of the thread pool.
-                // Seekable fds (regular files, block devices) fall back to the pool.
                 switch (completion.op) {
                     inline .file_read_streaming, .file_write_streaming => |op| {
-                        // Classify lazily and cache the verdict on the op, so a
-                        // reused op (or the caller) can skip re-probing.
+                        // Runtime support for streaming operations can depend on
+                        // whether this particular handle is pollable. Classify it
+                        // once before asking the backend to resolve `.maybe`.
                         const data = completion.cast(op.toType());
-                        const pollable = data.pollable orelse blk: {
+                        _ = data.pollable orelse blk: {
                             if (builtin.os.tag == .windows) {
-                                // A streaming op reaching the lazy path on Windows is a
-                                // handle zio did not open/classify (foreign, e.g. inherited
-                                // stdio reached via std.Io). Such handles are not associated
-                                // with our IOCP port, so the loop cannot drive them — route
-                                // to the thread pool's blocking read/write.
                                 data.pollable = false;
                                 break :blk false;
                             }
@@ -947,50 +928,26 @@ pub const Loop = struct {
                             data.pollable = p;
                             break :blk p;
                         };
-                        if (comptime !@field(Backend.capabilities, @tagName(op))) {
-                            // Route pollable fds to the backend readiness/overlapped path;
-                            // seekable fds (regular files, block devices) to the thread pool.
-                            if (pollable) {
-                                self.backend.submit(&self.state, completion);
-                            } else {
-                                self.submitFileOpToThreadPool(completion);
-                            }
-                            return;
-                        }
                     },
                     else => {},
                 }
 
-                // Ops a backend can handle natively only on some kernels (probed at
-                // runtime): if the backend advertises a runtime query and it says
-                // yes, use the native SQE path; otherwise fall through to the
-                // capability-based routing below (which sends it to the thread pool).
-                switch (completion.op) {
-                    .file_set_size => {
-                        if (comptime @hasDecl(Backend, "fileSetSizeSupported")) {
-                            if (self.backend.fileSetSizeSupported()) {
-                                self.backend.submit(&self.state, completion);
-                                return;
-                            }
-                        }
-                    },
-                    else => {},
-                }
-
-                // Regular backend operation
-                // Route file/dir ops to thread pool for backends without native support
                 switch (completion.op) {
                     inline else => |op| {
-                        if (@hasField(BackendCapabilities, @tagName(op))) {
-                            if (!@field(Backend.capabilities, @tagName(op))) {
+                        const op_data = completion.cast(op.toType());
+                        switch (comptime Backend.capability(op)) {
+                            .yes => self.backend.submit(&self.state, completion),
+                            .no => self.submitFileOpToThreadPool(completion),
+                            .maybe => if (self.backend.supports(op, op_data)) {
+                                op_data.route = .backend;
+                                self.backend.submit(&self.state, completion);
+                            } else {
+                                op_data.route = .fallback;
                                 self.submitFileOpToThreadPool(completion);
-                                return;
-                            }
+                            },
                         }
                     },
                 }
-
-                self.backend.submit(&self.state, completion);
                 return;
             },
         }
@@ -1002,7 +959,7 @@ pub const Loop = struct {
     };
 
     fn checkTimers(self: *Loop) TimerCheckResult {
-        const native_wall = Backend.capabilities.native_wall_timers;
+        const native_wall = Backend.native_wall_timers;
 
         var fired = false;
         var next_timeout: ?Duration = null;
@@ -1212,7 +1169,7 @@ pub const Loop = struct {
 
         switch (completion.op) {
             inline .file_open, .file_create, .file_close, .file_read, .file_write, .file_read_streaming, .file_write_streaming, .file_sync, .file_set_size, .file_set_permissions, .file_set_owner, .file_set_timestamps, .dir_create_dir, .dir_rename, .dir_rename_preserve, .dir_delete_file, .dir_delete_dir, .file_size, .file_stat, .dir_open, .dir_close, .dir_read, .dir_set_permissions, .dir_set_owner, .dir_set_file_permissions, .dir_set_file_owner, .dir_set_file_timestamps, .dir_sym_link, .dir_read_link, .dir_hard_link, .dir_access, .dir_real_path, .dir_real_path_file, .file_real_path, .file_hard_link, .device_io_control, .process_wait => |op| {
-                if (@field(Backend.capabilities, @tagName(op))) {
+                if (comptime Backend.capability(op) == .yes) {
                     unreachable;
                 }
 
@@ -1258,23 +1215,16 @@ pub const Loop = struct {
                 };
 
                 const op_data = completion.cast(op.toType());
-                if (@hasField(@TypeOf(op_data.internal), "allocator")) {
-                    op_data.internal.allocator = self.allocator;
-                }
-                op_data.internal.linked_context = .{
+                op_data.linked_work.allocator = self.allocator;
+                op_data.linked_work.linked_context = .{
                     .loop = self,
                     .linked = completion,
                 };
-                op_data.internal.work = Work.init(op_func, null);
-                op_data.internal.work.completion_fn = loopLinkedWorkComplete;
-                op_data.internal.work.completion_context = @ptrCast(&op_data.internal.linked_context);
-                // Ops whose internal is a DelegatedWork carry a cancellation
-                // token: bind it to the work so the worker enters/exits it and
-                // the blocking syscall becomes SIGURG-cancelable.
-                if (@hasField(@TypeOf(op_data.internal), "token")) {
-                    op_data.internal.work.cancel_token = &op_data.internal.token;
-                }
-                tp.submit(&op_data.internal.work);
+                op_data.linked_work.work = Work.init(op_func, null);
+                op_data.linked_work.work.completion_fn = loopLinkedWorkComplete;
+                op_data.linked_work.work.completion_context = @ptrCast(&op_data.linked_work.linked_context);
+                op_data.linked_work.work.cancel_token = &op_data.linked_work.token;
+                tp.submit(&op_data.linked_work.work);
             },
             else => unreachable,
         }
@@ -1295,17 +1245,17 @@ pub const Loop = struct {
     // from the same start, so buffers are sent in the order they were read.
 
     fn netSendFileStart(self: *Loop, op: *NetSendFile) void {
-        op.internal = .{};
-        op.internal.read_remaining = op.remaining;
+        op.fallback = .{};
+        op.fallback.read_remaining = op.remaining;
         // Lay out the working buffers from the (up to two) caller buffers. When
         // the result's bufs[1] is empty the index flips are suppressed (see
         // netSendFileStartRead / netSendFileOnSend), so the loop runs serially.
-        op.internal.bufs = sendfileLayout(op.bufs);
+        op.fallback.bufs = sendfileLayout(op.bufs);
         self.netSendFileAdvance(op);
     }
 
     fn netSendFileStartRead(self: *Loop, op: *NetSendFile) void {
-        const f = &op.internal;
+        const f = &op.fallback;
         const idx = f.next_read;
         const want = @min(f.bufs[idx].len, f.read_remaining);
         f.reading = idx;
@@ -1317,7 +1267,7 @@ pub const Loop = struct {
     }
 
     fn netSendFileStartSend(self: *Loop, op: *NetSendFile, idx: u1, from: usize) void {
-        const f = &op.internal;
+        const f = &op.fallback;
         f.sending = idx;
         f.send = NetSend.init(op.handle, WriteBuf.fromSlice(f.bufs[idx][from..f.filled[idx]], &f.send_iov), .{});
         f.send.c.userdata = op;
@@ -1329,12 +1279,12 @@ pub const Loop = struct {
     /// re-enter `netSendFileAdvance`, which finishes the parent only once both
     /// have drained.
     fn netSendFileCancel(self: *Loop, op: *NetSendFile) void {
-        if (op.internal.reading != null) self.cancel(&op.internal.read.c);
-        if (op.internal.sending != null) self.cancel(&op.internal.send.c);
+        if (op.fallback.reading != null) self.cancel(&op.fallback.read.c);
+        if (op.fallback.sending != null) self.cancel(&op.fallback.send.c);
     }
 
     fn netSendFileAdvance(self: *Loop, op: *NetSendFile) void {
-        const f = &op.internal;
+        const f = &op.fallback;
 
         // A cancel that arrived between callbacks turns into a parked error.
         if (op.c.loadState().cancel_requested and f.pending_err == null) {
@@ -1373,7 +1323,7 @@ pub const Loop = struct {
 
     fn netSendFileOnRead(loop: *Loop, child: *Completion) void {
         const op: *NetSendFile = @ptrCast(@alignCast(child.userdata.?));
-        const f = &op.internal;
+        const f = &op.fallback;
         const idx = f.reading.?;
         f.reading = null;
         const n = child.cast(FileRead).getResult() catch |err| {
@@ -1393,7 +1343,7 @@ pub const Loop = struct {
 
     fn netSendFileOnSend(loop: *Loop, child: *Completion) void {
         const op: *NetSendFile = @ptrCast(@alignCast(child.userdata.?));
-        const f = &op.internal;
+        const f = &op.fallback;
         const idx = f.sending.?;
         const m = child.cast(NetSend).getResult() catch |err| {
             f.sending = null;
@@ -1415,7 +1365,7 @@ pub const Loop = struct {
     }
 
     fn netSendFileFinish(self: *Loop, op: *NetSendFile, err: ?anyerror) void {
-        if (err) |e| op.c.setError(e) else op.c.setResult(.net_send_file, op.internal.total);
+        if (err) |e| op.c.setError(e) else op.c.setResult(.net_send_file, op.fallback.total);
         self.state.markCompleted(&op.c);
     }
 

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -914,25 +914,6 @@ pub const Loop = struct {
             },
             else => {
                 switch (completion.op) {
-                    inline .file_read_streaming, .file_write_streaming => |op| {
-                        // Runtime support for streaming operations can depend on
-                        // whether this particular handle is pollable. Classify it
-                        // once before asking the backend to resolve `.maybe`.
-                        const data = completion.cast(op.toType());
-                        _ = data.pollable orelse blk: {
-                            if (builtin.os.tag == .windows) {
-                                data.pollable = false;
-                                break :blk false;
-                            }
-                            const p = common.probePollable(data.handle);
-                            data.pollable = p;
-                            break :blk p;
-                        };
-                    },
-                    else => {},
-                }
-
-                switch (completion.op) {
                     inline else => |op| {
                         const op_data = completion.cast(op.toType());
                         switch (comptime Backend.capability(op)) {

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -1078,14 +1078,19 @@ pub const Loop = struct {
     /// Completion callback for internal file ops with linked completion
     pub fn loopLinkedWorkComplete(ctx: ?*anyopaque, work: *Work) void {
         const context: *LinkedWorkContext = @ptrCast(@alignCast(ctx));
+        // Publishing `linked` hands the containing operation back to the loop;
+        // its waiter may then resume and free that operation before this worker
+        // returns. Snapshot everything stored in the operation before the push.
+        const loop = context.loop;
+        const linked = context.linked;
         // Propagate cancel error from work to linked completion
         if (work.c.err) |err| {
-            if (!context.linked.has_result) {
-                context.linked.setError(err);
+            if (!linked.has_result) {
+                linked.setError(err);
             }
         }
-        context.loop.state.work_completions.push(context.linked);
-        context.loop.wake();
+        loop.state.work_completions.push(linked);
+        loop.wake();
     }
 
     pub fn processAsyncHandles(self: *Loop) void {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -822,13 +822,7 @@ pub const File = struct {
     pub const ReadError = os.fs.FileReadError || Cancelable;
     pub const WriteError = os.fs.FileWriteError || Cancelable;
 
-    /// Wrap a caller-owned descriptor or handle. On Windows its provenance is
-    /// unknown, so it cannot safely use overlapped IOCP: default Reader/Writer
-    /// operations to streaming semantics and delegate them to the thread pool.
     pub fn fromFd(fd: Handle) File {
-        if (builtin.os.tag == .windows) {
-            return .{ .fd = fd, .pollable = false, .preferred_mode = .streaming };
-        }
         return .{ .fd = fd };
     }
 
@@ -1417,14 +1411,6 @@ test "File: streaming changes caller-owned descriptor flags only for epoll" {
     const flags_after = os.posix.system.fcntl(fds[1], os.posix.system.F.GETFL, @as(c_int, 0));
     try std.testing.expectEqual(.SUCCESS, os.posix.errno(flags_after));
     try std.testing.expectEqual(readiness_backend, flags_after & nonblocking != 0);
-}
-
-test "File.fromFd: Windows defaults foreign handles to delegated streaming" {
-    if (builtin.os.tag != .windows) return error.SkipZigTest;
-
-    const file = File.fromFd(os.fs.stdin());
-    try std.testing.expectEqual(false, file.pollable.?);
-    try std.testing.expectEqual(Mode.streaming, resolveMode(file));
 }
 
 test "File: direct I/O round-trip" {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1928,7 +1928,7 @@ test "Dir: canceling a blocking open interrupts the worker" {
     // Only exercises the thread-pool-delegated path (kqueue/poll and friends);
     // backends that open natively (io_uring) cancel via the backend instead, and
     // the SIGURG mechanism is POSIX-only.
-    if (ev.Backend.capabilities.file_open) return;
+    if (ev.Backend.capability(.file_open) != .no) return;
     if (!os.syscall_cancel.enabled) return;
 
     // A FIFO opened O_RDONLY with no writer blocks in the worker's openat(). On

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -822,7 +822,13 @@ pub const File = struct {
     pub const ReadError = os.fs.FileReadError || Cancelable;
     pub const WriteError = os.fs.FileWriteError || Cancelable;
 
+    /// Wrap a caller-owned descriptor or handle. On Windows its provenance is
+    /// unknown, so it cannot safely use overlapped IOCP: default Reader/Writer
+    /// operations to streaming semantics and delegate them to the thread pool.
     pub fn fromFd(fd: Handle) File {
+        if (builtin.os.tag == .windows) {
+            return .{ .fd = fd, .pollable = false, .preferred_mode = .streaming };
+        }
         return .{ .fd = fd };
     }
 
@@ -1411,6 +1417,14 @@ test "File: streaming changes caller-owned descriptor flags only for epoll" {
     const flags_after = os.posix.system.fcntl(fds[1], os.posix.system.F.GETFL, @as(c_int, 0));
     try std.testing.expectEqual(.SUCCESS, os.posix.errno(flags_after));
     try std.testing.expectEqual(readiness_backend, flags_after & nonblocking != 0);
+}
+
+test "File.fromFd: Windows defaults foreign handles to delegated streaming" {
+    if (builtin.os.tag != .windows) return error.SkipZigTest;
+
+    const file = File.fromFd(os.fs.stdin());
+    try std.testing.expectEqual(false, file.pollable.?);
+    try std.testing.expectEqual(Mode.streaming, resolveMode(file));
 }
 
 test "File: direct I/O round-trip" {

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1387,6 +1387,32 @@ test "File: basic read and write" {
     try dir.deleteFile(file_path);
 }
 
+test "File: streaming changes caller-owned descriptor flags only for epoll" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    if (comptime !@hasDecl(ev.Backend, "selectedEngine")) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const readiness_backend = rt.main_executor.loop.backend.selectedEngine() == .epoll;
+
+    const fds = try os.posix.pipe(.{ .nonblocking = false });
+    defer os.posix.close(fds[0]);
+    defer os.posix.close(fds[1]);
+
+    const nonblocking = @as(c_int, 1) << @bitOffsetOf(os.posix.O, "NONBLOCK");
+    const flags_before = os.posix.system.fcntl(fds[1], os.posix.system.F.GETFL, @as(c_int, 0));
+    try std.testing.expectEqual(.SUCCESS, os.posix.errno(flags_before));
+    try std.testing.expect(flags_before & nonblocking == 0);
+
+    var iovecs: [1]os.iovec_const = undefined;
+    const file = File.fromFd(fds[1]);
+    try std.testing.expectEqual(1, try file.writeStreaming(ev.WriteBuf.fromSlice("x", &iovecs)));
+
+    const flags_after = os.posix.system.fcntl(fds[1], os.posix.system.F.GETFL, @as(c_int, 0));
+    try std.testing.expectEqual(.SUCCESS, os.posix.errno(flags_after));
+    try std.testing.expectEqual(readiness_backend, flags_after & nonblocking != 0);
+}
+
 test "File: direct I/O round-trip" {
     // Direct I/O requires the buffer, offset, and length to be aligned to the
     // device's logical block size (O_DIRECT on Linux/BSD, FILE_FLAG_NO_BUFFERING

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -159,7 +159,7 @@ pub const RuntimeOptions = struct {
 
 pub const DnsOptions = struct {
     /// Use the built-in native DNS resolver instead of getaddrinfo.
-    custom_resolver: bool = ev.backend == .io_uring,
+    custom_resolver: bool = ev.backend == .linux or ev.backend == .io_uring,
 };
 
 const Awaitable = @import("awaitable.zig").Awaitable;


### PR DESCRIPTION
## Summary

- merge the Linux io_uring and epoll engines behind a parametric backend facade
- prefer io_uring by default and select epoll group-wide when ring setup is unavailable or blocked
- keep `-Dbackend=epoll` and `-Dbackend=io_uring` as strict engine overrides; `-Dbackend=linux` selects automatic fallback
- replace backend capability booleans with exhaustive `yes`/`no`/`maybe` operation classification
- separate backend `internal` scratch from Loop-owned `linked_work`, recording runtime routes so cancellation follows submission
- probe optional io_uring `FTRUNCATE` and `WAITID` support and use thread-pool fallbacks when absent

## Fallback policy

Automatic fallback is limited to ring setup failures that mean io_uring is unavailable: `SystemOutdated`, `PermissionDenied`, and `ArgumentsInvalid`. Resource failures such as allocator, fd quota, or memory exhaustion remain errors instead of being hidden by epoll fallback.

The engine decision is serialized and stored in `LoopGroup` shared state, so every loop in a group uses the same engine.

## Backend control

- default / `-Dbackend=linux`: io_uring with epoll fallback
- `-Dbackend=io_uring`: strict io_uring
- `-Dbackend=epoll`: strict epoll

## Validation

- default Linux Debug: 601/601 tests passed
- forced epoll: 601/601 tests passed
- forced io_uring: 601/601 tests passed
- forced poll: 600/600 tests passed
- Linux ReleaseSafe: 601/601 tests passed
- RISC-V static QEMU without io_uring: 601/601 tests passed
- QEMU syscall trace confirmed unsupported `io_uring_setup` followed by `epoll_create1`
- injected native `ENOSYS` on `io_uring_setup`: 601/601 tests passed
- Windows and macOS test binaries cross-compiled
- examples built successfully
- `git diff --check` passed