### PR TITLE
AutoCancel: retire the previous arm before setting a new one

### DIFF
--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -54,11 +54,21 @@ pub const AutoCancel = struct {
     }
 
     pub fn set(self: *AutoCancel, timeout: Timeout) void {
-        // Disable timer if waiting forever
-        if (timeout == .none) {
-            self.clear();
-            return;
-        }
+        // Retire the previous arm before touching this struct again. Two
+        // things make that necessary: a timer still live on another
+        // executor's loop cannot be re-armed from this one, and a callback
+        // in flight is still writing `triggered` and `fired`, which the
+        // resets below would race. `setTimer` asserts both.
+        //
+        // TODO: a re-arm could take the new deadline and the in-flight race
+        // together, under the owning loop's timer lock where `phase` and
+        // `has_result` can be read without racing, instead of disarming and
+        // arming again. `Loop.clearTimer` has the states that would need
+        // telling apart.
+        self.clear();
+
+        // Waiting forever means no timer at all.
+        if (timeout == .none) return;
 
         const task = getCurrentTask();
         const executor = task.getExecutor();
@@ -579,4 +589,35 @@ test "withTimeout: nested, outer deadline fires while inner is running" {
     defer rt.deinit();
 
     try std.testing.expectError(error.Timeout, withTimeout(.fromMilliseconds(10), work, .{rt}));
+}
+
+test "AutoCancel: re-armed while the previous arm is still live on another executor" {
+    // The deadline is far past the end of the test, so every `set` below
+    // re-arms a timer that is still sitting in some loop's heap. After a
+    // migration that loop is not the one the task is running on, which is
+    // what `setTimer` refuses to do.
+    const worker = struct {
+        fn call(rounds: usize) void {
+            var timeout: AutoCancel = .init;
+            defer timeout.clear();
+
+            var round: usize = 0;
+            while (round < rounds) : (round += 1) {
+                timeout.set(.fromSeconds(60));
+                var spin: usize = 0;
+                while (spin < 16) : (spin += 1) yield() catch {};
+            }
+        }
+    }.call;
+
+    // More workers than executors, so they keep getting stolen and end up
+    // running on an executor other than the one that armed their timer.
+    const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
+    defer rt.deinit();
+
+    var handles: [8]JoinHandle(void) = undefined;
+    for (&handles) |*handle| {
+        handle.* = try rt.spawn(worker, .{@as(usize, 200)});
+    }
+    for (&handles) |*handle| handle.join();
 }


### PR DESCRIPTION
## The bug

`set()` arms the timer on whichever executor the task happens to be running on:

```zig
const task = getCurrentTask();
const executor = task.getExecutor();
...
executor.loop.setTimer(&self.timer, timeout);
```

A task that migrated between two arms therefore asks one loop to re-arm a timer still live in another's heap, which `Loop.setTimer` refuses:

```
thread panic: reached unreachable code
  ev/loop.zig:621: assert(st.phase != .running or timer.c.getLoop() == self)
  autocancel.zig:76: executor.loop.setTimer(&self.timer, timeout)
```

Its neighbouring assertion forbids the other half of the same problem — re-arming concurrently with a fire — and independently of either, `set()`'s resets of `triggered` and `fired` race a callback still in flight, since those are exactly the fields it writes.

In a release build the assertions are gone and the timer is pulled from the wrong loop's heap, leaving the owning loop's active count wrong.

## The fix

`clear()` already does what all three need: it disarms on the loop that *owns* the timer, and parks uncancelably until an in-flight callback has taken its last touch of the struct. `set()` now calls it unconditionally, which also subsumes the `.none` case it was already using it for.

Cost on the common path is one lock acquisition and a disarm/re-arm round trip. A fast path that re-arms in place when the loop matches would have to exclude the mid-fire state too — and `has_result` can be set from another thread, per `clearTimer`'s own comment — so it needs the owning loop's timer lock either way. There's a TODO on `set()` sketching where that would belong if it ever measures as worth having: inside the lock next to `clearTimer`, not as a second copy of its state analysis in `AutoCancel`.

## Test

`AutoCancel: attributed when it fires on a task running elsewhere` already re-arms under migration, but only after waiting for each timer to fire — so the previous arm is always complete and the assertion is never reached. The new test keeps the deadline far past the end of the run, so every re-arm lands on a timer still sitting in some loop's heap.

Verified it reproduces: with the fix reverted it panics on that exact assertion. 610 tests pass in Debug and ReleaseSafe.

## How it turned up

From [dusty](https://github.com/lalinsky/dusty), whose server arms a timeout for the request and again for the keepalive wait, so any connection carrying a second request could hit it — 2 in 15 runs of its integration suite crashed, and it was a hard failure on macOS CI.