### PR TITLE
completion_queue: reject a finished completion at submit

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -64,6 +64,17 @@ pub const CompletionQueue = struct {
 
     /// Submit a completion to the queue and event loop.
     pub fn submit(self: *CompletionQueue, c: *Completion) void {
+        // A completion carries its result, so it must be re-initialised before
+        // it is armed again. Submitting a finished one used to corrupt the
+        // queue silently: `Loop.add` resets a `.dead` completion, `reset`
+        // clears the whole `group` sub-struct, and that unlinks the node from
+        // `pending` right after we pushed it - leaving `head`/`tail` pointing
+        // at a node that no longer belongs, dropping `owner_callback` so the
+        // completion could never be reported, and making a later `cancel()`
+        // walk the wreckage. Fail here instead, at the call site that got it
+        // wrong.
+        std.debug.assert(c.loadState().phase != .dead);
+
         c.group.owner = self;
         c.group.owner_callback = &ownerCallback;
 


### PR DESCRIPTION
Fixes the corruption found while writing #671. **This is a guard, not a repair** — see the last section, which needs your call.

## Cause

`submit` sets `group.owner`/`owner_callback` and pushes the node onto `pending`, *then* calls `Loop.add`. For a `.dead` completion `addInternal` calls `Completion.reset`:

```zig
c.group.next = null;
c.group.prev = null;
c.group.owner = null;
c.group.owner_callback = null;
```

That clears the whole `group` sub-struct, so the node is unlinked from `pending` the instant after it was pushed, while `head`/`tail` still point at it, and the callback that would report completion is gone.

Caller-visible: the next `wait` reports the queue empty instead of blocking; that completion can never be armed again even after re-initialising; and `cancel()` walks the broken list and panics with `attempt to use null value`. So an idiomatic `defer cq.cancel()` turns the mistake into a crash during teardown, far from its cause.

```zig
var cq = CompletionQueue.init();
defer cq.cancel();              // panicked here
var t = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
cq.submit(&t.c);
_ = try cq.wait();
cq.submit(&t.c);                // real fault is here
_ = try cq.wait();              // returned null
```

## Change

Assert the phase in `submit`. Measured: a completion is `.new` before submission, `.dead` once `wait` has returned it, and `.new` again after re-initialising — so this rejects exactly the misuse and permits the correct re-arming pattern. With it, the case above panics at `completion_queue.zig:76` attributed to the offending `submit`, rather than in `cancel()`.

615/615, `zig fmt --check` clean.

## What this does not fix

The ordering conflict is real: `CompletionQueue` needs the node linked into `pending` before the operation is armed, while `Loop.add` needs to clear those links when re-arming a dead completion. Reordering `submit` alone doesn't work either — arming first and linking after trades the corruption for a null-`owner` race when an operation completes during `add`.

Resolving it properly means moving responsibility for `reset` out of `Loop.add` and onto callers, which also affects `ev.Group`. That is a semantics change I didn't want to make unilaterally. If you'd rather have that than an assert, say so and I'll do it — the assert is also only active under `runtime_safety`, so ReleaseFast still corrupts silently, which is an argument for the deeper fix.

Depends on nothing; independent of #670 and #671, though #671 documents the same rule from the caller's side.