### PR TITLE
io: add Runtime.blockingIo() for blocking std.Io dispatch

### DIFF
--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -101,6 +101,20 @@ pub const Awaitable = struct {
         };
     }
 
+    /// Get the raw result bytes from this awaitable.
+    pub fn getResultSlice(self: *Awaitable) []u8 {
+        return switch (self.kind) {
+            .task => {
+                const task = AnyTask.fromAwaitable(self);
+                return task.closure.getResultSlice(AnyTask, task);
+            },
+            .blocking_task => {
+                const task = AnyBlockingTask.fromAwaitable(self);
+                return task.closure.getResultSlice(AnyBlockingTask, task);
+            },
+        };
+    }
+
     /// Release the awaitable, decrementing the reference count and destroying it if necessary.
     pub fn release(self: *Awaitable) void {
         if (self.ref_count.decr()) self.destroy();

--- a/src/blocking_task.zig
+++ b/src/blocking_task.zig
@@ -182,6 +182,10 @@ fn registerBlockingTask(rt: *Runtime, task: *AnyBlockingTask) error{RuntimeShutd
 /// Spawn a blocking task with raw context bytes and start function.
 /// Used by Runtime.spawnBlocking and Group.spawnBlocking.
 /// Thread-safe: can be called from any thread.
+pub const SpawnOptions = struct {
+    reserve_thread: bool = false,
+};
+
 pub fn spawnBlockingTask(
     rt: *Runtime,
     result_len: usize,
@@ -190,6 +194,7 @@ pub fn spawnBlockingTask(
     context_alignment: std.mem.Alignment,
     start: Closure.Start,
     group: ?*Group,
+    options: SpawnOptions,
 ) !*AnyBlockingTask {
     const task = try AnyBlockingTask.create(
         rt,
@@ -200,6 +205,8 @@ pub fn spawnBlockingTask(
         start,
     );
     errdefer task.destroy();
+
+    task.work.reserve_thread = options.reserve_thread;
 
     // +1 ref before the task is reachable by anyone else, to prevent a race
     // where it completes before the caller can take ownership. See spawnTask

--- a/src/group.zig
+++ b/src/group.zig
@@ -146,7 +146,7 @@ pub const Group = struct {
         const ReturnType = @typeInfo(@TypeOf(func)).@"fn".return_type.?;
         const Context = struct { group: *Group, args: Args };
         const Wrapper = struct {
-            fn start(ctx: *const anyopaque, _: *anyopaque) void {
+            fn start(ctx: *const anyopaque) void {
                 const context: *const Context = @ptrCast(@alignCast(ctx));
                 const group = context.group;
                 if (@typeInfo(ReturnType) == .error_union) {
@@ -285,15 +285,15 @@ pub fn groupSpawnTask(
 }
 
 /// Spawn a blocking task in the group with raw context bytes and start function.
-/// Used by Group.spawnBlocking.
+/// Used by Group.spawnBlocking and std.Io vtable implementations.
 pub fn groupSpawnBlockingTask(
     group: *Group,
     rt: *Runtime,
     context: []const u8,
     context_alignment: std.mem.Alignment,
-    start: *const fn (context: *const anyopaque, result: *anyopaque) void,
+    start: *const fn (context: *const anyopaque) void,
 ) !void {
-    _ = try spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .regular = start }, group);
+    _ = try spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, group);
 }
 
 /// Register an awaitable with a group.

--- a/src/group.zig
+++ b/src/group.zig
@@ -15,7 +15,8 @@ const JoinHandle = @import("runtime.zig").JoinHandle;
 const WaitQueue = @import("utils/wait_queue.zig").WaitQueue;
 const Awaitable = @import("awaitable.zig").Awaitable;
 const spawnTask = @import("task.zig").spawnTask;
-const spawnBlockingTask = @import("blocking_task.zig").spawnBlockingTask;
+const spawnBlockingTask_mod = @import("blocking_task.zig");
+const spawnBlockingTask = spawnBlockingTask_mod.spawnBlockingTask;
 const Futex = @import("sync/Futex.zig");
 
 pub const Group = struct {
@@ -165,7 +166,7 @@ pub const Group = struct {
         };
 
         const context: Context = .{ .group = self, .args = args };
-        return groupSpawnBlockingTask(self, rt, std.mem.asBytes(&context), .fromByteUnits(@alignOf(Context)), &Wrapper.start);
+        return groupSpawnBlockingTask(self, rt, std.mem.asBytes(&context), .fromByteUnits(@alignOf(Context)), &Wrapper.start, .{});
     }
 
     /// Wait for every task currently in the group to finish.
@@ -292,8 +293,9 @@ pub fn groupSpawnBlockingTask(
     context: []const u8,
     context_alignment: std.mem.Alignment,
     start: *const fn (context: *const anyopaque) void,
+    options: spawnBlockingTask_mod.SpawnOptions,
 ) !void {
-    _ = try spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, group);
+    _ = try spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, group, options);
 }
 
 /// Register an awaitable with a group.

--- a/src/io.zig
+++ b/src/io.zig
@@ -22,8 +22,8 @@ const beginShield = runtime_mod.beginShield;
 const endShield = runtime_mod.endShield;
 const checkCancel = runtime_mod.checkCancel;
 
-const AnyTask = @import("task.zig").AnyTask;
 const spawnTask = @import("task.zig").spawnTask;
+const spawnBlockingTask = @import("blocking_task.zig").spawnBlockingTask;
 const Awaitable = @import("awaitable.zig").Awaitable;
 const Group = @import("group.zig").Group;
 const groupSpawnTask = @import("group.zig").groupSpawnTask;
@@ -114,21 +114,38 @@ fn positionalUnsupported(file: Io.File) bool {
     return flagsReadPollable(&file.flags) == null;
 }
 
-/// Construct a `std.Io` instance backed by `rt`.
-pub fn fromRuntime(rt: *Runtime) Io {
+pub const Mode = enum { evented, threaded };
+
+/// Tag bit stored in the low bit of `userdata` to select the dispatch mode.
+/// Safe because `Runtime` is pointer-aligned (>= 4 bytes).
+const mode_tag: usize = 1;
+
+fn encodeUserdata(rt: *Runtime, mode: Mode) ?*anyopaque {
+    return @ptrFromInt(@intFromPtr(rt) | switch (mode) {
+        .evented => @as(usize, 0),
+        .threaded => mode_tag,
+    });
+}
+
+fn decodeUserdata(userdata: ?*anyopaque) struct { *Runtime, Mode } {
+    const addr = @intFromPtr(userdata);
+    const rt: *Runtime = @ptrFromInt(addr & ~mode_tag);
+    const mode: Mode = if (addr & mode_tag != 0) .threaded else .evented;
+    return .{ rt, mode };
+}
+
+pub fn fromRuntime(rt: *Runtime, mode: Mode) Io {
     return .{
-        .userdata = @ptrCast(rt),
+        .userdata = encodeUserdata(rt, mode),
         .vtable = &vtable,
     };
 }
 
 /// Recover the underlying runtime from a `std.Io` produced by `fromRuntime`.
-///
-/// Asserts that the vtable matches; passing a `std.Io` from another backend
-/// is a programming error.
 pub fn toRuntime(io: Io) *Runtime {
     std.debug.assert(io.vtable == &vtable);
-    return @ptrCast(@alignCast(io.userdata));
+    const rt, _ = decodeUserdata(io.userdata);
+    return rt;
 }
 
 pub const vtable: Io.VTable = .{
@@ -299,11 +316,15 @@ fn concurrentImpl(
     context_alignment: Alignment,
     start: *const fn (context: *const anyopaque, result: *anyopaque) void,
 ) Io.ConcurrentError!*Io.AnyFuture {
-    const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    const task = spawnTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch {
-        return error.ConcurrencyUnavailable;
+    if (userdata == null) return error.ConcurrencyUnavailable;
+    const rt, const mode = decodeUserdata(userdata);
+    const awaitable = switch (mode) {
+        .evented => &(spawnTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
+            return error.ConcurrencyUnavailable).awaitable,
+        .threaded => &(spawnBlockingTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
+            return error.ConcurrencyUnavailable).awaitable,
     };
-    return @ptrCast(&task.awaitable);
+    return @ptrCast(awaitable);
 }
 
 fn awaitOrCancel(any_future: *Io.AnyFuture, result: []u8, should_cancel: bool) void {
@@ -315,9 +336,7 @@ fn awaitOrCancel(any_future: *Io.AnyFuture, result: []u8, should_cancel: bool) v
 
     _ = select.waitUntilComplete(awaitable);
 
-    const task = AnyTask.fromAwaitable(awaitable);
-    const task_result = task.closure.getResultSlice(AnyTask, task);
-    @memcpy(result, task_result);
+    @memcpy(result, awaitable.getResultSlice());
 
     awaitable.release();
 }
@@ -337,11 +356,21 @@ fn groupAsyncImpl(
     context_alignment: Alignment,
     start: *const fn (context: *const anyopaque) void,
 ) void {
-    const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    groupSpawnTask(Group.fromStd(group), rt, context, context_alignment, start) catch {
-        // Couldn't schedule - run synchronously, matching std.Io.Threaded fallback.
+    if (userdata == null) {
         start(context.ptr);
-    };
+        return;
+    }
+    const rt, const mode = decodeUserdata(userdata);
+    const g = Group.fromStd(group);
+    switch (mode) {
+        .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch {
+            start(context.ptr);
+        },
+        .threaded => _ = spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, g) catch {
+            start(context.ptr);
+            return;
+        },
+    }
 }
 
 fn groupConcurrentImpl(
@@ -351,10 +380,15 @@ fn groupConcurrentImpl(
     context_alignment: Alignment,
     start: *const fn (context: *const anyopaque) void,
 ) Io.ConcurrentError!void {
-    const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    groupSpawnTask(Group.fromStd(group), rt, context, context_alignment, start) catch {
-        return error.ConcurrencyUnavailable;
-    };
+    if (userdata == null) return error.ConcurrencyUnavailable;
+    const rt, const mode = decodeUserdata(userdata);
+    const g = Group.fromStd(group);
+    switch (mode) {
+        .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch
+            return error.ConcurrencyUnavailable,
+        .threaded => _ = spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, g) catch
+            return error.ConcurrencyUnavailable,
+    }
 }
 
 fn groupAwaitImpl(_: ?*anyopaque, group: *Io.Group, _: *anyopaque) Io.Cancelable!void {
@@ -2513,7 +2547,7 @@ fn netLookupImpl(
     options: Io.net.HostName.LookupOptions,
 ) Io.net.HostName.LookupError!void {
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    const io = fromRuntime(rt);
+    const io = fromRuntime(rt, .evented);
     defer resolved.close(io);
 
     // Sized for the largest answer the resolver can return: both families
@@ -4427,4 +4461,50 @@ test "io: concurrent cross-executor cancel of N blocked recvmsg fibers is UAF-fr
     group.await(io) catch {};
 
     try std.testing.expectEqual(N, ctx.canceled.load(.acquire));
+}
+
+test "io: blockingIo concurrent dispatches to thread pool" {
+    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer rt.deinit();
+    const bio = rt.blockingIo();
+
+    const S = struct {
+        fn work() i32 {
+            return 42;
+        }
+    };
+
+    var fut = try Io.concurrent(bio, S.work, .{});
+    try std.testing.expectEqual(42, fut.await(bio));
+}
+
+test "io: blockingIo group concurrent dispatches to thread pool" {
+    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer rt.deinit();
+    const bio = rt.blockingIo();
+
+    var done = std.atomic.Value(bool).init(false);
+
+    const S = struct {
+        fn work(flag: *std.atomic.Value(bool)) void {
+            flag.store(true, .release);
+        }
+    };
+
+    var group: Io.Group = .init;
+    try group.concurrent(bio, S.work, .{&done});
+    group.await(bio) catch {};
+
+    try std.testing.expect(done.load(.acquire));
+}
+
+test "io: fromIo round-trips through blockingIo" {
+    const rt = try Runtime.init(std.testing.allocator, .{ .thread_pool = .{} });
+    defer rt.deinit();
+
+    const bio = rt.blockingIo();
+    try std.testing.expectEqual(rt, Runtime.fromIo(bio).?);
+
+    const aio = rt.io();
+    try std.testing.expectEqual(rt, Runtime.fromIo(aio).?);
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -27,6 +27,7 @@ const spawnBlockingTask = @import("blocking_task.zig").spawnBlockingTask;
 const Awaitable = @import("awaitable.zig").Awaitable;
 const Group = @import("group.zig").Group;
 const groupSpawnTask = @import("group.zig").groupSpawnTask;
+const groupSpawnBlockingTask = @import("group.zig").groupSpawnBlockingTask;
 const select = @import("select.zig");
 const Futex = @import("sync/Futex.zig");
 const Mutex = @import("sync/Mutex.zig");
@@ -366,7 +367,7 @@ fn groupAsyncImpl(
         .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch {
             start(context.ptr);
         },
-        .threaded => _ = spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, g) catch {
+        .threaded => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch {
             start(context.ptr);
             return;
         },
@@ -386,7 +387,7 @@ fn groupConcurrentImpl(
     switch (mode) {
         .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch
             return error.ConcurrencyUnavailable,
-        .threaded => _ = spawnBlockingTask(rt, 0, .@"1", context, context_alignment, .{ .group = start }, g) catch
+        .threaded => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch
             return error.ConcurrencyUnavailable,
     }
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -115,7 +115,7 @@ fn positionalUnsupported(file: Io.File) bool {
     return flagsReadPollable(&file.flags) == null;
 }
 
-pub const Mode = enum { evented, threaded };
+pub const Mode = enum { regular, blocking };
 
 /// Tag bit stored in the low bit of `userdata` to select the dispatch mode.
 /// Safe because `Runtime` is pointer-aligned (>= 4 bytes).
@@ -123,15 +123,15 @@ const mode_tag: usize = 1;
 
 fn encodeUserdata(rt: *Runtime, mode: Mode) ?*anyopaque {
     return @ptrFromInt(@intFromPtr(rt) | switch (mode) {
-        .evented => @as(usize, 0),
-        .threaded => mode_tag,
+        .regular => @as(usize, 0),
+        .blocking => mode_tag,
     });
 }
 
 fn decodeUserdata(userdata: ?*anyopaque) struct { *Runtime, Mode } {
     const addr = @intFromPtr(userdata);
     const rt: *Runtime = @ptrFromInt(addr & ~mode_tag);
-    const mode: Mode = if (addr & mode_tag != 0) .threaded else .evented;
+    const mode: Mode = if (addr & mode_tag != 0) .blocking else .regular;
     return .{ rt, mode };
 }
 
@@ -320,9 +320,9 @@ fn concurrentImpl(
     if (userdata == null) return error.ConcurrencyUnavailable;
     const rt, const mode = decodeUserdata(userdata);
     const awaitable = switch (mode) {
-        .evented => &(spawnTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
+        .regular => &(spawnTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
             return error.ConcurrencyUnavailable).awaitable,
-        .threaded => &(spawnBlockingTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
+        .blocking => &(spawnBlockingTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
             return error.ConcurrencyUnavailable).awaitable,
     };
     return @ptrCast(awaitable);
@@ -364,10 +364,10 @@ fn groupAsyncImpl(
     const rt, const mode = decodeUserdata(userdata);
     const g = Group.fromStd(group);
     switch (mode) {
-        .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch {
+        .regular => groupSpawnTask(g, rt, context, context_alignment, start) catch {
             start(context.ptr);
         },
-        .threaded => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch {
+        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch {
             start(context.ptr);
             return;
         },
@@ -385,9 +385,9 @@ fn groupConcurrentImpl(
     const rt, const mode = decodeUserdata(userdata);
     const g = Group.fromStd(group);
     switch (mode) {
-        .evented => groupSpawnTask(g, rt, context, context_alignment, start) catch
+        .regular => groupSpawnTask(g, rt, context, context_alignment, start) catch
             return error.ConcurrencyUnavailable,
-        .threaded => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch
+        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch
             return error.ConcurrencyUnavailable,
     }
 }
@@ -2548,7 +2548,7 @@ fn netLookupImpl(
     options: Io.net.HostName.LookupOptions,
 ) Io.net.HostName.LookupError!void {
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    const io = fromRuntime(rt, .evented);
+    const io = fromRuntime(rt, .regular);
     defer resolved.close(io);
 
     // Sized for the largest answer the resolver can return: both families

--- a/src/io.zig
+++ b/src/io.zig
@@ -322,7 +322,7 @@ fn concurrentImpl(
     const awaitable = switch (mode) {
         .regular => &(spawnTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
             return error.ConcurrencyUnavailable).awaitable,
-        .blocking => &(spawnBlockingTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null) catch
+        .blocking => &(spawnBlockingTask(rt, result_len, result_alignment, context, context_alignment, .{ .regular = start }, null, .{ .reserve_thread = true }) catch
             return error.ConcurrencyUnavailable).awaitable,
     };
     return @ptrCast(awaitable);
@@ -367,7 +367,7 @@ fn groupAsyncImpl(
         .regular => groupSpawnTask(g, rt, context, context_alignment, start) catch {
             start(context.ptr);
         },
-        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch {
+        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start, .{ .reserve_thread = true }) catch {
             start(context.ptr);
             return;
         },
@@ -387,7 +387,7 @@ fn groupConcurrentImpl(
     switch (mode) {
         .regular => groupSpawnTask(g, rt, context, context_alignment, start) catch
             return error.ConcurrencyUnavailable,
-        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start) catch
+        .blocking => groupSpawnBlockingTask(g, rt, context, context_alignment, start, .{ .reserve_thread = true }) catch
             return error.ConcurrencyUnavailable,
     }
 }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1694,6 +1694,7 @@ pub const Runtime = struct {
             .fromByteUnits(@alignOf(Args)),
             .{ .regular = &Wrapper.start },
             null,
+            .{},
         );
 
         return JoinHandle(Result){

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1878,19 +1878,22 @@ pub const Runtime = struct {
 
     /// Construct a `std.Io` instance backed by this runtime.
     pub fn io(self: *Runtime) std.Io {
-        return @import("io.zig").fromRuntime(self);
+        return @import("io.zig").fromRuntime(self, .evented);
     }
 
-    /// Recover the `*Runtime` from a `std.Io` produced by `Runtime.io()`,
-    /// or null when it is backed by some other implementation. The vtable
-    /// pointer is the discriminator: every zio-backed `std.Io` shares the
-    /// one static vtable, and no other backend can carry its address. This
-    /// is how a library taking `std.Io` detects zio and unlocks zio-native
-    /// paths.
+    /// Construct a `std.Io` whose `concurrent`/`async` dispatch to
+    /// `spawnBlocking` instead of coroutine tasks. The returned handle
+    /// shares the same vtable and runtime; only the scheduling path for
+    /// new work differs.
+    pub fn blockingIo(self: *Runtime) std.Io {
+        return @import("io.zig").fromRuntime(self, .threaded);
+    }
+
+    /// Recover the `*Runtime` from a `std.Io` produced by `Runtime.io()`
+    /// or `Runtime.blockingIo()`, or null when it is backed by some other
+    /// implementation.
     pub fn fromIo(value: std.Io) ?*Runtime {
         const io_impl = @import("io.zig");
-        // The vtable alone is not enough: `debug_io` carries zio's vtable
-        // with no runtime behind it.
         if (value.vtable != &io_impl.vtable or value.userdata == null) return null;
         return io_impl.toRuntime(value);
     }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1878,7 +1878,7 @@ pub const Runtime = struct {
 
     /// Construct a `std.Io` instance backed by this runtime.
     pub fn io(self: *Runtime) std.Io {
-        return @import("io.zig").fromRuntime(self, .evented);
+        return @import("io.zig").fromRuntime(self, .regular);
     }
 
     /// Construct a `std.Io` whose `concurrent`/`async` dispatch to
@@ -1886,7 +1886,7 @@ pub const Runtime = struct {
     /// shares the same vtable and runtime; only the scheduling path for
     /// new work differs.
     pub fn blockingIo(self: *Runtime) std.Io {
-        return @import("io.zig").fromRuntime(self, .threaded);
+        return @import("io.zig").fromRuntime(self, .blocking);
     }
 
     /// Recover the `*Runtime` from a `std.Io` produced by `Runtime.io()`


### PR DESCRIPTION
## What

Adds `Runtime.blockingIo()`, which returns a `std.Io` whose `concurrent`/`async` methods dispatch to `spawnBlocking` (thread pool) instead of `spawnTask` (coroutines). All other vtable methods are shared -- no second vtable needed.

## How

The low bit of the `std.Io` userdata pointer tags blocking mode. `Runtime` is pointer-aligned, so the low bit is always free. The `concurrent`, `async`, `groupConcurrent`, and `groupAsync` vtable implementations branch on this tag to select the spawn path. `await`/`cancel` already work generically through `Awaitable`, which dispatches on `.kind` -- no changes needed there beyond switching from a hardcoded `AnyTask` result copy to a new `Awaitable.getResultSlice()` that handles both task kinds.

## Why

Groundwork for issue #567 (blocking `std.Io` implementation). With this plus the cancellation wiring from #569/#570, a blocking `std.Io` is functional: code written against `std.Io` can run on pool worker threads with full cancellation support.

## Test

Three new tests: concurrent dispatch to thread pool, group concurrent dispatch, and `fromIo` round-trip through both `io()` and `blockingIo()`. Full suite passes (655/655).