### PR TITLE
io: implement net-interface, executable-path, and ANSI-enable natively on POSIX

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1579,12 +1579,17 @@ fn fileIsTtyImpl(_: ?*anyopaque, file: Io.File) Io.Cancelable!bool {
     return os_fs.isTty(stdIoHandleToZio(file.handle));
 }
 
-fn fileEnableAnsiEscapeCodesImpl(_: ?*anyopaque, file: Io.File) Io.File.EnableAnsiEscapeCodesError!void {
+fn fileEnableAnsiEscapeCodesImpl(userdata: ?*anyopaque, file: Io.File) Io.File.EnableAnsiEscapeCodesError!void {
     // Turning the mode on for a Windows console is the one thing this does that
     // is not a query, and it goes through the console driver protocol that std
-    // implements.
-    const io = globalIo();
-    return io.vtable.fileEnableAnsiEscapeCodes(io.userdata, file);
+    // implements; keep delegating there. On POSIX there is nothing to enable,
+    // so the whole operation is just the terminal-device check.
+    if (builtin.os.tag == .windows) {
+        const io = globalIo();
+        return io.vtable.fileEnableAnsiEscapeCodes(io.userdata, file);
+    }
+    _ = userdata;
+    if (!os_fs.supportsAnsiEscapeCodes(stdIoHandleToZio(file.handle))) return error.NotTerminalDevice;
 }
 
 fn fileSupportsAnsiEscapeCodesImpl(_: ?*anyopaque, file: Io.File) Io.Cancelable!bool {
@@ -1706,9 +1711,19 @@ fn processExecutableOpenImpl(_: ?*anyopaque, _: Io.Dir.OpenFileOptions) std.proc
     @panic("processExecutableOpen: not supported");
 }
 
-fn processExecutablePathImpl(_: ?*anyopaque, buffer: []u8) std.process.ExecutablePathError!usize {
-    const io = globalIo();
-    return io.vtable.processExecutablePath(io.userdata, buffer);
+fn processExecutablePathImpl(userdata: ?*anyopaque, buffer: []u8) std.process.ExecutablePathError!usize {
+    switch (builtin.os.tag) {
+        .linux, .macos, .ios, .tvos, .watchos, .visionos => {
+            const rt: *Runtime = @ptrCast(@alignCast(userdata));
+            return os_process.getExecutablePath(rt.allocator, buffer);
+        },
+        // Windows (PEB), the BSDs (sysctl), and the argv0-only systems still go
+        // through std until they are implemented natively.
+        else => {
+            const io = globalIo();
+            return io.vtable.processExecutablePath(io.userdata, buffer);
+        },
+    }
 }
 
 fn lockStderrImpl(userdata: ?*anyopaque, terminal_mode: ?Io.Terminal.Mode) Io.Cancelable!Io.LockedStderr {
@@ -2532,13 +2547,26 @@ fn netShutdownImpl(_: ?*anyopaque, handle: Io.net.Socket.Handle, how: Io.net.Shu
 }
 
 fn netInterfaceNameResolveImpl(_: ?*anyopaque, name: *const Io.net.Interface.Name) Io.net.Interface.Name.ResolveError!Io.net.Interface {
-    const io = globalIo();
-    return io.vtable.netInterfaceNameResolve(io.userdata, name);
+    // Windows resolves names through iphlpapi, which std already wraps; keep
+    // delegating there until it is implemented natively.
+    if (builtin.os.tag == .windows) {
+        const io = globalIo();
+        return io.vtable.netInterfaceNameResolve(io.userdata, name);
+    }
+    const index = try os_net.interfaceNameToIndex(&name.bytes);
+    return .{ .index = index };
 }
 
 fn netInterfaceNameImpl(_: ?*anyopaque, interface: Io.net.Interface) Io.net.Interface.NameError!Io.net.Interface.Name {
-    const io = globalIo();
-    return io.vtable.netInterfaceName(io.userdata, interface);
+    // std only implements this for Windows (Linux/libc both panic there), so on
+    // POSIX we implement it ourselves and only delegate on Windows.
+    if (builtin.os.tag == .windows) {
+        const io = globalIo();
+        return io.vtable.netInterfaceName(io.userdata, interface);
+    }
+    var buf: [os_net.IF_NAMESIZE]u8 = undefined;
+    const len = try os_net.interfaceIndexToName(interface.index, &buf);
+    return Io.net.Interface.Name.fromSlice(buf[0..len]) catch return error.NameTooLong;
 }
 
 fn netLookupImpl(

--- a/src/os/net.zig
+++ b/src/os/net.zig
@@ -5,6 +5,7 @@ const windows = @import("windows.zig");
 
 const unexpectedError = @import("base.zig").unexpectedError;
 const thread = @import("thread.zig");
+const syscall_cancel = @import("syscall_cancel.zig");
 
 const log = @import("../common.zig").log;
 
@@ -1665,6 +1666,68 @@ fn errnoToGetAddrInfoError(err: anytype) GetAddrInfoError {
             };
         },
     }
+}
+
+// libc gives us if_nametoindex but not its inverse, so declare if_indextoname
+// ourselves. The name buffer it writes into must hold at least IF_NAMESIZE bytes.
+pub const IF_NAMESIZE = std.c.IFNAMESIZE;
+extern "c" fn if_indextoname(ifindex: c_uint, ifname: [*]u8) ?[*:0]u8;
+
+pub const InterfaceNameToIndexError = error{
+    InterfaceNotFound,
+    Canceled,
+    Unexpected,
+};
+
+/// Resolve a network interface name to its index. Wraps if_nametoindex(3).
+pub fn interfaceNameToIndex(name: [*:0]const u8) InterfaceNameToIndexError!u32 {
+    // A quick libc call, not a blocking syscall SIGURG could interrupt, so the
+    // most we can do for cancellation is honor a request that already arrived.
+    try syscall_cancel.checkCanceled();
+    const index = std.c.if_nametoindex(name);
+    // if_nametoindex returns 0 for an unknown interface; errno is not reliably
+    // set across platforms, so a zero result is all we have to go on.
+    if (index == 0) return error.InterfaceNotFound;
+    return @intCast(index);
+}
+
+pub const InterfaceIndexToNameError = error{
+    InterfaceNotFound,
+    Canceled,
+    Unexpected,
+};
+
+/// Look up a network interface name by index, writing it into `buffer` (which
+/// must be at least `IF_NAMESIZE` bytes) and returning its length. Wraps
+/// if_indextoname(3).
+pub fn interfaceIndexToName(index: u32, buffer: []u8) InterfaceIndexToNameError!usize {
+    std.debug.assert(buffer.len >= IF_NAMESIZE);
+    try syscall_cancel.checkCanceled();
+    if (if_indextoname(@intCast(index), buffer.ptr) == null) return error.InterfaceNotFound;
+    return std.mem.sliceTo(buffer[0..IF_NAMESIZE], 0).len;
+}
+
+test "interface index/name round-trip for loopback" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    // The loopback interface exists on every system we run these tests on, but
+    // its name varies (Linux "lo", the BSDs "lo0"), so resolve by index instead
+    // of assuming a name: index 1 is the loopback on all of them.
+    var buf: [IF_NAMESIZE]u8 = undefined;
+    const name_len = interfaceIndexToName(1, &buf) catch |err| switch (err) {
+        error.InterfaceNotFound => return error.SkipZigTest,
+        else => return err,
+    };
+    const name = buf[0..name_len :0];
+
+    const index = try interfaceNameToIndex(name);
+    try std.testing.expectEqual(1, index);
+}
+
+test "interfaceNameToIndex on unknown interface returns InterfaceNotFound" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try std.testing.expectError(error.InterfaceNotFound, interfaceNameToIndex("zzznope0"));
 }
 
 test "getaddrinfo - resolve example.com" {

--- a/src/os/process.zig
+++ b/src/os/process.zig
@@ -222,3 +222,42 @@ pub fn errnoToSetCurrentDirError(errno: posix.system.E) SetCurrentDirError {
         else => |e| unexpectedError(e),
     };
 }
