### PR TITLE
checkCancel: handle blocking task context via syscall_cancel token

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1386,6 +1386,8 @@ pub fn endShield() void {
 pub fn checkCancel() Cancelable!void {
     if (getCurrentTaskOrNull()) |task| {
         try task.checkCancel();
+    } else {
+        try os.syscall_cancel.checkCanceled();
     }
 }
 


### PR DESCRIPTION
## Summary

- `zio.checkCancel()` was a silent no-op on thread pool workers because there is no executor/AnyTask on those threads
- Fall through to `os.syscall_cancel.checkCanceled()` when no task context exists, so blocking tasks can observe cancellation through the same public API

## Test plan

- [x] All 655 tests pass