### PR TITLE
select: keep the conservation law (cancel-path delivery, claim-before-consume protocol)

### DIFF
--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 const RefCounter = @import("utils/ref_counter.zig").RefCounter;
 const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const Waiter = @import("common.zig").Waiter;
+const AsyncWaitState = @import("common.zig").AsyncWaitState;
 const GroupNode = @import("group.zig").GroupNode;
 const WaitQueue = @import("utils/wait_queue.zig").WaitQueue;
 
@@ -50,15 +51,16 @@ pub const Awaitable = struct {
     }
 
     /// Registers a waiter to be notified when the awaitable completes.
-    /// This is part of the Future protocol for select().
-    /// Returns false if the awaitable is already complete (no wait needed), true if added to queue.
-    pub fn asyncWait(self: *Awaitable, waiter: *Waiter) bool {
-        // Fast path: check if already complete
+    /// This is part of the Future protocol for select(); see
+    /// `common.AsyncWaitState` for the claim-before-ready contract.
+    pub fn asyncWait(self: *Awaitable, waiter: *Waiter) AsyncWaitState {
+        // Fast path: check if already complete (level state, nothing consumed)
         if (self.waiting_list.isFlagSet()) {
-            return false;
+            return if (waiter.tryClaim()) .ready else .lost;
         }
         // Try to push to queue - only succeeds if awaitable is not complete (flag not set)
-        return self.waiting_list.pushUnlessFlag(&waiter.node);
+        if (self.waiting_list.pushUnlessFlag(&waiter.node)) return .queued;
+        return if (waiter.tryClaim()) .ready else .lost;
     }
 
     /// Cancels a pending wait operation by removing the waiter.

--- a/src/common.zig
+++ b/src/common.zig
@@ -38,6 +38,25 @@ pub const Closeable = error{
 };
 
 /// Sentinel value indicating no winner has been selected yet in select operations
+/// Outcome of a future's `asyncWait` under the select protocol.
+///
+/// The conservation rule this encodes: a future must WIN the select (claim
+/// the shared winner slot via `waiter.tryClaim`) BEFORE any consuming fast
+/// path. A fast path that consumed first and reported ready later let a
+/// blind winner store clobber a concurrent claim of an earlier-registered
+/// branch, and the claimed item died on the select's dead stack frame.
+///
+/// - `.ready`: the operation completed on the fast path AND this waiter won
+///   the select. `getResult` is valid now. Nothing was registered.
+/// - `.queued`: the waiter is registered and will be woken exactly once via
+///   `waiter.wake()`. `asyncCancelWait` must be called if the caller stops
+///   waiting.
+/// - `.lost`: another branch of the same select already won, so this future
+///   consumed NOTHING and registered NOTHING. Only select waiters can lose;
+///   a direct waiter's claim always succeeds, so direct callers treat this
+///   as unreachable.
+pub const AsyncWaitState = enum { ready, queued, lost };
+
 pub const NO_WINNER = std.math.maxInt(usize);
 
 /// Stack-allocated waiter for async operations.

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -314,9 +314,11 @@ pub const CompletionQueue = struct {
         return !self.completed.isEmpty() or (self.closed and self.pending.isEmpty());
     }
 
-    pub fn asyncWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) bool {
-        // Fast path: something to report already.
-        if (self.isReady()) return false;
+    pub fn asyncWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
+        // The ready path consumes nothing (`getResult`/`next` pop), but the
+        // select must still be won before reporting ready: a branch that
+        // registered earlier may already hold a committed result.
+        if (self.isReady()) return if (waiter.tryClaim()) .ready else .lost;
 
         // Park on the completion futex word.
         Futex.prepareWait(&self.signal.raw, ctx, waiter);
@@ -324,13 +326,14 @@ pub const CompletionQueue = struct {
         // Double-check: a completion or the drained close may have landed (and
         // issued its wake) between the fast-path check and the registration.
         if (self.isReady()) {
-            // We removed ourselves before any wake -> report readiness now.
-            if (Futex.cancelWait(ctx)) return false;
+            // We removed ourselves before any wake -> report readiness now,
+            // after winning the select.
+            if (Futex.cancelWait(ctx)) return if (waiter.tryClaim()) .ready else .lost;
             // A concurrent wake already dequeued us; the signal is in-flight.
-            return true;
+            return .queued;
         }
 
-        return true;
+        return .queued;
     }
 
     pub fn asyncCancelWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) bool {

--- a/src/group.zig
+++ b/src/group.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const log = @import("common.zig").log;
+const common = @import("common.zig");
 const Waiter = @import("common.zig").Waiter;
 const meta = @import("meta.zig");
 const Runtime = @import("runtime.zig").Runtime;
@@ -245,11 +246,14 @@ pub const Group = struct {
         _ = ctx;
     }
 
-    pub fn asyncWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {
+    pub fn asyncWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
         const state_ptr = self.getState();
 
         // Fast path: no pending tasks means the group is already "complete".
-        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) return false;
+        // Level state, nothing consumed; still win the select first.
+        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) {
+            return if (waiter.tryClaim()) .ready else .lost;
+        }
 
         // Park on the completion futex address.
         Futex.prepareWait(state_ptr, ctx, waiter);
@@ -258,12 +262,14 @@ pub const Group = struct {
         // between the fast-path check and our registration above.
         if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) {
             // We removed ourselves before any wake -> already complete.
-            if (Futex.cancelWait(ctx)) return false;
+            if (Futex.cancelWait(ctx)) {
+                return if (waiter.tryClaim()) .ready else .lost;
+            }
             // A concurrent completion already dequeued us; the wake is in-flight.
-            return true;
+            return .queued;
         }
 
-        return true;
+        return .queued;
     }
 
     pub fn asyncCancelWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -35,6 +35,7 @@ const Group = @import("group.zig").Group;
 const dns = @import("dns/root.zig");
 
 const select = @import("select.zig");
+const common = @import("common.zig");
 const Waiter = @import("common.zig").Waiter;
 const random_mod = @import("random.zig");
 
@@ -220,13 +221,14 @@ pub fn JoinHandle(comptime T: type) type {
         }
 
         /// Registers a waiter to be notified when the task completes.
