### PR TITLE
sleep: make zero-duration sleep a cheap yield, fix Timeout.none

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1806,7 +1806,14 @@ fn clockResolutionImpl(_: ?*anyopaque, clock: Io.Clock) Io.Clock.ResolutionError
 }
 
 fn sleepImpl(_: ?*anyopaque, timeout: Io.Timeout) Io.Cancelable!void {
-    if (timeout == .none) return;
+    // A zero-length duration has nothing to time: don't arm a loop timer
+    // just to yield. This makes `Io.sleep(io, .{ .duration = .zero })` the
+    // portable way std.Io code spells "yield". `.none` has no time bound at
+    // all, so it falls through to the ordinary path below and blocks forever
+    // (until canceled), same as every other Timeout consumer.
+    if (timeout == .duration and timeout.duration.raw.nanoseconds <= 0) {
+        return runtime_mod.yield();
+    }
     var waiter: Waiter = .init();
     // Nothing ever signals this waiter, so the timeout firing is the sleep
     // finishing.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1396,6 +1396,8 @@ pub fn now() Timestamp {
 
 /// Sleep for a specified duration.
 pub fn sleep(duration: Duration) Cancelable!void {
+    // Nothing to time: don't arm a loop timer just to yield.
+    if (duration.value == 0) return yield();
     var waiter: Waiter = .init();
     // Nothing ever signals this waiter, so the timeout firing is the sleep
     // finishing.


### PR DESCRIPTION
## Why

`sleep(0)` / `Io.sleep(io, .{ .duration = .zero })` armed a real loop timer and parked on it just to fire immediately - needlessly expensive for what's otherwise the natural "yield now" idiom (matching e.g. `await asyncio.sleep(0)`). Came up while discussing #685/#686: `maybeYield()` isn't a drop-in replacement for that idiom since it's budget-gated rather than an unconditional-if-contended yield.

## What

- `sleep(duration)` and `sleepImpl` special-case a zero-length duration to call `yield()` directly instead of arming a timer. `yield()` still guarantees a bounded real reschedule (its own fast path falls through once tick budget or ready-queue contention requires it), so this stays a safe substitute, including for std.Io-generic code that has no zio-specific yield to call.
- Fixes an unrelated pre-existing bug found while touching this code: `sleepImpl` treated `Timeout.none` as "return immediately" instead of "no time bound, block until canceled" - inconsistent with how `Waiter.timedWaitClock`, which it calls into, already handles `.none` for every other caller.

## Test

`./check.sh --full`: 640 passed, 1 skipped.