+
+/// Write the path of the running executable into `buffer`, returning its
+/// length. Follows symlinks so the result names the real image. Windows, the
+/// BSDs, and the argv0-only systems (OpenBSD, Haiku) are not handled here yet
+/// and are still served by std's implementation from the vtable.
+///
+/// The zio error sets returned below are deliberately subsets of
+/// `std.process.ExecutablePathError`, so they coerce on return without an
+/// explicit remap.
+pub fn getExecutablePath(allocator: std.mem.Allocator, buffer: []u8) std.process.ExecutablePathError!usize {
+    switch (builtin.os.tag) {
+        .linux => {
+            // procfs exposes the executable image as a symlink at /proc/self/exe.
+            return fs.dirReadLink(allocator, fs.cwd(), "/proc/self/exe", buffer);
+        },
+        .macos, .ios, .tvos, .watchos, .visionos => {
+            // _NSGetExecutablePath can hand back a path that is itself a symlink
+            // (and not necessarily absolute), so resolve it afterward.
+            var symlink_buf: [posix.PATH_MAX + 1]u8 = undefined;
+            var symlink_len: u32 = symlink_buf.len;
+            if (std.c._NSGetExecutablePath(&symlink_buf, &symlink_len) != 0) return error.NameTooLong;
+            const symlink_path = std.mem.sliceTo(&symlink_buf, 0);
+            return fs.dirRealPathFile(allocator, fs.cwd(), symlink_path, buffer);
+        },
+        else => return error.OperationUnsupported,
+    }
+}
+
+test "getExecutablePath returns an absolute path to the test binary" {
+    switch (builtin.os.tag) {
+        .linux, .macos, .ios, .tvos, .watchos, .visionos => {},
+        else => return error.SkipZigTest,
+    }
+
+    var buf: [posix.PATH_MAX]u8 = undefined;
+    const len = try getExecutablePath(std.testing.allocator, &buf);
+    try std.testing.expect(len > 0);
+    try std.testing.expect(buf[0] == '/');
+}


