### PR TITLE
io_uring: submit bind/listen natively on kernels that have the opcodes

### DIFF
--- a/src/ev/backends/linux/io_uring.zig
+++ b/src/ev/backends/linux/io_uring.zig
@@ -42,6 +42,8 @@ fn wallKind(idx: usize) SpecialKind {
 }
 
 const NetOpen = @import("../../completion.zig").NetOpen;
+const NetBind = @import("../../completion.zig").NetBind;
+const NetListen = @import("../../completion.zig").NetListen;
 const NetConnect = @import("../../completion.zig").NetConnect;
 const NetAccept = @import("../../completion.zig").NetAccept;
 const NetRecv = @import("../../completion.zig").NetRecv;
@@ -167,6 +169,11 @@ pub const SharedState = struct {
     ftruncate_support: std.atomic.Value(FeatureSupport) = .init(.unknown),
     /// IORING_OP_WAITID was added after the minimum supported ring setup.
     waitid_support: std.atomic.Value(FeatureSupport) = .init(.unknown),
+    /// IORING_OP_BIND and IORING_OP_LISTEN arrived together in Linux 6.11, so
+    /// they are probed and gated as one feature. Unlike the two above there is
+    /// no thread-pool fallback — bind/listen never block, so the fallback is
+    /// the direct syscall on the loop thread, decided inside `submit`.
+    bind_listen_support: std.atomic.Value(FeatureSupport) = .init(.unknown),
 };
 
 pub const NetRecvData = struct {
@@ -363,10 +370,15 @@ fn probeAndStoreFeatures(ring: *linux.IoUring, shared_state: *SharedState) void 
     const probe = ring.get_probe() catch {
         shared_state.ftruncate_support.store(.no, .monotonic);
         shared_state.waitid_support.store(.no, .monotonic);
+        shared_state.bind_listen_support.store(.no, .monotonic);
         return;
     };
     shared_state.ftruncate_support.store(if (probe.is_supported(.FTRUNCATE)) .yes else .no, .monotonic);
     shared_state.waitid_support.store(if (probe.is_supported(.WAITID)) .yes else .no, .monotonic);
+    shared_state.bind_listen_support.store(
+        if (probe.is_supported(.BIND) and probe.is_supported(.LISTEN)) .yes else .no,
+        .monotonic,
+    );
 }
 
 pub fn supports(self: *const Self, comptime op: Op, _: *op.toType()) bool {
@@ -483,12 +495,29 @@ fn submitInner(self: *Self, state: *LoopState, c: *Completion, is_new: bool) voi
             state.markCompletedFromBackend(c);
         },
         .net_bind => {
-            common.handleNetBind(c);
-            state.markCompletedFromBackend(c);
+            // IORING_OP_BIND needs Linux >= 6.11 (probed once at master ring
+            // creation); otherwise complete synchronously — bind never blocks.
+            if (self.shared_state.bind_listen_support.load(.monotonic) == .yes) {
+                const data = c.cast(NetBind);
+                const sqe = self.getSqeOrDefer(c) orelse return;
+                sqe.prep_bind(data.handle, data.addr, data.addr_len.*, 0);
+                sqe.user_data = @intFromPtr(c);
+            } else {
+                common.handleNetBind(c);
+                state.markCompletedFromBackend(c);
+            }
         },
         .net_listen => {
-            common.handleNetListen(c);
-            state.markCompletedFromBackend(c);
+            // IORING_OP_LISTEN: same gate as .net_bind above.
+            if (self.shared_state.bind_listen_support.load(.monotonic) == .yes) {
+                const data = c.cast(NetListen);
+                const sqe = self.getSqeOrDefer(c) orelse return;
+                sqe.prep_listen(data.handle, data.backlog, 0);
+                sqe.user_data = @intFromPtr(c);
+            } else {
+                common.handleNetListen(c);
+                state.markCompletedFromBackend(c);
+            }
         },
 
         // Async operations through io_uring
