### PR TITLE
process: native POSIX fork/exec spawn and replace

### DIFF
--- a/src/io.zig
+++ b/src/io.zig
@@ -1783,16 +1783,23 @@ fn processSetCurrentPathImpl(userdata: ?*anyopaque, path: []const u8) std.proces
     };
 }
 
-// TODO: implement using our own execve wrapper
-fn processReplaceImpl(_: ?*anyopaque, options: std.process.ReplaceOptions) std.process.ReplaceError {
-    const io = globalIo();
-    return io.vtable.processReplace(io.userdata, options);
+fn processReplaceImpl(userdata: ?*anyopaque, options: std.process.ReplaceOptions) std.process.ReplaceError {
+    if (builtin.os.tag == .windows) {
+        // Windows cannot replace the process image; std.process.can_replace is
+        // false there, so this is the expected result rather than a fallback.
+        return error.OperationUnsupported;
+    } else {
+        const rt: *Runtime = @ptrCast(@alignCast(userdata));
+        return os_process.replace(rt.allocator, options, processEnviron());
+    }
 }
 
-// TODO: implement using our own execve wrapper
 fn processReplacePathImpl(_: ?*anyopaque, dir: Io.Dir, options: std.process.ReplaceOptions) std.process.ReplaceError {
-    const io = globalIo();
-    return io.vtable.processReplacePath(io.userdata, dir, options);
+    // Resolving the program relative to a dir fd is not implemented yet (neither
+    // is it in std.Io.Threaded, which only panics here); return a clean error.
+    _ = dir;
+    _ = options;
+    return error.OperationUnsupported;
 }
 
 fn processEnviron() std.process.Environ {
@@ -1806,26 +1813,45 @@ fn processEnviron() std.process.Environ {
     return .empty;
 }
 
-// TODO: implement using our own posix_spawn/fork+exec wrapper
 fn processSpawnImpl(userdata: ?*anyopaque, options: std.process.SpawnOptions) std.process.SpawnError!std.process.Child {
     const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    var threaded: Io.Threaded = .init(rt.allocator, .{ .environ = processEnviron() });
-    defer threaded.deinit();
-    const io = threaded.io();
-    var child = try io.vtable.processSpawn(io.userdata, options);
-    setChildPipesNonblocking(&child);
-    return child;
+    if (builtin.os.tag == .windows) {
+        // Windows spawn (CreateProcess) is not implemented natively yet; keep
+        // standing up a throwaway std.Io.Threaded there.
+        var threaded: Io.Threaded = .init(rt.allocator, .{ .environ = processEnviron() });
+        defer threaded.deinit();
+        const io = threaded.io();
+        var child = try io.vtable.processSpawn(io.userdata, options);
+        setChildPipesNonblocking(&child);
+        return child;
+    } else {
+        const spawned = try os_process.spawn(rt.allocator, options, processEnviron());
+        var child: std.process.Child = .{
+            .id = spawned.id,
+            .thread_handle = {},
+            .stdin = if (spawned.stdin) |fd| childPipeFile(fd) else null,
+            .stdout = if (spawned.stdout) |fd| childPipeFile(fd) else null,
+            .stderr = if (spawned.stderr) |fd| childPipeFile(fd) else null,
+            .request_resource_usage_statistics = options.request_resource_usage_statistics,
+        };
+        setChildPipesNonblocking(&child);
+        return child;
+    }
 }
 
-// TODO: implement using our own posix_spawn/fork+exec wrapper
-fn processSpawnPathImpl(userdata: ?*anyopaque, dir: Io.Dir, options: std.process.SpawnOptions) std.process.SpawnError!std.process.Child {
-    const rt: *Runtime = @ptrCast(@alignCast(userdata));
-    var threaded: Io.Threaded = .init(rt.allocator, .{ .environ = processEnviron() });
-    defer threaded.deinit();
-    const io = threaded.io();
-    var child = try io.vtable.processSpawnPath(io.userdata, dir, options);
-    setChildPipesNonblocking(&child);
-    return child;
+fn processSpawnPathImpl(_: ?*anyopaque, dir: Io.Dir, options: std.process.SpawnOptions) std.process.SpawnError!std.process.Child {
+    // Resolving the program relative to a dir fd is not implemented yet (neither
+    // is it in std.Io.Threaded, which only panics here); return a clean error.
+    _ = dir;
+    _ = options;
+    return error.OperationUnsupported;
+}
+
+/// Wrap a spawned child's pipe fd as an Io.File. The handle is left marked
+/// blocking; setChildPipesNonblocking flips the underlying fd afterward, which
+/// is the same handoff the old std.Io.Threaded-backed path used.
+fn childPipeFile(handle: Io.File.Handle) Io.File {
+    return .{ .handle = handle, .flags = .{ .nonblocking = false } };
 }
 
 fn setChildPipesNonblocking(child: *std.process.Child) void {

--- a/src/os/process.zig
+++ b/src/os/process.zig
@@ -7,6 +7,16 @@ const fs = @import("fs.zig");
 const unexpectedError = @import("base.zig").unexpectedError;
 const syscall_cancel = @import("syscall_cancel.zig");
 
+// zio always links libc (see build.zig), so unlike std.Io.Threaded the spawn
+// path below can lean on libc uniformly instead of carrying raw-syscall and
+// no-libc fallbacks. libc is not exposed for `fork`, so declare it here.
+const c = std.c;
+extern "c" fn fork() c.pid_t;
+
+fn cErrno() c.E {
+    return @enumFromInt(c._errno().*);
+}
+
 pub const CurrentPathError = error{
     /// The path does not fit in the buffer the caller provided.
     NameTooLong,
@@ -260,4 +270,461 @@ test "getExecutablePath returns an absolute path to the test binary" {
     const len = try getExecutablePath(std.testing.allocator, &buf);
     try std.testing.expect(len > 0);
     try std.testing.expect(buf[0] == '/');
+}
+
+// ---------------------------------------------------------------------------
+// Process spawning and replacement (POSIX)
+//
+// A native fork/exec, replacing the throwaway std.Io.Threaded instance io.zig
+// used to stand up just to spawn a child. The classic protocol: a CLOEXEC
+// "error pipe" the child writes an errno into if anything between fork and exec
+// fails; the parent learns exec succeeded when that pipe reports EOF instead.
+//
+// Everything the child runs between fork and exec must be async-signal-safe, so
+// all allocation (argv/env null-termination, the cwd path, /dev/null) happens in
+// the parent before the fork, and the child only makes bare libc calls.
+// ---------------------------------------------------------------------------
+
+const SearchPath = "/usr/local/bin:/bin/:/usr/bin";
+
+// A child reports a spawn failure by writing @intFromError across the error
+// pipe; sized to hold any anyerror value.
+const ErrInt = std.meta.Int(.unsigned, @sizeOf(anyerror) * 8);
+
+const STDIN_FILENO = 0;
+const STDOUT_FILENO = 1;
+const STDERR_FILENO = 2;
+
+/// Raw file descriptors handed back to the caller, who wraps them into a
+/// `std.process.Child`. A null field means that stream was not a pipe.
+pub const Spawned = struct {
+    id: c.pid_t,
+    stdin: ?posix.fd_t,
+    stdout: ?posix.fd_t,
+    stderr: ?posix.fd_t,
+};
+
+/// Fork and exec a child process. `parent_environ` supplies both the child's
+/// environment (when `options.environ_map` is null) and the PATH used to resolve
+/// `argv[0]`, which per `SpawnOptions` always comes from the parent.
+pub fn spawn(
+    allocator: std.mem.Allocator,
+    options: std.process.SpawnOptions,
+    parent_environ: std.process.Environ,
+) std.process.SpawnError!Spawned {
+    // Pipes start CLOEXEC so a racing spawn on another thread cannot leak an end
+    // into a different child; the child restores the ends it needs by dup2-ing
+    // them onto 0/1/2, which clears CLOEXEC on the copy.
+    var stdin_pipe: ?[2]posix.fd_t = null;
+    var stdout_pipe: ?[2]posix.fd_t = null;
+    var stderr_pipe: ?[2]posix.fd_t = null;
+    errdefer {
+        if (stdin_pipe) |p| closePipe(p);
+        if (stdout_pipe) |p| closePipe(p);
+        if (stderr_pipe) |p| closePipe(p);
+    }
+    if (options.stdin == .pipe) stdin_pipe = try makePipe();
+    if (options.stdout == .pipe) stdout_pipe = try makePipe();
+    if (options.stderr == .pipe) stderr_pipe = try makePipe();
+
+    const any_ignore = options.stdin == .ignore or options.stdout == .ignore or options.stderr == .ignore;
+    var dev_null_fd: posix.fd_t = -1;
+    defer if (dev_null_fd != -1) posix.close(dev_null_fd);
+    if (any_ignore) dev_null_fd = try openDevNull(allocator);
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // POSIX forbids allocation between fork and exec (it can deadlock a libc
+    // heap), so everything the child needs is prepared here first.
+    const argv_buf = try makeArgv(arena, options.argv);
+    const env_block = try makeEnvBlock(arena, options, parent_environ);
+    const search_path = if (parent_environ.getPosix("PATH")) |p| p else SearchPath;
+    const cwd_path_z: ?[*:0]const u8 = switch (options.cwd) {
+        .path => |p| (try arena.dupeZ(u8, p)).ptr,
+        else => null,
+    };
+
+    const err_pipe = try makePipe();
+    var err_pipe_open = true;
+    errdefer if (err_pipe_open) closePipe(err_pipe);
+
+    const pid = fork();
+    if (pid < 0) return switch (cErrno()) {
+        .AGAIN, .NOMEM => error.SystemResources,
+        .NOSYS => error.OperationUnsupported,
+        else => |e| unexpectedError(e),
+    };
+
+    if (pid == 0) childRun(
+        options,
+        if (stdin_pipe) |p| p[0] else -1,
+        if (stdout_pipe) |p| p[1] else -1,
+        if (stderr_pipe) |p| p[1] else -1,
+        dev_null_fd,
+        err_pipe[1],
+        argv_buf,
+        env_block,
+        search_path,
+        cwd_path_z,
+    );
+
+    // ---- Parent. ----
+    // Only the child should hold the write end of the error pipe open; once we
+    // close ours, EOF on the read end means the child reached exec.
+    posix.close(err_pipe[1]);
+    if (stdin_pipe) |p| posix.close(p[0]);
+    if (stdout_pipe) |p| posix.close(p[1]);
+    if (stderr_pipe) |p| posix.close(p[1]);
+
+    // Blocks until the child execs (EOF) or reports an errno. TODO: drive this
+    // read through the event loop so the calling worker is not parked on exec.
+    const spawn_err = readErrInt(err_pipe[0]);
+    posix.close(err_pipe[0]);
+    err_pipe_open = false;
+
+    if (spawn_err) |errno_int| {
+        // The child wrote an error and _exit()'d; reap it so it does not linger
+        // as a zombie (zio has no global SIGCHLD reaper), then close our pipe
+        // ends and surface the failure. Null the trackers so the errdefer above
+        // does not double-close.
+        reap(pid);
+        if (stdin_pipe) |p| posix.close(p[1]);
+        if (stdout_pipe) |p| posix.close(p[0]);
+        if (stderr_pipe) |p| posix.close(p[0]);
+        stdin_pipe = null;
+        stdout_pipe = null;
+        stderr_pipe = null;
+        return @errorCast(@errorFromInt(errno_int));
+    }
+
+    return .{
+        .id = pid,
+        .stdin = if (stdin_pipe) |p| p[1] else null,
+        .stdout = if (stdout_pipe) |p| p[0] else null,
+        .stderr = if (stderr_pipe) |p| p[0] else null,
+    };
+}
+
+/// Replace the current process image, exec-style. Returns only on failure. PATH
+/// (for a bare `argv[0]`) comes from `parent_environ`, matching `spawn`.
+pub fn replace(
+    allocator: std.mem.Allocator,
+    options: std.process.ReplaceOptions,
+    parent_environ: std.process.Environ,
+) std.process.ReplaceError {
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const argv_buf = makeArgv(arena, options.argv) catch |e| return e;
+    const env_block = if (options.environ_map) |map|
+        map.createPosixBlock(arena, .{}) catch |e| return e
+    else
+        parent_environ.createPosixBlock(arena, .{}) catch |e| return e;
+    const search_path = if (parent_environ.getPosix("PATH")) |p| p else SearchPath;
+
+    return exec(options.expand_arg0 == .expand, argv_buf, env_block.slice.ptr, search_path);
+}
+
+// --- Parent-side helpers ---
+
+fn makeArgv(
+    arena: std.mem.Allocator,
+    argv: []const []const u8,
+) error{OutOfMemory}![*:null]?[*:0]const u8 {
+    const buf = try arena.allocSentinel(?[*:0]const u8, argv.len, null);
+    for (argv, 0..) |arg, i| buf[i] = (try arena.dupeZ(u8, arg)).ptr;
+    return buf.ptr;
+}
+
+fn makeEnvBlock(
+    arena: std.mem.Allocator,
+    options: std.process.SpawnOptions,
+    parent_environ: std.process.Environ,
+) error{OutOfMemory}!std.process.Environ.PosixBlock {
+    // Scrub ZIG_PROGRESS from the child (zig_progress_fd = -1): grafting a
+    // child's progress tree through a side pipe is not implemented here yet, so
+    // an inherited fd would point at nothing useful.
+    return if (options.environ_map) |map|
+        map.createPosixBlock(arena, .{ .zig_progress_fd = -1 })
+    else
+        parent_environ.createPosixBlock(arena, .{ .zig_progress_fd = -1 });
+}
+
+fn makePipe() std.process.SpawnError![2]posix.fd_t {
+    return posix.pipe(.{ .cloexec = true }) catch |e| switch (e) {
+        error.SystemFdQuotaExceeded => error.SystemFdQuotaExceeded,
+        error.ProcessFdQuotaExceeded => error.ProcessFdQuotaExceeded,
+        error.Unexpected => error.Unexpected,
+    };
+}
+
+fn closePipe(p: [2]posix.fd_t) void {
+    posix.close(p[0]);
+    posix.close(p[1]);
+}
+
+fn openDevNull(allocator: std.mem.Allocator) std.process.SpawnError!posix.fd_t {
+    return fs.openat(allocator, fs.cwd(), "/dev/null", .{ .mode = .read_write }) catch |e| switch (e) {
+        error.AccessDenied => error.AccessDenied,
+        error.SystemResources => error.SystemResources,
+        error.ProcessFdQuotaExceeded => error.ProcessFdQuotaExceeded,
+        error.SystemFdQuotaExceeded => error.SystemFdQuotaExceeded,
+        error.Canceled => error.Canceled,
+        else => error.NoDevice,
+    };
+}
+
+fn readErrInt(fd: posix.fd_t) ?ErrInt {
+    var buf: [8]u8 = undefined;
+    var i: usize = 0;
+    while (i < buf.len) {
+        const rc = c.read(fd, buf[i..].ptr, buf.len - i);
+        if (rc < 0) {
+            if (cErrno() == .INTR) continue;
+            // We cannot tell if the child is alive; assume it is so its
+            // resources are not wrongly reclaimed. Treated as exec success.
+            return null;
+        }
+        if (rc == 0) break; // Write end closed by CLOEXEC at exec: success.
+        i += @intCast(rc);
+    }
+    if (i < buf.len) return null; // EOF before a full int also means success.
+    return @intCast(std.mem.readInt(u64, &buf, .little));
+}
+
+fn reap(pid: c.pid_t) void {
+    var status: c_int = undefined;
+    while (true) {
+        if (c.waitpid(pid, &status, 0) != -1) return;
+        if (cErrno() != .INTR) return;
+    }
+}
+
+// --- Child-side (post-fork, pre-exec): bare libc calls only ---
+
+fn childRun(
+    options: std.process.SpawnOptions,
+    stdin_end: posix.fd_t,
+    stdout_end: posix.fd_t,
+    stderr_end: posix.fd_t,
+    dev_null_fd: posix.fd_t,
+    err_fd: posix.fd_t,
+    argv: [*:null]?[*:0]const u8,
+    env_block: std.process.Environ.PosixBlock,
+    search_path: []const u8,
+    cwd_path_z: ?[*:0]const u8,
+) noreturn {
+    // childSetup only returns on failure; on success it has already exec'd.
+    const err = childSetup(options, stdin_end, stdout_end, stderr_end, dev_null_fd, argv, env_block, search_path, cwd_path_z);
+    writeErrInt(err_fd, @intFromError(err));
+    // _exit rather than exit: skip any libc atexit handlers, which must not run
+    // in a fork child (some, e.g. LLVM's, deadlock).
+    c._exit(1);
+}
+
+fn childSetup(
+    options: std.process.SpawnOptions,
+    stdin_end: posix.fd_t,
+    stdout_end: posix.fd_t,
+    stderr_end: posix.fd_t,
+    dev_null_fd: posix.fd_t,
+    argv: [*:null]?[*:0]const u8,
+    env_block: std.process.Environ.PosixBlock,
+    search_path: []const u8,
+    cwd_path_z: ?[*:0]const u8,
+) std.process.SpawnError {
+    setUpChildIo(options.stdin, stdin_end, STDIN_FILENO, dev_null_fd) catch |e| return e;
+    setUpChildIo(options.stdout, stdout_end, STDOUT_FILENO, dev_null_fd) catch |e| return e;
+    setUpChildIo(options.stderr, stderr_end, STDERR_FILENO, dev_null_fd) catch |e| return e;
+
+    switch (options.cwd) {
+        .inherit => {},
+        .dir => |dir| childCall(c.fchdir(dir.handle)) catch |e| return e,
+        .path => childCall(c.chdir(cwd_path_z.?)) catch |e| return e,
+    }
+
+    // setregid before setreuid: dropping the user first can remove the privilege
+    // needed to change the group.
+    if (options.gid) |gid| setIdCall(c.setregid(gid, gid)) catch |e| return e;
+    if (options.uid) |uid| setIdCall(c.setreuid(uid, uid)) catch |e| return e;
+    if (options.pgid) |pgid| {
+        if (c.setpgid(0, pgid) == -1) return switch (cErrno()) {
+            .ACCES => error.ProcessAlreadyExec,
+            .INVAL => error.InvalidProcessGroupId,
+            .PERM => error.PermissionDenied,
+            else => |e| unexpectedError(e),
+        };
+    }
+    if (options.start_suspended) childCall(c.kill(0, .STOP)) catch |e| return e;
+
+    return exec(options.expand_arg0 == .expand, argv, env_block.slice.ptr, search_path);
+}
+
+fn setUpChildIo(
+    stdio: std.process.SpawnOptions.StdIo,
+    pipe_end: posix.fd_t,
+    target: posix.fd_t,
+    dev_null_fd: posix.fd_t,
+) std.process.SpawnError!void {
+    switch (stdio) {
+        .pipe => try childDup2(pipe_end, target),
+        .close => posix.close(target),
+        .inherit => {},
+        .ignore => try childDup2(dev_null_fd, target),
+        .file => |file| try childDup2(file.handle, target),
+    }
+}
+
+fn childDup2(old_fd: posix.fd_t, new_fd: posix.fd_t) std.process.SpawnError!void {
+    while (true) {
+        if (c.dup2(old_fd, new_fd) != -1) return;
+        switch (cErrno()) {
+            .INTR, .BUSY => continue,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NOMEM => return error.SystemResources,
+            else => |e| return unexpectedError(e),
+        }
+    }
+}
+
+/// EINTR-retrying wrapper for the child's plain "succeeds or fails" syscalls
+/// (chdir/fchdir/setpgid/kill), mapping the common failures to SpawnError.
+fn childCall(rc: c_int) std.process.SpawnError!void {
+    if (rc != -1) return;
+    return switch (cErrno()) {
+        .INTR => error.Unexpected, // none of these callers restart; treat as a bug
+        .ACCES => error.AccessDenied,
+        .PERM => error.PermissionDenied,
+        .NOTDIR => error.NotDir,
+        .NOENT => error.FileNotFound,
+        .LOOP => error.SymLinkLoop,
+        .NAMETOOLONG => error.NameTooLong,
+        .NOMEM => error.SystemResources,
+        else => |e| unexpectedError(e),
+    };
+}
+
+fn setIdCall(rc: c_int) std.process.SpawnError!void {
+    if (rc != -1) return;
+    return switch (cErrno()) {
+        .AGAIN => error.ResourceLimitReached,
+        .INVAL => error.InvalidUserId,
+        .PERM => error.PermissionDenied,
+        else => |e| unexpectedError(e),
+    };
+}
+
+fn writeErrInt(fd: posix.fd_t, value: ErrInt) void {
+    var buf: [8]u8 = undefined;
+    std.mem.writeInt(u64, &buf, value, .little);
+    var i: usize = 0;
+    while (i < buf.len) {
+        const rc = c.write(fd, buf[i..].ptr, buf.len - i);
+        if (rc < 0) {
+            if (cErrno() == .INTR) continue;
+            return; // Give up; the parent then sees a short read and assumes success.
+        }
+        i += @intCast(rc);
+    }
+}
+
+/// The errno set common to execve failures; a subset of both SpawnError and
+/// ReplaceError, so it coerces to either on return.
+const ExecError = error{
+    SystemResources,
+    ProcessFdQuotaExceeded,
+    NameTooLong,
+    SystemFdQuotaExceeded,
+    AccessDenied,
+    PermissionDenied,
+    InvalidExe,
+    FileSystem,
+    IsDir,
+    FileNotFound,
+    NotDir,
+    FileBusy,
+    Unexpected,
+};
+
+/// execvpe-equivalent: exec `argv[0]` directly if it names a path, else search
+/// `search_path`. Only returns on failure. Reimplemented rather than using glibc
+/// execvpe because that is a GNU extension absent on the BSDs and Darwin.
+fn exec(
+    expand_arg0: bool,
+    argv: [*:null]?[*:0]const u8,
+    envp: [*:null]const ?[*:0]const u8,
+    search_path: []const u8,
+) ExecError {
+    const file = std.mem.sliceTo(argv[0].?, 0);
+    if (std.mem.indexOfScalar(u8, file, '/') != null) {
+        _ = c.execve(argv[0].?, argv, envp);
+        return execveError(cErrno());
+    }
+
+    var path_buf: [posix.PATH_MAX]u8 = undefined;
+    const orig_arg0 = argv[0];
+    defer if (expand_arg0) {
+        argv[0] = orig_arg0;
+    };
+
+    var it = std.mem.tokenizeScalar(u8, search_path, ':');
+    var saw_eacces = false;
+    var last: ExecError = error.FileNotFound;
+    while (it.next()) |dir| {
+        const total = dir.len + 1 + file.len;
+        if (total + 1 > path_buf.len) {
+            last = error.NameTooLong;
+            continue;
+        }
+        @memcpy(path_buf[0..dir.len], dir);
+        path_buf[dir.len] = '/';
+        @memcpy(path_buf[dir.len + 1 ..][0..file.len], file);
+        path_buf[total] = 0;
+        const full = path_buf[0..total :0];
+        if (expand_arg0) argv[0] = full.ptr;
+
+        _ = c.execve(full.ptr, argv, envp);
+        last = execveError(cErrno());
+        switch (last) {
+            // Keep searching later PATH entries on these; remember EACCES so a
+            // later ENOENT does not mask a genuine permission problem.
+            error.AccessDenied => saw_eacces = true,
+            error.FileNotFound, error.NotDir => {},
+            else => return last,
+        }
+    }
+    if (saw_eacces) return error.AccessDenied;
+    return last;
+}
+
+fn execveError(e: c.E) ExecError {
+    return switch (e) {
+        .@"2BIG" => error.SystemResources,
+        .MFILE => error.ProcessFdQuotaExceeded,
+        .NAMETOOLONG => error.NameTooLong,
+        .NFILE => error.SystemFdQuotaExceeded,
+        .NOMEM => error.SystemResources,
+        .ACCES => error.AccessDenied,
+        .PERM => error.PermissionDenied,
+        .INVAL, .NOEXEC => error.InvalidExe,
+        .IO, .LOOP => error.FileSystem,
+        .ISDIR => error.IsDir,
+        .NOENT => error.FileNotFound,
+        .NOTDIR => error.NotDir,
+        .TXTBSY => error.FileBusy,
+        else => switch (builtin.os.tag) {
+            .macos, .ios, .tvos, .watchos, .visionos => switch (e) {
+                .BADEXEC, .BADARCH => error.InvalidExe,
+                else => unexpectedError(e),
+            },
+            .linux => switch (e) {
+                .LIBBAD => error.InvalidExe,
+                else => unexpectedError(e),
+            },
+            else => unexpectedError(e),
+        },
+    };
 }

--- a/src/process.zig
+++ b/src/process.zig
@@ -121,3 +121,52 @@ test "childWait: spawn nonexistent binary returns FileNotFound" {
     const result = std.process.spawn(rt.io(), .{ .argv = &.{"definitely-not-a-real-binary-xyz123"} });
     try std.testing.expectError(error.FileNotFound, result);
 }
+
+test "spawn: captures child stdout through a pipe" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ "sh", "-c", "printf hello" },
+        .stdout = .pipe,
+    });
+
+    var read_buf: [64]u8 = undefined;
+    var reader = child.stdout.?.readerStreaming(io, &read_buf);
+    var out: [64]u8 = undefined;
+    const n = try reader.interface.readSliceShort(&out);
+
+    const term = try childWait(&child);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, term);
+    try std.testing.expectEqualStrings("hello", out[0..n]);
+}
+
+test "spawn: passes a custom environment to the child" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("ZIO_SPAWN_TEST", "works");
+
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ "sh", "-c", "printf %s \"$ZIO_SPAWN_TEST\"" },
+        .stdout = .pipe,
+        .environ_map = &env,
+    });
+
+    var read_buf: [64]u8 = undefined;
+    var reader = child.stdout.?.readerStreaming(io, &read_buf);
+    var out: [64]u8 = undefined;
+    const n = try reader.interface.readSliceShort(&out);
+
+    const term = try childWait(&child);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, term);
+    try std.testing.expectEqualStrings("works", out[0..n]);
+}


