### PR TITLE
waitForIo: refuse to start work for a task already canceled

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -351,6 +351,23 @@ pub fn waitForIo(c: *ev.Completion) Cancelable!void {
         return;
     };
 
+    // A task that is already canceled must not start new work.
+    //
+    // Without this, a caller that loops on an operation which keeps failing
+    // for its own reasons never observes the cancellation. The wait below
+    // does see it, and cancels the operation -- but if the operation had
+    // already completed with a result of its own, that result is what the
+    // caller must be given, so the cancellation is re-armed and handed back
+    // for the next cancelation point to deliver. When the caller's next
+    // cancelation point is the same operation, and it fails the same way
+    // again, the cancellation is re-armed forever and never acted on.
+    //
+    // It has to be before `loop.add`, not after: once the operation has run,
+    // reporting the cancellation instead of its result would throw away an
+    // accepted socket or bytes already read, which is exactly what the
+    // re-arm below is protecting.
+    try task.checkCancel();
+
     // Async path: Submit to the event loop and wait for completion
     task.getExecutor().loop.add(c);
     // Inline completions never park; charge the coop budget so they still

--- a/src/net.zig
+++ b/src/net.zig
@@ -3033,3 +3033,60 @@ test "multi-executor: full-duplex with task migration disabled" {
     try std.testing.expectEqual(@as(u32, 0), sh.errors.load(.monotonic));
     try std.testing.expectEqual(@as(u32, H.conns), sh.verified.load(.monotonic));
 }
+
+test "a canceled task does not start another operation" {
+    // The cancellation check has to happen before the operation is submitted.
+    // An operation that completes inline never parks -- `waitTask` returns on
+    // its fast path -- so a check that only lives in the park loop would let a
+    // canceled task keep issuing work indefinitely, as long as each one
+    // finished without blocking. A small write on a fresh socket is that case.
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const Outcome = struct {
+        after_recancel: ?anyerror = null,
+    };
+
+    const ServerTask = struct {
+        fn run(server_port: *Channel(u16)) !void {
+            const addr = try IpAddress.parseIp4("127.0.0.1", 0);
+            const server = try addr.listen(.{});
+            defer server.close();
+            try server_port.send(server.socket.address.ip.getPort());
+            var stream = try server.accept(.{});
+            defer stream.close();
+            // Never reads; the client only needs a peer to exist.
+            runtime_mod.sleep(.fromMilliseconds(60_000)) catch {};
+        }
+    };
+
+    const ClientTask = struct {
+        fn run(server_port: *Channel(u16), outcome: *Outcome) !void {
+            const port = try server_port.receive();
+            const addr = try IpAddress.parseIp4("127.0.0.1", port);
+            var stream = try tcpConnectToAddress(addr, .{});
+            defer stream.close();
+
+            // Wait to be canceled, then put the cancellation back and try to
+            // write. The write must report it rather than run.
+            runtime_mod.sleep(.fromMilliseconds(60_000)) catch |err| {
+                std.debug.assert(err == error.Canceled);
+                runtime_mod.getCurrentTask().recancel();
+                outcome.after_recancel = if (stream.writeAll("x", .none)) |_| null else |e| e;
+            };
+        }
+    };
+
+    var server_port_buf: [1]u16 = undefined;
+    var server_port_ch = Channel(u16).init(&server_port_buf);
+    var outcome: Outcome = .{};
+
+    var group: Group = .init;
+    try group.spawn(ServerTask.run, .{&server_port_ch});
+    try group.spawn(ClientTask.run, .{ &server_port_ch, &outcome });
+
+    runtime_mod.sleep(.fromMilliseconds(100)) catch {};
+    group.cancel();
+
+    try std.testing.expectEqual(@as(?anyerror, error.Canceled), outcome.after_recancel);
+}


### PR DESCRIPTION
`waitForIo` submits before it checks whether the task has already been canceled, so a caller looping on an operation that reliably completes before the cancel takes effect never observes the cancellation.

## How it gets stuck

The wait *does* see the cancel, and cancels the operation. But if the operation had already completed with a result of its own, that result is what the caller has to be given, so the cancellation is re-armed and left for the next cancelation point:

```zig
if (c.err) |io_err| {
    if (io_err == error.Canceled) return error.Canceled;
}
// IO completed successfully despite cancel request - restore the pending cancel
task.recancel();
```

That is correct on its own. It only fails when the caller's next cancelation point is the *same* operation, completing the same way again — then the cancellation is re-armed forever at a pending count of one and never delivered.

Whether the cancel is delivered or re-armed depends purely on which finishes first: the operation, or the cancel request against it. An operation that fails instantly and unconditionally wins that race every time, so what would otherwise be a transient re-arm becomes permanent.

## Trace

From dusty's accept loop backing off while the fd table is full, on the io_uring backend. After the cancel:

```
info: cancelling listen
TRACE accept: backend=io_uring pending=1 shield=0
TRACE accept: completed_inline=false
warning(dusty): Accept failed: error.ProcessFdQuotaExceeded; retrying in 1000ms
   ... repeats indefinitely
```

Every accept is submitted with a cancellation already pending, parks properly, and comes back with `EMFILE` rather than `Canceled`. Note `completed_inline=false` — this is not about inline completion.

## The fix

`try task.checkCancel()` before `loop.add`, so an already-canceled task reports the cancellation instead of starting more work. One acquire load and two predictable branches per operation.

It has to be before submission, not after: once the operation has run, reporting the cancellation instead of its result would discard an accepted socket or bytes already read — exactly what the re-arm above exists to protect.

`checkCancel` is the same call `yield` makes internally (`task.zig:288`), so consumption and auto-cancel attribution are unchanged, and it respects cancel protection, so shielded cleanup still submits.

## Test

Re-arms a cancellation and then writes one byte on a fresh socket. Before this the write ran and succeeded — a canceled task doing I/O — and now reports the cancellation. Verified it fails without the change (`expected error.Canceled, found null`).

610 tests pass in Debug and ReleaseSafe.

## Considered and not taken

Preferring `Canceled` over any non-`Canceled` `c.err` in the branch above would fix the failing-operation case at zero hot-path cost, and is a line shorter. It does not cover a loop over an operation that keeps *succeeding* instantly, where there is a real result each time and the cancel cannot be preferred without dropping it. The pre-check covers both.
