### PR TITLE
runtime: add zio.recancel()

### DIFF
--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -5,6 +5,8 @@ const std = @import("std");
 const ev = @import("ev/root.zig");
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTask = @import("runtime.zig").getCurrentTask;
+const recancel = @import("runtime.zig").recancel;
+const checkCancel = @import("runtime.zig").checkCancel;
 const yield = @import("runtime.zig").yield;
 const loopClearTimer = @import("runtime.zig").loopClearTimer;
 const JoinHandle = @import("runtime.zig").JoinHandle;
@@ -549,6 +551,28 @@ test "withTimeout: user cancel wins over the timeout" {
     try rt.sleep(.fromMilliseconds(5));
     handle.cancel();
     try handle.join();
+}
+
+test "withTimeout: recancel re-arms a cancellation the timeout delivered" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    const Work = struct {
+        fn run(runtime: *Runtime) !void {
+            runtime.sleep(.fromMilliseconds(60_000)) catch |err| {
+                std.debug.assert(err == error.Canceled);
+                // An auto-cancel is a cancellation like any other here: it can
+                // be put back and delivered again, and withTimeout still gets
+                // to attribute it and report error.Timeout.
+                recancel();
+                try checkCancel();
+                return error.TestUnexpectedResult;
+            };
+            return error.TestUnexpectedResult;
+        }
+    };
+
+    try std.testing.expectError(error.Timeout, withTimeout(.fromMilliseconds(10), Work.run, .{rt}));
 }
 
 test "withTimeout: nested, inner deadline fires first" {

--- a/src/net.zig
+++ b/src/net.zig
@@ -3202,7 +3202,7 @@ test "a canceled task does not start another operation" {
             // write. The write must report it rather than run.
             runtime_mod.sleep(.fromMilliseconds(60_000)) catch |err| {
                 std.debug.assert(err == error.Canceled);
-                runtime_mod.getCurrentTask().recancel();
+                runtime_mod.recancel();
                 outcome.after_recancel = if (stream.writeAll("x", .none)) |_| null else |e| e;
             };
         }

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1381,6 +1381,19 @@ pub fn endShield() void {
     }
 }
 
+/// Re-arm a cancellation that a previous cancellation point already reported, so
+/// that the next one returns error.Canceled again. Use it when a canceled
+/// operation still has a result to hand back before the cancellation is acted on.
+///
+/// Asserts the task is under a cancellation (an explicit cancel or a live
+/// auto-cancel). If not in a task context, this is a no-op: a blocking task's
+/// cancellation is never consumed, so there is nothing to put back.
+pub fn recancel() void {
+    if (getCurrentTaskOrNull()) |task| {
+        task.recancel();
+    }
+}
+
 /// Check if the current task has been cancelled and return an error if so.
 /// If not in a task context, this is a no-op.
 pub fn checkCancel() Cancelable!void {
@@ -2138,6 +2151,34 @@ test "runtime: shielded sleep is not cancelable" {
 
     // Ensure the sleep completed (took at least 50ms)
     try std.testing.expect(timer.read().toMilliseconds() >= 40);
+}
+
+test "runtime: recancel re-arms a delivered cancellation" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const recancelingTask = struct {
+        fn call() !void {
+            sleep(.fromMilliseconds(60_000)) catch |err| {
+                std.debug.assert(err == error.Canceled);
+                // The cancellation was consumed by the sleep; putting it back
+                // means the next cancellation point has to report it again.
+                recancel();
+                try checkCancel();
+                return error.TestUnexpectedResult;
+            };
+            return error.TestUnexpectedResult;
+        }
+    }.call;
+
+    var handle = try runtime.spawn(recancelingTask, .{});
+    defer handle.cancel();
+
+    // Let the task reach the sleep before canceling it.
+    try runtime.sleep(.fromMilliseconds(10));
+    handle.cancel();
+
+    try std.testing.expectError(error.Canceled, handle.join());
 }
 
 test "runtime: yield from main allows tasks to run" {

--- a/src/task.zig
+++ b/src/task.zig
@@ -385,14 +385,15 @@ pub const AnyTask = struct {
 
     /// Re-arm cancellation after it was acknowledged.
     /// This increments pending_errors so the next cancellation point returns error.Canceled.
-    /// Asserts that user_canceled is already set.
+    /// Asserts that the task is under a cancellation, either user-requested or from a
+    /// live auto-cancel, so that a re-arm is always putting back a delivered error.
     pub fn recancel(self: *AnyTask) void {
         var current = self.canceled_status.load(.acquire);
         while (true) {
             var status: CanceledStatus = @bitCast(current);
 
             // Must have been canceled already
-            std.debug.assert(status.user_canceled);
+            std.debug.assert(status.user_canceled or status.auto_canceled > 0);
 
             // Increment pending_errors
             status.pending_errors += 1;

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -23,6 +23,7 @@ pub const RandomSecureError = @import("random.zig").RandomSecureError;
 pub const beginShield = runtime.beginShield;
 pub const endShield = runtime.endShield;
 pub const checkCancel = runtime.checkCancel;
+pub const recancel = runtime.recancel;
 
 pub const AutoCancel = @import("autocancel.zig").AutoCancel;
 pub const withTimeout = @import("autocancel.zig").withTimeout;


### PR DESCRIPTION
Re-arming a cancellation that a cancellation point already reported was only reachable through `getCurrentTask().recancel()`. This exposes it as `zio.recancel()`, next to `checkCancel`/`beginShield`/`endShield`, and it is a no-op outside a task context for the same reason `checkCancel` falls through to the syscall token there: a blocking task's cancellation is never consumed, so there is nothing to put back.

`AnyTask.recancel()` asserted `user_canceled`. That is stricter than `std.Io.recancel`, which asserts only that "`error.Canceled` was returned from a prior cancelation point" without caring who requested it (`Dispatch`/`Uring` assert `cancel_protection.acknowledged`, `Threaded` marks every non-`.canceled` status `unreachable`). It also does not fit a public API, since a task canceled by `withTimeout` has `auto_canceled` set and no `user_canceled`. The assert now accepts either kind.

That second part is a fix, not just API polish: `waitForIo` re-arms when an operation completes successfully despite a cancel request, and reaches that path from an auto-cancel whenever a `withTimeout` deadline races an I/O completion, which trips the old assert under runtime safety.

One difference from std remains by design: std tracks a boolean `acknowledged` flag and can assert on a double recancel, while zio counts `pending_errors`, which has to tolerate a second real cancel arriving while the first is being handled.

Tests: user-cancel re-arm in `runtime.zig`, auto-cancel re-arm in `autocancel.zig` (verifying `withTimeout` still attributes the re-delivered error and reports `error.Timeout`). The existing net.zig test now uses the public API.