### PR TITLE
completion_queue: fix unlocked pending-list walk in requestCancelAll

### DIFF
--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -291,18 +291,35 @@ pub const CompletionQueue = struct {
     }
 
     fn requestCancelAll(self: *CompletionQueue) void {
-        self.mutex.lock();
-        var node = self.pending.head;
-        self.mutex.unlock();
-
-        // Cancel each pending operation. We don't hold the lock while calling
-        // loop.cancel() because the callback needs to acquire it.
+        // `ownerCallback` relinks `pending` nodes under the mutex from the
+        // loop threads, so walking the list is only safe with the mutex held.
+        // `loopCancel` cannot be called with it held (the callback takes it),
+        // so each pass walks to one operation that still needs a cancel,
+        // drops the lock, and cancels just that one.
+        //
+        // The walk terminates: `requestCancel` latches `cancel_requested`
+        // before `loopCancel` returns (or the operation is already completed
+        // or dead), and an operation cannot leave those states while it sits
+        // in `pending`, so every pass permanently disqualifies one node.
         const executor = getCurrentExecutor();
-        while (node) |n| {
-            const next_node = n.next;
-            const c = completionFromGroup(n);
-            executor.loopCancel(c);
-            node = next_node;
+        while (true) {
+            self.mutex.lock();
+            const target: ?*Completion = blk: {
+                var node = self.pending.head;
+                while (node) |n| : (node = n.next) {
+                    const c = completionFromGroup(n);
+                    const state = c.loadState();
+                    if (state.cancel_requested) continue;
+                    // Finished already: `requestCancel` would not latch, only
+                    // its dispatch to `completed` is still in flight.
+                    if (state.phase == .completed or state.phase == .dead) continue;
+                    break :blk c;
+                }
+                break :blk null;
+            };
+            self.mutex.unlock();
+
+            executor.loopCancel(target orelse return);
         }
     }
 


### PR DESCRIPTION
`requestCancelAll` walked the `pending` list with the mutex dropped: it snapshotted the head under the lock, then followed `next` pointers unlocked while calling `loopCancel` on each node.

`ownerCallback` relinks those same nodes under the mutex from the loop threads. With multiple executors, an operation finishing naturally on its home loop mid-walk has its `next`/`prev` nulled by `SimpleQueue.remove` while the walk is reading them. Capturing `next` before `loopCancel` only protects against the synchronous same-loop callback, not against that. Best case it is a data race; worst case the walk terminates early on a nulled `next`, the operations behind that node never get a cancel request, and `drainPending` then parks uncancelably until they finish on their own. For an `ev.Async` that never fires, that is a deadlock inside `cancelAll`.

The fix walks the list with the mutex held. `loopCancel` still cannot be called under it (the completion callback takes the same mutex), so each pass finds one operation that still needs a cancel, drops the lock, and cancels just that one, then re-walks. Termination: `requestCancel` latches `cancel_requested` before `loopCancel` returns, operations already `.completed`/`.dead` are skipped explicitly (`requestCancel` does not latch on those phases; only their dispatch into `completed` is still in flight), and neither condition can revert while the node sits in `pending`, so every pass permanently disqualifies one node. Worst case O(n²) passes, which is fine for a cancel path.

There is no regression test: pinning this needs an operation to finish on another loop's thread in the middle of the walk, and without scheduling hooks that only converts the race into a rare test hang. The existing cancelAll tests cover the new loop's behavior, including the skip path (multiple slow timers mean later passes re-walk over already-latched nodes).