### PR TITLE
ev: stop Loop.add clearing group membership state

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -63,7 +63,12 @@ pub const CompletionQueue = struct {
     }
 
     /// Submit a completion to the queue and event loop.
+    ///
+    /// A completion that has already finished may be submitted again; the loop
+    /// re-arms it. It must not be one that some queue or group still owns.
     pub fn submit(self: *CompletionQueue, c: *Completion) void {
+        std.debug.assert(c.group.owner == null); // still owned by a queue or a group
+        std.debug.assert(!c.flags.rearm); // the loop re-adds these itself, behind the queue's back
         c.group.owner = self;
         c.group.owner_callback = &ownerCallback;
 
@@ -240,6 +245,14 @@ pub const CompletionQueue = struct {
         self.mutex.lock();
         const removed = self.pending.remove(&c.group);
         std.debug.assert(removed);
+        // Drop our claim on the completion before it becomes visible in
+        // `completed`: from there a waiter can take it and re-submit it, which
+        // sets these again. The loop no longer clears `group` when re-arming a
+        // dead completion, so an owner that keeps a stale `owner_callback`
+        // would push a later incarnation into a queue nobody is waiting on.
+        // `next`/`prev` belong to the queue and stay.
+        c.group.owner = null;
+        c.group.owner_callback = null;
         self.completed.push(&c.group);
         self.mutex.unlock();
 
@@ -402,4 +415,74 @@ test "CompletionQueue: cancel pending operations" {
     // Queue should be empty after cancel
     const result = try cq.wait();
     try std.testing.expectEqual(null, result);
+}
+
+test "CompletionQueue: a finished completion can be submitted again (#673)" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancel();
+
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    cq.submit(&timer.c);
+
+    const first = try cq.wait();
+    try std.testing.expectEqual(&timer.c, first.?);
+
+    // Dead completion, re-armed. `Loop.add` used to clear the whole `group`
+    // sub-struct here, unlinking the node from `pending` the instant after
+    // `submit` pushed it and dropping the callback that reports completion.
+    cq.submit(&timer.c);
+    try std.testing.expect(cq.hasPending());
+
+    const second = try cq.wait();
+    try std.testing.expectEqual(&timer.c, second.?);
+    try std.testing.expectEqual(null, try cq.wait());
+}
+
+test "CompletionQueue: re-submitting the completion that fired leaves the others armed (#673)" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancel();
+
+    var fast = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    var slow = ev.Timer.init(.{ .duration = .fromMilliseconds(150) });
+    cq.submit(&fast.c);
+    cq.submit(&slow.c);
+
+    const first = try cq.wait();
+    try std.testing.expectEqual(&fast.c, first.?);
+
+    cq.submit(&fast.c);
+
+    // Both must come back: the re-armed one, then the one that stayed armed
+    // across the re-submission.
+    const second = try cq.wait();
+    try std.testing.expectEqual(&fast.c, second.?);
+    const third = try cq.wait();
+    try std.testing.expectEqual(&slow.c, third.?);
+    try std.testing.expectEqual(null, try cq.wait());
+}
+
+test "CompletionQueue: a delivered completion is no longer owned by the queue (#673)" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancel();
+
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    cq.submit(&timer.c);
+    const c = try cq.wait();
+    try std.testing.expectEqual(&timer.c, c.?);
+
+    // The queue dropped its claim when it handed the completion back, so this
+    // one is free to be used on its own. A stale `owner_callback` would send
+    // the result to the queue instead of the waiter, and hang here.
+    try common.waitForIo(&timer.c);
+    try timer.getResult();
+    try std.testing.expect(cq.isEmpty());
 }

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -64,10 +64,11 @@ pub const CompletionQueue = struct {
 
     /// Submit a completion to the queue and event loop.
     ///
-    /// A completion that has already finished may be submitted again; the loop
-    /// re-arms it. It must not be one that some queue or group still owns.
+    /// A completion that this queue has already handed back may be submitted
+    /// again; the loop re-arms it. Ownership is sticky, so one that belongs to
+    /// a group or to another queue must be re-initialised first.
     pub fn submit(self: *CompletionQueue, c: *Completion) void {
-        std.debug.assert(c.group.owner == null); // still owned by a queue or a group
+        std.debug.assert(c.group.owner == null or c.group.owner == @as(*anyopaque, @ptrCast(self))); // owned elsewhere
         std.debug.assert(!c.flags.rearm); // the loop re-adds these itself, behind the queue's back
         c.group.owner = self;
         c.group.owner_callback = &ownerCallback;
@@ -245,14 +246,6 @@ pub const CompletionQueue = struct {
         self.mutex.lock();
         const removed = self.pending.remove(&c.group);
         std.debug.assert(removed);
-        // Drop our claim on the completion before it becomes visible in
-        // `completed`: from there a waiter can take it and re-submit it, which
-        // sets these again. The loop no longer clears `group` when re-arming a
-        // dead completion, so an owner that keeps a stale `owner_callback`
-        // would push a later incarnation into a queue nobody is waiting on.
-        // `next`/`prev` belong to the queue and stay.
-        c.group.owner = null;
-        c.group.owner_callback = null;
         self.completed.push(&c.group);
         self.mutex.unlock();
 
@@ -467,22 +460,26 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
     try std.testing.expectEqual(null, try cq.wait());
 }
 
-test "CompletionQueue: a delivered completion is no longer owned by the queue (#673)" {
+test "CompletionQueue: a notify that lands while an Async is unarmed is not lost (#673)" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
     var cq = CompletionQueue.init();
     defer cq.cancel();
 
-    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
-    cq.submit(&timer.c);
-    const c = try cq.wait();
-    try std.testing.expectEqual(&timer.c, c.?);
+    var mailbox = ev.Async.init();
+    cq.submit(&mailbox.c);
+    mailbox.notify();
+    const first = try cq.wait();
+    try std.testing.expectEqual(&mailbox.c, first.?);
 
-    // The queue dropped its claim when it handed the completion back, so this
-    // one is free to be used on its own. A stale `owner_callback` would send
-    // the result to the queue instead of the waiter, and hang here.
-    try common.waitForIo(&timer.c);
-    try timer.getResult();
-    try std.testing.expect(cq.isEmpty());
+    // The handle is unarmed now. `notify` latches on the handle itself, and
+    // the re-submit below picks the latch up through `Loop.add`. Handing the
+    // same completion back is what makes this lossless: re-initialising the
+    // handle here would zero the latch and drop this notify.
+    mailbox.notify();
+    cq.submit(&mailbox.c);
+
+    const second = try cq.wait();
+    try std.testing.expectEqual(&mailbox.c, second.?);
 }

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -429,7 +429,7 @@ test "CompletionQueue: a finished completion can be submitted again (#673)" {
     cq.submit(&timer.c);
     try std.testing.expect(cq.hasPending());
 
-    const second = try cq.wait();
+    const second = try cq.timedWait(.fromSeconds(5));
     try std.testing.expectEqual(&timer.c, second.?);
     try std.testing.expectEqual(null, try cq.wait());
 }
@@ -446,17 +446,21 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
     cq.submit(&fast.c);
     cq.submit(&slow.c);
 
-    const first = try cq.wait();
+    const first = try cq.timedWait(.fromSeconds(5));
     try std.testing.expectEqual(&fast.c, first.?);
 
     cq.submit(&fast.c);
 
-    // Both must come back: the re-armed one, then the one that stayed armed
-    // across the re-submission.
-    const second = try cq.wait();
-    try std.testing.expectEqual(&fast.c, second.?);
-    const third = try cq.wait();
-    try std.testing.expectEqual(&slow.c, third.?);
+    // Both must come back: the re-armed one, and the one that stayed armed
+    // across the re-submission. Which lands first is a wall-clock question and
+    // not what this pins, so take them in either order. A lost queue link
+    // shows up as `error.Timeout` here rather than as a test that hangs.
+    const second = try cq.timedWait(.fromSeconds(5));
+    const third = try cq.timedWait(.fromSeconds(5));
+    try std.testing.expect(
+        (second.? == &fast.c and third.? == &slow.c) or
+            (second.? == &slow.c and third.? == &fast.c),
+    );
     try std.testing.expectEqual(null, try cq.wait());
 }
 
@@ -480,6 +484,6 @@ test "CompletionQueue: a notify that lands while an Async is unarmed is not lost
     mailbox.notify();
     cq.submit(&mailbox.c);
 
-    const second = try cq.wait();
+    const second = try cq.timedWait(.fromSeconds(5));
     try std.testing.expectEqual(&mailbox.c, second.?);
 }

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -406,18 +406,17 @@ pub const Completion = struct {
     }
 
     /// Clear per-incarnation fields when re-adding a dead completion.
