### PR TITLE
Runtime.fromIo: return null for a std.Io from another backend

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -2562,7 +2562,16 @@ test "Runtime.io / Runtime.fromIo round-trip" {
 
     const value = rt.io();
     try std.testing.expect(value.vtable == &vtable);
-    try std.testing.expectEqual(rt, Runtime.fromIo(value));
+    try std.testing.expectEqual(rt, Runtime.fromIo(value).?);
+}
+
+test "Runtime.fromIo answers null for a std.Io from another backend" {
+    // Same contents, different address: identity of the vtable pointer is
+    // what marks a zio-backed `std.Io`, not what the table contains. A `var`
+    // copy guarantees storage distinct from the real vtable's.
+    var foreign_vtable = vtable;
+    const foreign: Io = .{ .userdata = null, .vtable = &foreign_vtable };
+    try std.testing.expectEqual(null, Runtime.fromIo(foreign));
 }
 
 test "io: async/await returns task result" {

--- a/src/io.zig
+++ b/src/io.zig
@@ -2574,6 +2574,12 @@ test "Runtime.fromIo answers null for a std.Io from another backend" {
     try std.testing.expectEqual(null, Runtime.fromIo(foreign));
 }
 
+test "Runtime.fromIo answers null for debug_io" {
+    // zio's own vtable, but no runtime behind it: the userdata check is what
+    // stops this from being cast into a *Runtime.
+    try std.testing.expectEqual(null, Runtime.fromIo(debug_io));
+}
+
 test "io: async/await returns task result" {
     const rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();

--- a/src/net.zig
+++ b/src/net.zig
@@ -1230,7 +1230,7 @@ pub const Stream = struct {
         }
 
         pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Reader {
-            _ = Runtime.fromIo(io);
+            std.debug.assert(Runtime.fromIo(io) != null); // adopting the handle needs a zio-backed std.Io
             return init(stdIoHandleToZio(stream.socket.handle), buffer);
         }
 
@@ -1291,7 +1291,7 @@ pub const Stream = struct {
         }
 
         pub fn fromStd(stream: std.Io.net.Stream, io: std.Io, buffer: []u8) Writer {
-            _ = Runtime.fromIo(io);
+            std.debug.assert(Runtime.fromIo(io) != null); // adopting the handle needs a zio-backed std.Io
             return init(stdIoHandleToZio(stream.socket.handle), buffer);
         }
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1887,7 +1887,9 @@ pub const Runtime = struct {
     /// paths.
     pub fn fromIo(value: std.Io) ?*Runtime {
         const io_impl = @import("io.zig");
-        if (value.vtable != &io_impl.vtable) return null;
+        // The vtable alone is not enough: `debug_io` carries zio's vtable
+        // with no runtime behind it.
+        if (value.vtable != &io_impl.vtable or value.userdata == null) return null;
         return io_impl.toRuntime(value);
     }
 };

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1879,9 +1879,16 @@ pub const Runtime = struct {
         return @import("io.zig").fromRuntime(self);
     }
 
-    /// Recover the `*Runtime` from a `std.Io` produced by `Runtime.io()`.
-    pub fn fromIo(value: std.Io) *Runtime {
-        return @import("io.zig").toRuntime(value);
+    /// Recover the `*Runtime` from a `std.Io` produced by `Runtime.io()`,
+    /// or null when it is backed by some other implementation. The vtable
+    /// pointer is the discriminator: every zio-backed `std.Io` shares the
+    /// one static vtable, and no other backend can carry its address. This
+    /// is how a library taking `std.Io` detects zio and unlocks zio-native
+    /// paths.
+    pub fn fromIo(value: std.Io) ?*Runtime {
+        const io_impl = @import("io.zig");
+        if (value.vtable != &io_impl.vtable) return null;
+        return io_impl.toRuntime(value);
     }
 };
 


### PR DESCRIPTION
`Runtime.fromIo` asserted the vtable and cast unconditionally, so a library that takes `std.Io` and wants to detect zio — to unlock zio-native paths like parking keep-alive connections on a `CompletionQueue` — had no safe probe: a `std.Io.Threaded` instance would trip the assert in debug and cast garbage in release.

It now returns `?*Runtime`, null when the vtable pointer is not zio's static vtable. Identity of the pointer is the discriminator, which the new negative test pins by handing `fromIo` a byte-identical *copy* of the vtable at a different address.

The two `net.zig` `fromStd` callers that used `fromIo` purely as an assertion keep that guard as an explicit `std.debug.assert`.

Motivation: dusty's dual-engine detection — `if (zio.Runtime.fromIo(io)) |rt| { zio-native engine } else { portable engine }`.