### PR TITLE
netAccept: retry ECONNABORTED instead of surfacing it

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1973,39 +1973,44 @@ fn netListenIpImpl(_: ?*anyopaque, address: *const Io.net.IpAddress, options: Io
     };
 }
 
+/// `ConnectionAborted` stays in `AcceptError` because the error set is std's, but
+/// zio never returns it: a connection that left the accept queue before we got to
+/// it says nothing about the listener, so the next one is taken instead.
 fn netAcceptImpl(_: ?*anyopaque, server: Io.net.Socket.Handle, _: Io.net.Server.AcceptOptions) Io.net.Server.AcceptError!Io.net.Socket {
-    var peer_addr: zio_net.Address = undefined;
-    var peer_addr_len: os_net.socklen_t = @sizeOf(zio_net.Address);
+    while (true) {
+        var peer_addr: zio_net.Address = undefined;
+        var peer_addr_len: os_net.socklen_t = @sizeOf(zio_net.Address);
 
-    var op = ev.NetAccept.init(stdIoHandleToZio(server), &peer_addr.any, &peer_addr_len);
-    try waitForIo(&op.c);
-    const handle = op.getResult() catch |err| switch (err) {
-        error.WouldBlock => return error.WouldBlock,
-        error.ConnectionAborted => return error.ConnectionAborted,
-        error.ProcessFdQuotaExceeded => return error.ProcessFdQuotaExceeded,
-        error.SystemFdQuotaExceeded => return error.SystemFdQuotaExceeded,
-        error.SystemResources => return error.SystemResources,
-        error.SocketNotListening => return error.SocketNotListening,
-        error.ProtocolFailure => return error.ProtocolFailure,
-        error.BlockedByFirewall => return error.BlockedByFirewall,
-        error.NetworkDown => return error.NetworkDown,
-        error.Canceled => return error.Canceled,
-        error.ConnectionResetByPeer,
-        error.FileDescriptorNotASocket,
-        error.OperationNotSupported,
-        error.Unexpected,
-        => return error.Unexpected,
-    };
+        var op = ev.NetAccept.init(stdIoHandleToZio(server), &peer_addr.any, &peer_addr_len);
+        try waitForIo(&op.c);
+        const handle = op.getResult() catch |err| switch (err) {
+            error.ConnectionAborted => continue,
+            error.WouldBlock => return error.WouldBlock,
+            error.ProcessFdQuotaExceeded => return error.ProcessFdQuotaExceeded,
+            error.SystemFdQuotaExceeded => return error.SystemFdQuotaExceeded,
+            error.SystemResources => return error.SystemResources,
+            error.SocketNotListening => return error.SocketNotListening,
+            error.ProtocolFailure => return error.ProtocolFailure,
+            error.BlockedByFirewall => return error.BlockedByFirewall,
+            error.NetworkDown => return error.NetworkDown,
+            error.Canceled => return error.Canceled,
+            error.ConnectionResetByPeer,
+            error.FileDescriptorNotASocket,
+            error.OperationNotSupported,
+            error.Unexpected,
+            => return error.Unexpected,
+        };
 
-    return .{
-        .handle = handle,
-        .address = switch (peer_addr.any.family) {
-            os_net.AF.INET, os_net.AF.INET6 => zioIpToStdIo(peer_addr.ip),
-            // std.Io.net.Socket.address is an IpAddress; use an IPv4 loopback
-            // placeholder for Unix peers, matching std.Io.UnixAddress.listen.
-            else => .{ .ip4 = .loopback(0) },
-        },
-    };
+        return .{
+            .handle = handle,
+            .address = switch (peer_addr.any.family) {
+                os_net.AF.INET, os_net.AF.INET6 => zioIpToStdIo(peer_addr.ip),
+                // std.Io.net.Socket.address is an IpAddress; use an IPv4 loopback
+                // placeholder for Unix peers, matching std.Io.UnixAddress.listen.
+                else => .{ .ip4 = .loopback(0) },
+            },
+        };
+    }
 }
 
 fn openErrToBindErr(err: OpenOrCancel) Io.net.IpAddress.BindError {

--- a/src/io.zig
+++ b/src/io.zig
@@ -1994,7 +1994,6 @@ fn netAcceptImpl(_: ?*anyopaque, server: Io.net.Socket.Handle, _: Io.net.Server.
             error.BlockedByFirewall => return error.BlockedByFirewall,
             error.NetworkDown => return error.NetworkDown,
             error.Canceled => return error.Canceled,
-            error.ConnectionResetByPeer,
             error.FileDescriptorNotASocket,
             error.OperationNotSupported,
             error.Unexpected,

--- a/src/net.zig
+++ b/src/net.zig
@@ -1123,14 +1123,27 @@ pub const Server = struct {
         timeout: Timeout = .none,
     };
 
+    /// Accepts the next incoming connection.
+    ///
+    /// `ConnectionAborted` is not reported: it means a connection sitting in the
+    /// accept queue went away before we got to it, which says nothing about the
+    /// listener, so the next connection is taken instead. The timeout covers the
+    /// whole call, not each attempt, so a stream of aborted connections cannot
+    /// extend it.
     pub fn accept(self: Server, options: AcceptOptions) !Stream {
-        var peer_addr: Address = undefined;
-        var peer_addr_len: os.net.socklen_t = @sizeOf(Address);
+        const deadline = options.timeout.toDeadline();
+        while (true) {
+            var peer_addr: Address = undefined;
+            var peer_addr_len: os.net.socklen_t = @sizeOf(Address);
 
-        var op = ev.NetAccept.init(self.socket.handle, &peer_addr.any, &peer_addr_len);
-        try timedWaitForIo(&op.c, options.timeout);
-        const handle = try op.getResult();
-        return .{ .socket = .{ .handle = handle, .address = .fromPosix(&peer_addr.any, peer_addr_len) } };
+            var op = ev.NetAccept.init(self.socket.handle, &peer_addr.any, &peer_addr_len);
+            try timedWaitForIo(&op.c, deadline);
+            const handle = op.getResult() catch |err| switch (err) {
+                error.ConnectionAborted => continue,
+                else => |e| return e,
+            };
+            return .{ .socket = .{ .handle = handle, .address = .fromPosix(&peer_addr.any, peer_addr_len) } };
+        }
     }
 
     pub fn shutdown(self: Server, how: ShutdownHow) !void {
@@ -2530,6 +2543,69 @@ test "Server: accept timeout" {
 
     const result = server.accept(.{ .timeout = Timeout.fromMilliseconds(10) });
     try std.testing.expectError(error.Timeout, result);
+}
+
+test "Server: accept deadline timeout" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try addr.listen(.{});
+    defer server.close();
+
+    const deadline = Timeout.fromMilliseconds(10).toDeadline();
+    const result = server.accept(.{ .timeout = deadline });
+    try std.testing.expectError(error.Timeout, result);
+}
+
+test "Server: accept never reports ConnectionAborted" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try addr.listen(.{});
+    defer server.close();
+
+    // Call it first so the inferred error set is resolved by the time the check
+    // below runs.
+    const result = server.accept(.{ .timeout = Timeout.fromMilliseconds(10) });
+    try std.testing.expectError(error.Timeout, result);
+
+    const AcceptError = @typeInfo(@typeInfo(@TypeOf(Server.accept)).@"fn".return_type.?).error_union.error_set;
+    comptime {
+        for (@typeInfo(AcceptError).error_set.?) |e| {
+            if (std.mem.eql(u8, e.name, "ConnectionAborted")) {
+                @compileError("Server.accept must retry ConnectionAborted, not report it");
+            }
+        }
+    }
+}
+
+test "Server: accept cancellation" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const addr = try IpAddress.parseIp4("127.0.0.1", 0);
+    const server = try addr.listen(.{});
+    defer server.close();
+
+    const Acceptor = struct {
+        fn run(srv: Server) !void {
+            const stream = try srv.accept(.{});
+            stream.close();
+        }
+    };
+
+    // The test body runs as the runtime's main task, so spawn the acceptor and
+    // give it time to block in accept before canceling. cancel() blocks until
+    // the acceptor finishes, which only happens if the cancellation broke out of
+    // the accept retry loop (a hang here means it did not).
+    var handle = try runtime.spawn(Acceptor.run, .{server});
+    defer handle.cancel();
+    try runtime_mod.sleep(.fromMilliseconds(50));
+    handle.cancel();
+
+    try std.testing.expectError(error.Canceled, handle.join());
 }
 
 test "Stream.Reader/Writer.fromStd" {

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -635,7 +635,6 @@ pub fn connect(fd: fd_t, addr: *const sockaddr, addr_len: socklen_t) ConnectErro
 pub const AcceptError = error{
     WouldBlock,
     ConnectionAborted,
-    ConnectionResetByPeer,
     ProcessFdQuotaExceeded,
     SystemFdQuotaExceeded,
     SystemResources,
@@ -836,19 +835,14 @@ pub fn errnoToConnectError(err: E) ConnectError {
     }
 }
 
+// Winsock reports "the queued connection went away before we took it" as
+// ECONNRESET, POSIX as ECONNABORTED; both collapse into ConnectionAborted.
 pub fn errnoToAcceptError(err: E) AcceptError {
     switch (builtin.os.tag) {
         .windows => {
             return switch (err) {
                 .EWOULDBLOCK => error.WouldBlock,
-                .ECONNABORTED => error.ConnectionAborted,
-                // Winsock spells "the queued connection went away before we got
-                // to it" as WSAECONNRESET ("An incoming connection was
-                // indicated, but was subsequently terminated by the remote peer
-                // prior to accepting the call"), where POSIX uses ECONNABORTED.
-                // Report the POSIX spelling so callers have one condition to
-                // reason about.
-                .ECONNRESET => error.ConnectionAborted,
+                .ECONNABORTED, .ECONNRESET => error.ConnectionAborted,
                 .EMFILE => error.ProcessFdQuotaExceeded,
                 .ENOBUFS => error.SystemResources,
                 .ENOTSOCK => error.FileDescriptorNotASocket,
@@ -864,8 +858,7 @@ pub fn errnoToAcceptError(err: E) AcceptError {
             return switch (err) {
                 .SUCCESS => unreachable,
                 .AGAIN => error.WouldBlock,
-                .CONNABORTED => error.ConnectionAborted,
-                .CONNRESET => error.ConnectionResetByPeer,
+                .CONNABORTED, .CONNRESET => error.ConnectionAborted,
                 .MFILE => error.ProcessFdQuotaExceeded,
                 .NFILE => error.SystemFdQuotaExceeded,
                 .NOMEM, .NOBUFS => error.SystemResources,

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -842,7 +842,13 @@ pub fn errnoToAcceptError(err: E) AcceptError {
             return switch (err) {
                 .EWOULDBLOCK => error.WouldBlock,
                 .ECONNABORTED => error.ConnectionAborted,
-                .ECONNRESET => error.ConnectionResetByPeer,
+                // Winsock spells "the queued connection went away before we got
+                // to it" as WSAECONNRESET ("An incoming connection was
+                // indicated, but was subsequently terminated by the remote peer
+                // prior to accepting the call"), where POSIX uses ECONNABORTED.
+                // Report the POSIX spelling so callers have one condition to
+                // reason about.
+                .ECONNRESET => error.ConnectionAborted,
                 .EMFILE => error.ProcessFdQuotaExceeded,
                 .ENOBUFS => error.SystemResources,
                 .ENOTSOCK => error.FileDescriptorNotASocket,


### PR DESCRIPTION
Fixes #658.

`ECONNABORTED` from `accept` says a connection sat in the queue and the peer went away before we got to it. The listener is healthy, and the only sensible response is to take the next one, so both wrappers now loop on it instead of returning it.

### Where the retry lives

`zio.net.Server.accept` and the `std.Io` vtable, not `src/ev/`. Accept is one-shot in every backend (the only multishot in the tree is the waker's poll on io_uring), so a wrapper-level retry is a fresh completion plus a wait. Retrying in the loop would mean re-arming from inside the driver, tangled up with cancellation and with group accounting when an accept sits in a `.race` group with a timer. The wrappers are also where the error-set policy already lives.

`Server.accept` resolves its timeout to a deadline once before the loop, so a stream of aborted connections cannot extend it. Its inferred error set loses `ConnectionAborted` as a result, and a compile-time check in the tests fails the build if it ever comes back. The `std.Io` path keeps it declared, since `AcceptError` is std's.

This does not remove the need for an `std.Io` server to handle `ConnectionAborted`: such a server cannot assume its `Io` is zio (see lalinsky/dusty#134). It is about zio not being the implementation that surfaces it.

### One error for the condition, on every platform

Winsock documents this as `WSAECONNRESET` ("An incoming connection was indicated, but was subsequently terminated by the remote peer prior to accepting the call") and does not list `WSAECONNABORTED` for `accept` at all. Without normalizing that, the retry would never fire on IOCP, where the condition surfaced as `error.Unexpected` by way of `ConnectionResetByPeer`.

Nothing documents `ECONNRESET` for `accept` anywhere else: it is in neither POSIX group, and no Linux, BSD, macOS or illumos page lists it. It stayed reachable through one path, though, since a listener signalling `POLLERR`/`POLLHUP` on the readiness backends has its `SO_ERROR` read and passed through the same mapping, so any socket-level errno can arrive there. That argues for mapping it rather than dropping it: if it shows up it means what `ECONNABORTED` means and wants the same retry.

So both spellings map to `ConnectionAborted` on every platform and `ConnectionResetByPeer` leaves `AcceptError`. Accept now has exactly one error for "the incoming connection died before we got to it".

### Scope

`ECONNABORTED` only. POSIX lists it under "shall fail" and every system checked (Linux, FreeBSD, NetBSD, OpenBSD, macOS, illumos) gives it the same meaning, so retrying it is portable.

Linux additionally passes pending network errors for the new connection out of `accept` (`EPROTO`, `ENOPROTOOPT`, `EHOSTDOWN`, `ENONET`, `EHOSTUNREACH`, `ENETUNREACH`, `ENETDOWN`) and its man page says to treat those like `EAGAIN`. That behavior is documented nowhere else, and some of those errnos mean something different on other systems (`WSAENETDOWN` is "the network subsystem has failed", illumos `EPROTO` is an uninitialized STREAMS stack), so they are left alone here. Five of them are not currently mapped at all and reach `unexpectedError`, which prints a bug-report notice and a stack trace in debug builds. Worth a follow-up.

### Prior art

Go retries inside its accept wrapper (`internal/poll/fd_unix.go`) and classifies it temporary if it escapes (golang/go#6163). libuv's `uv__server_io` returns on any accept error, so `connection_cb` never sees it.

### Tests

There is no direct test of the retry: `ECONNABORTED` is not portably reproducible, because Linux keeps a reset connection in the accept queue and hands it over successfully (the read fails later with `ECONNRESET`) where the BSDs return `ECONNABORTED`. A test built on an RST would assert the same thing whether or not the fix is present on the platform CI mostly runs on. So the tests cover what the loop actually puts at risk:

- a compile-time guard on `Server.accept`'s error set, verified by reverting the retry (it fails with "Server.accept must retry ConnectionAborted, not report it")
- accept cancellation, which had no coverage before and would hang if the loop swallowed a cancel
- a caller-supplied `.deadline` timeout

Green on io_uring, epoll and poll, on `--full`, and on `--target x86_64-windows --wine` (528 passed, 68 skipped).
