### PR TITLE
Preserve x86 frame pointer across context switch

### DIFF
--- a/src/coro/coroutines.zig
+++ b/src/coro/coroutines.zig
@@ -1358,7 +1358,6 @@ pub inline fn switchContext(
               .ebx = true,
               .esi = true,
               .edi = true,
-              .ebp = true,
               .st0 = true,
               .st1 = true,
               .st2 = true,


### PR DESCRIPTION
## Summary

- remove `ebp` from the 32-bit x86 context-switch clobber list
- keep `switchContext` fully inline while preserving normal frame-unwind metadata

## Root cause

The x86 context switch saves the current `ebp` and restores that same value before the invocation resumes, so `ebp` is preserved from the compiler's point of view. Declaring it clobbered made LLVM emit extra frame-pointer save/restore code and a temporary DWARF CFA expression around each inlined switch.

When LLVM tail-merged two switch continuations, the second CFA state could remain active across unrelated code by address range. Debug allocator stack-trace capture then interpreted a code address as the stack pointer, causing an alignment panic and eventual segmentation fault in the x86 ReleaseSafe test suite.

Removing the inaccurate clobber matches the existing x86-64 treatment of `rbp`, removes the temporary CFA expression, and avoids the unwind failure without disabling optimization or adding a call boundary.

## Validation

- `zig build test -Dtarget=x86-linux -Dbackend=linux -fqemu -Doptimize=ReleaseSafe` — 603 passed, 6 skipped
- `./check.sh` — 608 passed, 1 skipped
- inspected generated x86 code and DWARF frame information; the extra frame-pointer save/restore and CFA-expression rows are gone