@@ -1320,8 +1349,28 @@ fn storeResult(self: *Self, c: *Completion, res: i32) void {
     switch (c.op) {
         .group, .timer, .async, .work => unreachable,
         .net_open => unreachable,
-        .net_bind => unreachable,
-        .net_listen => unreachable,
+        .net_bind => {
+            if (res < 0) {
+                c.setError(net.errnoToBindError(@enumFromInt(-res)));
+            } else {
+                const data = c.cast(NetBind);
+                // IORING_OP_BIND does not report the bound address, so fetch
+                // it here — callers rely on seeing the actual port after
+                // binding port 0 (mirrors handleNetBind).
+                if (net.getsockname(data.handle, data.addr, data.addr_len)) |_| {
+                    c.setResult(.net_bind, {});
+                } else |err| {
+                    c.setError(err);
+                }
+            }
+        },
+        .net_listen => {
+            if (res < 0) {
+                c.setError(net.errnoToListenError(@enumFromInt(-res)));
+            } else {
+                c.setResult(.net_listen, {});
+            }
+        },
         .dir_set_permissions => unreachable, // Handled synchronously
         .dir_set_owner => unreachable, // Handled synchronously
         .dir_set_file_permissions => unreachable, // Handled synchronously

--- a/src/ev/tests.zig
+++ b/src/ev/tests.zig
@@ -118,6 +118,11 @@ test "Loop: socket create and bind" {
 
     try bind.c.getResult(.net_bind);
 
+    // Binding port 0 must write the actual bound address back — a contract
+    // every backend path has to keep, including IORING_OP_BIND (which does
+    // not report the address by itself).
+    try std.testing.expect(addr.port != 0);
+
     // Close socket
     var close: NetClose = .init(sock);
     loop.add(&close.c);

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -461,6 +461,7 @@ pub const BindError = error{
     NetworkDown,
     InputOutput,
     SystemResources,
+    Canceled,
     Unexpected,
 };
 
@@ -475,6 +476,7 @@ pub fn errnoToBindError(err: E) BindError {
                 .ENOTSOCK => error.FileDescriptorNotASocket,
                 .ENETDOWN => error.NetworkDown,
                 .ENOBUFS => error.SystemResources,
+                .OPERATION_ABORTED => error.Canceled,
                 else => unexpectedError(err),
             };
         },
@@ -495,6 +497,7 @@ pub fn errnoToBindError(err: E) BindError {
                 .ROFS => error.ReadOnlyFileSystem,
                 .IO => error.InputOutput,
                 .NETDOWN => error.NetworkDown,
+                .CANCELED => error.Canceled, // io_uring completion after cancel
                 else => |e| unexpectedError(e),
             };
         },
@@ -530,6 +533,7 @@ pub const ListenError = error{
     FileDescriptorNotASocket,
     NetworkDown,
     SystemResources,
+    Canceled,
     Unexpected,
 };
 
@@ -543,6 +547,7 @@ pub fn errnoToListenError(err: E) ListenError {
                 .ENOTSOCK => error.FileDescriptorNotASocket,
                 .ENETDOWN => error.NetworkDown,
                 .ENOBUFS, .EMFILE => error.SystemResources,
+                .OPERATION_ABORTED => error.Canceled,
                 else => unexpectedError(err),
             };
         },
@@ -553,6 +558,7 @@ pub fn errnoToListenError(err: E) ListenError {
                 .OPNOTSUPP => error.OperationNotSupported,
                 .NOTSOCK => error.FileDescriptorNotASocket,
                 .NETDOWN => error.NetworkDown,
+                .CANCELED => error.Canceled, // io_uring completion after cancel
                 else => |e| unexpectedError(e),
             };
         },


### PR DESCRIPTION
`IORING_OP_BIND` and `IORING_OP_LISTEN` (Linux 6.11) join `FTRUNCATE` and `WAITID` in the once-at-ring-creation probe, and `net_bind`/`net_listen` are submitted as SQEs when the kernel has them.

## Design

- The two opcodes shipped together in 6.11, so they are probed and gated as **one feature** (`bind_listen_support`).
- The ops stay `capability = .yes` with a branch inside `submit()`, rather than becoming `.maybe`: the `.maybe` route machinery models "SQE vs thread pool" and adds `DelegatedWork` + route state to the completion, which is the wrong shape here — bind/listen never block, so the fallback is the existing synchronous completion on the loop thread.
- `IORING_OP_BIND` does not report the bound address, so the CQE path re-reads it with `getsockname`, preserving the `handleNetBind` contract that binding port 0 writes the real port back. The bind test now asserts that contract, so no backend path can drop it.
- `BindError`/`ListenError` gain `Canceled`, mapped in `errnoToBindError`/`errnoToListenError` (posix `.CANCELED`, windows `.OPERATION_ABORTED`) like every other CQE-capable mapper — the backend feeds raw `-res` through with no call-site special-casing.

## Testing

- Kernel 6.8 (probe resolves to *no*, fallback path + probe exercised): `zig build test` 604/604, `-Dbackend=epoll` 604/604, `-Dbackend=poll` 602/602.
- **The native SQE path has not executed anywhere yet** — it needs a 6.11+ kernel. It compiles and mirrors `net_connect`'s submit/storeResult shape, but a test run on a 6.11+ box before merging would be prudent.

## Not covered

- `file_set_size` needed no change: it already probes at ring creation and routes directly via the `.maybe` tri-state.
- Widening `BindError`/`ListenError` is a (minor) public error-set change; nothing in-tree switched exhaustively over them.