-        /// This is part of the Future protocol for select().
-        /// Returns false if the task is already complete (no wait needed), true if added to queue.
-        pub fn asyncWait(self: Self, waiter: *Waiter) bool {
+        /// This is part of the Future protocol for select(); see
+        /// `common.AsyncWaitState` for the claim-before-ready contract.
+        pub fn asyncWait(self: Self, waiter: *Waiter) common.AsyncWaitState {
             if (self.awaitable) |awaitable| {
                 return awaitable.asyncWait(waiter);
             }
-            return false; // Already complete
+            // Already complete: level state; still win the select first.
+            return if (waiter.tryClaim()) .ready else .lost;
         }
 
         /// Cancels a pending wait operation by removing the waiter.

--- a/src/select.zig
+++ b/src/select.zig
@@ -268,8 +268,13 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
     // Only incremented when asyncWait returns true (future is pending).
     var registered_count: usize = 0;
 
+    // The cancel path runs its own epilogue (it must resolve every branch
+    // BEFORE deciding whether a claim won); this flag keeps the defer from
+    // double-canceling and double-counting signals after it has.
+    var cleanup_done = false;
+
     // Clean up waiters on all exit paths
-    defer {
+    defer if (!cleanup_done) {
         const winner_index = winner.load(.acquire);
 
         // Count expected signals: all registered futures will signal unless we cancel them.
@@ -293,7 +298,7 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
 
         // Wait for all expected signals (winner + in-flight non-winners)
         waiter.wait(expected, .no_cancel);
-    }
+    };
 
     // Add waiters to all waiting lists - fast path: return immediately if already complete
     inline for (fields, 0..) |field, i| {
@@ -316,7 +321,48 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
     }
 
     // Wait for one to complete (Waiter.wait handles spurious wakeups)
-    try waiter.wait(1, .allow_cancel);
+    waiter.wait(1, .allow_cancel) catch |err| {
+        // Canceled while parked. A queuing future may have COMMITTED an item
+        // to this select already, or may still commit one while the cancel
+        // loop below runs (asyncCancelWait returning false is that commitment,
+        // per the protocol contract above). Dropping a committed item would
+        // un-send it — Channel.receive keeps the same promise by returning
+        // the item instead of error.Canceled, and select must too. So: cancel
+        // every branch, absorb every in-flight signal, and only then decide.
+        // The task's cancellation stays pending and re-fires at the next
+        // cancelable operation.
+        var expected: u32 = 0;
+        inline for (fields, 0..) |field, i| {
+            if (i < registered_count) {
+                var future = @field(futures, field.name);
+                const was_removed = if (comptime hasWaitContext(field.type))
+                    future.asyncCancelWait(&waiters[i], &@field(contexts, field.name))
+                else
+                    future.asyncCancelWait(&waiters[i]);
+                if (!was_removed) {
+                    expected += 1;
+                }
+            }
+        }
+        // Absorbing the winner's signal is also what orders its result copy
+        // before the read below.
+        waiter.wait(expected, .no_cancel);
+        cleanup_done = true;
+
+        const canceled_winner = winner.load(.acquire);
+        if (canceled_winner == NO_WINNER) return err;
+        inline for (fields, 0..) |field, i| {
+            if (i == canceled_winner) {
+                const future = @field(futures, field.name);
+                const result = if (comptime hasWaitContext(field.type))
+                    future.getResult(&@field(contexts, field.name))
+                else
+                    future.getResult();
+                return @unionInit(U, field.name, result);
+            }
+        }
+        unreachable;
+    };
 
     // O(1) winner lookup
     const winner_index = winner.load(.acquire);
@@ -652,6 +698,76 @@ test "select: with cancellation" {
     // Should return error.Canceled
     const result = select_handle.join();
     try std.testing.expectError(error.Canceled, result);
+}
+
+test "select: canceled select delivers a claimed channel item" {
+    // Conservation law: an item sent while the selecting task is being
+    // canceled is EITHER still in the channel OR returned by the select.
+    // Before the cancel-path epilogue, the claim's copy died on the dead
+    // select frame and the item vanished (starh2 t-882: a dropped write
+    // ack leaked its accounting on every teardown race).
+    const Channel = @import("sync/channel.zig").Channel;
+    const ResetEvent = @import("sync/ResetEvent.zig");
+
+    const Shared = struct {
+        ch: *Channel(u64),
+        never: *ResetEvent,
+        received: std.atomic.Value(u64) = .init(0),
+        parked: std.atomic.Value(bool) = .init(false),
+
+        fn waiterTask(sh: *@This()) !void {
+            sh.parked.store(true, .release);
+            const result = select(.{
+                .item = sh.ch.asyncReceive(),
+                .never = sh.never,
+            }) catch return;
+            switch (result) {
+                .item => |r| {
+                    const v = r catch return;
+                    sh.received.store(v, .release);
+                },
+                .never => unreachable,
+            }
+        }
+
+        fn senderTask(sh: *@This()) !void {
+            sh.ch.trySend(1) catch {};
+        }
+    };
+
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const Body = struct {
+        fn run(rt: *Runtime) !void {
+            var buf: [4]u64 = undefined;
+            var iter: usize = 0;
+            while (iter < 2000) : (iter += 1) {
+                var ch = Channel(u64).init(&buf);
+                var never = ResetEvent.init;
+                var sh: Shared = .{ .ch = &ch, .never = &never };
+
+                var w = try rt.spawn(Shared.waiterTask, .{&sh});
+                while (!sh.parked.load(.acquire)) try yield();
+                try yield();
+
+                var snd = try rt.spawn(Shared.senderTask, .{&sh});
+                w.cancel();
+                w.join() catch {};
+                snd.join() catch {};
+
+                const in_channel: u64 = ch.tryReceive() catch 0;
+                const got = sh.received.load(.acquire);
+                if (in_channel == 0 and got == 0) {
+                    std.debug.print("item dropped at iteration {d}\n", .{iter});
+                    return error.ItemDropped;
+                }
+            }
+        }
+    };
+
+    var handle = try runtime.spawn(Body.run, .{runtime});
+    try handle.join();
 }
 
 test "select: with error unions - success case" {

--- a/src/select.zig
+++ b/src/select.zig
@@ -26,22 +26,34 @@ const meta = @import("meta.zig");
 //     asyncWait/asyncCancelWait. Useful for storing completions, results, or other
 //     data that varies per wait operation.
 //
-//   fn asyncWait(self: *Self, waiter: *Waiter) bool           // if WaitContext == void
-//   fn asyncWait(self: *Self, waiter: *Waiter, ctx: *WaitContext) bool  // if WaitContext != void
+//   fn asyncWait(self: *Self, waiter: *Waiter) AsyncWaitState           // if WaitContext == void
+//   fn asyncWait(self: *Self, waiter: *Waiter, ctx: *WaitContext) AsyncWaitState  // if WaitContext != void
 //     Register for notification when this future completes.
 //
 //     If WaitContext != void, the ctx parameter points to caller-allocated per-wait state
 //     that persists for the duration of this wait operation.
 //
-//     Returns:
-//       - false: Operation already complete (fast path). Result is available via getResult().
-//                The waiter was NOT added to any queue.
-//       - true: Operation pending (slow path). The waiter was added to an internal wait
-//               queue and will be woken via waiter.wake() when the operation completes.
+//     Returns (see common.AsyncWaitState):
+//       - .ready: Operation complete (fast path) AND this waiter WON the select
+//                 (the future called waiter.tryClaim() BEFORE any consuming side
+//                 effect). Result is available via getResult(). Nothing was
+//                 registered.
+//       - .queued: Operation pending (slow path). The waiter was added to an
+//                  internal wait queue and will be woken via waiter.wake() when
+//                  the operation completes.
+//       - .lost: Another branch of the same select already won. The future
+//                consumed NOTHING and registered NOTHING. Only select waiters
+//                can lose; a direct waiter's claim always succeeds.
+//
+//     The claim-before-consume rule is the load-bearing invariant: a fast path
+//     that consumed first and reported ready afterwards let select() overwrite
+//     a concurrent claim of an earlier-registered branch, and the claimed item
+//     died on the select's dead stack frame.
 //
 //     Guarantees:
-//       - If returns false, getResult() can be called immediately
-//       - If returns true, waiter.wake() will be called exactly once when complete
+//       - If .ready, getResult() can be called immediately and the winner slot
+//         holds this branch's index
+//       - If .queued, waiter.wake() will be called exactly once when complete
 //       - Thread-safe: can be called from any thread
 //       - The ctx pointer (if present) remains valid until asyncCancelWait() or waiter.wake()
 //
@@ -264,9 +276,11 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
         w.* = Waiter.initSelect(&waiter, &winner, i);
     }
 
-    // Track how many futures we've registered with (for cleanup).
-    // Only incremented when asyncWait returns true (future is pending).
-    var registered_count: usize = 0;
+    // Per-branch registration state. A prefix count is not enough once a
+    // branch can report `.lost` (nothing registered) between two `.queued`
+    // branches; cancel/cleanup must touch exactly the queued set.
+    const BranchState = enum { untouched, queued, lost };
+    var states = [_]BranchState{.untouched} ** fields.len;
 
     // The cancel path runs its own epilogue (it must resolve every branch
     // BEFORE deciding whether a claim won); this flag keeps the defer from
@@ -277,21 +291,26 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
     defer if (!cleanup_done) {
         const winner_index = winner.load(.acquire);
 
-        // Count expected signals: all registered futures will signal unless we cancel them.
-        // Successfully canceled futures (asyncCancelWait returns true) won't signal.
-        var expected: u32 = @intCast(registered_count);
+        // Count expected signals: every queued branch will signal unless we
+        // cancel it; `.lost` and `.untouched` branches registered nothing
+        // and never signal.
+        var expected: u32 = 0;
         inline for (fields, 0..) |field, i| {
-            // Only cancel if we registered and didn't win
-            if (i < registered_count and winner_index != i) {
-                var future = @field(futures, field.name);
-                const was_removed = if (comptime hasWaitContext(field.type))
-                    future.asyncCancelWait(&waiters[i], &@field(contexts, field.name))
-                else
-                    future.asyncCancelWait(&waiters[i]);
+            if (states[i] == .queued) {
+                if (winner_index != i) {
+                    var future = @field(futures, field.name);
+                    const was_removed = if (comptime hasWaitContext(field.type))
+                        future.asyncCancelWait(&waiters[i], &@field(contexts, field.name))
+                    else
+                        future.asyncCancelWait(&waiters[i]);
 
-                if (was_removed) {
-                    // Successfully removed from queue - won't signal
-                    expected -= 1;
+                    if (!was_removed) {
+                        // Claimed or completing: its signal is in flight.
+                        expected += 1;
+                    }
+                } else {
+                    // The winner signals exactly once.
+                    expected += 1;
                 }
             }
         }
@@ -300,24 +319,53 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
         waiter.wait(expected, .no_cancel);
     };
 
-    // Add waiters to all waiting lists - fast path: return immediately if already complete
+    // Fast-path/registration pass. The claim-before-ready contract
+    // (`AsyncWaitState` in common.zig) makes the old clobber unsayable:
+    // `.ready` means the future already WON the winner slot before it
+    // consumed anything, so no concurrent claim of an earlier branch can be
+    // overwritten. `.lost` means another branch won during this pass; that
+    // branch's signal is in flight and drives the wait below.
+    var lost_any = false;
     inline for (fields, 0..) |field, i| {
         const future = @field(futures, field.name);
-        const waiting = if (comptime hasWaitContext(field.type))
+        const state = if (comptime hasWaitContext(field.type))
             future.asyncWait(&waiters[i], &@field(contexts, field.name))
         else
             future.asyncWait(&waiters[i]);
 
-        if (!waiting) {
-            winner.store(i, .release);
-            const result = if (comptime hasWaitContext(field.type))
-                future.getResult(&@field(contexts, field.name))
-            else
-                future.getResult();
-            return @unionInit(U, field.name, result);
+        switch (state) {
+            .ready => {
+                std.debug.assert(winner.load(.acquire) == i);
+                const result = if (comptime hasWaitContext(field.type))
+                    future.getResult(&@field(contexts, field.name))
+                else
+                    future.getResult();
+                return @unionInit(U, field.name, result);
+            },
+            .queued => states[i] = .queued,
+            .lost => {
+                states[i] = .lost;
+                lost_any = true;
+            },
         }
-
-        registered_count += 1;
+    }
+    if (lost_any) {
+        // Some queued branch was claimed while this pass ran; absorb its
+        // signal (which also orders its result copy) and deliver it.
+        waiter.wait(1, .no_cancel);
+        const winner_index = winner.load(.acquire);
+        std.debug.assert(winner_index != NO_WINNER);
+        inline for (fields, 0..) |field, i| {
+            if (i == winner_index) {
+                const future = @field(futures, field.name);
+                const result = if (comptime hasWaitContext(field.type))
+                    future.getResult(&@field(contexts, field.name))
+                else
+                    future.getResult();
+                return @unionInit(U, field.name, result);
+            }
+        }
+        unreachable;
     }
 
     // Wait for one to complete (Waiter.wait handles spurious wakeups)
@@ -333,7 +381,7 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
         // cancelable operation.
         var expected: u32 = 0;
         inline for (fields, 0..) |field, i| {
-            if (i < registered_count) {
+            if (states[i] == .queued) {
                 var future = @field(futures, field.name);
                 const was_removed = if (comptime hasWaitContext(field.type))
                     future.asyncCancelWait(&waiters[i], &@field(contexts, field.name))
@@ -400,22 +448,26 @@ pub fn selectAwaitables(awaitables: []const *Awaitable) Cancelable!usize {
         w.* = Waiter.initSelect(&waiter, &winner, i);
     }
 
-    // Only incremented when asyncWait returns true (future is pending).
-    var registered_count: usize = 0;
+    // Per-branch registration state; see select() for why a prefix count
+    // is not enough.
+    const BranchState = enum { untouched, queued, lost };
+    var states = [_]BranchState{.untouched} ** max_awaitables;
 
     defer {
         const winner_index = winner.load(.acquire);
 
-        // Count expected signals: all registered futures will signal unless we cancel them.
-        // Successfully canceled futures (asyncCancelWait returns true) won't signal.
-        var expected: u32 = @intCast(registered_count);
-        for (awaitables[0..registered_count], waiters[0..registered_count], 0..) |awaitable, *w, i| {
+        // Count expected signals: every queued branch signals unless its
+        // cancel removed it; `.lost`/`.untouched` registered nothing.
+        var expected: u32 = 0;
+        for (awaitables, waiters[0..awaitables.len], 0..) |awaitable, *w, i| {
+            if (states[i] != .queued) continue;
             if (winner_index != i) {
                 const was_removed = awaitable.asyncCancelWait(w);
-                if (was_removed) {
-                    // Successfully removed from queue - won't signal
-                    expected -= 1;
+                if (!was_removed) {
+                    expected += 1;
                 }
+            } else {
+                expected += 1;
             }
         }
 
@@ -423,15 +475,27 @@ pub fn selectAwaitables(awaitables: []const *Awaitable) Cancelable!usize {
         waiter.wait(expected, .no_cancel);
     }
 
-    for (awaitables, waiters[0..awaitables.len]) |awaitable, *w| {
-        const waiting = awaitable.asyncWait(w);
-
-        if (!waiting) {
-            winner.store(w.mode.select.index, .release);
-            return w.mode.select.index;
+    var lost_any = false;
+    for (awaitables, waiters[0..awaitables.len], 0..) |awaitable, *w, i| {
+        switch (awaitable.asyncWait(w)) {
+            .ready => {
+                std.debug.assert(winner.load(.acquire) == i);
+                return i;
+            },
+            .queued => states[i] = .queued,
+            .lost => {
+                states[i] = .lost;
+                lost_any = true;
+            },
         }
-
-        registered_count += 1;
+    }
+    if (lost_any) {
+        // A queued branch was claimed during this pass; absorb its signal
+        // and deliver it.
+        waiter.wait(1, .no_cancel);
+        const winner_index = winner.load(.acquire);
+        std.debug.assert(winner_index != NO_WINNER);
+        return winner_index;
     }
 
     // Wait for one to complete (Waiter.wait handles spurious wakeups)
@@ -456,14 +520,19 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
 
     // Fast path: check if already complete
     var fut = future;
-    const added = if (has_context)
+    const state = if (has_context)
         fut.asyncWait(&waiter, &context)
     else
         fut.asyncWait(&waiter);
 
-    if (!added) {
-        const result = if (has_context) fut.getResult(&context) else fut.getResult();
-        return .{ .value = result };
+    switch (state) {
+        .ready => {
+            const result = if (has_context) fut.getResult(&context) else fut.getResult();
+            return .{ .value = result };
+        },
+        // A direct waiter's claim always succeeds.
+        .lost => unreachable,
+        .queued => {},
     }
 
     // Clean up waiter on exit
@@ -760,6 +829,112 @@ test "select: canceled select delivers a claimed channel item" {
                 const got = sh.received.load(.acquire);
                 if (in_channel == 0 and got == 0) {
                     std.debug.print("item dropped at iteration {d}\n", .{iter});
+                    return error.ItemDropped;
+                }
+            }
+        }
+    };
+
+    var handle = try runtime.spawn(Body.run, .{runtime});
+    try handle.join();
+}
+
+test "select: fast path does not clobber an earlier branch's claim" {
+    // Conservation law: an item sent to channel A while the select is
+    // registering is EITHER still in A OR returned by the select. Branch
+    // `.a` (A, empty) registers first; branch `.b` (B, already buffered)
+    // takes the fast path. Before claim-before-consume, that fast path
+    // did a blind `winner.store(b)` over a concurrent claim of `.a`, and
+    // the item copied into the select frame vanished.
+    //
+    // The race needs a sender on ANOTHER executor: one long-lived sender
+    // task spins on a per-round counter and fires `trySend` into the
+    // registration window. On one executor the sender could only run
+    // when the select task yields, and the registration pass never does.
+    const Channel = @import("sync/channel.zig").Channel;
+    const rounds: u64 = 50000;
+
+    const Shared = struct {
+        ch_a: std.atomic.Value(?*Channel(u64)) = .init(null),
+        go: std.atomic.Value(u64) = .init(0),
+        sent: std.atomic.Value(u64) = .init(0),
+        running: std.atomic.Value(bool) = .init(false),
+        // Set when the select side stops early (a detected drop), so the
+        // sender does not spin forever on a round that never comes.
+        stop: std.atomic.Value(bool) = .init(false),
+
+        fn senderTask(sh: *@This()) !void {
+            sh.running.store(true, .release);
+            var round: u64 = 1;
+            while (round <= rounds) : (round += 1) {
+                while (sh.go.load(.acquire) < round) {
+                    if (sh.stop.load(.acquire)) return;
+                    std.atomic.spinLoopHint();
+                }
+                // Sweep the arrival phase: the two threads otherwise settle
+                // into a fixed offset that can miss the window for a whole run.
+                var delay: u64 = round % 64;
+                while (delay > 0) : (delay -= 1) std.atomic.spinLoopHint();
+                sh.ch_a.load(.acquire).?.trySend(1) catch {};
+                sh.sent.store(round, .release);
+            }
+        }
+    };
+
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
+
+    const Body = struct {
+        fn run(rt: *Runtime) !void {
+            var sh: Shared = .{};
+            var snd = try rt.spawn(Shared.senderTask, .{&sh});
+            defer snd.join() catch {};
+            defer sh.stop.store(true, .release);
+            while (!sh.running.load(.acquire)) try yield();
+
+            var buf_a: [4]u64 = undefined;
+            var buf_b: [4]u64 = undefined;
+            var buf_f: [4]u64 = undefined;
+            var round: u64 = 1;
+            while (round <= rounds) : (round += 1) {
+                var ch_a = Channel(u64).init(&buf_a);
+                var ch_b = Channel(u64).init(&buf_b);
+                // Idle filler branches between `.a` and `.b` stretch the
+                // registration pass from tens of nanoseconds to a window the
+                // sender's claim can land in. They never fire.
+                var f1 = Channel(u64).init(&buf_f);
+                var f2 = Channel(u64).init(&buf_f);
+                var f3 = Channel(u64).init(&buf_f);
+                var f4 = Channel(u64).init(&buf_f);
+                var f5 = Channel(u64).init(&buf_f);
+                var f6 = Channel(u64).init(&buf_f);
+                // `.b` is ready before the select starts: its fast path fires.
+                try ch_b.trySend(7);
+                sh.ch_a.store(&ch_a, .release);
+                sh.go.store(round, .release);
+                var got_a: u64 = 0;
+                const result = try select(.{
+                    .a = ch_a.asyncReceive(),
+                    .f1 = f1.asyncReceive(),
+                    .f2 = f2.asyncReceive(),
+                    .f3 = f3.asyncReceive(),
+                    .f4 = f4.asyncReceive(),
+                    .f5 = f5.asyncReceive(),
+                    .f6 = f6.asyncReceive(),
+                    .b = ch_b.asyncReceive(),
+                });
+                switch (result) {
+                    .a => |r| got_a = r catch 0,
+                    .b => |r| _ = r catch 0,
+                    else => unreachable,
+                }
+                // The sender must be done with this round's channel before
+                // the frame holding it is reused.
+                while (sh.sent.load(.acquire) < round) std.atomic.spinLoopHint();
+
+                const in_a: u64 = ch_a.tryReceive() catch 0;
+                if (in_a == 0 and got_a == 0) {
+                    std.debug.print("item dropped at round {d}\n", .{round});
                     return error.ItemDropped;
                 }
             }

--- a/src/select.zig
+++ b/src/select.zig
@@ -250,6 +250,9 @@ test "SelectResult: result types" {
 /// }
 /// ```
 pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
+    // Wide selects (many branches, each with WaitContext plumbing) exceed
+    // the default comptime branch quota.
+    @setEvalBranchQuota(100_000);
     const S = @TypeOf(futures);
     const U = SelectResult(S);
     const fields = @typeInfo(S).@"struct".fields;

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -13,7 +13,8 @@ const WaitQueue = @import("utils/wait_queue.zig").WaitQueue;
 const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const AutoCancel = @import("autocancel.zig").AutoCancel;
 const w = @import("os/windows.zig");
-const Waiter = @import("common.zig").Waiter;
+const common = @import("common.zig");
+const Waiter = common.Waiter;
 
 pub const SignalKind = switch (builtin.os.tag) {
     .windows => enum(u8) {
@@ -351,17 +352,23 @@ pub const Signal = struct {
     }
 
     /// Registers a waiter to be notified when the signal is received.
-    /// This is part of the Future protocol for select().
-    /// Returns false if the signal was already received (no wait needed), true if added to wait queue.
-    pub fn asyncWait(self: *Signal, waiter: *Waiter) bool {
-        // Fast path: signal already received
-        if (self.entry.counter.swap(0, .acquire) > 0) {
-            return false;
+    /// This is part of the Future protocol for select(); see
+    /// `common.AsyncWaitState` for the claim-before-ready contract.
+    pub fn asyncWait(self: *Signal, waiter: *Waiter) common.AsyncWaitState {
+        // Fast path: signal pending. Win the select BEFORE the consuming
+        // swap; a swap on a losing branch would eat the signal count.
+        if (self.entry.counter.load(.acquire) > 0) {
+            if (!waiter.tryClaim()) return .lost;
+            // A raced swap-to-zero still reports ready: the count was
+            // observed positive, and signal delivery tolerates spurious
+            // wakeups by POSIX convention.
+            _ = self.entry.counter.swap(0, .acquire);
+            return .ready;
         }
 
         // Add to wait queue
         self.entry.waiters.push(&waiter.node);
-        return true;
+        return .queued;
     }
 
     /// Cancels a pending wait operation by removing the waiter.

--- a/src/sync/Notify.zig
+++ b/src/sync/Notify.zig
@@ -185,10 +185,10 @@ pub fn getResult(self: *const Notify) void {
 
 /// Registers a waiter to be notified when signal() or broadcast() is called.
 /// This is part of the Future protocol for select().
-/// Always returns true since Notify has no persistent state (never pre-completed).
-pub fn asyncWait(self: *Notify, waiter: *Waiter) bool {
+/// Always queues since Notify has no persistent state (never pre-completed).
+pub fn asyncWait(self: *Notify, waiter: *Waiter) @import("../common.zig").AsyncWaitState {
     self.wait_queue.push(&waiter.node);
-    return true;
+    return .queued;
 }
 
 /// Cancels a pending wait operation by removing the waiter.

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -54,7 +54,8 @@ const Timeoutable = @import("../common.zig").Timeoutable;
 const Timeout = @import("../time.zig").Timeout;
 const WaitQueue = @import("../utils/wait_queue.zig").WaitQueue;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
-const Waiter = @import("../common.zig").Waiter;
+const common = @import("../common.zig");
+const Waiter = common.Waiter;
 
 /// Wait queue with flag indicating whether event is set.
 wait_queue: WaitQueue(WaitNode) = .empty,
@@ -204,11 +205,14 @@ pub fn getResult(self: *const ResetEvent) void {
 }
 
 /// Registers a waiter to be notified when the event is set.
-/// This is part of the Future protocol for select().
-/// Returns false if the event is already set (no wait needed), true if added to queue.
-pub fn asyncWait(self: *ResetEvent, waiter: *Waiter) bool {
+/// This is part of the Future protocol for select(); see
+/// `common.AsyncWaitState` for the claim-before-ready contract.
+pub fn asyncWait(self: *ResetEvent, waiter: *Waiter) common.AsyncWaitState {
     // Try to push to queue - only succeeds if event is not set (flag not set)
-    return self.wait_queue.pushUnlessFlag(&waiter.node);
+    if (self.wait_queue.pushUnlessFlag(&waiter.node)) return .queued;
+    // Already set: level state, nothing to consume, but the select must
+    // still be won before reporting ready.
+    return if (waiter.tryClaim()) .ready else .lost;
 }
 
 /// Cancels a pending wait operation by removing the waiter.

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -9,6 +9,7 @@ const SimpleQueue = @import("../utils/simple_queue.zig").SimpleQueue;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const Barrier = @import("Barrier.zig");
 const select = @import("../select.zig").select;
+const common = @import("../common.zig");
 const Waiter = @import("../common.zig").Waiter;
 const Closeable = @import("../common.zig").Closeable;
 const Mutex = @import("Mutex.zig");
@@ -167,7 +168,7 @@ const AsyncReceiveImpl = struct {
         result: ?(Closeable || error{Lagged})!void = null,
     };
 
-    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) bool {
+    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) common.AsyncWaitState {
         ctx.result_ptr = result_ptr;
         ctx.result = null;
 
@@ -177,33 +178,47 @@ const AsyncReceiveImpl = struct {
 
         // Check if lagged
         if (unread > self.channel.capacity) {
+            // Win the select before mutating consumer state.
+            if (!waiter.tryClaim()) {
+                self.channel.mutex.unlock();
+                return .lost;
+            }
             self.consumer.read_pos = self.channel.write_pos -% self.channel.capacity;
             ctx.result = error.Lagged;
             self.channel.mutex.unlock();
-            return false; // Complete immediately with error
+            return .ready; // Complete immediately with error
         }
 
         // Fast path: message available
         if (unread > 0) {
+            // Win the select BEFORE consuming (claim-before-ready).
+            if (!waiter.tryClaim()) {
+                self.channel.mutex.unlock();
+                return .lost;
+            }
             const src = self.channel.elemPtr(self.consumer.read_pos % self.channel.capacity);
             @memcpy(ctx.result_ptr[0..self.channel.elem_size], src[0..self.channel.elem_size]);
             self.consumer.read_pos +%= 1;
             ctx.result = {};
             self.channel.mutex.unlock();
-            return false; // Complete immediately
+            return .ready; // Complete immediately
         }
 
         // Fast path: channel closed
         if (self.channel.closed) {
+            if (!waiter.tryClaim()) {
+                self.channel.mutex.unlock();
+                return .lost;
+            }
             ctx.result = error.Closed;
             self.channel.mutex.unlock();
-            return false; // Complete immediately with error
+            return .ready; // Complete immediately with error
         }
 
         // Slow path: enqueue and wait
         self.channel.wait_queue.push(&waiter.node);
         self.channel.mutex.unlock();
-        return true;
+        return .queued;
     }
 
     pub fn asyncCancelWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) bool {
@@ -438,7 +453,7 @@ pub fn AsyncReceive(comptime T: type) type {
 
         /// Register for notification when receive can complete.
         /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
+        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
             return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&ctx.result).ptr);
         }
 

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -66,8 +66,11 @@ const ChannelImpl = struct {
         var ctx: AsyncReceiveImpl.WaitContext = .{ .result_ptr = undefined };
         var waiter = Waiter.init();
 
-        if (!recv.asyncWait(&waiter, &ctx, elem_ptr)) {
-            return recv.getResult(&ctx);
+        switch (recv.asyncWait(&waiter, &ctx, elem_ptr)) {
+            .ready => return recv.getResult(&ctx),
+            // A direct waiter's claim always succeeds.
+            .lost => unreachable,
+            .queued => {},
         }
 
         waiter.wait(1, .allow_cancel) catch |err| {
@@ -134,8 +137,11 @@ const ChannelImpl = struct {
         var ctx: AsyncSendImpl.WaitContext = .{ .item_ptr = undefined };
         var waiter = Waiter.init();
 
-        if (!send_op.asyncWait(&waiter, &ctx, elem_ptr)) {
-            return send_op.getResult(&ctx);
+        switch (send_op.asyncWait(&waiter, &ctx, elem_ptr)) {
+            .ready => return send_op.getResult(&ctx),
+            // A direct waiter's claim always succeeds.
+            .lost => unreachable,
+            .queued => {},
         }
 
         waiter.wait(1, .allow_cancel) catch |err| {
@@ -225,41 +231,58 @@ const AsyncSendImpl = struct {
         succeeded: bool = false,
     };
 
-    pub fn asyncWait(self: *const SendSelf, waiter: *Waiter, ctx: *WaitContext, item_ptr: [*]const u8) bool {
+    pub fn asyncWait(self: *const SendSelf, waiter: *Waiter, ctx: *WaitContext, item_ptr: [*]const u8) common.AsyncWaitState {
         ctx.item_ptr = item_ptr;
 
         self.channel.mutex.lockUncancelable();
 
         if (self.channel.closed) {
+            // Nothing consumed; win the select before reporting ready.
             self.channel.mutex.unlock();
-            return false;
+            return if (waiter.tryClaim()) .ready else .lost;
         }
 
-        while (self.channel.receiver_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const recv_ctx: *AsyncReceiveImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(recv_ctx.result_ptr[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
-                recv_ctx.result_set = true;
+        if (!self.channel.receiver_queue.isEmpty() or
+            self.channel.count < self.channel.capacity)
+        {
+            // The send can complete now. Win the select FIRST: committing
+            // the transfer on a branch that then lost dropped the item on
+            // the dead select frame (the fast-path clobber).
+            if (!waiter.tryClaim()) {
+                self.channel.mutex.unlock();
+                return .lost;
+            }
+            while (self.channel.receiver_queue.pop()) |node| {
+                if (Waiter.fromNode(node).tryClaim()) {
+                    const recv_ctx: *AsyncReceiveImpl.WaitContext = @ptrFromInt(node.userdata);
+                    @memcpy(recv_ctx.result_ptr[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
+                    recv_ctx.result_set = true;
+                    ctx.succeeded = true;
+                    self.channel.mutex.unlock();
+                    Waiter.fromNode(node).signal();
+                    return .ready;
+                }
+            }
+            if (self.channel.count < self.channel.capacity) {
+                @memcpy(self.channel.elemPtr(self.channel.tail)[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
+                self.channel.tail = (self.channel.tail + 1) % self.channel.capacity;
+                self.channel.count += 1;
                 ctx.succeeded = true;
                 self.channel.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return false;
+                return .ready;
             }
-        }
-
-        if (self.channel.count < self.channel.capacity) {
-            @memcpy(self.channel.elemPtr(self.channel.tail)[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
-            self.channel.tail = (self.channel.tail + 1) % self.channel.capacity;
-            self.channel.count += 1;
-            ctx.succeeded = true;
-            self.channel.mutex.unlock();
-            return false;
+            // Won the select, but every parked receiver was a select loser
+            // and there is no buffer space. Only an unbuffered select-vs-
+            // select rendezvous can reach this; the fork does not support
+            // that composition, and silently losing the win would strand
+            // the select.
+            @panic("channel select-send won with no committable receiver (unbuffered select-vs-select rendezvous is unsupported)");
         }
 
         waiter.node.userdata = @intFromPtr(ctx);
         self.channel.sender_queue.push(&waiter.node);
         self.channel.mutex.unlock();
-        return true;
+        return .queued;
     }
 
     pub fn asyncCancelWait(self: *const SendSelf, waiter: *Waiter, ctx: *WaitContext) bool {
@@ -295,39 +318,61 @@ const AsyncReceiveImpl = struct {
         result_set: bool = false,
     };
 
-    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) bool {
+    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) common.AsyncWaitState {
         ctx.result_ptr = result_ptr;
         ctx.result_set = false;
 
         self.channel.mutex.lockUncancelable();
 
         if (self.channel.count > 0) {
+            // Win the select BEFORE consuming: an item taken by a branch
+            // that then lost died on the dead select frame (the fast-path
+            // clobber that leaked starh2's write-ack accounting).
+            if (!waiter.tryClaim()) {
+                self.channel.mutex.unlock();
+                return .lost;
+            }
             self.channel.takeItemAndWakeSender(ctx.result_ptr);
             ctx.result_set = true;
-            return false;
+            return .ready;
         }
 
-        while (self.channel.sender_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const send_ctx: *AsyncSendImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(ctx.result_ptr[0..self.channel.elem_size], send_ctx.item_ptr[0..self.channel.elem_size]);
-                send_ctx.succeeded = true;
-                ctx.result_set = true;
+        if (!self.channel.sender_queue.isEmpty()) {
+            if (!waiter.tryClaim()) {
                 self.channel.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return false;
+                return .lost;
             }
+            while (self.channel.sender_queue.pop()) |node| {
+                if (Waiter.fromNode(node).tryClaim()) {
+                    const send_ctx: *AsyncSendImpl.WaitContext = @ptrFromInt(node.userdata);
+                    @memcpy(ctx.result_ptr[0..self.channel.elem_size], send_ctx.item_ptr[0..self.channel.elem_size]);
+                    send_ctx.succeeded = true;
+                    ctx.result_set = true;
+                    self.channel.mutex.unlock();
+                    Waiter.fromNode(node).signal();
+                    return .ready;
+                }
+            }
+            if (self.channel.closed) {
+                self.channel.mutex.unlock();
+                return .ready;
+            }
+            // Won the select, but every parked sender was a select loser
+            // and the buffer is empty. Only an unbuffered select-vs-select
+            // rendezvous can reach this; the fork does not support that
+            // composition.
+            @panic("channel select-receive won with no committable sender (unbuffered select-vs-select rendezvous is unsupported)");
         }
 
         if (self.channel.closed) {
             self.channel.mutex.unlock();
-            return false;
+            return if (waiter.tryClaim()) .ready else .lost;
         }
 
         waiter.node.userdata = @intFromPtr(ctx);
         self.channel.receiver_queue.push(&waiter.node);
         self.channel.mutex.unlock();
-        return true;
+        return .queued;
     }
 
     pub fn asyncCancelWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) bool {
@@ -559,8 +604,8 @@ pub fn AsyncReceive(comptime T: type) type {
         }
 
         /// Register for notification when receive can complete.
-        /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
+        /// See `common.AsyncWaitState` for the claim-before-ready contract.
+        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
             return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&ctx.result).ptr);
         }
 
@@ -612,8 +657,8 @@ pub fn AsyncSend(comptime T: type) type {
         }
 
         /// Register for notification when send can complete.
-        /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
+        /// See `common.AsyncWaitState` for the claim-before-ready contract.
+        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
             return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&self.item).ptr);
         }
 
@@ -1620,7 +1665,7 @@ test "Channel: close classifies select waiters before signaling" {
     var claimed_receive_winner: std.atomic.Value(usize) = .init(NO_WINNER);
     var claimed_receive_waiter = Waiter.initSelect(&claimed_receive_parent, &claimed_receive_winner, 0);
 
-    try std.testing.expect(claimed_receive.asyncWait(&claimed_receive_waiter, &claimed_receive_ctx));
+    try std.testing.expectEqual(.queued, claimed_receive.asyncWait(&claimed_receive_waiter, &claimed_receive_ctx));
     claimed_receive_channel.close(.graceful);
     try std.testing.expectEqual(0, claimed_receive_winner.load(.acquire));
     try std.testing.expect(!claimed_receive.asyncCancelWait(&claimed_receive_waiter, &claimed_receive_ctx));
@@ -1635,7 +1680,7 @@ test "Channel: close classifies select waiters before signaling" {
     var claimed_send_winner: std.atomic.Value(usize) = .init(NO_WINNER);
     var claimed_send_waiter = Waiter.initSelect(&claimed_send_parent, &claimed_send_winner, 0);
 
-    try std.testing.expect(claimed_send.asyncWait(&claimed_send_waiter, &claimed_send_ctx));
+    try std.testing.expectEqual(.queued, claimed_send.asyncWait(&claimed_send_waiter, &claimed_send_ctx));
     claimed_send_channel.close(.graceful);
     try std.testing.expectEqual(0, claimed_send_winner.load(.acquire));
     try std.testing.expect(!claimed_send.asyncCancelWait(&claimed_send_waiter, &claimed_send_ctx));
@@ -1651,7 +1696,7 @@ test "Channel: close classifies select waiters before signaling" {
     var receive_winner: std.atomic.Value(usize) = .init(1);
     var receive_waiter = Waiter.initSelect(&receive_parent, &receive_winner, 0);
 
-    try std.testing.expect(receive.asyncWait(&receive_waiter, &receive_ctx));
+    try std.testing.expectEqual(.queued, receive.asyncWait(&receive_waiter, &receive_ctx));
     receive_channel.close(.graceful);
     try std.testing.expect(receive.asyncCancelWait(&receive_waiter, &receive_ctx));
     try std.testing.expectEqual(0, Helpers.notifyState(&receive_parent));
@@ -1664,7 +1709,7 @@ test "Channel: close classifies select waiters before signaling" {
     var send_winner: std.atomic.Value(usize) = .init(1);
     var send_waiter = Waiter.initSelect(&send_parent, &send_winner, 0);
 
-    try std.testing.expect(send.asyncWait(&send_waiter, &send_ctx));
+    try std.testing.expectEqual(.queued, send.asyncWait(&send_waiter, &send_ctx));
     send_channel.close(.graceful);
     try std.testing.expect(send.asyncCancelWait(&send_waiter, &send_ctx));
     try std.testing.expectEqual(0, Helpers.notifyState(&send_parent));

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -6,7 +6,8 @@ const builtin = @import("builtin");
 const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
 const Cancelable = @import("../common.zig").Cancelable;
-const Waiter = @import("../common.zig").Waiter;
+const common = @import("../common.zig");
+const Waiter = common.Waiter;
 const WaitQueue = @import("../utils/wait_queue.zig").WaitQueue;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const meta = @import("../meta.zig");
@@ -115,15 +116,16 @@ pub fn Future(comptime T: type) type {
         }
 
         /// Registers a waiter to be notified when the future is set.
-        /// This is part of the Future protocol for select().
-        /// Returns false if the future is already set (no wait needed), true if added to queue.
-        pub fn asyncWait(self: *Self, waiter: *Waiter) bool {
-            // Fast path: check if already set
+        /// This is part of the Future protocol for select(); see
+        /// `common.AsyncWaitState` for the claim-before-ready contract.
+        pub fn asyncWait(self: *Self, waiter: *Waiter) common.AsyncWaitState {
+            // Fast path: check if already set (level state, nothing consumed)
             if (self.value.isSet()) {
-                return false;
+                return if (waiter.tryClaim()) .ready else .lost;
             }
             // Try to push to queue - only succeeds if future is not done (flag not set)
-            return self.wait_queue.pushUnlessFlag(&waiter.node);
+            if (self.wait_queue.pushUnlessFlag(&waiter.node)) return .queued;
+            return if (waiter.tryClaim()) .ready else .lost;
         }
 
         /// Cancels a pending wait operation by removing the waiter.

--- a/src/task.zig
+++ b/src/task.zig
@@ -178,6 +178,9 @@ pub const TaskLocalNode = struct {
     next: ?*TaskLocalNode = null,
 };
 
+/// t-866 wake-ledger global sequence. See `AnyTask.diag_mark`.
+pub var diag_stamp_counter: std.atomic.Value(u64) = .init(0);
+
 pub const AnyTask = struct {
     awaitable: Awaitable,
     coro: Coroutine,
@@ -194,6 +197,15 @@ pub const AnyTask = struct {
     /// Head of this task's intrusive task-local binding chain (see `TaskLocal`).
     /// Only ever accessed by the task itself, so it needs no synchronization.
     tls_head: ?*TaskLocalNode = null,
+
+    /// t-866 wake-ledger diagnostic. Packs (global sequence << 8) | branch,
+    /// stamped at every scheduling hop this task passes through, so a probe
+    /// outside the runtime can name the LAST hop of a task that never ran
+    /// again. Branches: 1 awaken-token, 2 main-wake, 3 timer-local,
+    /// 4 migrate-local, 5 same-executor local, 6 remote, 7 parked,
+    /// 8 prewoken-requeue, 9 popped-to-run, 10 waiter-signal,
+    /// 11 futex-wake-dequeue.
+    diag_mark: std.atomic.Value(u64) = .init(0),
 
     /// Task state and park token, packed into a single byte for atomic operations.
     ///
@@ -468,6 +480,12 @@ pub const AnyTask = struct {
     /// Wake this task (mark it as ready and schedule for execution).
     pub fn wake(self: *AnyTask) void {
         Executor.scheduleTask(self);
+    }
+
+    /// t-866 wake-ledger stamp. See `diag_mark`.
+    pub fn diagStamp(self: *AnyTask, branch: u8) void {
+        const seq = diag_stamp_counter.fetchAdd(1, .monotonic) + 1;
+        self.diag_mark.store((seq << 8) | branch, .release);
     }
 
     /// Return the coroutine's stack to the pool and retire its TSan fiber.

--- a/src/time.zig
+++ b/src/time.zig
@@ -13,6 +13,7 @@ const ev = @import("ev/root.zig");
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
 const loopClearTimer = @import("runtime.zig").loopClearTimer;
+const common = @import("common.zig");
 const Waiter = @import("common.zig").Waiter;
 
 // Time configuration - adjust these for different platforms
@@ -551,10 +552,10 @@ pub const Timeout = union(enum) {
         waiter: ?*Waiter = null,
     };
 
-    pub fn asyncWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
+    pub fn asyncWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) common.AsyncWaitState {
         // Timeout.none means wait forever - never completes
         if (self.* == .none) {
-            return true;
+            return .queued;
         }
 
         ctx.timer = ev.Timer.init(self.*);
@@ -564,7 +565,7 @@ pub const Timeout = union(enum) {
 
         const executor = getCurrentExecutor();
         executor.loopAdd(&ctx.timer.c);
-        return true;
+        return .queued;
     }
 
     fn timerCallback(_: *ev.Loop, c: *ev.Completion) void {


### PR DESCRIPTION
Fixes #700. Fixes #701.

## Why

Two conservation breaks in `select()`, both found the same way: an item that a sender had committed to a select vanished, neither in the channel nor returned.

1. A task canceled while parked in `select` returned `error.Canceled` after a sender's claim had already copied the item into the select frame (#700).
2. The registration loop's blind `winner.store(i)` on a fast-path branch overwrote a concurrent claim of an earlier-registered branch; the claimed item died, and cleanup's expected-signal count was wrong because `didWin()` no longer held for the clobbered waiter (#701).

## What

Three commits, in order:

- **select: deliver a claimed result when the selecting task is canceled.** The cancel path runs its own epilogue: cancel every registered branch (a claim can land during this loop, so the winner decision comes after it), absorb every in-flight signal, then return a claimed winner's result; otherwise `error.Canceled`. The cancellation stays pending and re-fires at the next cancelable operation, as `Channel.receive` already does. A `cleanup_done` flag keeps the normal-path defer from double-canceling.
- **Future protocol: win the select before any consuming fast path.** `asyncWait` returns `common.AsyncWaitState` (`.ready | .queued | .lost`) instead of `bool`. `.ready` means the future won the select (`waiter.tryClaim()`) before any consuming side effect; `.lost` means another branch already won and nothing was consumed or registered. `select()` and `selectAwaitables()` track per-branch state instead of a prefix `registered_count`, cancel exactly the queued set, and count expected signals per branch. All implementations move to claim-before-consume: channel receive/send (buffered, peer handoff, closed), broadcast channel, CompletionQueue, ResetEvent, Future, Awaitable, JoinHandle, Group, Signal, Notify, Timeout. The protocol doc in `select.zig` carries the new contract.
- **select: raise comptime branch quota for wide selects.** Needed once a select has more than a handful of branches (the new test has 8).

This is a protocol break for any out-of-tree `asyncWait` implementation: the return type changes. Direct waiters always claim, so non-select `wait()` paths are unchanged in behaviour.

## Boundary kept loud

An unbuffered select-vs-select rendezvous (a select-send racing a select-receive with no buffer) can win a select and then find every peer lost. That composition needs a reversible reservation/commit step for the peer handoff, which this PR does not add; it panics with a named message instead of stranding the select. Every consumer I have uses direct senders, whose claims cannot fail. Happy to do the rendezvous case as a follow-up if you want it supported.

## Tests

- `select: canceled select delivers a claimed channel item` — 2000 iterations, `trySend` raced against `cancel()` of a parked select. On `main` without the first commit: `item dropped at iteration 0`, 3 of 3 runs.
- `select: fast path does not clobber an earlier branch's claim` — two executors, one long-lived sender that sweeps its arrival phase (`round % 64` spins), six idle filler branches between the empty `.a` and the already-buffered `.b` so the registration window is wide enough to hit. On the tree with only the first commit: `item dropped at round 19-27`, 5 of 5 runs. With the protocol commit: 3 of 3 green, ~45ms.
- `./check.sh --full` on the branch tip: all checks passed.

## Residual

`selectAwaitables` (the `std.Io.selectImpl` path) gets the per-branch state tracking from the second commit, but the cancel-path result delivery from the first commit applies only to `select()`: `selectAwaitables` returns an index and result extraction belongs to its caller.