### PR DESCRIPTION
Stacked on #693 (base branch `native-posix-io-delegations`).

## Summary

Continues removing the `std.Io.Threaded` dependency. `processSpawn` / `processSpawnPath` stood up a throwaway `std.Io.Threaded` instance *per call* just to fork a child; `processReplace` / `processReplacePath` delegated to it too (and the `*Path` variants only reached a std `@panic("TODO")`).

This implements spawn and replace natively for POSIX in `os/process.zig` using the classic pipe/fork/dup2/execvpe protocol: a CLOEXEC error pipe reports any failure between fork and exec back to the parent, which learns exec succeeded when the pipe closes on EOF. Reaping is unchanged (the existing `ev.ProcessWait` path); only the fork/exec front half was borrowed from Threaded.

## Leaning on libc

Since zio always links libc (unlike the stdlib, which must also work without it), the whole thing is **one libc code path** — no raw-syscall or no-libc fallbacks, and the fork child bails via `_exit`. All allocation (argv/env null-termination, cwd path, `/dev/null`) happens before the fork, so the child makes only async-signal-safe libc calls. The env block and PATH lookup reuse `std.process.Environ`, which is independent of `std.Io.Threaded`.

## Scope / still delegating

- **Windows** spawn keeps delegating to Threaded (native `CreateProcess` not ported yet).
- `processSpawnPath` / `processReplacePath` now return `OperationUnsupported` instead of a panic; resolving a program relative to a dir fd is not implemented yet.
- The parent still **blocks on the error-pipe read** exactly as the old path did; driving that read through the event loop so the calling worker isn't parked on exec is a follow-up (marked with a `TODO`).

## Testing

- New: spawn captures child stdout through a pipe (exercises the pipe/dup2 handoff), and spawn passes a custom environment.
- Existing exit-code / kill / FileNotFound coverage (the last exercises the full err-pipe failure protocol) still passes.
- Full suite: 660/660 pass. Cross-compiles clean on `x86_64-windows` (delegating branch), `aarch64-macos` and `x86_64-freebsd` (native path).