### PR DESCRIPTION
## Summary

Part of an effort to stop leaning on a shared `std.Io.Threaded` instance (via `globalIo()`) for `std.Io` vtable methods. This first pass takes over four surfaces on POSIX.

One of these delegations was a live landmine: `Threaded`'s `netInterfaceName` is `@panic("TODO")` on both Linux and libc, so any caller of `Interface.name()` would have crashed. It now has a real implementation.

## What's native now (POSIX)

| Surface | Implementation |
|---|---|
| `netInterfaceNameResolve` | `if_nametoindex` |
| `netInterfaceName` | `if_indextoname` (was a panic in std on Linux/libc) |
| `processExecutablePath` | `/proc/self/exe` (Linux), `_NSGetExecutablePath` + realpath (Darwin) |
| `fileEnableAnsiEscapeCodes` | plain terminal-device check (nothing to enable on POSIX) |

## Notes

- New helpers `os_net.interfaceNameToIndex` / `interfaceIndexToName` and `os_process.getExecutablePath`. `if_indextoname` is declared locally since `std.c` only exposes the forward direction.
- `getExecutablePath` reuses the existing cancelable `dirReadLink` / `dirRealPathFile` wrappers; the returned zio error sets are subsets of `std.process.ExecutablePathError`, so they coerce without a remap.
- Cancellation: the interface lookups are quick libc calls (not SIGURG-interruptible), so they use `syscall_cancel.checkCanceled()` to honor an already-pending cancel, matching how `Threaded` guards them. The executable-path helpers inherit full cancellation from the underlying syscall loops.

## Scope / still delegating

- Windows keeps delegating on all four (iphlpapi / condrv / PEB).
- The BSDs and the argv0-only systems (OpenBSD, Haiku) still delegate for executable-path only (sysctl / argv0).
- The `Io.Threaded` process-spawn sites are untouched.

## Testing

- Full suite: 658/658 pass, plus new tests (interface round-trip, unknown-interface, executable-path).
- Cross-compiles clean: `x86_64-windows`, `aarch64-macos` (native Darwin branch), `x86_64-freebsd` (delegating branch).