### PR TITLE
Allow dir_close in blocking-mode groups

### DIFF
--- a/src/ev/blocking.zig
+++ b/src/ev/blocking.zig
@@ -133,10 +133,10 @@ pub fn executeBlocking(c: *Completion, allocator: std.mem.Allocator) void {
 ///
 /// Only gather groups whose children are all individually supported in blocking
 /// mode are handled. Today that means close batches (see `io.fileCloseImpl` /
-/// `io.netCloseImpl`), which the panic/crash path exercises when std's stack-trace
-/// symbolization opens and then closes the executable through `debug_io`. Anything
-/// else keeps the "requires event loop" panic. Children are validated before any is
-/// run so we never leave a group half-executed.
+/// `io.netCloseImpl` / `io.dirCloseImpl`), which the panic/crash path exercises when
+/// std's stack-trace symbolization opens and then closes the executable through
+/// `debug_io`. Anything else keeps the "requires event loop" panic. Children are
+/// validated before any is run so we never leave a group half-executed.
 fn handleBlockingGroup(c: *Completion, allocator: std.mem.Allocator) void {
     const group: *Group = @alignCast(@fieldParentPtr("c", c));
 
@@ -150,7 +150,7 @@ fn handleBlockingGroup(c: *Completion, allocator: std.mem.Allocator) void {
     while (node) |n| : (node = n.next) {
         const child: *Completion = @alignCast(@fieldParentPtr("group", n));
         switch (child.op) {
-            .file_close, .net_close => {},
+            .file_close, .net_close, .dir_close => {},
             else => @panic("Group contains an operation not supported in blocking mode"),
         }
     }

--- a/src/io.zig
+++ b/src/io.zig
@@ -3840,6 +3840,37 @@ test "io: dir createDirPathOpen creates and opens" {
     sub2.close(io);
 }
 
+test "io: dir open/close from a thread that is not a task" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const dir: Io.Dir = .cwd();
+    const dir_path = "test_io_dir_close_off_runtime";
+    dir.deleteDir(io, dir_path) catch {};
+    try dir.createDir(io, dir_path, .default_dir);
+    defer dir.deleteDir(io, dir_path) catch {};
+
+    // A plain OS thread runs no task, so operations it submits through `io`
+    // take the blocking path. `Io.Dir.close` batches its handles into a gather
+    // group, which that path has to accept the same way it does file and
+    // socket close batches.
+    const Worker = struct {
+        fn run(worker_io: Io, path: []const u8, err_out: *?anyerror) void {
+            const sub = Io.Dir.cwd().openDir(worker_io, path, .{}) catch |err| {
+                err_out.* = err;
+                return;
+            };
+            sub.close(worker_io);
+        }
+    };
+
+    var worker_err: ?anyerror = null;
+    const thread = try std.Thread.spawn(.{}, Worker.run, .{ io, dir_path, &worker_err });
+    thread.join();
+    if (worker_err) |err| return err;
+}
+
 test "io: dir iterate over files" {
     // NetBSD's getdirentries can return dirents with either 32-bit or
     // 64-bit d_fileno depending on the filesystem, shifting all field


### PR DESCRIPTION
Fixes #660.

`Io.Dir.close` goes through `dirCloseImpl`, which batches handles into a gather group, the same way `fileCloseImpl` and `netCloseImpl` do. On the blocking path (a plain thread using a `Runtime`'s `Io`, so `waitForIo` finds no task), `handleBlockingGroup` validated children against an allowlist of `file_close` and `net_close` only, so a dir close batch panicked with

```
Group contains an operation not supported in blocking mode
```

even though `executeBlocking` a few lines above already maps `.dir_close` to `common.handleDirClose`, a plain synchronous `close()`. The op was runnable inline all along; only the group wrapper rejected it.

The dispatcher switch is exhaustive over the op enum, so it stays current by compiler force; the group allowlist is hand-maintained and had not kept up with the third close-batch caller.

Sequential execution is sound for these: gather groups impose no ordering, and closes are independent, terminal, and cannot wait on each other. Race groups are still rejected above this point, since they need the loop to arbitrate.

## Test

`io: dir open/close from a thread that is not a task` opens and closes a directory from a plain `std.Thread`. The custom test runner runs every test body inside a runtime task, so the existing dir tests take the event-loop path and never reached this code; the thread is what forces the blocking path.

Verified it aborts with the reported panic without the `blocking.zig` change and passes with it. Full suite: 612 passed, 1 skipped.