+    ///
+    /// `group` is not one of them: it is membership state belonging to whoever
+    /// linked the completion, and its links are maintained by that owner. A
+    /// caller that links and then arms - `CompletionQueue.submit`, the batch
+    /// path in `io.zig` - would have its bookkeeping erased here. Each owner
+    /// drops its own `owner`/`owner_callback` when it takes delivery, so a dead
+    /// completion is free of them by the time anyone can re-arm it.
     pub fn reset(c: *Completion) void {
         c.has_result = false;
         c.err = null;
         c.cancel_next = null;
-        c.group.next = null;
-        c.group.prev = null;
-        c.group.owner = null;
-        c.group.owner_callback = null;
-        c.group.userdata = 0;
-        if (std.debug.runtime_safety) {
-            c.group.in_list = false;
-        }
     }
 
     pub fn call(c: *Completion, loop: *Loop) void {
@@ -518,6 +517,15 @@ pub const Group = struct {
                 node = next;
             }
         }
+
+        // This child is delivered, so drop its link to us: the loop no longer
+        // clears `group` when a dead completion is re-armed, and a stale
+        // `owner_callback` would dispatch a later incarnation into a Group that
+        // is finished, or gone. `next` stays - the walk above needs the chain,
+        // and a group is single-shot anyway. Like the walk, this must happen
+        // before the decrement that can free the frame `completion` lives on.
+        completion.group.owner = null;
+        completion.group.owner_callback = null;
 
         const prev = self.remaining.fetchSub(1, .acq_rel);
         if (prev == 1) {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -410,9 +410,12 @@ pub const Completion = struct {
     /// `group` is not one of them: it is membership state belonging to whoever
     /// linked the completion, and its links are maintained by that owner. A
     /// caller that links and then arms - `CompletionQueue.submit`, the batch
-    /// path in `io.zig` - would have its bookkeeping erased here. Each owner
-    /// drops its own `owner`/`owner_callback` when it takes delivery, so a dead
-    /// completion is free of them by the time anyone can re-arm it.
+    /// path in `io.zig` - would have its bookkeeping erased here.
+    ///
+    /// Ownership is sticky: a completion that has been in a group or a queue
+    /// stays marked as that owner's until it is re-initialised. Its owner may
+    /// arm it again (a queue re-submitting a finished completion does), anyone
+    /// else must `init` it first.
     pub fn reset(c: *Completion) void {
         c.has_result = false;
         c.err = null;
@@ -517,15 +520,6 @@ pub const Group = struct {
                 node = next;
             }
         }
-
-        // This child is delivered, so drop its link to us: the loop no longer
-        // clears `group` when a dead completion is re-armed, and a stale
-        // `owner_callback` would dispatch a later incarnation into a Group that
-        // is finished, or gone. `next` stays - the walk above needs the chain,
-        // and a group is single-shot anyway. Like the walk, this must happen
-        // before the decrement that can free the frame `completion` lives on.
-        completion.group.owner = null;
-        completion.group.owner_callback = null;
 
         const prev = self.remaining.fetchSub(1, .acq_rel);
         if (prev == 1) {

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -512,30 +512,3 @@ test "group: large batch exceeding queue size exercises deferred pending list" {
     for (closes) |*pc| try pc.getResult();
     try close_group.getResult();
 }
-
-test "group: a finished member can be armed again on its own (#673)" {
-    var loop: Loop = undefined;
-    try loop.init(.{});
-    defer loop.deinit();
-
-    var timer: Timer = .init(.{ .duration = .fromMilliseconds(5) });
-    var group: Group = .init(.gather);
-
-    group.add(&timer.c);
-    loop.add(&group.c);
-    try loop.run();
-    try group.getResult();
-
-    // The group drops its claim on a member as it takes delivery, rather than
-    // relying on `Loop.add` to clear it on the next arm - `Loop.add` must not
-    // touch `group`, since for a queue those links are live state.
-    try std.testing.expectEqual(null, timer.c.group.owner);
-    try std.testing.expectEqual(null, timer.c.group.owner_callback);
-
-    // So re-arming the member reports to whoever arms it, not to the finished
-    // group.
-    loop.add(&timer.c);
-    try loop.run();
-    try timer.getResult();
-    try std.testing.expectEqual(0, group.remaining.load(.monotonic));
-}

--- a/src/ev/test/group.zig
+++ b/src/ev/test/group.zig
@@ -512,3 +512,30 @@ test "group: large batch exceeding queue size exercises deferred pending list" {
     for (closes) |*pc| try pc.getResult();
     try close_group.getResult();
 }
+
+test "group: a finished member can be armed again on its own (#673)" {
+    var loop: Loop = undefined;
+    try loop.init(.{});
+    defer loop.deinit();
+
+    var timer: Timer = .init(.{ .duration = .fromMilliseconds(5) });
+    var group: Group = .init(.gather);
+
+    group.add(&timer.c);
+    loop.add(&group.c);
+    try loop.run();
+    try group.getResult();
+
+    // The group drops its claim on a member as it takes delivery, rather than
+    // relying on `Loop.add` to clear it on the next arm - `Loop.add` must not
+    // touch `group`, since for a queue those links are live state.
+    try std.testing.expectEqual(null, timer.c.group.owner);
+    try std.testing.expectEqual(null, timer.c.group.owner_callback);
+
+    // So re-arming the member reports to whoever arms it, not to the finished
+    // group.
+    loop.add(&timer.c);
+    try loop.run();
+    try timer.getResult();
+    try std.testing.expectEqual(0, group.remaining.load(.monotonic));
+}


### PR DESCRIPTION
Fixes #673.

## Cause

`Completion.reset` (completion.zig) is called from `addInternal` when a dead completion is re-armed, and it cleared the whole `group` sub-struct. Those fields are not per-incarnation. They are membership state owned by whoever linked the completion, and there are three such linkers in tree: `CompletionQueue.submit`, `ev.Group.add`, and the batch path at `io.zig:649`, which sets `group.userdata` immediately before `loopAdd`.

For a dead completion the reset unlinked the node from `pending` the instant after `submit` pushed it, while `head`/`tail` still pointed at it, and dropped the callback that reports completion. Hence the reported symptoms: `wait` reports the queue empty rather than blocking, that completion can never be armed again even after re-initialising, and `cancel()` walks the broken list and panics, so `defer cq.cancel()` turns it into a crash during teardown.

Re-arming a dead completion is supported, not misuse: `enterRunning` documents `{new,dead} -> running` and `flags.rearm` depends on it (loop.zig re-adds a dead completion with no re-init). That is the part #672 got wrong by asserting against it at the queue layer.

## Change

`reset` keeps `has_result`, `err`, `cancel_next` and leaves `group` alone.

Ownership is sticky: a completion that has been in a group or a queue stays marked as that owner's until it is re-initialised. Its owner may arm it again, which is what a queue re-submitting a finished completion does; anyone else has to `init` it first. `Group.add`'s existing `assert(owner == null)` therefore means what it says, and `submit` asserts `owner == null or owner == self`.

`submit` also keeps asserting `!flags.rearm`. Supporting persistent handles in a queue is a real feature rather than a missing assert: the loop re-adds the handle before the owner callback runs, so the node would arrive in `completed` while the op is live, `hasPending` would go false with the handle still running, and a second fire before the caller pops it would need membership state the queue does not track. Worth doing separately if wanted.

## Tests

Three, all failing without the fix, verified by reverting the change under them rather than by inspection. Without it each one panics with `attempt to use null value`, the symptom reported on the issue:

- `CompletionQueue: a finished completion can be submitted again (#673)` — the issue reproducer, `defer cq.cancel()` included.
- `CompletionQueue: re-submitting the completion that fired leaves the others armed (#673)` — waits again after the re-armed one and asserts it gets the timer that stayed armed. This is the shape #671's version of this test missed, where `hasPending()` was true because of the re-submitted timer regardless.
- `CompletionQueue: a notify that lands while an Async is unarmed is not lost (#673)` — the pattern the fix exists for. `Async.notify` latches on the handle (loop.zig:1052 picks the latch up at add), so handing the same completion back to `submit` is lossless across the gap, while re-initialising it would zero the latch and drop the notify.

`zig build test`: 618/618, 1 skipped, in Debug and in ReleaseFast. `zig fmt --check src/` clean. The new tests ran 8x with no flakes. Nothing else was run: Linux x86_64 only, and the timing margins in the multi-timer test (5ms against 150ms) were not stressed on a loaded machine.

## Not covered

**A re-armed `Group` silently reports success.** `remaining` is drained to 0 by `groupCallback`, so re-adding a dead group takes the "empty group, complete immediately" branch in `addInternal` and never walks its children. It is why the corruption #673 guessed at in the group path is not reachable that way: `Group.add` refuses a dead child or a submitted group, and in ReleaseFast a dead child does reach the old reset and hangs the group, but only after that misuse. Deciding between recomputing `remaining` and asserting that groups are not re-armable is a second semantics call, so it is left alone.

**Arming a completion that belongs elsewhere is not caught by the loop.** `submit` sets `owner` and then calls `loopAdd`, so from inside `addInternal` a legitimate queue submission and a stale ex-group member are indistinguishable. The asserts live at `Group.add` and `submit`; raw `ev.Loop.add` on an owned completion stays unguarded, as the rest of that layer is.

**#671.** The re-arming paragraph it documented becomes false with this landed, so that redo wants doing on top of this rather than beside it.
