### PR TITLE
Reuse executor across yield

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1214,11 +1214,14 @@ pub fn markCrashed() void {
 /// Returns error.Canceled if the task was canceled.
 /// No-op if called from a thread without an executor (returns without error).
 pub fn yield() Cancelable!void {
-    const task = getCurrentTaskOrNull() orelse {
+    const exec = getCurrentExecutorOrNull() orelse {
         os.thread.yield();
         return;
     };
-    const exec = getCurrentExecutor();
+    const task = exec.current_task orelse {
+        os.thread.yield();
+        return;
+    };
     // Fast path: no other task is ready and there is tick budget left, so
     // there is nothing to switch to and no poll due yet — spend a quantum and
     // keep running. Budget exhaustion falls through to the real yield, which
@@ -1233,7 +1236,7 @@ pub fn yield() Cancelable!void {
         exec.spendQuantum();
         return;
     }
-    return task.yield(.reschedule, .allow_cancel);
+    return task.yieldFrom(exec, .reschedule, .allow_cancel);
 }
 
 /// Cooperatively yield, but only if enough other tasks are waiting (a cheap

--- a/src/task.zig
+++ b/src/task.zig
@@ -268,7 +268,14 @@ pub const AnyTask = struct {
     /// - `.reschedule`: Reschedule immediately (cooperative yielding).
     ///   The task state remains `.ready`.
     pub fn yield(self: *AnyTask, comptime mode: YieldMode, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
-        var executor = getCurrentExecutor();
+        return self.yieldFrom(getCurrentExecutor(), mode, cancel_mode);
+    }
+
+    /// Yield using the executor already resolved by the caller. `executor` is
+    /// valid only until the context switch; the resume path still reloads TLS
+    /// because the task may have migrated to another executor thread.
+    pub fn yieldFrom(self: *AnyTask, initial_executor: *Executor, comptime mode: YieldMode, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
+        var executor = initial_executor;
 
         // Check and consume cancellation flag before yielding (unless no_cancel).
         // On the cancel-error return, `state` must be left untouched: the tag is


### PR DESCRIPTION
## Summary

- reuse the executor already loaded by `zio.yield`
- pass that executor into the task yield path
- reload TLS only after a context switch, where task migration makes it necessary

## Why

`zio.yield` loaded the current executor once to find the task and again before yielding it. The second lookup is redundant before the switch. The resumed task still performs a fresh lookup because it may now be running on another executor thread.

## Benchmark

ReleaseFast `yield_bench`, 20 `perf stat` repetitions, compared with `main`:

| case | main instructions | this PR | delta |
| --- | ---: | ---: | ---: |
| two tasks, 2M switching yields | 422,349,458 | 402,341,149 | -4.74% |
| one task, 1M no-switch yields | 51,290,461 | 52,288,998 | +1.95% |

The no-switch case retains the executor in a callee-saved register so it can be reused if the slow path is taken; assembly inspection accounts for the roughly one extra retired instruction per call.

## Validation

- `./check.sh` (608 passed, 1 skipped)
- `zig build test -Dtask-migration=false` (609 passed)
- `./check.sh --full` (tests and examples)
