### PR TITLE
io: guard std.Io net_receive address against uninitialized recvmsg data

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -842,7 +842,7 @@ fn extractBatchResult(data: *BatchCompletionData, tag: Io.Operation.Tag) Io.Oper
                 const result = data.net_receive.op.getResult() catch |err| break :blk .{ recvMsgErrToReceiveErr(err), 0 };
                 // Populate the message buffer with received data
                 data.net_receive.message_buffer.* = .{
-                    .from = zioIpToStdIo(data.net_receive.addr_storage.ip),
+                    .from = zioIpToStdIo(zio_net.Address.fromPosix(&data.net_receive.addr_storage.any, data.net_receive.addr_len).ip),
                     .data = data.net_receive.data_buffer[0..result.len],
                     .control = data.net_receive.message_buffer.control[0..result.controllen],
                     .flags = decodeIncomingFlags(result.flags),
@@ -2408,7 +2408,7 @@ fn netReceiveImpl(
     try timedWaitForIoClock(&op.c, timeout, clock);
     const result = op.getResult() catch |err| return recvMsgErrToReceiveErr(err);
     message.* = .{
-        .from = zioIpToStdIo(storage.ip),
+        .from = zioIpToStdIo(zio_net.Address.fromPosix(&storage.any, addr_len).ip),
         // When flags.trunc is set on Linux, result.len is the full datagram
         // length — which may exceed data_buffer.len. We slice verbatim to
         // match std.Io.Threaded; callers that enable .trunc are responsible


### PR DESCRIPTION
## Summary

- `recvmsg` only fills `msg_name` for datagram sockets; on stream/connection-oriented sockets it's left uninitialized by the kernel. `netReceiveImpl` and the batch `net_receive` completion path in `src/io.zig` fed that possibly-uninitialized `sockaddr` straight into `zioIpToStdIo`, which switches on `.family` unconditionally, a read of uninitialized memory used in a branch.
- Same bug class just fixed upstream in [ziglang/zig#36367](https://codeberg.org/ziglang/zig/pulls/36367) (`Threaded.zig`'s `addressFromPosix`/`netReceivePosix`), caught there by Valgrind ("Conditional jump or move depends on uninitialised value(s)").
- `src/net.zig`'s own `Address.fromPosix` already guards against this (checks the kernel-reported length before touching `.family`, used by `receiveFrom`/`receiveMsg`/`accept`), but the separate `std.Io` vtable implementation in `io.zig` had its own unguarded conversion path.
- Fix: route both call sites through `zio_net.Address.fromPosix` before converting, reusing the existing safe/length-checked path instead of reading the raw union unconditionally.

Note: upstream's fix makes `IncomingMessage.from` an `?IpAddress` (null when the OS didn't provide an address). That requires a newer std than zio's `minimum_zig_version = 0.16.0` currently vendors, so this PR keeps `.from` as a plain `IpAddress` and falls back to the unspecified address (`0.0.0.0:0`) instead, matching `net.zig`'s existing behavior for the same case.

## Test plan
- [x] `zig build`
- [x] `zig build test` (604 tests passed, 1 skipped)