### PR TITLE
BroadcastChannel: use a fresh Waiter for each receive attempt

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -44,6 +44,33 @@ pub const NO_WINNER = std.math.maxInt(usize);
 /// future.asyncWait(&waiter);
 /// try waiter.wait(1, .allow_cancel);
 /// ```
+///
+/// **A waiter is good for one wait.** The signal count only ever increases:
+/// `signal` adds to it and `wait` compares against it without consuming, so
+/// once a waiter has been signaled it satisfies every later `wait(1, ...)`
+/// immediately. Do not reuse one for a second, independent wait.
+///
+/// The one legitimate second call is the cancellation handshake, where both
+/// calls are waiting for the *same* signal:
+///
+/// ```zig
+/// waiter.wait(1, .allow_cancel) catch |err| {
+///     if (!queue.remove(&waiter.node)) {
+///         // Already dequeued by a waker; its signal is in flight and the
+///         // waker still owns our node, so block until it lands.
+///         waiter.wait(1, .no_cancel);
+///         // We are not going to act on it, so pass it to someone who will.
+///         if (queue.pop()) |node| Waiter.fromNode(node).signal();
+///     }
+///     return err;
+/// };
+/// ```
+///
+/// A primitive that retries must therefore construct a fresh waiter on each
+/// attempt, inside the loop rather than outside it - see `Mutex.lock`. Hoisting
+/// it out is silent: the second attempt's `wait` returns at once, and a
+/// primitive that re-queues its node per attempt will push a node that is still
+/// linked into the queue.
 pub const Waiter = struct {
     node: WaitNode = .{},
     mode: union(enum) {
@@ -160,6 +187,11 @@ pub const Waiter = struct {
 
     /// Wait for at least `expected` signals, handling spurious wakeups internally.
     /// Only valid for direct waiters.
+    ///
+    /// Level-triggered: this checks `count >= expected` and does not consume
+    /// anything, so calling it twice for two different signals does not work.
+    /// See the note on `Waiter` - one waiter, one wait, plus the `.no_cancel`
+    /// re-wait of the cancellation handshake.
     pub fn wait(self: *Waiter, expected: u32, comptime cancel_mode: Executor.YieldCancelMode) if (cancel_mode == .allow_cancel) Cancelable!void else void {
         const d = &self.mode.direct;
         if (d.task) |task| {

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -44,9 +44,14 @@ const BroadcastChannelImpl = struct {
     }
 
     fn receive(self: *Self, consumer: *BroadcastChannelConsumer, elem_ptr: [*]u8) !void {
-        var waiter: Waiter = .init();
-
         while (true) {
+            // A `Waiter` is single-use: `Waiter.wait` compares the signal count
+            // against `expected` and never consumes it, so a waiter that has
+            // been signaled once satisfies every later `wait(1, ...)`
+            // immediately. Reusing one across iterations lets a woken-but-empty
+            // consumer spin here, re-pushing a node that is still queued.
+            var waiter: Waiter = .init();
+
             self.mutex.lockUncancelable();
 
             const unread = self.write_pos -% consumer.read_pos;
@@ -974,4 +979,46 @@ test "BroadcastChannel: position counter overflow handling" {
     // After lag, we should be at the oldest available message (201)
     const val7 = try channel.tryReceive(&consumer);
     try std.testing.expectEqual(201, val7);
+}
+
+test "BroadcastChannel: cancelling parked consumers does not re-queue a live wait node" {
+    // Regression test for a reused `Waiter` in `receive`. Cancelling a consumer
+    // that is parked in `receive` hands its pending signal to the next queued
+    // consumer, which then wakes with nothing to read and loops. With a single
+    // waiter shared across those iterations, the second `wait(1, ...)` returned
+    // immediately off the already-satisfied signal count and the loop pushed a
+    // wait node that was still linked into the queue. Under runtime safety that
+    // trips `assert(!item.in_list)` in `SimpleQueue.push`; without it, the queue
+    // is corrupted and the runtime deadlocks.
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(8) });
+    defer runtime.deinit();
+
+    var buffer: [4]u32 = undefined;
+    var channel = BroadcastChannel(u32).init(&buffer);
+
+    const TestFn = struct {
+        fn consumer(ch: *BroadcastChannel(u32)) void {
+            var seat = ch.subscribe();
+            while (true) {
+                _ = ch.receive(&seat) catch return;
+            }
+        }
+
+        fn producer(ch: *BroadcastChannel(u32), n: u32) void {
+            var i: u32 = 0;
+            while (i < n) : (i += 1) {
+                ch.send(i) catch return;
+                yield() catch return;
+            }
+        }
+    };
+
+    // Each round parks several consumers on the same channel and then cancels
+    // them out from under it while the producer is still waking them.
+    for (0..200) |_| {
+        var group: Group = .init;
+        for (0..32) |_| try group.spawn(TestFn.consumer, .{&channel});
+        try group.spawn(TestFn.producer, .{ &channel, 16 });
+        group.cancel();
+    }
 }


### PR DESCRIPTION
Fixes #667.

## Cause

`Waiter` is single-use. `Waiter.wait` compares the signal count against `expected` and never consumes it:

```zig
var current = signalCount(d.notify.state.load(.acquire));
if (current >= expected) return;
```

`signal()` only ever `fetchAdd(1)`s, so once a waiter has been signaled it satisfies every later `wait(1, ...)` immediately. `Mutex.lock` accounts for this by constructing its waiter *inside* the retry loop. `BroadcastChannelImpl.receive` constructed one before the loop and reused it across iterations.

Cancelling a consumer parked in `receive` hands its pending signal to the next queued consumer:

```zig
const next_consumer = self.wait_queue.pop();
if (next_consumer) |node| Waiter.fromNode(node).signal();
```

That consumer wakes with nothing to read, loops, and pushes its wait node again. The following `wait(1, ...)` returns at once off the already-satisfied count, so the loop pushes a node that is still linked into the queue. Under runtime safety that trips `assert(!item.in_list)` in `SimpleQueue.push`; in ReleaseFast the assert is absent, the push relinks a live node, and the runtime deadlocks.

Only cancellation reaches it. Without cancellation a woken consumer always has data to read or sees the channel closed, so it never loops with the signal count already raised — which is why the issue's `close` control mode is clean.

This rules out `SimpleQueue.popAll` not clearing `in_list`, which the reporter had already suspected and tested. Instrumenting `push` to record the last queue operation on the offending node showed `push` itself, with `prev == null` and `next == null` — no `pop`, `popAll` or `remove` in between.

## Fix

Move the waiter inside the loop, matching `Mutex.lock`.

## Testing

Regression test added: 32 consumers parked on one channel, cancelled under a running producer, 200 rounds on 8 executors.

| | without fix | with fix |
|---|---|---|
| new test | fails 5/5 | passes 5/5 (51ms) |

Against the issue's reproduction (2000 rounds, 32 consumers, 8 executors) at v0.17.0:

| build | before | after |
|---|---|---|
| Debug | aborted 5/5 | 0/10 failed |
| ReleaseSafe | aborted | 0/5 failed |
| ReleaseFast | hung | 0/20 failed |

Full suite: 616/616 pass, `zig fmt --check` clean.

## Not covered

The underlying sharp edge is unchanged: `Waiter` is single-use by contract, but nothing enforces it, and `expected` reads like a parameter you could meaningfully vary. Every current caller passes `1`. Making reuse a compile error or an assert would prevent the next instance of this, but that is a wider change than this fix and I have left it alone.