### PR TITLE
Remove idle mask from static scheduler

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -384,6 +384,8 @@ pub const SchedulerMetrics = struct {
 
 const MetricsStorage = if (metrics_enabled) SchedulerMetrics else void;
 const metrics_storage_init: MetricsStorage = if (metrics_enabled) .{} else {};
+const IdleMask = if (zio_options.task_migration) std.atomic.Value(usize) else void;
+const idle_mask_init: IdleMask = if (zio_options.task_migration) .init(0) else {};
 
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
@@ -773,6 +775,13 @@ pub const Executor = struct {
     /// then idleness is proven and the steal is also what makes the park's
     /// wake protocol sound (see park).
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
+        if (comptime !zio_options.task_migration) {
+            self.bump("parks_full", 1);
+            try self.loop.poll(.max);
+            self.drainDispatched();
+            return;
+        }
+
         if (!self.dozed) {
             self.dozed = true;
             // With nobody to steal from (or to) the probe and doze would only
@@ -1313,7 +1322,7 @@ pub const Runtime = struct {
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
     global_overflow: OverflowQueue(WaitNode) = .{},
-    idle_mask: std.atomic.Value(usize) = .init(0),
+    idle_mask: IdleMask = idle_mask_init,
     searchers: std.atomic.Value(u32) = .init(0),
     loop_group: ev.LoopGroup = .{},
     main_executor: Executor,
@@ -1651,6 +1660,8 @@ pub const Runtime = struct {
     }
 
     fn armSearcher(self: *Runtime, hint: ?ExecutorId) void {
+        if (comptime !zio_options.task_migration) return;
+
         // The two early-return loads pair with the parker: an executor sets its
         // idle bit (seq_cst RMW) and only then makes its final work check, while
         // a pusher publishes the task and only then reads idle_mask/searchers
@@ -1703,6 +1714,8 @@ pub const Runtime = struct {
     /// that lets one extra election through, it never loses a wake.
     /// Returns the number of sleepers actually woken.
     fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) u64 {
+        if (comptime !zio_options.task_migration) return 0;
+
         if (!self.stealingActive() or ready < 2) return 0;
         if (self.idle_mask.load(.seq_cst) == 0) return 0;
 


### PR DESCRIPTION
## Summary

- bypass the work-stealing park protocol when task migration is compiled out
- compile searcher announcements and batched wake elections to no-ops in that configuration
- make the runtime idle-mask field zero-sized when migration support is absent

## Why

The idle mask coordinates work stealing between executors. A build with `-Dtask-migration=false` pins tasks to their home executor, so publishing and withdrawing an idle bit cannot enable useful work. The old common park path still paid those sequentially consistent/locked atomic operations.

The static path can park directly in its own event loop: remote scheduling already pushes to the home executor's overflow queue and wakes that executor's loop.

## Performance

A Callgrind microbenchmark performing 10,000 sequential one-nanosecond sleeps, forcing repeated executor parks, was stable across five runs:

- clean `main`: 11,959,422 instructions
- this change: 11,529,402 instructions
- difference: -430,020 (-3.60%), approximately 43 instructions per park

Hardware counters over 15 runs measured instructions decreasing from 51.50M to 51.09M (-0.81%). Cycles and elapsed time were neutral at this short runtime.

An overflow-heavy `worker_pool_native` workload, which rarely parks, remained effectively neutral: -0.035% median Callgrind instructions.

Disassembly confirms the migration-disabled run loop no longer contains the idle-mask `lock or` and two `lock btr` operations. With migration enabled, the ReleaseFast `.text` section is byte-for-byte identical to `main`.

## Validation

- `zig build test -Dtask-migration=false -Doptimize=ReleaseSafe` (610/610)
- `zig build test -Doptimize=ReleaseSafe` (609/609, one expected skip)
- `zig fmt --check src/runtime.zig`
- `git diff --check`
