### PR TITLE
completion_queue: thread-safe submit, blocking wait, close protocol

### DIFF
--- a/examples/parallel_grep.zig
+++ b/examples/parallel_grep.zig
@@ -59,7 +59,7 @@ fn worker(
 ) zio.Cancelable!void {
     while (true) {
         const path = work_channel.receive() catch |err| switch (err) {
-            error.ChannelClosed => {
+            error.Closed => {
                 std.log.info("Worker {} exiting", .{id});
                 return;
             },
@@ -85,7 +85,7 @@ fn collector(
 
     while (true) {
         const result = results_channel.receive() catch |err| switch (err) {
-            error.ChannelClosed => return,
+            error.Closed => return,
             error.Canceled => return error.Canceled,
         };
 
@@ -148,7 +148,7 @@ pub fn main(init: std.process.Init) !void {
     // Distribute work
     for (files) |file_path| {
         work_channel.send(file_path) catch |err| switch (err) {
-            error.ChannelClosed => break,
+            error.Closed => break,
             error.Canceled => return error.Canceled,
         };
     }

--- a/examples/producer_consumer.zig
+++ b/examples/producer_consumer.zig
@@ -10,7 +10,7 @@ fn producer(channel: *zio.Channel(i32), id: u32) zio.Cancelable!void {
     for (0..5) |i| {
         const item = @as(i32, @intCast(id * 100 + i));
         channel.send(item) catch |err| switch (err) {
-            error.ChannelClosed => {
+            error.Closed => {
                 std.log.info("Producer {}: channel closed, exiting", .{id});
                 return;
             },
@@ -28,7 +28,7 @@ fn producer(channel: *zio.Channel(i32), id: u32) zio.Cancelable!void {
 fn consumer(channel: *zio.Channel(i32), id: u32) zio.Cancelable!void {
     for (0..5) |_| {
         const item = channel.receive() catch |err| switch (err) {
-            error.ChannelClosed => {
+            error.Closed => {
                 std.log.info("Consumer {}: channel closed, exiting", .{id});
                 return;
             },

--- a/src/common.zig
+++ b/src/common.zig
@@ -31,6 +31,11 @@ pub const Timeoutable = error{
     Timeout,
 };
 
+/// Error set for operations against something that can be closed
+pub const Closeable = error{
+    Closed,
+};
+
 /// Sentinel value indicating no winner has been selected yet in select operations
 pub const NO_WINNER = std.math.maxInt(usize);
 

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -95,17 +95,29 @@ pub const CompletionQueue = struct {
         return @fieldParentPtr("group", node);
     }
 
+    pub const SubmitError = Closeable || error{
+        /// The queue cannot own this completion: it belongs to a group or to
+        /// another queue (ownership is sticky, re-initialise it first), or it
+        /// is a rearm completion, which the loop re-adds itself, behind the
+        /// queue's back.
+        InvalidCompletion,
+    };
+
     /// Submit a completion to the queue and event loop. Thread-safe: any task
     /// may submit, and the operation is added to the submitter's own loop.
     ///
     /// A completion that this queue has already handed back may be submitted
-    /// again; the loop re-arms it. Ownership is sticky, so one that belongs to
-    /// a group or to another queue must be re-initialised first.
+    /// again; the loop re-arms it.
     ///
-    /// Returns `error.Closed` once the queue is closed, leaving `c` untouched.
-    pub fn submit(self: *CompletionQueue, c: *Completion) Closeable!void {
-        std.debug.assert(c.group.owner == null or c.group.owner == @as(*anyopaque, @ptrCast(self))); // owned elsewhere
-        std.debug.assert(!c.flags.rearm); // the loop re-adds these itself, behind the queue's back
+    /// Returns `error.Closed` once the queue is closed. A refused completion
+    /// is left untouched, whatever the error.
+    pub fn submit(self: *CompletionQueue, c: *Completion) SubmitError!void {
+        if (c.group.owner != null and c.group.owner != @as(*anyopaque, @ptrCast(self))) {
+            return error.InvalidCompletion;
+        }
+        if (c.flags.rearm) {
+            return error.InvalidCompletion;
+        }
 
         self.mutex.lock();
         if (self.closed) {
@@ -793,6 +805,35 @@ test "CompletionQueue: submit after close returns error.Closed" {
     // The refused completion was left untouched: no ownership taken, nothing
     // queued, free to go to another queue.
     try std.testing.expectEqual(null, timer.c.group.owner);
+    try std.testing.expect(cq.isEmpty());
+}
+
+test "CompletionQueue: submit refuses completions the queue cannot own" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancelAll(.discard);
+
+    // A group member is owned by its group.
+    var member = ev.Timer.init(.{ .duration = .fromSeconds(10) });
+    var grp = ev.Group.init(.race);
+    grp.add(&member.c);
+    try std.testing.expectError(error.InvalidCompletion, cq.submit(&member.c));
+
+    // An operation parked in another queue is owned by that queue.
+    var other = CompletionQueue.init();
+    defer other.cancelAll(.discard);
+    var parked = ev.Timer.init(.{ .duration = .fromSeconds(10) });
+    try other.submit(&parked.c);
+    try std.testing.expectError(error.InvalidCompletion, cq.submit(&parked.c));
+
+    // Rearm completions re-add themselves; the queue can never own one.
+    var mail = ev.Async.init();
+    mail.c.flags.rearm = true;
+    try std.testing.expectError(error.InvalidCompletion, cq.submit(&mail.c));
+
+    // Every refusal left the queue and the completions untouched.
     try std.testing.expect(cq.isEmpty());
 }
 

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -3,25 +3,49 @@
 
 //! A queue for waiting on multiple I/O operations with an iterator-like interface.
 //!
-//! Unlike `waitForIo` (single operation) or `ev.Group` (combine into one virtual completion),
-//! `CompletionQueue` lets you submit multiple operations, dynamically add more, and process
-//! completions one at a time as they finish.
+//! Unlike `waitForIo` (single operation) or `ev.Group` (combine into one virtual
+//! completion), `CompletionQueue` lets you submit multiple operations, dynamically
+//! add more, and process completions one at a time as they finish.
 //!
 //! Runtime-only: must be used from within an async task context.
 //!
-//! Usage:
+//! One task drives the queue: `wait`, `timedWait`, `next`, `cancel` and
+//! `cancelAll` belong to it. `submit` and `close` are thread-safe, so other
+//! tasks can park their own operations here for the driver to process. An
+//! operation submitted from another task must not live in that task's frame:
+//! the submitter may unwind before the driver takes the completion, so such
+//! operations belong on the heap, with the driver owning their results and
+//! memory. Heap-backed operations rule out `cancelAll(.discard)` — it drops
+//! the only pointers to them — so shut such a queue down with
+//! `cancelAll(.keep)` and free each operation as `next` hands it out.
+//!
+//! Waiting for a batch to finish (the driver submits everything itself):
 //! ```zig
 //! var cq = CompletionQueue.init();
 //! defer cq.cancelAll(.discard);
 //!
 //! var timer1 = ev.Timer.init(.{ .duration = .fromMilliseconds(100) });
 //! var timer2 = ev.Timer.init(.{ .duration = .fromMilliseconds(200) });
-//! cq.submit(&timer1.c);
-//! cq.submit(&timer2.c);
+//! try cq.submit(&timer1.c);
+//! try cq.submit(&timer2.c);
 //!
-//! while (try cq.wait()) |c| {
+//! while (!cq.isEmpty()) {
+//!     const c = try cq.wait();
+//!     // Process completion; can submit more operations here
+//! }
+//! ```
+//!
+//! Long-lived dispatcher (operations submitted by other tasks):
+//! ```zig
+//! while (true) {
+//!     const c = cq.wait() catch |err| switch (err) {
+//!         // Closed and fully drained.
+//!         error.Closed => break,
+//!         // The queue is closed and every operation is canceled with its
+//!         // result kept; drain with `next` before freeing them.
+//!         error.Canceled => return err,
+//!     };
 //!     // Process completion
-//!     // Can submit more operations here
 //! }
 //! ```
 
@@ -30,13 +54,14 @@ const std = @import("std");
 const ev = @import("ev/root.zig");
 const os = @import("os/root.zig");
 const common = @import("common.zig");
+const Futex = @import("sync/Futex.zig");
 const SimpleQueue = @import("utils/simple_queue.zig").SimpleQueue;
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
 
-const Waiter = common.Waiter;
 const Cancelable = common.Cancelable;
 const Timeoutable = common.Timeoutable;
+const Closeable = common.Closeable;
 const Timeout = @import("time.zig").Timeout;
 const Completion = ev.Completion;
 
@@ -44,7 +69,13 @@ pub const CompletionQueue = struct {
     mutex: os.Mutex,
     pending: Queue,
     completed: Queue,
-    waiter: Waiter,
+    /// Futex word the driver waits on. Counts completion arrivals and the
+    /// close, and is never reset: waiters snapshot it before checking the
+    /// queues, so a push landing between the check and the wait flips the
+    /// word and the wait returns immediately.
+    signal: std.atomic.Value(u32),
+    /// No new submissions. Written under `mutex`.
+    closed: bool,
 
     const GroupNode = @FieldType(Completion, "group");
     const Queue = SimpleQueue(GroupNode);
@@ -54,7 +85,8 @@ pub const CompletionQueue = struct {
             .mutex = .init(),
             .pending = .empty,
             .completed = .empty,
-            .waiter = Waiter.init(),
+            .signal = .init(0),
+            .closed = false,
         };
     }
 
@@ -63,107 +95,118 @@ pub const CompletionQueue = struct {
         return @fieldParentPtr("group", node);
     }
 
-    /// Submit a completion to the queue and event loop.
+    /// Submit a completion to the queue and event loop. Thread-safe: any task
+    /// may submit, and the operation is added to the submitter's own loop.
     ///
     /// A completion that this queue has already handed back may be submitted
     /// again; the loop re-arms it. Ownership is sticky, so one that belongs to
     /// a group or to another queue must be re-initialised first.
-    pub fn submit(self: *CompletionQueue, c: *Completion) void {
+    ///
+    /// Returns `error.Closed` once the queue is closed, leaving `c` untouched.
+    pub fn submit(self: *CompletionQueue, c: *Completion) Closeable!void {
         std.debug.assert(c.group.owner == null or c.group.owner == @as(*anyopaque, @ptrCast(self))); // owned elsewhere
         std.debug.assert(!c.flags.rearm); // the loop re-adds these itself, behind the queue's back
-        c.group.owner = self;
-        c.group.owner_callback = &ownerCallback;
 
         self.mutex.lock();
+        if (self.closed) {
+            self.mutex.unlock();
+            return error.Closed;
+        }
+        c.group.owner = self;
+        c.group.owner_callback = &ownerCallback;
         self.pending.push(&c.group);
         self.mutex.unlock();
 
         getCurrentExecutor().loopAdd(c);
     }
 
-    /// Reset the signal counter before checking the completed queue.
-    /// This must be called BEFORE checking the completed queue to avoid
-    /// a race where a signal is lost between checking and waiting.
-    fn resetSignals(self: *CompletionQueue) void {
-        self.waiter.mode.direct.notify.state.store(0, .monotonic);
+    /// Close the queue: `submit` fails with `error.Closed` from now on, and
+    /// the driver's `wait` returns `error.Closed` once everything already in
+    /// the queue has been handed out. Operations in flight keep running and
+    /// are still delivered; use `cancelAll` to stop them. Thread-safe and
+    /// idempotent.
+    pub fn close(self: *CompletionQueue) void {
+        self.mutex.lock();
+        const was_closed = self.closed;
+        self.closed = true;
+        self.mutex.unlock();
+        if (was_closed) return;
+
+        _ = self.signal.fetchAdd(1, .release);
+        Futex.wake(&self.signal.raw, 1);
     }
 
-    /// Wait for the next completion. Blocks until one is available.
-    /// Returns null when there are no more pending or completed operations.
-    pub fn wait(self: *CompletionQueue) Cancelable!?*Completion {
+    /// Wait for the next completion. Blocks while the queue is open, even if
+    /// it is momentarily empty: operations submitted later (also by other
+    /// tasks) satisfy a wait already in progress. To wait only for what is
+    /// already in the queue, guard with `isEmpty`:
+    /// `while (!cq.isEmpty()) { const c = try cq.wait(); ... }`
+    ///
+    /// Returns `error.Closed` when the queue is closed and fully drained.
+    ///
+    /// On cancellation the queue is closed and every operation is canceled
+    /// with its result kept: drain with `next` (nothing blocks at that point)
+    /// before freeing the operations.
+    pub fn wait(self: *CompletionQueue) (Cancelable || Closeable)!*Completion {
         while (true) {
-            self.resetSignals();
+            const seen = self.signal.load(.acquire);
 
             self.mutex.lock();
-            const completed_node = self.completed.pop();
-            const pending_empty = self.pending.isEmpty();
+            const node = self.completed.pop();
+            const drained = node == null and self.closed and self.pending.isEmpty();
             self.mutex.unlock();
 
-            if (completed_node) |node| {
-                return completionFromGroup(node);
-            }
+            if (node) |n| return completionFromGroup(n);
+            if (drained) return error.Closed;
 
-            if (pending_empty) {
-                return null;
-            }
-
-            self.waiter.wait(1, .allow_cancel) catch |err| switch (err) {
+            // A bare submit does not bump `signal`: a driver parked here is
+            // waiting for a completion, and the submitted operation delivers
+            // one through `ownerCallback` when it finishes.
+            Futex.wait(&self.signal.raw, seen) catch |err| switch (err) {
                 error.Canceled => {
-                    self.cancelAll(.discard);
+                    self.closeAndKeepResults();
                     return error.Canceled;
                 },
             };
         }
     }
 
-    /// Wait for the next completion with a timeout.
-    /// Returns `error.Timeout` if no completion is ready before the timeout expires.
-    /// Returns null when there are no more pending or completed operations.
-    pub fn timedWait(self: *CompletionQueue, timeout: Timeout) (Timeoutable || Cancelable)!?*Completion {
+    /// Wait for the next completion with a timeout. Blocks like `wait` while
+    /// the queue is open and returns `error.Timeout` if no completion is
+    /// ready before the timeout expires.
+    ///
+    /// Returns `error.Closed` when the queue is closed and fully drained.
+    pub fn timedWait(self: *CompletionQueue, timeout: Timeout) (Timeoutable || Cancelable || Closeable)!*Completion {
         if (timeout == .none) {
             return self.wait();
         }
 
         while (true) {
-            self.resetSignals();
+            const seen = self.signal.load(.acquire);
 
-            self.mutex.lock();
-            const completed_node = self.completed.pop();
-            const pending_empty = self.pending.isEmpty();
-            self.mutex.unlock();
-
-            if (completed_node) |node| {
-                return completionFromGroup(node);
-            }
-
-            if (pending_empty) {
-                return null;
-            }
-
-            const timed_out = if (self.waiter.timedWait(1, timeout, .allow_cancel)) |_| false else |err| switch (err) {
-                error.Canceled => {
-                    self.cancelAll(.discard);
-                    return error.Canceled;
-                },
-                error.Timeout => true,
-            };
-
-            // A completion can still have landed together with the timeout.
             self.mutex.lock();
             const node = self.completed.pop();
+            const drained = node == null and self.closed and self.pending.isEmpty();
             self.mutex.unlock();
 
-            if (node) |n| {
-                return completionFromGroup(n);
-            }
+            if (node) |n| return completionFromGroup(n);
+            if (drained) return error.Closed;
 
-            if (timed_out) {
-                return error.Timeout;
-            }
-
-            // Signaled without a completion to hand out (a pending op finished
-            // into the queue and was taken, or the signal raced the pop): go
-            // around rather than reporting a timeout that did not happen.
+            Futex.timedWait(&self.signal.raw, seen, timeout) catch |err| switch (err) {
+                error.Canceled => {
+                    self.closeAndKeepResults();
+                    return error.Canceled;
+                },
+                error.Timeout => {
+                    // A completion can still have landed together with the
+                    // timeout; hand it out rather than reporting a timeout
+                    // that did not happen.
+                    self.mutex.lock();
+                    const n = self.completed.pop();
+                    self.mutex.unlock();
+                    return if (n) |x| completionFromGroup(x) else error.Timeout;
+                },
+            };
         }
     }
 
@@ -206,9 +249,12 @@ pub const CompletionQueue = struct {
         /// Leave them in the queue, to be taken with `wait` or `next`. An
         /// operation that completed before its cancellation landed is in
         /// there too, carrying a real result rather than `error.Canceled`.
+        /// The only correct choice when other tasks submitted heap-backed
+        /// operations: whoever drains the queue frees them.
         keep,
         /// Drop them, leaving the queue empty. This also drops results that
-        /// were already waiting to be taken.
+        /// were already waiting to be taken. Only for operations the caller
+        /// still holds by other means (a batch in the driver's own frame).
         discard,
     };
 
@@ -244,7 +290,7 @@ pub const CompletionQueue = struct {
         getCurrentExecutor().loopCancel(c);
 
         while (true) {
-            self.resetSignals();
+            const seen = self.signal.load(.acquire);
 
             self.mutex.lock();
             const taken = unlink(&self.completed, &c.group);
@@ -254,7 +300,7 @@ pub const CompletionQueue = struct {
 
             // Under the lock the node is in exactly one of the two queues, so
             // not being in `completed` means it is still pending.
-            self.waiter.wait(1, .no_cancel);
+            Futex.waitUncancelable(&self.signal.raw, seen);
         }
     }
 
@@ -263,7 +309,8 @@ pub const CompletionQueue = struct {
     ///
     /// Safe to call more than once, and safe with nothing pending. Like `wait`,
     /// this belongs to the task that drives the queue, and its wait cannot
-    /// itself be canceled.
+    /// itself be canceled. Does not close the queue: on an open queue another
+    /// task can submit while this drains, extending the wait.
     pub fn cancelAll(self: *CompletionQueue, results: Results) void {
         self.requestCancelAll();
         self.drainPending(results);
@@ -325,7 +372,7 @@ pub const CompletionQueue = struct {
 
     fn drainPending(self: *CompletionQueue, results: Results) void {
         while (true) {
-            self.resetSignals();
+            const seen = self.signal.load(.acquire);
 
             self.mutex.lock();
             const pending_empty = self.pending.isEmpty();
@@ -338,8 +385,17 @@ pub const CompletionQueue = struct {
 
             if (pending_empty) break;
 
-            self.waiter.wait(1, .no_cancel);
+            Futex.waitUncancelable(&self.signal.raw, seen);
         }
+    }
+
+    /// Shut the queue down from a canceled wait: no new submissions, every
+    /// operation canceled, all results kept in `completed` for `next` to hand
+    /// out. Close comes first so no submission can slip in behind the drain
+    /// and extend it.
+    fn closeAndKeepResults(self: *CompletionQueue) void {
+        self.close();
+        self.cancelAll(.keep);
     }
 
     fn ownerCallback(_: *ev.Loop, c: *Completion) void {
@@ -351,11 +407,12 @@ pub const CompletionQueue = struct {
         self.completed.push(&c.group);
         self.mutex.unlock();
 
-        self.waiter.signal();
+        _ = self.signal.fetchAdd(1, .release);
+        Futex.wake(&self.signal.raw, 1);
     }
 };
 
-test "CompletionQueue: wait on empty queue returns null" {
+test "CompletionQueue: wait on a closed empty queue returns error.Closed" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -364,8 +421,13 @@ test "CompletionQueue: wait on empty queue returns null" {
     try std.testing.expect(!cq.hasPending());
     try std.testing.expect(!cq.hasCompleted());
 
-    const result = try cq.wait();
-    try std.testing.expectEqual(null, result);
+    cq.close();
+    try std.testing.expectError(error.Closed, cq.wait());
+    try std.testing.expectError(error.Closed, cq.timedWait(.fromMilliseconds(10)));
+
+    // Idempotent.
+    cq.close();
+    try std.testing.expectError(error.Closed, cq.wait());
 }
 
 test "CompletionQueue: single timer" {
@@ -375,22 +437,18 @@ test "CompletionQueue: single timer" {
     var cq = CompletionQueue.init();
 
     var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
 
     try std.testing.expect(!cq.isEmpty());
     try std.testing.expect(cq.hasPending());
 
     const c = try cq.wait();
-    try std.testing.expect(c != null);
-    try std.testing.expectEqual(&timer.c, c.?);
+    try std.testing.expectEqual(&timer.c, c);
 
     // Queue is now empty
     try std.testing.expect(cq.isEmpty());
     try std.testing.expect(!cq.hasPending());
     try std.testing.expect(!cq.hasCompleted());
-
-    const end = try cq.wait();
-    try std.testing.expectEqual(null, end);
 }
 
 test "CompletionQueue: multiple timers" {
@@ -402,12 +460,13 @@ test "CompletionQueue: multiple timers" {
     var timer1 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
     var timer2 = ev.Timer.init(.{ .duration = .fromMilliseconds(20) });
     var timer3 = ev.Timer.init(.{ .duration = .fromMilliseconds(30) });
-    cq.submit(&timer1.c);
-    cq.submit(&timer2.c);
-    cq.submit(&timer3.c);
+    try cq.submit(&timer1.c);
+    try cq.submit(&timer2.c);
+    try cq.submit(&timer3.c);
 
     var count: u32 = 0;
-    while (try cq.wait()) |_| {
+    while (!cq.isEmpty()) {
+        _ = try cq.wait();
         count += 1;
     }
     try std.testing.expectEqual(3, count);
@@ -420,16 +479,17 @@ test "CompletionQueue: dynamic submit during iteration" {
     var cq = CompletionQueue.init();
 
     var timer1 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
-    cq.submit(&timer1.c);
+    try cq.submit(&timer1.c);
 
     var timer2 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
     var submitted_second = false;
 
     var count: u32 = 0;
-    while (try cq.wait()) |_| {
+    while (!cq.isEmpty()) {
+        _ = try cq.wait();
         count += 1;
         if (!submitted_second) {
-            cq.submit(&timer2.c);
+            try cq.submit(&timer2.c);
             submitted_second = true;
         }
     }
@@ -444,15 +504,15 @@ test "CompletionQueue: wait then timedWait does not false-timeout" {
 
     // First: submit and wait() — pops without blocking, consuming a signal
     var timer1 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
-    cq.submit(&timer1.c);
+    try cq.submit(&timer1.c);
     const c1 = try cq.wait();
-    try std.testing.expectEqual(&timer1.c, c1.?);
+    try std.testing.expectEqual(&timer1.c, c1);
 
     // Second: submit and timedWait() — must not return false Timeout
     var timer2 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
-    cq.submit(&timer2.c);
+    try cq.submit(&timer2.c);
     const c2 = try cq.timedWait(.{ .duration = .fromSeconds(1) });
-    try std.testing.expectEqual(&timer2.c, c2.?);
+    try std.testing.expectEqual(&timer2.c, c2);
 }
 
 test "CompletionQueue: timedWait completes before timeout" {
@@ -462,11 +522,10 @@ test "CompletionQueue: timedWait completes before timeout" {
     var cq = CompletionQueue.init();
 
     var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
 
     const c = try cq.timedWait(.{ .duration = .fromSeconds(1) });
-    try std.testing.expect(c != null);
-    try std.testing.expectEqual(&timer.c, c.?);
+    try std.testing.expectEqual(&timer.c, c);
 }
 
 test "CompletionQueue: timedWait returns timeout" {
@@ -477,7 +536,7 @@ test "CompletionQueue: timedWait returns timeout" {
 
     // Long timer with short timeout
     var timer = ev.Timer.init(.{ .duration = .fromSeconds(10) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
 
     try std.testing.expectError(error.Timeout, cq.timedWait(.fromMilliseconds(10)));
 
@@ -485,13 +544,14 @@ test "CompletionQueue: timedWait returns timeout" {
     cq.cancelAll(.discard);
 }
 
-test "CompletionQueue: timedWait on empty queue returns null" {
+test "CompletionQueue: timedWait on an open empty queue waits for the timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
+    // An open queue blocks on empty rather than reporting exhaustion, so
+    // with nothing submitted the timeout is the only way out.
     var cq = CompletionQueue.init();
-    const result = try cq.timedWait(.fromMilliseconds(10));
-    try std.testing.expectEqual(null, result);
+    try std.testing.expectError(error.Timeout, cq.timedWait(.fromMilliseconds(10)));
 }
 
 test "CompletionQueue: cancel pending operations" {
@@ -502,14 +562,13 @@ test "CompletionQueue: cancel pending operations" {
 
     // Submit a long timer
     var timer = ev.Timer.init(.{ .duration = .fromSeconds(10) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
 
     // Cancel should complete without waiting 10 seconds
     cq.cancelAll(.discard);
 
     // Queue should be empty after cancel
-    const result = try cq.wait();
-    try std.testing.expectEqual(null, result);
+    try std.testing.expect(cq.isEmpty());
 }
 
 test "CompletionQueue: a finished completion can be submitted again (#673)" {
@@ -520,20 +579,20 @@ test "CompletionQueue: a finished completion can be submitted again (#673)" {
     defer cq.cancelAll(.discard);
 
     var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
 
     const first = try cq.wait();
-    try std.testing.expectEqual(&timer.c, first.?);
+    try std.testing.expectEqual(&timer.c, first);
 
     // Dead completion, re-armed. `Loop.add` used to clear the whole `group`
     // sub-struct here, unlinking the node from `pending` the instant after
     // `submit` pushed it and dropping the callback that reports completion.
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
     try std.testing.expect(cq.hasPending());
 
     const second = try cq.timedWait(.fromSeconds(5));
-    try std.testing.expectEqual(&timer.c, second.?);
-    try std.testing.expectEqual(null, try cq.wait());
+    try std.testing.expectEqual(&timer.c, second);
+    try std.testing.expect(cq.isEmpty());
 }
 
 test "CompletionQueue: re-submitting the completion that fired leaves the others armed (#673)" {
@@ -545,13 +604,13 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
 
     var fast = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
     var slow = ev.Timer.init(.{ .duration = .fromMilliseconds(150) });
-    cq.submit(&fast.c);
-    cq.submit(&slow.c);
+    try cq.submit(&fast.c);
+    try cq.submit(&slow.c);
 
     const first = try cq.timedWait(.fromSeconds(5));
-    try std.testing.expectEqual(&fast.c, first.?);
+    try std.testing.expectEqual(&fast.c, first);
 
-    cq.submit(&fast.c);
+    try cq.submit(&fast.c);
 
     // Both must come back: the re-armed one, and the one that stayed armed
     // across the re-submission. Which lands first is a wall-clock question and
@@ -560,10 +619,10 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
     const second = try cq.timedWait(.fromSeconds(5));
     const third = try cq.timedWait(.fromSeconds(5));
     try std.testing.expect(
-        (second.? == &fast.c and third.? == &slow.c) or
-            (second.? == &slow.c and third.? == &fast.c),
+        (second == &fast.c and third == &slow.c) or
+            (second == &slow.c and third == &fast.c),
     );
-    try std.testing.expectEqual(null, try cq.wait());
+    try std.testing.expect(cq.isEmpty());
 }
 
 test "CompletionQueue: a notify that lands while an Async is unarmed is not lost (#673)" {
@@ -574,20 +633,20 @@ test "CompletionQueue: a notify that lands while an Async is unarmed is not lost
     defer cq.cancelAll(.discard);
 
     var mailbox = ev.Async.init();
-    cq.submit(&mailbox.c);
+    try cq.submit(&mailbox.c);
     mailbox.notify();
     const first = try cq.wait();
-    try std.testing.expectEqual(&mailbox.c, first.?);
+    try std.testing.expectEqual(&mailbox.c, first);
 
     // The handle is unarmed now. `notify` latches on the handle itself, and
     // the re-submit below picks the latch up through `Loop.add`. Handing the
     // same completion back is what makes this lossless: re-initialising the
     // handle here would zero the latch and drop this notify.
     mailbox.notify();
-    cq.submit(&mailbox.c);
+    try cq.submit(&mailbox.c);
 
     const second = try cq.timedWait(.fromSeconds(5));
-    try std.testing.expectEqual(&mailbox.c, second.?);
+    try std.testing.expectEqual(&mailbox.c, second);
 }
 
 test "CompletionQueue: cancel takes one operation out and leaves the rest armed" {
@@ -601,10 +660,10 @@ test "CompletionQueue: cancel takes one operation out and leaves the rest armed"
     var doomed = ev.Timer.init(.{ .duration = .fromSeconds(10) });
     var tail = ev.Timer.init(.{ .duration = .fromSeconds(10) });
     var keeper = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
-    cq.submit(&head.c);
-    cq.submit(&doomed.c);
-    cq.submit(&tail.c);
-    cq.submit(&keeper.c);
+    try cq.submit(&head.c);
+    try cq.submit(&doomed.c);
+    try cq.submit(&tail.c);
+    try cq.submit(&keeper.c);
 
     // Let `keeper` finish, so the cancel below has to find `doomed` in the
     // middle of a non-empty `pending` while `completed` is non-empty too.
@@ -618,7 +677,7 @@ test "CompletionQueue: cancel takes one operation out and leaves the rest armed"
 
     // `doomed` is out of the queue; everything else is where it was.
     const c = try cq.wait();
-    try std.testing.expectEqual(&keeper.c, c.?);
+    try std.testing.expectEqual(&keeper.c, c);
     try keeper.getResult();
     try std.testing.expect(cq.hasPending());
 
@@ -636,9 +695,9 @@ test "CompletionQueue: cancel of an operation that already finished keeps its re
     var first = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
     var middle = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
     var last = ev.Timer.init(.{ .duration = .fromMilliseconds(15) });
-    cq.submit(&first.c);
-    cq.submit(&middle.c);
-    cq.submit(&last.c);
+    try cq.submit(&first.c);
+    try cq.submit(&middle.c);
+    try cq.submit(&last.c);
 
     // Let all three finish into `completed` without taking any of them.
     var pause = ev.Timer.init(.{ .duration = .fromMilliseconds(80) });
@@ -652,10 +711,9 @@ test "CompletionQueue: cancel of an operation that already finished keeps its re
     try middle.getResult();
 
     const a = try cq.wait();
-    try std.testing.expectEqual(&first.c, a.?);
+    try std.testing.expectEqual(&first.c, a);
     const b = try cq.wait();
-    try std.testing.expectEqual(&last.c, b.?);
-    try std.testing.expectEqual(null, try cq.wait());
+    try std.testing.expectEqual(&last.c, b);
     try std.testing.expect(cq.isEmpty());
 }
 
@@ -667,9 +725,9 @@ test "CompletionQueue: cancel of an operation the queue already handed out" {
     defer cq.cancelAll(.discard);
 
     var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
-    cq.submit(&timer.c);
+    try cq.submit(&timer.c);
     const c = try cq.wait();
-    try std.testing.expectEqual(&timer.c, c.?);
+    try std.testing.expectEqual(&timer.c, c);
 
     // In neither queue any more: a no-op rather than a broken list walk.
     cq.cancel(&timer.c);
@@ -684,17 +742,17 @@ test "CompletionQueue: cancelAll(.keep) hands back what the operations returned"
     var cq = CompletionQueue.init();
 
     var slow: [3]ev.Timer = @splat(ev.Timer.init(.{ .duration = .fromSeconds(10) }));
-    for (&slow) |*t| cq.submit(&t.c);
+    for (&slow) |*t| try cq.submit(&t.c);
 
     cq.cancelAll(.keep);
     try std.testing.expect(!cq.hasPending());
 
     var seen: usize = 0;
-    while (try cq.wait()) |c| : (seen += 1) {
+    while (!cq.isEmpty()) : (seen += 1) {
+        const c = try cq.wait();
         try std.testing.expectError(error.Canceled, c.cast(ev.Timer).getResult());
     }
     try std.testing.expectEqual(3, seen);
-    try std.testing.expect(cq.isEmpty());
 }
 
 test "CompletionQueue: cancelAll(.discard) leaves the queue empty" {
@@ -705,8 +763,8 @@ test "CompletionQueue: cancelAll(.discard) leaves the queue empty" {
 
     var slow = ev.Timer.init(.{ .duration = .fromSeconds(10) });
     var done = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
-    cq.submit(&slow.c);
-    cq.submit(&done.c);
+    try cq.submit(&slow.c);
+    try cq.submit(&done.c);
 
     // Let the short one finish so a result is sitting in `completed` too.
     var pause = ev.Timer.init(.{ .duration = .fromMilliseconds(80) });
@@ -715,8 +773,107 @@ test "CompletionQueue: cancelAll(.discard) leaves the queue empty" {
 
     cq.cancelAll(.discard);
     try std.testing.expect(cq.isEmpty());
-    try std.testing.expectEqual(null, try cq.wait());
 
     // Calling it again with nothing left is fine.
     cq.cancelAll(.discard);
+}
+
+test "CompletionQueue: submit after close returns error.Closed" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    cq.close();
+
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    try std.testing.expectError(error.Closed, cq.submit(&timer.c));
+
+    // The refused completion was left untouched: no ownership taken, nothing
+    // queued, free to go to another queue.
+    try std.testing.expectEqual(null, timer.c.group.owner);
+    try std.testing.expect(cq.isEmpty());
+}
+
+test "CompletionQueue: close hands out in-flight completions before error.Closed" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
+    try cq.submit(&timer.c);
+    cq.close();
+
+    // Closed but not drained: the wait still blocks for the in-flight
+    // operation and delivers it.
+    const c = try cq.timedWait(.fromSeconds(5));
+    try std.testing.expectEqual(&timer.c, c);
+    try timer.getResult();
+
+    try std.testing.expectError(error.Closed, cq.wait());
+}
+
+test "CompletionQueue: another task's submit satisfies a wait blocked on an empty queue" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancelAll(.discard);
+
+    const Producer = struct {
+        fn run(cq_: *CompletionQueue, timer: *ev.Timer) !void {
+            // Give the driver time to park on the empty queue first.
+            var pause = ev.Timer.init(.{ .duration = .fromMilliseconds(20) });
+            try common.waitForIo(&pause.c);
+            try cq_.submit(&timer.c);
+        }
+    };
+
+    // The timer outlives the producer task: it is handed to the driver, not
+    // kept in the producer's frame.
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    var handle = try rt.spawn(Producer.run, .{ &cq, &timer });
+    defer handle.cancel();
+
+    // Empty and open: parks until the producer's operation completes.
+    const c = try cq.timedWait(.fromSeconds(5));
+    try std.testing.expectEqual(&timer.c, c);
+    try timer.getResult();
+    try handle.join();
+}
+
+test "CompletionQueue: canceling the waiting driver closes the queue and keeps results" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+
+    var slow = ev.Timer.init(.{ .duration = .fromSeconds(10) });
+    try cq.submit(&slow.c);
+
+    const Driver = struct {
+        fn run(cq_: *CompletionQueue) (Cancelable || Closeable)!void {
+            _ = try cq_.wait();
+        }
+    };
+
+    var handle = try rt.spawn(Driver.run, .{&cq});
+
+    // Let the driver park on the queue, then cancel it.
+    var pause = ev.Timer.init(.{ .duration = .fromMilliseconds(20) });
+    try common.waitForIo(&pause.c);
+    handle.cancel();
+
+    // The canceled wait closed the queue and canceled every operation with
+    // its result kept, so producers are turned away and the cleanup path can
+    // take the results without blocking.
+    var other = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    try std.testing.expectError(error.Closed, cq.submit(&other.c));
+    try std.testing.expect(!cq.hasPending());
+
+    const c = cq.next().?;
+    try std.testing.expectEqual(&slow.c, c);
+    try std.testing.expectError(error.Canceled, slow.getResult());
+    try std.testing.expect(cq.isEmpty());
+    try std.testing.expectError(error.Closed, cq.wait());
 }

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -844,6 +844,59 @@ test "CompletionQueue: another task's submit satisfies a wait blocked on an empt
     try handle.join();
 }
 
+test "CompletionQueue: race group of I/O and timer works as an idle timeout (#677)" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+    defer cq.cancelAll(.discard);
+
+    // The I/O side wins: the group comes back through the queue with the
+    // timer canceled alongside it.
+    var mail1 = ev.Async.init();
+    var idle1 = ev.Timer.init(.{ .duration = .fromSeconds(10) });
+    var grp1 = ev.Group.init(.race);
+    grp1.add(&mail1.c);
+    grp1.add(&idle1.c);
+    try cq.submit(&grp1.c);
+
+    mail1.notify();
+    const first = try cq.timedWait(.fromSeconds(5));
+    try std.testing.expectEqual(&grp1.c, first);
+    try grp1.getResult();
+    try mail1.getResult();
+    try std.testing.expectError(error.Canceled, idle1.getResult());
+
+    // The timer wins: the queue reports the idle timeout. Group membership is
+    // sticky, so a re-park builds a fresh group over re-initialised members
+    // rather than re-submitting the finished one.
+    var mail2 = ev.Async.init();
+    var idle2 = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    var grp2 = ev.Group.init(.race);
+    grp2.add(&mail2.c);
+    grp2.add(&idle2.c);
+    try cq.submit(&grp2.c);
+
+    const second = try cq.timedWait(.fromSeconds(5));
+    try std.testing.expectEqual(&grp2.c, second);
+    try grp2.getResult();
+    try idle2.getResult();
+    try std.testing.expectError(error.Canceled, mail2.getResult());
+
+    // A group still parked in the queue is torn down by cancelAll: the cancel
+    // reaches the group root and takes its members down with it.
+    var mail3 = ev.Async.init();
+    var idle3 = ev.Timer.init(.{ .duration = .fromSeconds(10) });
+    var grp3 = ev.Group.init(.race);
+    grp3.add(&mail3.c);
+    grp3.add(&idle3.c);
+    try cq.submit(&grp3.c);
+
+    cq.cancelAll(.discard);
+    try std.testing.expect(cq.isEmpty());
+    try std.testing.expectError(error.Canceled, grp3.getResult());
+}
+
 test "CompletionQueue: canceling the waiting driver closes the queue and keeps results" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -281,8 +281,15 @@ pub const CompletionQueue = struct {
     /// finish. A cancel that lost the race leaves a real result behind, so read
     /// the operation's own `getResult` rather than assuming `error.Canceled`.
     ///
-    /// Like `wait`, this belongs to the task that drives the queue, and its
-    /// wait cannot itself be canceled.
+    /// NOT thread-safe, unlike `submit` and `close`: this belongs to the task
+    /// that drives the queue and must never run concurrently with `wait`,
+    /// `timedWait`, `next` or `cancelAll`. A concurrent consumer could take
+    /// the finished `c` out of the queue first, leaving the wait below stuck
+    /// forever on a node that already left; the single-driver rule is what
+    /// makes that impossible. To cancel a specific operation from another
+    /// task, ask the driver instead: park an `ev.Async` doorbell in the queue
+    /// and let the driver do the cancel. The wait here cannot itself be
+    /// canceled.
     pub fn cancel(self: *CompletionQueue, c: *Completion) void {
         self.mutex.lock();
         if (unlink(&self.completed, &c.group)) {

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -198,13 +198,15 @@ pub const CompletionQueue = struct {
                     return error.Canceled;
                 },
                 error.Timeout => {
-                    // A completion can still have landed together with the
-                    // timeout; hand it out rather than reporting a timeout
-                    // that did not happen.
+                    // A completion, or the close, can still have landed
+                    // together with the timeout; report those rather than a
+                    // timeout that did not happen.
                     self.mutex.lock();
                     const n = self.completed.pop();
+                    const drained_now = n == null and self.closed and self.pending.isEmpty();
                     self.mutex.unlock();
-                    return if (n) |x| completionFromGroup(x) else error.Timeout;
+                    if (n) |x| return completionFromGroup(x);
+                    return if (drained_now) error.Closed else error.Timeout;
                 },
             };
         }

--- a/src/group.zig
+++ b/src/group.zig
@@ -299,7 +299,7 @@ pub fn groupSpawnBlockingTask(
 /// Register an awaitable with a group.
 /// Increments counter, sets group_node.group, and adds to task list.
 /// Returns error.Closed if group is closed.
-pub fn registerGroupTask(group: *Group, awaitable: *Awaitable) error{Closed}!void {
+pub fn registerGroupTask(group: *Group, awaitable: *Awaitable) Closeable!void {
     if (group.isClosed()) return error.Closed;
     const prev_state = @atomicRmw(u32, group.getState(), .Add, 1, .acq_rel);
     const prev_counter = prev_state & Group.counter_mask;
@@ -343,6 +343,7 @@ pub const GroupNode = struct {
 };
 
 const Cancelable = @import("common.zig").Cancelable;
+const Closeable = @import("common.zig").Closeable;
 
 fn testFn(arg: usize) usize {
     return arg + 1;

--- a/src/select.zig
+++ b/src/select.zig
@@ -71,7 +71,7 @@ const meta = @import("meta.zig");
 //     Must only be called after asyncWait() returns false or after waiter.wake() is called.
 //
 //     Returns: The result value. For operations that can fail, Result may be an error union
-//              (e.g., error{ChannelClosed}!T).
+//              (e.g., error{Closed}!T).
 //
 //     Guarantees:
 //       - All side effects from the operation that produced the result are visible

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -10,6 +10,7 @@ const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const Barrier = @import("Barrier.zig");
 const select = @import("../select.zig").select;
 const Waiter = @import("../common.zig").Waiter;
+const Closeable = @import("../common.zig").Closeable;
 const Mutex = @import("Mutex.zig");
 
 /// Consumer position tracker.
@@ -163,7 +164,7 @@ const AsyncReceiveImpl = struct {
 
     pub const WaitContext = struct {
         result_ptr: [*]u8 = undefined,
-        result: ?error{ Closed, Lagged }!void = null,
+        result: ?(Closeable || error{Lagged})!void = null,
     };
 
     pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) bool {
@@ -213,7 +214,7 @@ const AsyncReceiveImpl = struct {
         return was_in_queue;
     }
 
-    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) error{ Closed, Lagged }!void {
+    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) (Closeable || error{Lagged})!void {
         // Fast path: result already set by asyncWait
         if (ctx.result) |r| {
             return r;

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -11,14 +11,15 @@ const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const select = @import("../select.zig").select;
 const common = @import("../common.zig");
 const Waiter = common.Waiter;
+const Closeable = common.Closeable;
 const NO_WINNER = common.NO_WINNER;
 const Mutex = @import("Mutex.zig");
 
 /// Specifies how a channel should be closed.
 pub const CloseMode = enum {
-    /// Close gracefully - allows receivers to drain buffered values before receiving error.ChannelClosed
+    /// Close gracefully - allows receivers to drain buffered values before receiving error.Closed
     graceful,
-    /// Close immediately - clears all buffered items so receivers get error.ChannelClosed right away
+    /// Close immediately - clears all buffered items so receivers get error.Closed right away
     immediate,
 };
 
@@ -102,7 +103,7 @@ const ChannelImpl = struct {
 
         const is_closed = self.closed;
         self.mutex.unlock();
-        return if (is_closed) error.ChannelClosed else error.ChannelEmpty;
+        return if (is_closed) error.Closed else error.WouldBlock;
     }
 
     fn takeItemAndWakeSender(self: *Self, elem_ptr: [*]u8) void {
@@ -154,7 +155,7 @@ const ChannelImpl = struct {
 
         if (self.closed) {
             self.mutex.unlock();
-            return error.ChannelClosed;
+            return error.Closed;
         }
 
         while (self.receiver_queue.pop()) |node| {
@@ -170,7 +171,7 @@ const ChannelImpl = struct {
 
         if (self.count == self.capacity) {
             self.mutex.unlock();
-            return error.ChannelFull;
+            return error.WouldBlock;
         }
 
         @memcpy(self.elemPtr(self.tail)[0..self.elem_size], elem_ptr[0..self.elem_size]);
@@ -274,12 +275,12 @@ const AsyncSendImpl = struct {
         return !waiter.didWin();
     }
 
-    pub fn getResult(self: *const SendSelf, ctx: *WaitContext) error{ChannelClosed}!void {
+    pub fn getResult(self: *const SendSelf, ctx: *WaitContext) Closeable!void {
         if (ctx.succeeded) {
             return {};
         }
         std.debug.assert(self.channel.closed);
-        return error.ChannelClosed;
+        return error.Closed;
     }
 };
 
@@ -342,7 +343,7 @@ const AsyncReceiveImpl = struct {
         return !waiter.didWin();
     }
 
-    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) error{ChannelClosed}!void {
+    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) Closeable!void {
         // Result already set by direct transfer or fast path
         if (ctx.result_set) {
             return;
@@ -358,7 +359,7 @@ const AsyncReceiveImpl = struct {
 
         std.debug.assert(self.channel.closed);
         self.channel.mutex.unlock();
-        return error.ChannelClosed;
+        return error.Closed;
     }
 };
 
@@ -376,7 +377,7 @@ const AsyncReceiveImpl = struct {
 /// proceed.
 ///
 /// Channels can be closed to signal that no more values will be sent. After closing,
-/// receivers can drain any remaining buffered values before receiving `error.ChannelClosed`.
+/// receivers can drain any remaining buffered values before receiving `error.Closed`.
 ///
 /// ## Example
 ///
@@ -391,7 +392,7 @@ const AsyncReceiveImpl = struct {
 ///     while (ch.receive()) |value| {
 ///         std.debug.print("Received: {}\n", .{value});
 ///     } else |err| switch (err) {
-///         error.ChannelClosed => {}, // Normal shutdown
+///         error.Closed => {}, // Normal shutdown
 ///         else => return err,
 ///     }
 /// }
@@ -436,7 +437,7 @@ pub fn Channel(comptime T: type) type {
         /// Suspends the current task if the channel is empty until a value is sent.
         /// Values are received in FIFO order.
         ///
-        /// Returns `error.ChannelClosed` if the channel is closed and empty.
+        /// Returns `error.Closed` if the channel is closed and empty.
         /// Returns `error.Canceled` if the task is cancelled while waiting.
         pub fn receive(self: *Self) !T {
             var result: T = undefined;
@@ -448,8 +449,8 @@ pub fn Channel(comptime T: type) type {
         ///
         /// Returns immediately with a value if available, otherwise returns an error.
         ///
-        /// Returns `error.ChannelEmpty` if the channel is empty and no sender waiting.
-        /// Returns `error.ChannelClosed` if the channel is closed and empty.
+        /// Returns `error.WouldBlock` if the channel is empty and no sender waiting.
+        /// Returns `error.Closed` if the channel is closed and empty.
         pub fn tryReceive(self: *Self) !T {
             var result: T = undefined;
             try self.impl.tryReceive(std.mem.asBytes(&result).ptr);
@@ -460,7 +461,7 @@ pub fn Channel(comptime T: type) type {
         ///
         /// Suspends the current task if the channel is full until space becomes available.
         ///
-        /// Returns `error.ChannelClosed` if the channel is closed.
+        /// Returns `error.Closed` if the channel is closed.
         /// Returns `error.Canceled` if the task is cancelled while waiting.
         pub fn send(self: *Self, item: T) !void {
             return self.impl.send(std.mem.asBytes(&item).ptr);
@@ -470,21 +471,21 @@ pub fn Channel(comptime T: type) type {
         ///
         /// Returns immediately with success if space is available, otherwise returns an error.
         ///
-        /// Returns `error.ChannelFull` if the channel is full.
-        /// Returns `error.ChannelClosed` if the channel is closed.
+        /// Returns `error.WouldBlock` if the channel is full.
+        /// Returns `error.Closed` if the channel is closed.
         pub fn trySend(self: *Self, item: T) !void {
             return self.impl.trySend(std.mem.asBytes(&item).ptr);
         }
 
         /// Closes the channel.
         ///
-        /// After closing, all send operations will fail with `error.ChannelClosed`.
+        /// After closing, all send operations will fail with `error.Closed`.
         /// Receive operations can still drain any buffered values before returning
-        /// `error.ChannelClosed`.
+        /// `error.Closed`.
         ///
         /// Use `CloseMode.graceful` to allow receivers to drain buffered values.
         /// Use `CloseMode.immediate` to clear all buffered items immediately,
-        /// causing receivers to get `error.ChannelClosed` right away.
+        /// causing receivers to get `error.Closed` right away.
         pub fn close(self: *Self, mode: CloseMode) void {
             self.impl.close(mode);
         }
@@ -544,7 +545,7 @@ pub fn AsyncReceive(comptime T: type) type {
 
         const Self = @This();
 
-        pub const Result = error{ChannelClosed}!T;
+        pub const Result = Closeable!T;
 
         pub const WaitContext = struct {
             impl_ctx: AsyncReceiveImpl.WaitContext = .{ .result_ptr = undefined },
@@ -597,7 +598,7 @@ pub fn AsyncSend(comptime T: type) type {
 
         const Self = @This();
 
-        pub const Result = error{ChannelClosed}!void;
+        pub const Result = Closeable!void;
 
         pub const WaitContext = struct {
             impl_ctx: AsyncSendImpl.WaitContext = .{ .item_ptr = undefined },
@@ -678,7 +679,7 @@ test "Channel: trySend and tryReceive" {
         fn testTry(ch: *Channel(u32)) !void {
             // tryReceive on empty channel should fail
             const empty_err = ch.tryReceive();
-            try std.testing.expectError(error.ChannelEmpty, empty_err);
+            try std.testing.expectError(error.WouldBlock, empty_err);
 
             // trySend should succeed
             try ch.trySend(1);
@@ -686,7 +687,7 @@ test "Channel: trySend and tryReceive" {
 
             // trySend on full channel should fail
             const full_err = ch.trySend(3);
-            try std.testing.expectError(error.ChannelFull, full_err);
+            try std.testing.expectError(error.WouldBlock, full_err);
 
             // tryReceive should succeed
             const val1 = try ch.tryReceive();
@@ -697,7 +698,7 @@ test "Channel: trySend and tryReceive" {
 
             // tryReceive on empty channel should fail again
             const empty_err2 = ch.tryReceive();
-            try std.testing.expectError(error.ChannelEmpty, empty_err2);
+            try std.testing.expectError(error.WouldBlock, empty_err2);
         }
     };
 
@@ -830,7 +831,7 @@ test "Channel: close graceful" {
             try yield(); // Let producer finish
             results[0] = ch.receive() catch null;
             results[1] = ch.receive() catch null;
-            results[2] = ch.receive() catch null; // Should fail with ChannelClosed
+            results[2] = ch.receive() catch null; // Should fail with Closed
         }
     };
 
@@ -897,10 +898,10 @@ test "Channel: send on closed channel" {
             ch.close(.graceful);
 
             const put_err = ch.send(1);
-            try std.testing.expectError(error.ChannelClosed, put_err);
+            try std.testing.expectError(error.Closed, put_err);
 
             const tryput_err = ch.trySend(2);
-            try std.testing.expectError(error.ChannelClosed, tryput_err);
+            try std.testing.expectError(error.Closed, tryput_err);
         }
     };
 
@@ -1055,7 +1056,7 @@ test "Channel: asyncReceive with select - closed channel" {
             const result = try select(.{ .recv = &recv });
             switch (result) {
                 .recv => |val| {
-                    try std.testing.expectError(error.ChannelClosed, val);
+                    try std.testing.expectError(error.Closed, val);
                 },
             }
         }
@@ -1145,7 +1146,7 @@ test "Channel: asyncSend with select - closed channel" {
             const result = try select(.{ .send = &send_op });
             switch (result) {
                 .send => |res| {
-                    try std.testing.expectError(error.ChannelClosed, res);
+                    try std.testing.expectError(error.Closed, res);
                 },
             }
         }
@@ -1302,7 +1303,7 @@ test "Channel: unbuffered - trySend fails without receiver" {
 
     // trySend should fail immediately - no buffer space and no receiver
     const err = channel.trySend(42);
-    try std.testing.expectError(error.ChannelFull, err);
+    try std.testing.expectError(error.WouldBlock, err);
 }
 
 test "Channel: unbuffered - tryReceive fails without sender" {
@@ -1310,7 +1311,7 @@ test "Channel: unbuffered - tryReceive fails without sender" {
 
     // tryReceive should fail immediately - no buffer and no sender
     const err = channel.tryReceive();
-    try std.testing.expectError(error.ChannelEmpty, err);
+    try std.testing.expectError(error.WouldBlock, err);
 }
 
 test "Channel: unbuffered - sender blocks until receiver ready" {
@@ -1443,7 +1444,7 @@ test "Channel: unbuffered - close wakes blocked sender" {
     const TestFn = struct {
         fn sender(ch: *Channel(u32), got_closed: *bool) !void {
             ch.send(42) catch |err| {
-                got_closed.* = (err == error.ChannelClosed);
+                got_closed.* = (err == error.Closed);
                 return;
             };
         }
@@ -1478,7 +1479,7 @@ test "Channel: unbuffered - close wakes blocked receiver" {
     const TestFn = struct {
         fn receiver(ch: *Channel(u32), got_error: *bool) !void {
             _ = ch.receive() catch |err| {
-                got_error.* = (err == error.ChannelClosed);
+                got_error.* = (err == error.Closed);
                 return;
             };
         }
@@ -1548,7 +1549,7 @@ test "Channel: close wakes blocked select receiver" {
             var recv = ch.asyncReceive();
             const result = try select(.{ .recv = &recv });
             switch (result) {
-                .recv => |value| try std.testing.expectError(error.ChannelClosed, value),
+                .recv => |value| try std.testing.expectError(error.Closed, value),
             }
         }
 
@@ -1580,7 +1581,7 @@ test "Channel: close wakes blocked select sender" {
             var send = ch.asyncSend(42);
             const result = try select(.{ .send = &send });
             switch (result) {
-                .send => |send_result| try std.testing.expectError(error.ChannelClosed, send_result),
+                .send => |send_result| try std.testing.expectError(error.Closed, send_result),
             }
         }
 
@@ -1624,7 +1625,7 @@ test "Channel: close classifies select waiters before signaling" {
     try std.testing.expectEqual(0, claimed_receive_winner.load(.acquire));
     try std.testing.expect(!claimed_receive.asyncCancelWait(&claimed_receive_waiter, &claimed_receive_ctx));
     try std.testing.expectEqual(1, Helpers.notifyState(&claimed_receive_parent));
-    try std.testing.expectError(error.ChannelClosed, claimed_receive.getResult(&claimed_receive_ctx));
+    try std.testing.expectError(error.Closed, claimed_receive.getResult(&claimed_receive_ctx));
 
     // Exercise the same committed-signal handshake for a pending send.
     var claimed_send_channel = Channel(u32).init(&.{});
@@ -1639,7 +1640,7 @@ test "Channel: close classifies select waiters before signaling" {
     try std.testing.expectEqual(0, claimed_send_winner.load(.acquire));
     try std.testing.expect(!claimed_send.asyncCancelWait(&claimed_send_waiter, &claimed_send_ctx));
     try std.testing.expectEqual(1, Helpers.notifyState(&claimed_send_parent));
-    try std.testing.expectError(error.ChannelClosed, claimed_send.getResult(&claimed_send_ctx));
+    try std.testing.expectError(error.Closed, claimed_send.getResult(&claimed_send_ctx));
 
     // Simulate another select arm having already won before close removes a
     // pending receive. The losing waiter must be discarded without a signal.

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -36,6 +36,7 @@ pub const TaskLocal = @import("task.zig").TaskLocal;
 const common = @import("common.zig");
 pub const Cancelable = common.Cancelable;
 pub const Timeoutable = common.Timeoutable;
+pub const Closeable = common.Closeable;
 pub const blockInPlace = common.blockInPlace;
 
 pub const time = @import("time.zig"); // TODO: make non-pub


### PR DESCRIPTION
Reworks `CompletionQueue` so tasks other than the driver can park their operations in it (e.g. a task handing its `NetRecv` to a central dispatcher), per the design discussion, and unifies close-related error naming across the library:

- **`submit` is thread-safe** and callable from any task. The operation joins the submitter's own loop; cross-loop cancellation was already routed by `Loop.cancel`. Operations submitted from another task must be heap-backed (the submitter may unwind before the driver takes the completion); the module doc spells out the ownership rules.
- **`wait`/`timedWait` block on an empty open queue** instead of returning null, so a later submission (from any task) satisfies a wait already in progress. The optional is gone from the return type. Batch-style waiting (driver submits everything itself) uses `while (!cq.isEmpty()) { const c = try cq.wait(); ... }` — race-free because the driver is the only consumer: nodes only leave the union of the two queues through the driver's own pops.
- **`close()`** is the end-of-stream signal: thread-safe, idempotent; further submissions fail with `error.Closed`, in-flight operations still get delivered, and once the queue is drained `wait` returns `error.Closed` — the same drained-then-closed semantics as `Channel`.
- **A canceled wait now closes the queue and runs `cancelAll(.keep)`** instead of `cancelAll(.discard)`. With foreign heap-backed operations the old discard would leak every one of them; now the cleanup path drains results with `next` (which cannot block at that point) and frees them. Close comes first so no submission slips in behind the drain.
- **`common.Waiter` is replaced by a `zio.Futex` generation word** that counts completion arrivals and the close and is never reset; waiters snapshot it before checking the queues. This removes `resetSignals` (which reached into the Waiter's notify internals) and the init-time task capture (the Waiter bound the queue to the task that called `init`; the futex resolves the waiting task per wait). Wake batching is unaffected either way: owner-callback wakes run inline during poll, outside `drainDispatched`, under both mechanisms.
- **`Closeable` error set** (`error{Closed}`) joins `Cancelable`/`Timeoutable` in `common.zig`, re-exported from `zio`, and is adopted where ad-hoc sets were spelled out: `registerGroupTask` and the broadcast channel's receive plumbing.
- **`Channel` error rename** (breaking): `error.ChannelClosed` → `error.Closed` via `Closeable`, matching every other closeable type; `error.ChannelEmpty`/`error.ChannelFull` → `error.WouldBlock`, the name `BroadcastChannel.tryReceive` and the io try-operations already use (each try-operation has one blocking cause, so nothing is lost). `select.zig` and the examples are updated.

Existing tests are migrated mechanically (guard loop instead of null-check loop, `try cq.submit`). New tests: submit-after-close, close-drains-before-`error.Closed`, a wait blocked on an empty queue satisfied by another task's submit, driver cancellation keeping results for a non-blocking `next` drain, and `timedWait` on an open empty queue timing out rather than reporting exhaustion. Full suite passes; the CompletionQueue tests were run 10x for flake-checking.
