### PR TITLE
select: implement two-phase prepare/commit protocol

### DIFF
--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -62,7 +62,8 @@ pub const Awaitable = struct {
             return .pending;
         }
 
-        pub fn commit(self: *Awaitable, ctx: *Context) CommitResult(void) {
+        pub fn commit(self: *Awaitable, waiter: *Waiter, ctx: *Context) CommitResult(void) {
+            _ = waiter;
             _ = ctx;
             std.debug.assert(self.waiting_list.isFlagSet());
             return .{ .done = {} };

--- a/src/awaitable.zig
+++ b/src/awaitable.zig
@@ -7,6 +7,9 @@ const builtin = @import("builtin");
 const RefCounter = @import("utils/ref_counter.zig").RefCounter;
 const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const Waiter = @import("common.zig").Waiter;
+const Prepare = @import("select.zig").Prepare;
+const CommitResult = @import("select.zig").CommitResult;
+const Rollback = @import("select.zig").Rollback;
 const GroupNode = @import("group.zig").GroupNode;
 const WaitQueue = @import("utils/wait_queue.zig").WaitQueue;
 
@@ -37,9 +40,6 @@ pub const Awaitable = struct {
     // Group membership - group_node.group is null if standalone
     group_node: GroupNode = .{},
 
-    // Future protocol - type-erased result type
-    pub const Result = void;
-
     /// Request cancellation of this awaitable.
     /// Dispatches to the sub-type's cancel method.
     pub fn cancel(self: *Awaitable) void {
@@ -49,24 +49,30 @@ pub const Awaitable = struct {
         }
     }
 
-    /// Registers a waiter to be notified when the awaitable completes.
-    /// This is part of the Future protocol for select().
-    /// Returns false if the awaitable is already complete (no wait needed), true if added to queue.
-    pub fn asyncWait(self: *Awaitable, waiter: *Waiter) bool {
-        // Fast path: check if already complete
-        if (self.waiting_list.isFlagSet()) {
-            return false;
-        }
-        // Try to push to queue - only succeeds if awaitable is not complete (flag not set)
-        return self.waiting_list.pushUnlessFlag(&waiter.node);
-    }
+    // AsyncWait protocol (see select.zig). Completion is the sticky queue
+    // flag; markComplete() dequeues and notifies every registration while
+    // setting it.
+    pub const AsyncWait = struct {
+        pub const Result = void;
+        pub const Context = struct {};
 
-    /// Cancels a pending wait operation by removing the waiter.
-    /// This is part of the Future protocol for select().
-    /// Returns true if removed, false if already removed by completion (wake in-flight).
-    pub fn asyncCancelWait(self: *Awaitable, waiter: *Waiter) bool {
-        return self.waiting_list.remove(&waiter.node);
-    }
+        pub fn prepare(self: *Awaitable, waiter: *Waiter, ctx: *Context) Prepare {
+            _ = ctx;
+            if (!self.waiting_list.pushUnlessFlag(&waiter.node)) return .ready;
+            return .pending;
+        }
+
+        pub fn commit(self: *Awaitable, ctx: *Context) CommitResult(void) {
+            _ = ctx;
+            std.debug.assert(self.waiting_list.isFlagSet());
+            return .{ .done = {} };
+        }
+
+        pub fn rollback(self: *Awaitable, waiter: *Waiter, ctx: *Context) Rollback {
+            _ = ctx;
+            return if (self.waiting_list.remove(&waiter.node)) .removed else .signal_in_flight;
+        }
+    };
 
     /// Mark this awaitable as complete and wake all waiters (both coroutines and threads).
     /// Waiting tasks may belong to different executors, so always uses `.maybe_remote` mode.
@@ -79,12 +85,6 @@ pub const Awaitable = struct {
             Waiter.fromNode(result.node).signal();
             if (result.is_last) break;
         }
-    }
-
-    /// Get the result (void for type-erased awaitable)
-    /// Part of the Future protocol for use with select()
-    pub fn getResult(self: *Awaitable) void {
-        _ = self;
     }
 
     /// Check if the awaitable has completed and a result is available.

--- a/src/common.zig
+++ b/src/common.zig
@@ -37,7 +37,9 @@ pub const Closeable = error{
     Closed,
 };
 
-/// Sentinel value indicating no winner has been selected yet in select operations
+/// Sentinel value indicating no winner has been selected yet in select operations.
+/// The winner word itself is owned and interpreted by select.zig; this constant
+/// lives here only because `Waiter.initSelect` callers initialize the word.
 pub const NO_WINNER = std.math.maxInt(usize);
 
 /// Stack-allocated waiter for async operations.
@@ -49,7 +51,7 @@ pub const NO_WINNER = std.math.maxInt(usize);
 /// Usage:
 /// ```zig
 /// var waiter = Waiter.init();
-/// future.asyncWait(&waiter);
+/// queue.push(&waiter.node);
 /// try waiter.wait(1, .allow_cancel);
 /// ```
 ///
@@ -102,10 +104,17 @@ pub const Waiter = struct {
     };
 
     /// Select waiter for multi-future select().
+    /// The winner word and `index` are passive identity here: their values and
+    /// transitions are owned entirely by select.zig.
     pub const Select = struct {
         parent: *Waiter,
         winner: *std.atomic.Value(usize),
         index: usize,
+        /// Set by `signal` before the parent is woken; consumed by the owning
+        /// select loop to identify which arms were notified. A notifier
+        /// dequeues the registration, so a consumed notification also means
+        /// "this arm is no longer registered".
+        notified: std.atomic.Value(bool) = .init(false),
 
         pub fn init(parent: *Waiter, winner: *std.atomic.Value(usize), index: usize) Select {
             return .{
@@ -137,7 +146,11 @@ pub const Waiter = struct {
 
     /// Signal this waiter.
     /// For direct: increments signal count and wakes the task.
-    /// For select: tries to claim winner slot, then signals the parent.
+    /// For select: marks the arm notified and signals the parent waiter. No
+    /// winner decision is made here; the select re-runs its prepare/commit
+    /// sweep over the notified arms, and the one externally decided case (a
+    /// claimed channel send arm) goes through select.zig's claim entry point
+    /// before signaling.
     pub fn signal(self: *Waiter) void {
         switch (self.mode) {
             .direct => |*d| {
@@ -149,35 +162,15 @@ pub const Waiter = struct {
                 }
             },
             .select => |*s| {
-                // Try to claim winner slot with our index (may already be claimed)
-                _ = s.winner.cmpxchgStrong(NO_WINNER, s.index, .acq_rel, .acquire);
-                // Always signal parent - needed for both winner notification and
-                // cleanup synchronization (waiting for in-flight wakes to complete)
+                s.notified.store(true, .release);
                 s.parent.signal();
             },
         }
     }
 
-    /// Try to claim this waiter as a winner in select().
-    /// Returns true if claimed (or if direct waiter), false if another waiter already won.
-    ///
-    /// Queue consumers that discard losing select waiters must remove and claim
-    /// under the same lock used by cancellation. A successful claim commits the
-    /// caller to exactly one later signal; a failed claim must not be signaled.
-    pub fn tryClaim(self: *Waiter) bool {
-        return switch (self.mode) {
-            .direct => true,
-            .select => |*s| s.winner.cmpxchgStrong(NO_WINNER, s.index, .acq_rel, .acquire) == null,
-        };
-    }
-
-    /// Check if this waiter won its select (was claimed).
-    /// Returns true if won (or if direct waiter).
-    pub fn didWin(self: *const Waiter) bool {
-        return switch (self.mode) {
-            .direct => true,
-            .select => |s| s.winner.load(.acquire) == s.index,
-        };
+    /// Number of signals that have landed on this direct waiter so far.
+    pub fn landedSignals(self: *const Waiter) u32 {
+        return signalCount(self.mode.direct.notify.state.load(.acquire));
     }
 
     /// Top bit of a direct waiter's notify state, set when its timeout timer

--- a/src/common.zig
+++ b/src/common.zig
@@ -147,8 +147,8 @@ pub const Waiter = struct {
     /// Signal this waiter.
     /// For direct: increments signal count and wakes the task.
     /// For select: marks the arm notified and signals the parent waiter. No
-    /// winner decision is made here; the select re-runs its prepare/commit
-    /// sweep over the notified arms, and the one externally decided case (a
+    /// winner decision is made here; the select tries commit on notified arms,
+    /// and the one externally decided case (a
     /// claimed channel send arm) goes through select.zig's claim entry point
     /// before signaling.
     pub fn signal(self: *Waiter) void {

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -70,6 +70,9 @@ const Cancelable = common.Cancelable;
 const Timeoutable = common.Timeoutable;
 const Closeable = common.Closeable;
 const Waiter = common.Waiter;
+const Prepare = @import("select.zig").Prepare;
+const CommitResult = @import("select.zig").CommitResult;
+const Rollback = @import("select.zig").Rollback;
 const Timeout = @import("time.zig").Timeout;
 const Completion = ev.Completion;
 
@@ -77,14 +80,16 @@ pub const CompletionQueue = struct {
     mutex: os.Mutex,
     pending: Queue,
     completed: Queue,
-    /// Futex word the driver waits on. Counts completion arrivals and a close
-    /// with nothing in flight (a close over in-flight operations stays silent,
-    /// each of them wakes the driver on its own way to `completed`). Never
-    /// reset: waiters snapshot it before checking the queues, so a push
+    /// Futex word the blocking waits park on. Counts completion arrivals and a
+    /// close with nothing in flight (a close over in-flight operations stays
+    /// silent, each of them wakes the driver on its own way to `completed`).
+    /// Never reset: waiters snapshot it before checking the queues, so a push
     /// landing between the check and the wait flips the word and the wait
-    /// returns immediately. The future protocol depends on the strict reading
-    /// of a wake: a completion is takeable, or the queue is drained.
+    /// returns immediately.
     signal: std.atomic.Value(u32),
+    /// The driver's AsyncWait registration, if a select is parked on the
+    /// queue. Guarded by `mutex`; single-driver, so at most one.
+    wait_waiter: ?*Waiter,
     /// No new submissions. Written under `mutex`.
     closed: bool,
 
@@ -97,6 +102,7 @@ pub const CompletionQueue = struct {
             .pending = .empty,
             .completed = .empty,
             .signal = .init(0),
+            .wait_waiter = null,
             .closed = false,
         };
     }
@@ -153,15 +159,19 @@ pub const CompletionQueue = struct {
         const was_closed = self.closed;
         self.closed = true;
         const pending_empty = self.pending.isEmpty();
-        self.mutex.unlock();
-        if (was_closed) return;
-
         // Wake only when this close is what makes the queue drained: a driver
         // parked over in-flight operations has nothing new to see, and each of
         // those operations wakes it through `ownerCallback` later.
+        const to_notify = if (!was_closed and pending_empty) self.takeWaiter() else null;
+        self.mutex.unlock();
+        if (was_closed) return;
+
         if (pending_empty) {
             _ = self.signal.fetchAdd(1, .release);
             Futex.wake(&self.signal.raw, 1);
+            // Signaling may let a remote select return and destroy a
+            // stack-owned queue. Nothing may touch `self` after this point.
+            if (to_notify) |w| w.signal();
         }
     }
 
@@ -275,68 +285,62 @@ pub const CompletionQueue = struct {
         return null;
     }
 
-    // Future protocol implementation for use with select() / wait().
+    // AsyncWait protocol (see select.zig).
     //
-    // The registered wait completes when a completion is ready to be taken or
-    // the queue is drained; `getResult` then pops one like `next`, or reports
-    // `error.Closed`. The single-driver rule applies: a select over the queue
-    // is the driver's wait. Canceling the select only deregisters; it does not
-    // close the queue or cancel the operations in it the way a canceled
-    // `wait()` does, that cleanup is the caller's to do.
+    // The single-driver rule applies: a select over the queue is the driver's
+    // wait. Canceling the select only deregisters; it does not close the queue
+    // or cancel the operations in it the way a canceled `wait()` does, that
+    // cleanup is the caller's to do.
     //
-    // Registration parks on the same futex word that `ownerCallback` and a
-    // drained `close` wake, so the queue needs no waiter storage.
+    // Registration is the `wait_waiter` slot under the queue mutex, so the
+    // check and the registration are fused: there is no lost-wakeup window
+    // and no stale-wake state. A notification whose completion the driver
+    // already consumed through `next` just makes commit find nothing, and the
+    // arm re-prepares.
+    pub const AsyncWait = struct {
+        pub const Result = Closeable!*Completion;
+        pub const Context = struct {};
 
-    pub const Result = Closeable!*Completion;
-
-    pub const WaitContext = Futex.FutexWaiter;
-
-    pub fn getResult(self: *CompletionQueue, ctx: *WaitContext) Closeable!*Completion {
-        _ = ctx;
-        self.mutex.lock();
-        const node = self.completed.pop();
-        const drained = node == null and self.closed and self.pending.isEmpty();
-        self.mutex.unlock();
-
-        if (node) |n| return completionFromGroup(n);
-        // A wake on `signal` means a completion was pushed (and only the
-        // caller, as the driver, takes completions out) or the queue is
-        // drained; a close over in-flight operations stays silent.
-        std.debug.assert(drained);
-        return error.Closed;
-    }
-
-    /// Whether a registered wait would have something to report: a takeable
-    /// completion, or the drained state behind `error.Closed`.
-    fn isReady(self: *CompletionQueue) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        return !self.completed.isEmpty() or (self.closed and self.pending.isEmpty());
-    }
-
-    pub fn asyncWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) bool {
-        // Fast path: something to report already.
-        if (self.isReady()) return false;
-
-        // Park on the completion futex word.
-        Futex.prepareWait(&self.signal.raw, ctx, waiter);
-
-        // Double-check: a completion or the drained close may have landed (and
-        // issued its wake) between the fast-path check and the registration.
-        if (self.isReady()) {
-            // We removed ourselves before any wake -> report readiness now.
-            if (Futex.cancelWait(ctx)) return false;
-            // A concurrent wake already dequeued us; the signal is in-flight.
-            return true;
+        pub fn prepare(self: *CompletionQueue, waiter: *Waiter, ctx: *Context) Prepare {
+            _ = ctx;
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            if (!self.completed.isEmpty() or (self.closed and self.pending.isEmpty())) return .ready;
+            std.debug.assert(self.wait_waiter == null);
+            self.wait_waiter = waiter;
+            return .pending;
         }
 
-        return true;
-    }
+        pub fn commit(self: *CompletionQueue, ctx: *Context) CommitResult(Result) {
+            _ = ctx;
+            self.mutex.lock();
+            const node = self.completed.pop();
+            const drained = node == null and self.closed and self.pending.isEmpty();
+            self.mutex.unlock();
 
-    pub fn asyncCancelWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) bool {
-        _ = self;
-        _ = waiter;
-        return Futex.cancelWait(ctx);
+            if (node) |n| return .{ .done = completionFromGroup(n) };
+            if (drained) return .{ .done = error.Closed };
+            return .retry;
+        }
+
+        pub fn rollback(self: *CompletionQueue, waiter: *Waiter, ctx: *Context) Rollback {
+            _ = ctx;
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            if (self.wait_waiter == waiter) {
+                self.wait_waiter = null;
+                return .removed;
+            }
+            return .signal_in_flight;
+        }
+    };
+
+    /// Under the mutex: take the parked driver's waiter out of the slot, if
+    /// any, consuming its registration. The caller notifies after unlocking.
+    fn takeWaiter(self: *CompletionQueue) ?*Waiter {
+        const w = self.wait_waiter orelse return null;
+        self.wait_waiter = null;
+        return w;
     }
 
     /// What `cancelAll` does with the results of the operations it waited for.
@@ -507,10 +511,14 @@ pub const CompletionQueue = struct {
         const removed = self.pending.remove(&c.group);
         std.debug.assert(removed);
         self.completed.push(&c.group);
+        const to_notify = self.takeWaiter();
         self.mutex.unlock();
 
         _ = self.signal.fetchAdd(1, .release);
         Futex.wake(&self.signal.raw, 1);
+        // Signaling may let a remote select return and destroy a stack-owned
+        // queue. Keep this as the final action in the callback.
+        if (to_notify) |w| w.signal();
     }
 };
 
@@ -1120,6 +1128,34 @@ test "CompletionQueue: select fast path on an already finished completion" {
         .io => |r| try std.testing.expectEqual(&timer.c, try r),
         .other => return error.TestUnexpectedResult,
     }
+}
+
+test "CompletionQueue: a consumed notification retries instead of becoming a stale win" {
+    var cq = CompletionQueue.init();
+    var waiter = Waiter.init();
+    var context: CompletionQueue.AsyncWait.Context = .{};
+
+    try std.testing.expectEqual(Prepare.pending, CompletionQueue.AsyncWait.prepare(&cq, &waiter, &context));
+
+    // Model ownerCallback's publication and notification, then let another
+    // driver consume the completion before this arm reaches commit.
+    var timer = ev.Timer.init(.{ .duration = .zero });
+    cq.mutex.lock();
+    cq.completed.push(&timer.c.group);
+    const to_notify = cq.takeWaiter().?;
+    cq.mutex.unlock();
+    to_notify.signal();
+    waiter.wait(1, .no_cancel);
+
+    try std.testing.expectEqual(&timer.c, cq.next().?);
+    switch (CompletionQueue.AsyncWait.commit(&cq, &context)) {
+        .retry => {},
+        .done => return error.TestUnexpectedResult,
+    }
+
+    // Retry is a complete attempt: the arm can register again normally.
+    try std.testing.expectEqual(Prepare.pending, CompletionQueue.AsyncWait.prepare(&cq, &waiter, &context));
+    try std.testing.expectEqual(Rollback.removed, CompletionQueue.AsyncWait.rollback(&cq, &waiter, &context));
 }
 
 test "CompletionQueue: losing a select does not lose the completion" {

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -295,8 +295,8 @@ pub const CompletionQueue = struct {
     // Registration is the `wait_waiter` slot under the queue mutex, so the
     // check and the registration are fused: there is no lost-wakeup window
     // and no stale-wake state. A notification whose completion the driver
-    // already consumed through `next` just makes commit find nothing, and the
-    // arm re-prepares.
+    // already consumed through `next` just makes commit find nothing and
+    // atomically install the next registration.
     pub const AsyncWait = struct {
         pub const Result = Closeable!*Completion;
         pub const Context = struct {};
@@ -311,16 +311,20 @@ pub const CompletionQueue = struct {
             return .pending;
         }
 
-        pub fn commit(self: *CompletionQueue, ctx: *Context) CommitResult(Result) {
+        pub fn commit(self: *CompletionQueue, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
             _ = ctx;
             self.mutex.lock();
             const node = self.completed.pop();
             const drained = node == null and self.closed and self.pending.isEmpty();
+            if (node == null and !drained) {
+                std.debug.assert(self.wait_waiter == null);
+                self.wait_waiter = waiter;
+            }
             self.mutex.unlock();
 
             if (node) |n| return .{ .done = completionFromGroup(n) };
             if (drained) return .{ .done = error.Closed };
-            return .retry;
+            return .{ .pending = .{} };
         }
 
         pub fn rollback(self: *CompletionQueue, waiter: *Waiter, ctx: *Context) Rollback {
@@ -1130,7 +1134,7 @@ test "CompletionQueue: select fast path on an already finished completion" {
     }
 }
 
-test "CompletionQueue: a consumed notification retries instead of becoming a stale win" {
+test "CompletionQueue: a consumed notification parks instead of becoming a stale win" {
     var cq = CompletionQueue.init();
     var waiter = Waiter.init();
     var context: CompletionQueue.AsyncWait.Context = .{};
@@ -1148,13 +1152,12 @@ test "CompletionQueue: a consumed notification retries instead of becoming a sta
     waiter.wait(1, .no_cancel);
 
     try std.testing.expectEqual(&timer.c, cq.next().?);
-    switch (CompletionQueue.AsyncWait.commit(&cq, &context)) {
-        .retry => {},
+    switch (CompletionQueue.AsyncWait.commit(&cq, &waiter, &context)) {
+        .pending => {},
         .done => return error.TestUnexpectedResult,
     }
 
-    // Retry is a complete attempt: the arm can register again normally.
-    try std.testing.expectEqual(Prepare.pending, CompletionQueue.AsyncWait.prepare(&cq, &waiter, &context));
+    // Commit atomically installed the next registration.
     try std.testing.expectEqual(Rollback.removed, CompletionQueue.AsyncWait.rollback(&cq, &waiter, &context));
 }
 

--- a/src/group.zig
+++ b/src/group.zig
@@ -259,12 +259,11 @@ pub const Group = struct {
             return .pending;
         }
 
-        pub fn commit(self: *Group, ctx: *Context) CommitResult(void) {
-            _ = ctx;
-            // The drained state a wake reported may since have been undone by
-            // a respawn; report the decay and let the caller re-prepare.
-            if (@atomicLoad(u32, self.getState(), .acquire) & counter_mask == 0) return .{ .done = {} };
-            return .retry;
+        pub fn commit(self: *Group, waiter: *Waiter, ctx: *Context) CommitResult(void) {
+            while (true) {
+                if (@atomicLoad(u32, self.getState(), .acquire) & counter_mask == 0) return .{ .done = {} };
+                if (prepare(self, waiter, ctx) == .pending) return .{ .pending = .{} };
+            }
         }
 
         pub fn rollback(self: *Group, waiter: *Waiter, ctx: *Context) Rollback {

--- a/src/group.zig
+++ b/src/group.zig
@@ -18,6 +18,9 @@ const spawnTask = @import("task.zig").spawnTask;
 const spawnBlockingTask_mod = @import("blocking_task.zig");
 const spawnBlockingTask = spawnBlockingTask_mod.spawnBlockingTask;
 const Futex = @import("sync/Futex.zig");
+const Prepare = @import("select.zig").Prepare;
+const CommitResult = @import("select.zig").CommitResult;
+const Rollback = @import("select.zig").Rollback;
 
 pub const Group = struct {
     inner: std.Io.Group = .init,
@@ -226,7 +229,7 @@ pub const Group = struct {
         group.getTasks().clearFlag();
     }
 
-    // Future protocol implementation for use with select() / wait().
+    // AsyncWait protocol (see select.zig).
     //
     // Waits until the group naturally drains to zero pending tasks. Unlike
     // `wait()`, this does NOT close the group and does not participate in
@@ -235,42 +238,41 @@ pub const Group = struct {
     //
     // Registration parks on the same futex address that `unregisterGroupTask`
     // wakes when the counter hits zero, so no per-group waiter storage is needed.
+    pub const AsyncWait = struct {
+        pub const Result = void;
+        pub const Context = Futex.FutexWaiter;
 
-    pub const Result = void;
+        pub fn prepare(self: *Group, waiter: *Waiter, ctx: *Context) Prepare {
+            const state_ptr = self.getState();
 
-    pub const WaitContext = Futex.FutexWaiter;
+            if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) return .ready;
 
-    pub fn getResult(self: *Group, ctx: *WaitContext) void {
-        _ = self;
-        _ = ctx;
-    }
+            Futex.prepareWait(state_ptr, ctx, waiter);
 
-    pub fn asyncWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {
-        const state_ptr = self.getState();
-
-        // Fast path: no pending tasks means the group is already "complete".
-        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) return false;
-
-        // Park on the completion futex address.
-        Futex.prepareWait(state_ptr, ctx, waiter);
-
-        // Double-check: the last task may have completed (and issued its wake)
-        // between the fast-path check and our registration above.
-        if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) {
-            // We removed ourselves before any wake -> already complete.
-            if (Futex.cancelWait(ctx)) return false;
-            // A concurrent completion already dequeued us; the wake is in-flight.
-            return true;
+            // Double-check: the last task may have completed (and issued its
+            // wake) between the check above and the registration.
+            if (@atomicLoad(u32, state_ptr, .acquire) & counter_mask == 0) {
+                if (Futex.cancelWait(ctx)) return .ready;
+                // A concurrent completion already dequeued us; its
+                // notification is in flight and re-runs this arm.
+            }
+            return .pending;
         }
 
-        return true;
-    }
+        pub fn commit(self: *Group, ctx: *Context) CommitResult(void) {
+            _ = ctx;
+            // The drained state a wake reported may since have been undone by
+            // a respawn; report the decay and let the caller re-prepare.
+            if (@atomicLoad(u32, self.getState(), .acquire) & counter_mask == 0) return .{ .done = {} };
+            return .retry;
+        }
 
-    pub fn asyncCancelWait(self: *Group, waiter: *Waiter, ctx: *WaitContext) bool {
-        _ = self;
-        _ = waiter;
-        return Futex.cancelWait(ctx);
-    }
+        pub fn rollback(self: *Group, waiter: *Waiter, ctx: *Context) Rollback {
+            _ = self;
+            _ = waiter;
+            return if (Futex.cancelWait(ctx)) .removed else .signal_in_flight;
+        }
+    };
 };
 
 /// Spawn a task in the group with raw context bytes and start function.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -223,30 +223,24 @@ pub fn JoinHandle(comptime T: type) type {
         // awaitable. A null awaitable means the result is already cached.
         pub const AsyncWait = struct {
             pub const Result = T;
-            pub const Context = struct {};
+            pub const Context = Awaitable.AsyncWait.Context;
 
             pub fn prepare(self: *Self, waiter: *Waiter, ctx: *@This().Context) select.Prepare {
-                _ = ctx;
                 const awaitable = self.awaitable orelse return .ready;
-                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
-                return Awaitable.AsyncWait.prepare(awaitable, waiter, &awaitable_ctx);
+                return Awaitable.AsyncWait.prepare(awaitable, waiter, ctx);
             }
 
             pub fn commit(self: *Self, ctx: *@This().Context) select.CommitResult(T) {
-                _ = ctx;
                 const awaitable = self.awaitable orelse return .{ .done = self.result };
-                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
-                switch (Awaitable.AsyncWait.commit(awaitable, &awaitable_ctx)) {
+                switch (Awaitable.AsyncWait.commit(awaitable, ctx)) {
                     .retry => return .retry,
                     .done => return .{ .done = awaitable.getTypedResult(T) },
                 }
             }
 
             pub fn rollback(self: *Self, waiter: *Waiter, ctx: *@This().Context) select.Rollback {
-                _ = ctx;
                 const awaitable = self.awaitable orelse return .removed;
-                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
-                return Awaitable.AsyncWait.rollback(awaitable, waiter, &awaitable_ctx);
+                return Awaitable.AsyncWait.rollback(awaitable, waiter, ctx);
             }
         };
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -219,25 +219,36 @@ pub fn JoinHandle(comptime T: type) type {
             return self.result;
         }
 
-        /// Registers a waiter to be notified when the task completes.
-        /// This is part of the Future protocol for select().
-        /// Returns false if the task is already complete (no wait needed), true if added to queue.
-        pub fn asyncWait(self: Self, waiter: *Waiter) bool {
-            if (self.awaitable) |awaitable| {
-                return awaitable.asyncWait(waiter);
-            }
-            return false; // Already complete
-        }
+        // AsyncWait protocol (see select.zig), delegating to the task's
+        // awaitable. A null awaitable means the result is already cached.
+        pub const AsyncWait = struct {
+            pub const Result = T;
+            pub const Context = struct {};
 
-        /// Cancels a pending wait operation by removing the waiter.
-        /// This is part of the Future protocol for select().
-        /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: Self, waiter: *Waiter) bool {
-            if (self.awaitable) |awaitable| {
-                return awaitable.asyncCancelWait(waiter);
+            pub fn prepare(self: *Self, waiter: *Waiter, ctx: *@This().Context) select.Prepare {
+                _ = ctx;
+                const awaitable = self.awaitable orelse return .ready;
+                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
+                return Awaitable.AsyncWait.prepare(awaitable, waiter, &awaitable_ctx);
             }
-            return true; // No awaitable means already completed, no wake in-flight
-        }
+
+            pub fn commit(self: *Self, ctx: *@This().Context) select.CommitResult(T) {
+                _ = ctx;
+                const awaitable = self.awaitable orelse return .{ .done = self.result };
+                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
+                switch (Awaitable.AsyncWait.commit(awaitable, &awaitable_ctx)) {
+                    .retry => return .retry,
+                    .done => return .{ .done = awaitable.getTypedResult(T) },
+                }
+            }
+
+            pub fn rollback(self: *Self, waiter: *Waiter, ctx: *@This().Context) select.Rollback {
+                _ = ctx;
+                const awaitable = self.awaitable orelse return .removed;
+                var awaitable_ctx: Awaitable.AsyncWait.Context = .{};
+                return Awaitable.AsyncWait.rollback(awaitable, waiter, &awaitable_ctx);
+            }
+        };
 
         /// Request cancellation and wait for the task to complete.
         ///

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -230,10 +230,10 @@ pub fn JoinHandle(comptime T: type) type {
                 return Awaitable.AsyncWait.prepare(awaitable, waiter, ctx);
             }
 
-            pub fn commit(self: *Self, ctx: *@This().Context) select.CommitResult(T) {
+            pub fn commit(self: *Self, waiter: *Waiter, ctx: *@This().Context) select.CommitResult(T) {
                 const awaitable = self.awaitable orelse return .{ .done = self.result };
-                switch (Awaitable.AsyncWait.commit(awaitable, ctx)) {
-                    .retry => return .retry,
+                switch (Awaitable.AsyncWait.commit(awaitable, waiter, ctx)) {
+                    .pending => |pending| return .{ .pending = pending },
                     .done => return .{ .done = awaitable.getTypedResult(T) },
                 }
             }

--- a/src/select.zig
+++ b/src/select.zig
@@ -7,75 +7,177 @@ const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTask = @import("runtime.zig").getCurrentTask;
 const getCurrentTaskOrNull = @import("runtime.zig").getCurrentTaskOrNull;
 const yield = @import("runtime.zig").yield;
+const random = @import("random.zig").random;
 const common = @import("common.zig");
 const Cancelable = common.Cancelable;
 const Waiter = common.Waiter;
 const NO_WINNER = common.NO_WINNER;
 const AnyTask = @import("task.zig").AnyTask;
-const Awaitable = @import("awaitable.zig").Awaitable;
 const meta = @import("meta.zig");
 
-// Future protocol - Any type implementing these methods can be used with select():
+// AsyncWait protocol - a type can be used with select() and wait() iff it
+// declares a nested `AsyncWait` namespace:
 //
-//   const Result = T
-//     The type of value this future produces when complete.
+//   pub const AsyncWait = struct {
+//       /// What a committed wait on this source yields.
+//       pub const Result = T;
 //
-//   const WaitContext = void | SomeStruct
-//     Optional per-wait mutable state. Use void if the future needs no per-wait state.
-//     If non-void, this struct will be allocated on the caller's stack and passed to
-//     asyncWait/asyncCancelWait. Useful for storing completions, results, or other
-//     data that varies per wait operation.
+//       /// Per-operation state, allocated in the waiting frame and always
+//       /// passed to prepare/commit/rollback. Use `struct {}` when empty.
+//       pub const Context = ...;
 //
-//   fn asyncWait(self: *Self, waiter: *Waiter) bool           // if WaitContext == void
-//   fn asyncWait(self: *Self, waiter: *Waiter, ctx: *WaitContext) bool  // if WaitContext != void
-//     Register for notification when this future completes.
+//       /// True if peers may decide a select containing this arm from the
+//       /// outside, through `claimArm`. Channel rendezvous arms set this:
+//       /// a peer can complete a queued send or receive directly. A select
+//       /// containing a claimable arm compiles in the winner-word fence; one
+//       /// without never consults the winner word.
+//       pub const claimable = false;   // optional, defaults to false
 //
-//     If WaitContext != void, the ctx parameter points to caller-allocated per-wait state
-//     that persists for the duration of this wait operation.
+//       pub fn prepare(self: *Source, waiter: *Waiter, ctx: *Context) Prepare
+//       pub fn commit(self: *Source, ctx: *Context) CommitResult(Result)
+//       pub fn rollback(self: *Source, waiter: *Waiter, ctx: *Context) Rollback
+//   };
 //
-//     Returns:
-//       - false: Operation already complete (fast path). Result is available via getResult().
-//                The waiter was NOT added to any queue.
-//       - true: Operation pending (slow path). The waiter was added to an internal wait
-//               queue and will be woken via waiter.wake() when the operation completes.
+// prepare - register as a candidate, unless already complete. The check and
+// the registration are fused under the source's lock: `.ready` means the
+// operation can complete right now and nothing was registered; `.pending`
+// means the waiter is queued and a notification follows if the source becomes
+// ready or closes. Called only on unregistered arms; never consumes.
 //
-//     Guarantees:
-//       - If returns false, getResult() can be called immediately
-//       - If returns true, waiter.wake() will be called exactly once when complete
-//       - Thread-safe: can be called from any thread
-//       - The ctx pointer (if present) remains valid until asyncCancelWait() or waiter.wake()
+// commit - the consume, under the source's lock: take the item, swap the
+// counter, pop the completion. Called on an arm that prepared `.ready`, on an
+// arm whose notification the caller consumed, or on an arm decided externally
+// (a claimed send arm reports the outcome its claimer left in ctx). Returns
+// `.retry` if readiness has decayed (another consumer got there first); the
+// caller re-prepares. A retry ends this attempt and leaves no reservation.
+// Never touches the registration; a notified arm has none, and a `.ready`
+// arm never had one.
 //
-//   fn asyncCancelWait(self: *Self, waiter: *Waiter) bool     // if WaitContext == void
-//   fn asyncCancelWait(self: *Self, waiter: *Waiter, ctx: *WaitContext) bool  // if WaitContext != void
-//     Cancel a pending wait operation by removing the waiter from internal queues.
+// rollback - abandon a losing pending or notified attempt, under the source's
+// lock. `.removed`: the registration was removed cleanly and no notification
+// will come. `.signal_in_flight`: a notifier already consumed the
+// registration, and exactly one signal is landed or in flight. Rollback must
+// also release any readiness offer/reservation and hand it to another waiter.
+// It is called for notified losers even though their registration is gone.
 //
-//     Must be called if asyncWait() returned true and the caller no longer wants to wait
-//     (e.g., select() chose a different future).
+// Notification discipline: a source dequeues a registration exactly once,
+// and, per dequeue, sets the waiter's notified flag and signals exactly once
+// (`Waiter.signal` does both). A notification carries no decision, it only
+// means "this arm's registration was consumed, re-run prepare/commit on it".
+// The select loop owns all remaining bookkeeping: which arms are registered,
+// which notifications it has consumed, and how many signals to absorb before
+// returning.
 //
-//     Returns:
-//       - true: Successfully removed from queue. The future will not wake this waiter.
-//       - false: Already removed by completion. The future has committed to waking this
-//                waiter (wake is in-flight or already happened).
+// The one externally decided case is a claimable arm: a rendezvous peer wins
+// the select's winner word through `claimArm` under the channel lock, records
+// the outcome in the arm's ctx, and then notifies. Every other notifier leaves
+// the outcome at the source.
 //
-//     For queuing operations (Channel), when returning false the implementation
-//     must transfer the wakeup to another waiter to avoid losing the signal/item.
-//
-//     Guarantees:
-//       - Thread-safe: can be called from any thread
-//       - Safe to call even if asyncWait() returned false (returns false, no-op)
-//
-//   fn getResult(self: *const Self) Result                                        // if WaitContext == void
-//   fn getResult(self: *const Self, ctx: *WaitContext) Result                      // if WaitContext != void
-//     Retrieve the result of the completed operation.
-//
-//     Must only be called after asyncWait() returns false or after waiter.wake() is called.
-//
-//     Returns: The result value. For operations that can fail, Result may be an error union
-//              (e.g., error{Closed}!T).
-//
-//     Guarantees:
-//       - All side effects from the operation that produced the result are visible
-//       - Thread-safe: can be called from any thread after completion
+// Lifetime: sources must outlive the select()/wait() call using them.
+// Completion paths that can free the source after waking its waiters
+// (ResetEvent.set and friends) must not touch the source after signaling the
+// last waiter; the waiting side may touch the source until its wait returns.
+
+/// Result of `AsyncWait.prepare`.
+pub const Prepare = enum {
+    /// The operation can complete right now; nothing was registered.
+    ready,
+    /// The waiter was registered; a notification follows when the source
+    /// becomes ready or closes.
+    pending,
+};
+
+/// Result of the consuming phase. A tagged union keeps protocol retry
+/// separate from operation results that may themselves contain optional or
+/// error-union values (including an application-level `error.Retry`).
+pub fn CommitResult(comptime Result: type) type {
+    return union(enum) {
+        retry,
+        done: Result,
+    };
+}
+
+test "CommitResult keeps protocol retry separate from user results" {
+    const ErrorResult = CommitResult(error{Retry}!u8);
+    const application_retry: ErrorResult = .{ .done = error.Retry };
+    switch (application_retry) {
+        .done => |result| try std.testing.expectError(error.Retry, result),
+        .retry => return error.TestUnexpectedResult,
+    }
+
+    const OptionalResult = CommitResult(?u8);
+    const application_null: OptionalResult = .{ .done = null };
+    switch (application_null) {
+        .done => |result| try std.testing.expectEqual(null, result),
+        .retry => return error.TestUnexpectedResult,
+    }
+}
+
+/// Result of abandoning an active wait attempt.
+pub const Rollback = enum {
+    /// The registration was removed, or had never been queued. No signal is
+    /// owed for this attempt.
+    removed,
+    /// A notifier consumed the registration. Exactly one signal is already
+    /// landed or will land, and must be absorbed before the waiter can die.
+    signal_in_flight,
+};
+
+// Winner-word states. NO_WINNER (common.zig) means undecided and an arm index
+// means decided; the values and transitions are owned here. The sentinels:
+// COMMITTING is held by the select's own sweep while an arm's commit may
+// consume, CANCELED is set by the cancel path and means the select will never
+// commit.
+const COMMITTING = std.math.maxInt(usize) - 1;
+const CANCELED = std.math.maxInt(usize) - 2;
+
+pub const ClaimResult = enum {
+    /// The claim landed (direct waiters are always won). The claimer must
+    /// complete the committed side effect under the source lock, record the
+    /// outcome in the arm's ctx, dequeue the registration and notify.
+    won,
+    /// The select's own sweep holds the fence right now. The claimer must
+    /// nudge: dequeue the registration under the source lock and notify, so
+    /// the select re-runs prepare/commit on the arm.
+    busy,
+    /// The select is already decided (another arm won, or it canceled). Skip
+    /// the registration in place; the select's cleanup removes it.
+    lost,
+};
+
+/// Decide a select from the outside. This is the single external entry point
+/// into select arbitration, used only for parked channel rendezvous arms. Must
+/// be called under the same source lock that guards the arm's registration and
+/// rollback.
+pub fn claimArm(waiter: *Waiter) ClaimResult {
+    switch (waiter.mode) {
+        .direct => return .won,
+        .select => |*s| {
+            const cur = s.winner.cmpxchgStrong(NO_WINNER, s.index, .acq_rel, .acquire) orelse return .won;
+            return if (cur == COMMITTING) .busy else .lost;
+        },
+    }
+}
+
+/// Non-committal read of an arm's arbitration state, for a source deciding
+/// whether a parked registration is worth reporting as ready. Racy by nature:
+/// the consuming path re-checks through `claimArm`. `.won` means open.
+pub fn peekArm(waiter: *Waiter) ClaimResult {
+    switch (waiter.mode) {
+        .direct => return .won,
+        .select => |*s| {
+            const cur = s.winner.load(.acquire);
+            if (cur == NO_WINNER) return .won;
+            return if (cur == COMMITTING) .busy else .lost;
+        },
+    }
+}
+
+/// Consume a select arm's notification. Owned by the select loop; a consumed
+/// notification means the arm is unregistered and must be re-prepared.
+fn consumeNotified(waiter: *Waiter) bool {
+    return waiter.mode.select.notified.swap(false, .acq_rel);
+}
 
 /// Extract the Future type from a pointer or value type
 fn FutureType(comptime T: type) type {
@@ -91,10 +193,30 @@ fn isPointerFuture(comptime T: type) bool {
     return @typeInfo(T) == .pointer;
 }
 
+fn AsyncWaitOf(comptime future_type: type) type {
+    return FutureType(future_type).AsyncWait;
+}
+
 /// Extract the Result type from a future (pointer or value)
 fn FutureResult(comptime future_type: type) type {
-    const Future = FutureType(future_type);
-    return Future.Result;
+    return AsyncWaitOf(future_type).Result;
+}
+
+/// Extract the Context type from a future (pointer or value)
+fn FutureContext(comptime future_type: type) type {
+    return AsyncWaitOf(future_type).Context;
+}
+
+fn isClaimable(comptime future_type: type) bool {
+    const AW = AsyncWaitOf(future_type);
+    return @hasDecl(AW, "claimable") and AW.claimable;
+}
+
+fn anyClaimable(comptime futures_type: type) bool {
+    for (@typeInfo(futures_type).@"struct".fields) |field| {
+        if (isClaimable(field.type)) return true;
+    }
+    return false;
 }
 
 /// Check for self-wait deadlock if the future has a toAwaitable() method
@@ -109,54 +231,53 @@ fn checkSelfWait(task: *AnyTask, future: anytype) void {
     }
 }
 
-/// Extract the WaitContext type from a future pointer type
-fn FutureWaitContext(comptime future_type: type) type {
-    const Future = FutureType(future_type);
-    if (@hasDecl(Future, "WaitContext")) {
-        return Future.WaitContext;
-    }
-    return void;
-}
-
-/// Check if a future has a non-void WaitContext
-fn hasWaitContext(comptime future_type: type) bool {
-    return FutureWaitContext(future_type) != void;
-}
-
-/// Build a struct type containing WaitContext fields for each future that needs one
+/// Build a struct type containing one Context field per future.
 fn WaitContextsType(comptime futures_type: type) type {
     const fields = @typeInfo(futures_type).@"struct".fields;
 
-    // Count how many fields have non-void WaitContext
-    comptime var count: usize = 0;
-    inline for (fields) |field| {
-        if (FutureWaitContext(field.type) != void) {
-            count += 1;
-        }
-    }
-
-    // Handle the zero-field case
-    if (count == 0) {
-        return @Struct(.auto, null, &.{}, &.{}, &.{});
-    }
-
-    // Build arrays of field names, types, and attributes
-    var field_names: [count][:0]const u8 = undefined;
-    var field_types: [count]type = undefined;
-    var field_attrs: [count]std.builtin.Type.StructField.Attributes = undefined;
+    var field_names: [fields.len][:0]const u8 = undefined;
+    var field_types: [fields.len]type = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
 
     comptime var i: usize = 0;
     inline for (fields) |field| {
-        const WaitCtx = FutureWaitContext(field.type);
-        if (WaitCtx != void) {
-            const default_value: WaitCtx = .{};
-            field_names[i] = field.name;
-            field_types[i] = WaitCtx;
-            field_attrs[i] = .{
-                .default_value_ptr = @ptrCast(&default_value),
-            };
-            i += 1;
-        }
+        const Context = FutureContext(field.type);
+        const default_value: Context = .{};
+        field_names[i] = field.name;
+        field_types[i] = Context;
+        field_attrs[i] = .{ .default_value_ptr = @ptrCast(&default_value) };
+        i += 1;
+    }
+
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
+}
+
+fn ResultSlot(comptime Result: type) type {
+    return struct { value: Result };
+}
+
+/// Build a struct type with an optional result wrapper per arm, all defaulting
+/// to null. The wrapper keeps "no committed result" distinct from a legitimate
+/// optional Result whose value is null. Results are stored here at commit time,
+/// because signals may still be in flight when an arm commits and the frame
+/// must not return until they are absorbed.
+fn ResultsType(comptime futures_type: type) type {
+    const fields = @typeInfo(futures_type).@"struct".fields;
+
+    var field_names: [fields.len][:0]const u8 = undefined;
+    var field_types: [fields.len]type = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
+
+    comptime var i: usize = 0;
+    inline for (fields) |field| {
+        const R = ?ResultSlot(FutureResult(field.type));
+        const default_value: R = null;
+        field_names[i] = field.name;
+        field_types[i] = R;
+        field_attrs[i] = .{
+            .default_value_ptr = @ptrCast(&default_value),
+        };
+        i += 1;
     }
 
     return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
@@ -190,9 +311,8 @@ pub fn SelectResult(comptime S: type) type {
     var field_attrs: [struct_fields.len]std.builtin.Type.UnionField.Attributes = undefined;
 
     for (struct_fields, 0..) |struct_field, i| {
-        const Future = FutureType(struct_field.type);
         field_names[i] = struct_field.name;
-        field_types[i] = Future.Result;
+        field_types[i] = FutureResult(struct_field.type);
         field_attrs[i] = .{};
     }
 
@@ -201,10 +321,16 @@ pub fn SelectResult(comptime S: type) type {
 
 test "SelectResult: result types" {
     const Future1 = struct {
-        const Result = void;
+        pub const AsyncWait = struct {
+            pub const Result = void;
+            pub const Context = struct {};
+        };
     };
     const Future2 = struct {
-        const Result = u32;
+        pub const AsyncWait = struct {
+            pub const Result = u32;
+            pub const Context = struct {};
+        };
     };
 
     const Select = SelectResult(struct {
@@ -216,16 +342,40 @@ test "SelectResult: result types" {
     _ = Select{ .future2 = 32 };
 }
 
+/// Reshuffle the sweep order (Fisher-Yates over per-round random bytes).
+fn shuffle(order: []usize) void {
+    if (order.len < 2) return;
+    std.debug.assert(order.len <= 64);
+    var bytes: [64]u8 = undefined;
+    random(bytes[0..order.len]);
+    var i: usize = order.len - 1;
+    while (i > 0) : (i -= 1) {
+        const j: usize = bytes[i] % @as(u8, @intCast(i + 1));
+        std.mem.swap(usize, &order[i], &order[j]);
+    }
+}
+
+const ArmPhase = enum { inactive, pending, ready };
+
+/// Loop-owned state for one prepare/commit attempt. A ready arm with
+/// `signal_expected` came from a notification; its losing rollback may report
+/// `.signal_in_flight`, but that signal is already included in the select's
+/// expected-signal count.
+const ArmState = struct {
+    phase: ArmPhase = .inactive,
+    signal_expected: bool = false,
+};
+
 /// Wait for multiple futures simultaneously and return whichever completes first.
 ///
 /// `futures` is a struct with each field being either:
 /// - A pointer to a future (e.g., `*JoinHandle(T)`) for futures that mutate self
-/// - A value future (e.g., `channel.asyncReceive()`) for futures using WaitContext
+/// - A value future (e.g., `channel.asyncReceive()`) for futures using a Context
 ///
-/// Returns a tagged union with the same field names, containing the result of whichever completed first.
-///
-/// When multiple handles complete at the same time, fields are checked in declaration order
-/// and the first ready handle is returned.
+/// Returns a tagged union with the same field names, containing the result of
+/// whichever completed first. When several arms are ready in the same round, a
+/// random one wins. A select may contain at most 64 arms; larger selects panic
+/// in every build mode.
 ///
 /// Example:
 /// ```
@@ -241,6 +391,9 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
     const S = @TypeOf(futures);
     const U = SelectResult(S);
     const fields = @typeInfo(S).@"struct".fields;
+    const has_claimable = comptime anyClaimable(S);
+
+    if (fields.len > 64) @panic("select: too many arms (max 64)");
 
     // Self-wait detection: check all futures for self-wait
     const task = getCurrentTask();
@@ -248,150 +401,147 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
         checkSelfWait(task, @field(futures, field.name));
     }
 
-    // Winner tracking: NO_WINNER means no winner yet
+    // Winner word: consulted only when a claimable arm exists; everything else
+    // is decided by the sweep alone.
     var winner: std.atomic.Value(usize) = .init(NO_WINNER);
 
-    // Parent waiter that select waiters will signal when they win
-    var waiter = Waiter.init();
+    // Parent waiter that arm notifications land on
+    var parent = Waiter.init();
 
-    // Allocate WaitContext struct on stack for futures that need per-wait state
+    // Allocate Context struct on stack for futures that need per-wait state
     const ContextsType = WaitContextsType(S);
     var contexts: ContextsType = .{};
 
-    // Create waiter structures on the stack
+    var results: ResultsType(S) = .{};
+
     var waiters: [fields.len]Waiter = undefined;
     inline for (&waiters, 0..) |*w, i| {
-        w.* = Waiter.initSelect(&waiter, &winner, i);
+        w.* = Waiter.initSelect(&parent, &winner, i);
     }
 
-    // Track how many futures we've registered with (for cleanup).
-    // Only incremented when asyncWait returns true (future is pending).
-    var registered_count: usize = 0;
+    var states: [fields.len]ArmState = @splat(.{});
+    var order: [fields.len]usize = undefined;
+    inline for (&order, 0..) |*slot, i| slot.* = i;
 
-    // Clean up waiters on all exit paths
-    defer {
-        const winner_index = winner.load(.acquire);
+    // Signals accounted for so far: one per consumed notification. Each round
+    // parks until one more lands.
+    var signals_expected: u32 = 0;
+    var deliver_recancel = false;
 
-        // Count expected signals: all registered futures will signal unless we cancel them.
-        // Successfully canceled futures (asyncCancelWait returns true) won't signal.
-        var expected: u32 = @intCast(registered_count);
+    const winner_index: usize = main: while (true) {
+        shuffle(&order);
+        sweep: for (order) |arm| {
+            inline for (fields, 0..) |field, i| {
+                if (arm == i) {
+                    if (states[i].phase == .pending) {
+                        // Registered arms are dormant until notified; a
+                        // consumed notification means the registration is
+                        // gone and the arm must re-run prepare/commit.
+                        if (!consumeNotified(&waiters[i])) continue :sweep;
+                        signals_expected += 1;
+                        states[i] = .{ .phase = .ready, .signal_expected = true };
+                    }
+                    var future = @field(futures, field.name);
+                    const fp = if (comptime isPointerFuture(field.type)) future else &future;
+                    while (true) {
+                        if (states[i].phase == .inactive) {
+                            const prep = AsyncWaitOf(field.type).prepare(fp, &waiters[i], &@field(contexts, field.name));
+                            if (prep == .pending) {
+                                states[i] = .{ .phase = .pending };
+                                continue :sweep;
+                            }
+                            states[i] = .{ .phase = .ready };
+                        }
+                        // Ready: commit, holding the fence so no peer can
+                        // decide a claimable arm while this one consumes.
+                        if (has_claimable) {
+                            if (winner.cmpxchgStrong(NO_WINNER, COMMITTING, .acq_rel, .acquire)) |decided| {
+                                std.debug.assert(decided < fields.len);
+                                break :main decided;
+                            }
+                        }
+                        const committed = AsyncWaitOf(field.type).commit(fp, &@field(contexts, field.name));
+                        switch (committed) {
+                            .done => |value| {
+                                states[i] = .{};
+                                if (has_claimable) winner.store(i, .release);
+                                @field(results, field.name) = .{ .value = value };
+                                break :main i;
+                            },
+                            .retry => {
+                                states[i] = .{};
+                                if (has_claimable) winner.store(NO_WINNER, .release);
+                            },
+                        }
+                        // Readiness decayed; the attempt ended without a side
+                        // effect or reservation. Prepare again.
+                    }
+                }
+            }
+        }
+
+        parent.wait(signals_expected + 1, .allow_cancel) catch {
+            if (has_claimable) {
+                // A claim that landed before this transition decided the
+                // select: its arm consumed on our behalf, so the result must
+                // be delivered, with the cancellation re-armed to fire at the
+                // next cancelable operation.
+                if (winner.cmpxchgStrong(NO_WINNER, CANCELED, .acq_rel, .acquire)) |decided| {
+                    std.debug.assert(decided < fields.len);
+                    deliver_recancel = true;
+                    break :main decided;
+                }
+            }
+            break :main NO_WINNER;
+        };
+    };
+
+    // An externally decided arm carries its outcome in ctx; commit reports it.
+    if (winner_index != NO_WINNER) {
         inline for (fields, 0..) |field, i| {
-            // Only cancel if we registered and didn't win
-            if (i < registered_count and winner_index != i) {
+            if (winner_index == i and @field(results, field.name) == null) {
                 var future = @field(futures, field.name);
-                const was_removed = if (comptime hasWaitContext(field.type))
-                    future.asyncCancelWait(&waiters[i], &@field(contexts, field.name))
-                else
-                    future.asyncCancelWait(&waiters[i]);
+                const fp = if (comptime isPointerFuture(field.type)) future else &future;
+                const committed = AsyncWaitOf(field.type).commit(fp, &@field(contexts, field.name));
+                @field(results, field.name) = switch (committed) {
+                    .done => |value| .{ .value = value },
+                    .retry => unreachable,
+                };
 
-                if (was_removed) {
-                    // Successfully removed from queue - won't signal
-                    expected -= 1;
-                }
+                // An external claim consumes a queued registration and owes
+                // exactly one signal. It may not have reached `notified` yet,
+                // so account it from the claim rather than the flag.
+                if (!states[i].signal_expected) signals_expected += 1;
+                states[i] = .{};
             }
         }
-
-        // Wait for all expected signals (winner + in-flight non-winners)
-        waiter.wait(expected, .no_cancel);
     }
 
-    // Add waiters to all waiting lists - fast path: return immediately if already complete
+    // Deregister every pending arm and absorb every signal: one per consumed
+    // notification, plus one per registration a notifier already consumed
+    // (rollback false), whose signal may still be in flight.
     inline for (fields, 0..) |field, i| {
-        const future = @field(futures, field.name);
-        const waiting = if (comptime hasWaitContext(field.type))
-            future.asyncWait(&waiters[i], &@field(contexts, field.name))
-        else
-            future.asyncWait(&waiters[i]);
-
-        if (!waiting) {
-            winner.store(i, .release);
-            const result = if (comptime hasWaitContext(field.type))
-                future.getResult(&@field(contexts, field.name))
-            else
-                future.getResult();
-            return @unionInit(U, field.name, result);
+        const needs_rollback = states[i].phase == .pending or
+            (states[i].phase == .ready and states[i].signal_expected);
+        if (needs_rollback) {
+            var future = @field(futures, field.name);
+            const fp = if (comptime isPointerFuture(field.type)) future else &future;
+            const rolled_back = AsyncWaitOf(field.type).rollback(fp, &waiters[i], &@field(contexts, field.name));
+            if (rolled_back == .signal_in_flight and !states[i].signal_expected) signals_expected += 1;
         }
-
-        registered_count += 1;
+        states[i] = .{};
     }
+    parent.wait(signals_expected, .no_cancel);
 
-    // Wait for one to complete (Waiter.wait handles spurious wakeups)
-    try waiter.wait(1, .allow_cancel);
+    if (winner_index == NO_WINNER) return error.Canceled;
+    if (deliver_recancel) task.recancel();
 
-    // O(1) winner lookup
-    const winner_index = winner.load(.acquire);
-
-    // Return result from winner
     inline for (fields, 0..) |field, i| {
-        if (i == winner_index) {
-            const future = @field(futures, field.name);
-            const result = if (comptime hasWaitContext(field.type))
-                future.getResult(&@field(contexts, field.name))
-            else
-                future.getResult();
-            return @unionInit(U, field.name, result);
+        if (winner_index == i) {
+            return @unionInit(U, field.name, @field(results, field.name).?.value);
         }
     }
-
-    // Should never reach here - we were woken up, so something must be signaled
     unreachable;
-}
-
-/// Select on a runtime slice of type-erased Awaitables.
-/// Returns the index of the first awaitable to complete.
-/// Used by std.Io.selectImpl.
-pub fn selectAwaitables(awaitables: []const *Awaitable) Cancelable!usize {
-    const max_awaitables = 64;
-    if (awaitables.len > max_awaitables) {
-        @panic("selectAwaitables: too many awaitables (max 64)");
-    }
-
-    var winner: std.atomic.Value(usize) = .init(NO_WINNER);
-    var waiter = Waiter.init();
-    var waiters: [max_awaitables]Waiter = undefined;
-
-    for (waiters[0..awaitables.len], 0..) |*w, i| {
-        w.* = Waiter.initSelect(&waiter, &winner, i);
-    }
-
-    // Only incremented when asyncWait returns true (future is pending).
-    var registered_count: usize = 0;
-
-    defer {
-        const winner_index = winner.load(.acquire);
-
-        // Count expected signals: all registered futures will signal unless we cancel them.
-        // Successfully canceled futures (asyncCancelWait returns true) won't signal.
-        var expected: u32 = @intCast(registered_count);
-        for (awaitables[0..registered_count], waiters[0..registered_count], 0..) |awaitable, *w, i| {
-            if (winner_index != i) {
-                const was_removed = awaitable.asyncCancelWait(w);
-                if (was_removed) {
-                    // Successfully removed from queue - won't signal
-                    expected -= 1;
-                }
-            }
-        }
-
-        // Wait for all expected signals (winner + in-flight non-winners)
-        waiter.wait(expected, .no_cancel);
-    }
-
-    for (awaitables, waiters[0..awaitables.len]) |awaitable, *w| {
-        const waiting = awaitable.asyncWait(w);
-
-        if (!waiting) {
-            winner.store(w.mode.select.index, .release);
-            return w.mode.select.index;
-        }
-
-        registered_count += 1;
-    }
-
-    // Wait for one to complete (Waiter.wait handles spurious wakeups)
-    try waiter.wait(1, .allow_cancel);
-
-    return winner.load(.acquire);
 }
 
 /// Internal wait implementation with configurable cancellation behavior.
@@ -401,55 +551,96 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
         checkSelfWait(task, future);
     }
 
-    var waiter = Waiter.init();
-
-    // Allocate WaitContext if needed
-    const WaitCtx = FutureWaitContext(@TypeOf(future));
-    var context: WaitCtx = if (WaitCtx == void) {} else .{};
-    const has_context = comptime (WaitCtx != void);
-
-    // Fast path: check if already complete
+    const FT = @TypeOf(future);
+    const AW = AsyncWaitOf(FT);
     var fut = future;
-    const added = if (has_context)
-        fut.asyncWait(&waiter, &context)
-    else
-        fut.asyncWait(&waiter);
+    const fp = if (comptime isPointerFuture(FT)) fut else &fut;
 
-    if (!added) {
-        const result = if (has_context) fut.getResult(&context) else fut.getResult();
-        return .{ .value = result };
-    }
+    var waiter = Waiter.init();
+    var context: FutureContext(FT) = .{};
 
-    // Clean up waiter on exit
-    defer {
-        const was_removed = if (has_context)
-            fut.asyncCancelWait(&waiter, &context)
-        else
-            fut.asyncCancelWait(&waiter);
+    // For a direct waiter every signal reports a consumed registration, so
+    // the landed count doubles as the notification flag.
+    var registered = false;
+    var signals_landed: u32 = 0;
 
-        if (!was_removed) {
-            // Wake is in-flight, wait for it to complete (1 signal expected)
-            waiter.wait(1, .no_cancel);
+    const result: AW.Result = main: while (true) {
+        if (!registered) {
+            const prep = AW.prepare(fp, &waiter, &context);
+            if (prep == .pending) {
+                registered = true;
+                continue;
+            }
+            switch (AW.commit(fp, &context)) {
+                .done => |value| break :main value,
+                .retry => continue,
+            }
         }
-    }
 
-    if (flags.on_cancel == .cancel_and_continue) {
-        // Wait with cancellation enabled first
-        waiter.wait(1, .allow_cancel) catch |err| switch (err) {
+        waiter.wait(signals_landed + 1, .allow_cancel) catch |err| switch (err) {
             error.Canceled => {
-                // On cancellation, cancel child and wait for completion
-                fut.cancel();
-                waiter.wait(1, .no_cancel);
-                const result = if (has_context) fut.getResult(&context) else fut.getResult();
-                return .{ .value = result };
+                if (flags.on_cancel == .cancel_and_continue) {
+                    // On cancellation, cancel the future and keep waiting for
+                    // its completion.
+                    fp.cancel();
+                    while (true) {
+                        if (!registered) {
+                            const prep = AW.prepare(fp, &waiter, &context);
+                            if (prep == .pending) {
+                                registered = true;
+                                continue;
+                            }
+                            switch (AW.commit(fp, &context)) {
+                                .done => |value| break :main value,
+                                .retry => continue,
+                            }
+                        }
+                        waiter.wait(signals_landed + 1, .no_cancel);
+                        signals_landed = waiter.landedSignals();
+                        registered = false;
+                        switch (AW.commit(fp, &context)) {
+                            .done => |value| break :main value,
+                            .retry => {},
+                        }
+                    }
+                }
+
+                var signals_to_wait_for = signals_landed;
+                var notification_pending = false;
+                if (registered) {
+                    const rolled_back = AW.rollback(fp, &waiter, &context);
+                    if (rolled_back == .signal_in_flight) {
+                        signals_to_wait_for += 1;
+                        notification_pending = true;
+                    }
+                    registered = false;
+                }
+                waiter.wait(signals_to_wait_for, .no_cancel);
+                if (notification_pending) {
+                    // A signal to a direct waiter reports a completed
+                    // operation: deliver its result rather than dropping it,
+                    // and re-arm the cancellation for the next cancelable
+                    // operation.
+                    switch (AW.commit(fp, &context)) {
+                        .done => |value| {
+                            if (waiter.mode.direct.task) |t| t.recancel();
+                            return .{ .value = value };
+                        },
+                        .retry => {},
+                    }
+                }
+                return err;
             },
         };
-    } else {
-        // Propagate cancellation to caller (Waiter.wait handles spurious wakeups)
-        try waiter.wait(1, .allow_cancel);
-    }
+        signals_landed = waiter.landedSignals();
+        registered = false;
+        switch (AW.commit(fp, &context)) {
+            .done => |value| break :main value,
+            .retry => {},
+        }
+        // Readiness decayed; prepare again.
+    };
 
-    const result = if (has_context) fut.getResult(&context) else fut.getResult();
     return .{ .value = result };
 }
 
@@ -484,7 +675,6 @@ pub fn waitUntilComplete(future: anytype) FutureResult(@TypeOf(future)) {
     const result = waitInternal(future, .{ .on_cancel = .cancel_and_continue }) catch unreachable;
     return result.value;
 }
-
 test "select: basic - first completes" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
@@ -550,6 +740,103 @@ test "select: already complete - fast path" {
         .immediate => |val| try std.testing.expectEqual(123, val),
         .slow => return error.TestUnexpectedResult,
     }
+}
+
+test "select: sixteen arms fit the comptime quota" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const Ready = struct {
+        value: u8,
+        const Source = @This();
+
+        pub const AsyncWait = struct {
+            pub const Result = u8;
+            pub const Context = struct {};
+
+            pub fn prepare(self: *const Source, waiter: *Waiter, ctx: *Context) Prepare {
+                _ = self;
+                _ = waiter;
+                _ = ctx;
+                return .ready;
+            }
+
+            pub fn commit(self: *const Source, ctx: *Context) CommitResult(Result) {
+                _ = ctx;
+                return .{ .done = self.value };
+            }
+
+            pub fn rollback(self: *const Source, waiter: *Waiter, ctx: *Context) Rollback {
+                _ = self;
+                _ = waiter;
+                _ = ctx;
+                return .removed;
+            }
+        };
+    };
+
+    const result = try select(.{
+        .arm00 = Ready{ .value = 0 },
+        .arm01 = Ready{ .value = 1 },
+        .arm02 = Ready{ .value = 2 },
+        .arm03 = Ready{ .value = 3 },
+        .arm04 = Ready{ .value = 4 },
+        .arm05 = Ready{ .value = 5 },
+        .arm06 = Ready{ .value = 6 },
+        .arm07 = Ready{ .value = 7 },
+        .arm08 = Ready{ .value = 8 },
+        .arm09 = Ready{ .value = 9 },
+        .arm10 = Ready{ .value = 10 },
+        .arm11 = Ready{ .value = 11 },
+        .arm12 = Ready{ .value = 12 },
+        .arm13 = Ready{ .value = 13 },
+        .arm14 = Ready{ .value = 14 },
+        .arm15 = Ready{ .value = 15 },
+    });
+    const chosen = switch (result) {
+        inline else => |value| value,
+    };
+    try std.testing.expect(chosen < 16);
+}
+
+test "select: null is a committed optional result" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
+
+    const NullReady = struct {
+        commits: *usize,
+        const Source = @This();
+
+        pub const AsyncWait = struct {
+            pub const Result = ?u8;
+            pub const Context = struct {};
+
+            pub fn prepare(self: *const Source, waiter: *Waiter, ctx: *Context) Prepare {
+                _ = self;
+                _ = waiter;
+                _ = ctx;
+                return .ready;
+            }
+
+            pub fn commit(self: *const Source, ctx: *Context) CommitResult(Result) {
+                _ = ctx;
+                self.commits.* += 1;
+                return .{ .done = null };
+            }
+
+            pub fn rollback(self: *const Source, waiter: *Waiter, ctx: *Context) Rollback {
+                _ = self;
+                _ = waiter;
+                _ = ctx;
+                return .removed;
+            }
+        };
+    };
+
+    var commits: usize = 0;
+    const result = try select(.{ .optional = NullReady{ .commits = &commits } });
+    try std.testing.expectEqual(null, result.optional);
+    try std.testing.expectEqual(1, commits);
 }
 
 test "select: heterogeneous types" {
@@ -927,5 +1214,5 @@ test "select: wait on JoinHandle from spawned task" {
     }
 
     // Both should be valid results, though timing determines which completes first
-    try std.testing.expect(std.meta.activeTag(result) == .first or std.meta.activeTag(result) == .second);
+    try std.testing.expectEqual(true, std.meta.activeTag(result) == .first or std.meta.activeTag(result) == .second);
 }

--- a/src/select.zig
+++ b/src/select.zig
@@ -34,7 +34,7 @@ const meta = @import("meta.zig");
 //       pub const claimable = false;   // optional, defaults to false
 //
 //       pub fn prepare(self: *Source, waiter: *Waiter, ctx: *Context) Prepare
-//       pub fn commit(self: *Source, ctx: *Context) CommitResult(Result)
+//       pub fn commit(self: *Source, waiter: *Waiter, ctx: *Context) CommitResult(Result)
 //       pub fn rollback(self: *Source, waiter: *Waiter, ctx: *Context) Rollback
 //   };
 //
@@ -47,11 +47,12 @@ const meta = @import("meta.zig");
 // commit - the consume, under the source's lock: take the item, swap the
 // counter, pop the completion. Called on an arm that prepared `.ready`, on an
 // arm whose notification the caller consumed, or on an arm decided externally
-// (a claimed send arm reports the outcome its claimer left in ctx). Returns
-// `.retry` if readiness has decayed (another consumer got there first); the
-// caller re-prepares. A retry ends this attempt and leaves no reservation.
-// Never touches the registration; a notified arm has none, and a `.ready`
-// arm never had one.
+// (a claimed send arm reports the outcome its claimer left in ctx). If
+// readiness decayed, commit installs a new registration and returns `.pending`.
+// A pending result may carry one deferred notification; the driver first
+// publishes the arm as pending and releases the COMMITTING fence, then signals
+// that waiter. This ordering is used by rendezvous channels to park one side
+// before nudging a busy select peer.
 //
 // rollback - abandon a losing pending or notified attempt, under the source's
 // lock. `.removed`: the registration was removed cleanly and no notification
@@ -63,7 +64,7 @@ const meta = @import("meta.zig");
 // Notification discipline: a source dequeues a registration exactly once,
 // and, per dequeue, sets the waiter's notified flag and signals exactly once
 // (`Waiter.signal` does both). A notification carries no decision, it only
-// means "this arm's registration was consumed, re-run prepare/commit on it".
+// means "this arm's registration was consumed; try commit again".
 // The select loop owns all remaining bookkeeping: which arms are registered,
 // which notifications it has consumed, and how many signals to absorb before
 // returning.
@@ -87,29 +88,36 @@ pub const Prepare = enum {
     pending,
 };
 
-/// Result of the consuming phase. A tagged union keeps protocol retry
+pub const Pending = struct {
+    /// A registration consumed while this operation parked. The driver sends
+    /// this notification only after publishing its own pending state and
+    /// releasing the select commit fence.
+    notify: ?*Waiter = null,
+};
+
+/// Result of the consuming phase. A tagged union keeps protocol pending
 /// separate from operation results that may themselves contain optional or
 /// error-union values (including an application-level `error.Retry`).
 pub fn CommitResult(comptime Result: type) type {
     return union(enum) {
-        retry,
+        pending: Pending,
         done: Result,
     };
 }
 
-test "CommitResult keeps protocol retry separate from user results" {
+test "CommitResult keeps protocol pending separate from user results" {
     const ErrorResult = CommitResult(error{Retry}!u8);
     const application_retry: ErrorResult = .{ .done = error.Retry };
     switch (application_retry) {
         .done => |result| try std.testing.expectError(error.Retry, result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
 
     const OptionalResult = CommitResult(?u8);
     const application_null: OptionalResult = .{ .done = null };
     switch (application_null) {
         .done => |result| try std.testing.expectEqual(null, result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
 }
 
@@ -137,8 +145,9 @@ pub const ClaimResult = enum {
     /// outcome in the arm's ctx, dequeue the registration and notify.
     won,
     /// The select's own sweep holds the fence right now. The claimer must
-    /// nudge: dequeue the registration under the source lock and notify, so
-    /// the select re-runs prepare/commit on the arm.
+    /// not consume. A blocking rendezvous may park itself, dequeue this
+    /// registration, and return a deferred notification so the select tries
+    /// commit on the arm after the requester is externally claimable.
     busy,
     /// The select is already decided (another arm won, or it canceled). Skip
     /// the registration in place; the select's cleanup removes it.
@@ -174,7 +183,7 @@ pub fn peekArm(waiter: *Waiter) ClaimResult {
 }
 
 /// Consume a select arm's notification. Owned by the select loop; a consumed
-/// notification means the arm is unregistered and must be re-prepared.
+/// notification means the arm is unregistered and ready for commit.
 fn consumeNotified(waiter: *Waiter) bool {
     return waiter.mode.select.notified.swap(false, .acq_rel);
 }
@@ -460,7 +469,7 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
                                 break :main decided;
                             }
                         }
-                        const committed = AsyncWaitOf(field.type).commit(fp, &@field(contexts, field.name));
+                        const committed = AsyncWaitOf(field.type).commit(fp, &waiters[i], &@field(contexts, field.name));
                         switch (committed) {
                             .done => |value| {
                                 states[i] = .{};
@@ -468,13 +477,13 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
                                 @field(results, field.name) = .{ .value = value };
                                 break :main i;
                             },
-                            .retry => {
-                                states[i] = .{};
+                            .pending => |pending| {
+                                states[i] = .{ .phase = .pending };
                                 if (has_claimable) winner.store(NO_WINNER, .release);
+                                if (pending.notify) |notified| notified.signal();
+                                continue :sweep;
                             },
                         }
-                        // Readiness decayed; the attempt ended without a side
-                        // effect or reservation. Prepare again.
                     }
                 }
             }
@@ -502,10 +511,10 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
             if (winner_index == i and @field(results, field.name) == null) {
                 var future = @field(futures, field.name);
                 const fp = if (comptime isPointerFuture(field.type)) future else &future;
-                const committed = AsyncWaitOf(field.type).commit(fp, &@field(contexts, field.name));
+                const committed = AsyncWaitOf(field.type).commit(fp, &waiters[i], &@field(contexts, field.name));
                 @field(results, field.name) = switch (committed) {
                     .done => |value| .{ .value = value },
-                    .retry => unreachable,
+                    .pending => unreachable,
                 };
 
                 // An external claim consumes a queued registration and owes
@@ -571,9 +580,13 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
                 registered = true;
                 continue;
             }
-            switch (AW.commit(fp, &context)) {
+            switch (AW.commit(fp, &waiter, &context)) {
                 .done => |value| break :main value,
-                .retry => continue,
+                .pending => |pending| {
+                    registered = true;
+                    if (pending.notify) |notified| notified.signal();
+                    continue;
+                },
             }
         }
 
@@ -590,17 +603,24 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
                                 registered = true;
                                 continue;
                             }
-                            switch (AW.commit(fp, &context)) {
+                            switch (AW.commit(fp, &waiter, &context)) {
                                 .done => |value| break :main value,
-                                .retry => continue,
+                                .pending => |pending| {
+                                    registered = true;
+                                    if (pending.notify) |notified| notified.signal();
+                                    continue;
+                                },
                             }
                         }
                         waiter.wait(signals_landed + 1, .no_cancel);
                         signals_landed = waiter.landedSignals();
                         registered = false;
-                        switch (AW.commit(fp, &context)) {
+                        switch (AW.commit(fp, &waiter, &context)) {
                             .done => |value| break :main value,
-                            .retry => {},
+                            .pending => |pending| {
+                                registered = true;
+                                if (pending.notify) |notified| notified.signal();
+                            },
                         }
                     }
                 }
@@ -615,18 +635,26 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
                     }
                     registered = false;
                 }
-                waiter.wait(signals_to_wait_for, .no_cancel);
-                if (notification_pending) {
+                while (notification_pending) {
+                    waiter.wait(signals_to_wait_for, .no_cancel);
                     // A signal to a direct waiter reports a completed
                     // operation: deliver its result rather than dropping it,
                     // and re-arm the cancellation for the next cancelable
                     // operation.
-                    switch (AW.commit(fp, &context)) {
+                    switch (AW.commit(fp, &waiter, &context)) {
                         .done => |value| {
                             if (waiter.mode.direct.task) |t| t.recancel();
                             return .{ .value = value };
                         },
-                        .retry => {},
+                        .pending => |pending| {
+                            if (pending.notify) |notified| notified.signal();
+                            const rolled_back = AW.rollback(fp, &waiter, &context);
+                            if (rolled_back == .signal_in_flight) {
+                                signals_to_wait_for += 1;
+                            } else {
+                                notification_pending = false;
+                            }
+                        },
                     }
                 }
                 return err;
@@ -634,11 +662,13 @@ fn waitInternal(future: anytype, comptime flags: WaitFlags) Cancelable!WaitResul
         };
         signals_landed = waiter.landedSignals();
         registered = false;
-        switch (AW.commit(fp, &context)) {
+        switch (AW.commit(fp, &waiter, &context)) {
             .done => |value| break :main value,
-            .retry => {},
+            .pending => |pending| {
+                registered = true;
+                if (pending.notify) |notified| notified.signal();
+            },
         }
-        // Readiness decayed; prepare again.
     };
 
     return .{ .value = result };
@@ -761,7 +791,8 @@ test "select: sixteen arms fit the comptime quota" {
                 return .ready;
             }
 
-            pub fn commit(self: *const Source, ctx: *Context) CommitResult(Result) {
+            pub fn commit(self: *const Source, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
+                _ = waiter;
                 _ = ctx;
                 return .{ .done = self.value };
             }
@@ -820,7 +851,8 @@ test "select: null is a committed optional result" {
                 return .ready;
             }
 
-            pub fn commit(self: *const Source, ctx: *Context) CommitResult(Result) {
+            pub fn commit(self: *const Source, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
+                _ = waiter;
                 _ = ctx;
                 self.commits.* += 1;
                 return .{ .done = null };

--- a/src/select.zig
+++ b/src/select.zig
@@ -374,8 +374,8 @@ const ArmState = struct {
 ///
 /// Returns a tagged union with the same field names, containing the result of
 /// whichever completed first. When several arms are ready in the same round, a
-/// random one wins. A select may contain at most 64 arms; larger selects panic
-/// in every build mode.
+/// random one wins. A select may contain at most 64 arms; larger selects fail
+/// at compile time.
 ///
 /// Example:
 /// ```
@@ -393,7 +393,7 @@ pub fn select(futures: anytype) !SelectResult(@TypeOf(futures)) {
     const fields = @typeInfo(S).@"struct".fields;
     const has_claimable = comptime anyClaimable(S);
 
-    if (fields.len > 64) @panic("select: too many arms (max 64)");
+    if (fields.len > 64) @compileError("select: too many arms (max 64)");
 
     // Self-wait detection: check all futures for self-wait
     const task = getCurrentTask();
@@ -793,10 +793,12 @@ test "select: sixteen arms fit the comptime quota" {
         .arm14 = Ready{ .value = 14 },
         .arm15 = Ready{ .value = 15 },
     });
-    const chosen = switch (result) {
-        inline else => |value| value,
-    };
-    try std.testing.expect(chosen < 16);
+    switch (result) {
+        inline else => |value, tag| {
+            const expected = comptime std.fmt.parseInt(u8, @tagName(tag)["arm".len..], 10) catch unreachable;
+            try std.testing.expectEqual(expected, value);
+        },
+    }
 }
 
 test "select: null is a committed optional result" {

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -247,9 +247,6 @@ pub const Signal = struct {
     kind: SignalKind,
     entry: *HandlerEntry,
 
-    // Future protocol - allows Signal to be used with select()
-    pub const Result = void;
-
     /// Initializes a new signal watcher for the specified signal kind.
     /// Multiple watchers can be registered for the same signal type.
     ///

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -14,6 +14,9 @@ const WaitNode = @import("utils/wait_queue.zig").WaitNode;
 const AutoCancel = @import("autocancel.zig").AutoCancel;
 const w = @import("os/windows.zig");
 const Waiter = @import("common.zig").Waiter;
+const Prepare = @import("select.zig").Prepare;
+const CommitResult = @import("select.zig").CommitResult;
+const Rollback = @import("select.zig").Rollback;
 
 pub const SignalKind = switch (builtin.os.tag) {
     .windows => enum(u8) {
@@ -350,34 +353,42 @@ pub const Signal = struct {
         _ = self.entry.counter.swap(0, .acquire);
     }
 
-    /// Registers a waiter to be notified when the signal is received.
-    /// This is part of the Future protocol for select().
-    /// Returns false if the signal was already received (no wait needed), true if added to wait queue.
-    pub fn asyncWait(self: *Signal, waiter: *Waiter) bool {
-        // Fast path: signal already received
-        if (self.entry.counter.swap(0, .acquire) > 0) {
-            return false;
+    // AsyncWait protocol (see select.zig). A delivery bumps the counter and
+    // then dequeues and notifies every registration. The counter swap is the
+    // consuming commit; when several waiters race for one delivery, the
+    // losers re-prepare.
+    pub const AsyncWait = struct {
+        pub const Result = void;
+        pub const Context = struct {};
+
+        pub fn prepare(self: *Signal, waiter: *Waiter, ctx: *Context) Prepare {
+            _ = ctx;
+            if (self.entry.counter.load(.acquire) > 0) return .ready;
+
+            self.entry.waiters.push(&waiter.node);
+
+            // Double-check: a delivery may have swept the queue between the
+            // check above and the push.
+            if (self.entry.counter.load(.acquire) > 0) {
+                if (self.entry.waiters.remove(&waiter.node)) return .ready;
+                // The delivery dequeued us; its notification is in flight and
+                // re-runs this arm.
+            }
+            return .pending;
         }
 
-        // Add to wait queue
-        self.entry.waiters.push(&waiter.node);
-        return true;
-    }
+        pub fn commit(self: *Signal, ctx: *Context) CommitResult(void) {
+            _ = ctx;
+            if (self.entry.counter.swap(0, .acquire) > 0) return .{ .done = {} };
+            // Another waiter consumed the delivery; re-prepare.
+            return .retry;
+        }
 
-    /// Cancels a pending wait operation by removing the waiter.
-    /// This is part of the Future protocol for select().
-    /// Returns true if removed, false if already removed by completion (wake in-flight).
-    pub fn asyncCancelWait(self: *Signal, waiter: *Waiter) bool {
-        // Simply remove from queue - no need to wake another waiter since signals broadcast to all
-        return self.entry.waiters.remove(&waiter.node);
-    }
-
-    /// Gets the result value.
-    /// This is part of the Future protocol for select().
-    pub fn getResult(self: *Signal) void {
-        // Consume the counter to ensure signal is acknowledged
-        _ = self.entry.counter.swap(0, .acquire);
-    }
+        pub fn rollback(self: *Signal, waiter: *Waiter, ctx: *Context) Rollback {
+            _ = ctx;
+            return if (self.entry.waiters.remove(&waiter.node)) .removed else .signal_in_flight;
+        }
+    };
 };
 
 test "Signal: basic signal handling" {

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -352,8 +352,8 @@ pub const Signal = struct {
 
     // AsyncWait protocol (see select.zig). A delivery bumps the counter and
     // then dequeues and notifies every registration. The counter swap is the
-    // consuming commit; when several waiters race for one delivery, the
-    // losers re-prepare.
+    // consuming commit; when several waiters race for one delivery, losing
+    // commits install their next registration before returning pending.
     pub const AsyncWait = struct {
         pub const Result = void;
         pub const Context = struct {};
@@ -374,11 +374,11 @@ pub const Signal = struct {
             return .pending;
         }
 
-        pub fn commit(self: *Signal, ctx: *Context) CommitResult(void) {
-            _ = ctx;
-            if (self.entry.counter.swap(0, .acquire) > 0) return .{ .done = {} };
-            // Another waiter consumed the delivery; re-prepare.
-            return .retry;
+        pub fn commit(self: *Signal, waiter: *Waiter, ctx: *Context) CommitResult(void) {
+            while (true) {
+                if (self.entry.counter.swap(0, .acquire) > 0) return .{ .done = {} };
+                if (prepare(self, waiter, ctx) == .pending) return .{ .pending = .{} };
+            }
         }
 
         pub fn rollback(self: *Signal, waiter: *Waiter, ctx: *Context) Rollback {

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -207,12 +207,11 @@ pub const AsyncWait = struct {
         return .pending;
     }
 
-    pub fn commit(self: *ResetEvent, ctx: *Context) CommitResult(void) {
-        _ = ctx;
-        // `set` may be followed by `reset` after it has dequeued us but before
-        // this arm commits. Readiness is therefore allowed to decay.
-        if (self.wait_queue.isFlagSet()) return .{ .done = {} };
-        return .retry;
+    pub fn commit(self: *ResetEvent, waiter: *Waiter, ctx: *Context) CommitResult(void) {
+        while (true) {
+            if (self.wait_queue.isFlagSet()) return .{ .done = {} };
+            if (prepare(self, waiter, ctx) == .pending) return .{ .pending = .{} };
+        }
     }
 
     pub fn rollback(self: *ResetEvent, waiter: *Waiter, ctx: *Context) Rollback {

--- a/src/sync/ResetEvent.zig
+++ b/src/sync/ResetEvent.zig
@@ -55,6 +55,9 @@ const Timeout = @import("../time.zig").Timeout;
 const WaitQueue = @import("../utils/wait_queue.zig").WaitQueue;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const Waiter = @import("../common.zig").Waiter;
+const Prepare = @import("../select.zig").Prepare;
+const CommitResult = @import("../select.zig").CommitResult;
+const Rollback = @import("../select.zig").Rollback;
 
 /// Wait queue with flag indicating whether event is set.
 wait_queue: WaitQueue(WaitNode) = .empty,
@@ -187,36 +190,36 @@ pub fn timedWait(self: *ResetEvent, timeout: Timeout) (Timeoutable || Cancelable
     _ = self.wait_queue.isFlagSet();
 }
 
-// Future protocol implementation for use with select()
-pub const Result = void;
-
 /// Returns true if the event is set (has a result).
-/// This is part of the Future protocol for select().
 pub fn hasResult(self: *const ResetEvent) bool {
     return self.isSet();
 }
 
-/// Gets the result (void) of the event.
-/// This is part of the Future protocol for select().
-pub fn getResult(self: *const ResetEvent) void {
-    _ = self;
-    return;
-}
+// AsyncWait protocol (see select.zig). Completion is the sticky queue flag;
+// set() dequeues and notifies every registration while setting it.
+pub const AsyncWait = struct {
+    pub const Result = void;
+    pub const Context = struct {};
 
-/// Registers a waiter to be notified when the event is set.
-/// This is part of the Future protocol for select().
-/// Returns false if the event is already set (no wait needed), true if added to queue.
-pub fn asyncWait(self: *ResetEvent, waiter: *Waiter) bool {
-    // Try to push to queue - only succeeds if event is not set (flag not set)
-    return self.wait_queue.pushUnlessFlag(&waiter.node);
-}
+    pub fn prepare(self: *ResetEvent, waiter: *Waiter, ctx: *Context) Prepare {
+        _ = ctx;
+        if (!self.wait_queue.pushUnlessFlag(&waiter.node)) return .ready;
+        return .pending;
+    }
 
-/// Cancels a pending wait operation by removing the waiter.
-/// This is part of the Future protocol for select().
-/// Returns true if removed, false if already removed by completion (wake in-flight).
-pub fn asyncCancelWait(self: *ResetEvent, waiter: *Waiter) bool {
-    return self.wait_queue.remove(&waiter.node);
-}
+    pub fn commit(self: *ResetEvent, ctx: *Context) CommitResult(void) {
+        _ = ctx;
+        // `set` may be followed by `reset` after it has dequeued us but before
+        // this arm commits. Readiness is therefore allowed to decay.
+        if (self.wait_queue.isFlagSet()) return .{ .done = {} };
+        return .retry;
+    }
+
+    pub fn rollback(self: *ResetEvent, waiter: *Waiter, ctx: *Context) Rollback {
+        _ = ctx;
+        return if (self.wait_queue.remove(&waiter.node)) .removed else .signal_in_flight;
+    }
+};
 
 test "ResetEvent basic set/reset/isSet" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -9,6 +9,9 @@ const SimpleQueue = @import("../utils/simple_queue.zig").SimpleQueue;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const Barrier = @import("Barrier.zig");
 const select = @import("../select.zig").select;
+const Prepare = @import("../select.zig").Prepare;
+const CommitResult = @import("../select.zig").CommitResult;
+const Rollback = @import("../select.zig").Rollback;
 const Waiter = @import("../common.zig").Waiter;
 const Closeable = @import("../common.zig").Closeable;
 const Mutex = @import("Mutex.zig");
@@ -164,90 +167,54 @@ const AsyncReceiveImpl = struct {
 
     pub const WaitContext = struct {
         result_ptr: [*]u8 = undefined,
-        result: ?(Closeable || error{Lagged})!void = null,
     };
 
-    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) bool {
-        ctx.result_ptr = result_ptr;
-        ctx.result = null;
-
-        self.channel.mutex.lockUncancelable();
-
-        const unread = self.channel.write_pos -% self.consumer.read_pos;
-
-        // Check if lagged
-        if (unread > self.channel.capacity) {
-            self.consumer.read_pos = self.channel.write_pos -% self.channel.capacity;
-            ctx.result = error.Lagged;
-            self.channel.mutex.unlock();
-            return false; // Complete immediately with error
-        }
-
-        // Fast path: message available
-        if (unread > 0) {
-            const src = self.channel.elemPtr(self.consumer.read_pos % self.channel.capacity);
-            @memcpy(ctx.result_ptr[0..self.channel.elem_size], src[0..self.channel.elem_size]);
-            self.consumer.read_pos +%= 1;
-            ctx.result = {};
-            self.channel.mutex.unlock();
-            return false; // Complete immediately
-        }
-
-        // Fast path: channel closed
-        if (self.channel.closed) {
-            ctx.result = error.Closed;
-            self.channel.mutex.unlock();
-            return false; // Complete immediately with error
-        }
-
-        // Slow path: enqueue and wait
-        self.channel.wait_queue.push(&waiter.node);
-        self.channel.mutex.unlock();
-        return true;
-    }
-
-    pub fn asyncCancelWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) bool {
+    // AsyncWait protocol core (see select.zig): the send/close sweeps dequeue
+    // and notify every registration. Nothing is ever committed into the
+    // waiting frame from outside; commit consumes by advancing the consumer's
+    // own read position.
+    pub fn prepare(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) Prepare {
         _ = ctx;
         self.channel.mutex.lockUncancelable();
-        const was_in_queue = self.channel.wait_queue.remove(&waiter.node);
-        self.channel.mutex.unlock();
-        return was_in_queue;
+        defer self.channel.mutex.unlock();
+
+        const unread = self.channel.write_pos -% self.consumer.read_pos;
+        if (unread > 0 or self.channel.closed) return .ready;
+
+        self.channel.wait_queue.push(&waiter.node);
+        return .pending;
     }
 
-    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) (Closeable || error{Lagged})!void {
-        // Fast path: result already set by asyncWait
-        if (ctx.result) |r| {
-            return r;
-        }
-
-        // Slow path: woken from wait, read from buffer now
+    pub fn commit(self: *const RecvSelf, ctx: *WaitContext) CommitResult((Closeable || error{Lagged})!void) {
         self.channel.mutex.lockUncancelable();
+        defer self.channel.mutex.unlock();
 
         const unread = self.channel.write_pos -% self.consumer.read_pos;
 
-        // Check if lagged
         if (unread > self.channel.capacity) {
             self.consumer.read_pos = self.channel.write_pos -% self.channel.capacity;
-            self.channel.mutex.unlock();
-            return error.Lagged;
+            return .{ .done = error.Lagged };
         }
 
-        // Message available
         if (unread > 0) {
             const src = self.channel.elemPtr(self.consumer.read_pos % self.channel.capacity);
             @memcpy(ctx.result_ptr[0..self.channel.elem_size], src[0..self.channel.elem_size]);
             self.consumer.read_pos +%= 1;
-            self.channel.mutex.unlock();
-            return;
+            return .{ .done = {} };
         }
 
-        // Channel closed
         if (self.channel.closed) {
-            self.channel.mutex.unlock();
-            return error.Closed;
+            return .{ .done = error.Closed };
         }
 
-        unreachable;
+        return .retry;
+    }
+
+    pub fn rollback(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) Rollback {
+        _ = ctx;
+        self.channel.mutex.lockUncancelable();
+        defer self.channel.mutex.unlock();
+        return if (self.channel.wait_queue.remove(&waiter.node)) .removed else .signal_in_flight;
     }
 };
 
@@ -420,13 +387,6 @@ pub fn AsyncReceive(comptime T: type) type {
 
         const Self = @This();
 
-        pub const Result = error{ Closed, Lagged }!T;
-
-        pub const WaitContext = struct {
-            impl_ctx: AsyncReceiveImpl.WaitContext = .{},
-            result: T = undefined,
-        };
-
         fn init(channel: *BroadcastChannelImpl, consumer: *BroadcastChannelConsumer) Self {
             return .{
                 .impl = .{
@@ -436,24 +396,31 @@ pub fn AsyncReceive(comptime T: type) type {
             };
         }
 
-        /// Register for notification when receive can complete.
-        /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&ctx.result).ptr);
-        }
+        // AsyncWait protocol (see select.zig), delegating to the type-erased impl.
+        pub const AsyncWait = struct {
+            pub const Result = error{ Closed, Lagged }!T;
 
-        /// Cancel a pending wait operation.
-        /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncCancelWait(waiter, &ctx.impl_ctx);
-        }
+            pub const Context = struct {
+                impl_ctx: AsyncReceiveImpl.WaitContext = .{},
+                result: T = undefined,
+            };
 
-        /// Get the result of the receive operation.
-        /// Must only be called after asyncWait() returns false or the wait_node is woken.
-        pub fn getResult(self: *const Self, ctx: *WaitContext) Result {
-            try self.impl.getResult(&ctx.impl_ctx);
-            return ctx.result;
-        }
+            pub fn prepare(self: *const Self, waiter: *Waiter, ctx: *Context) Prepare {
+                ctx.impl_ctx.result_ptr = std.mem.asBytes(&ctx.result).ptr;
+                return self.impl.prepare(waiter, &ctx.impl_ctx);
+            }
+
+            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
+                return switch (self.impl.commit(&ctx.impl_ctx)) {
+                    .retry => .retry,
+                    .done => |r| if (r) |_| .{ .done = ctx.result } else |err| .{ .done = err },
+                };
+            }
+
+            pub fn rollback(self: *const Self, waiter: *Waiter, ctx: *Context) Rollback {
+                return self.impl.rollback(waiter, &ctx.impl_ctx);
+            }
+        };
     };
 }
 

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -185,7 +185,7 @@ const AsyncReceiveImpl = struct {
         return .pending;
     }
 
-    pub fn commit(self: *const RecvSelf, ctx: *WaitContext) CommitResult((Closeable || error{Lagged})!void) {
+    pub fn commit(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) CommitResult((Closeable || error{Lagged})!void) {
         self.channel.mutex.lockUncancelable();
         defer self.channel.mutex.unlock();
 
@@ -207,7 +207,8 @@ const AsyncReceiveImpl = struct {
             return .{ .done = error.Closed };
         }
 
-        return .retry;
+        self.channel.wait_queue.push(&waiter.node);
+        return .{ .pending = .{} };
     }
 
     pub fn rollback(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) Rollback {
@@ -410,9 +411,9 @@ pub fn AsyncReceive(comptime T: type) type {
                 return self.impl.prepare(waiter, &ctx.impl_ctx);
             }
 
-            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
-                return switch (self.impl.commit(&ctx.impl_ctx)) {
-                    .retry => .retry,
+            pub fn commit(self: *const Self, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
+                return switch (self.impl.commit(waiter, &ctx.impl_ctx)) {
+                    .pending => |pending| .{ .pending = pending },
                     .done => |r| if (r) |_| .{ .done = ctx.result } else |err| .{ .done = err },
                 };
             }

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -15,6 +15,7 @@ const claimArm = @import("../select.zig").claimArm;
 const peekArm = @import("../select.zig").peekArm;
 const common = @import("../common.zig");
 const Waiter = common.Waiter;
+const NO_WINNER = common.NO_WINNER;
 const Cancelable = common.Cancelable;
 const Closeable = common.Closeable;
 const Mutex = @import("Mutex.zig");
@@ -28,12 +29,12 @@ pub const CloseMode = enum {
     immediate,
 };
 
-/// Type-erased channel implementation. Preparation only observes readiness or
-/// queues a waiter; all transfers happen under the mutex in commit. Each new
-/// buffered item or slot is reserved for at most one queued waiter. A losing
-/// notified arm hands that reservation to the next waiter in rollback.
-/// Rendezvous readiness remains optimistic: commit claims the parked peer's
-/// select before copying its resident value.
+/// Type-erased channel implementation. All transfers happen under the mutex in
+/// commit. Each buffered item or slot is reserved for at most one waiter, and
+/// rollback hands a losing reservation to exactly one successor. Rendezvous
+/// channels similarly keep at most one dequeued candidate holding a baton: if
+/// its peer is busy, the current operation parks before that baton is passed;
+/// commit consumes it and rollback passes it to one compatible waiter.
 const ChannelImpl = struct {
     buffer: [*]u8,
     elem_size: usize,
@@ -47,6 +48,7 @@ const ChannelImpl = struct {
     mutex: Mutex = .init,
     receiver_queue: SimpleQueue(WaitNode) = .empty,
     sender_queue: SimpleQueue(WaitNode) = .empty,
+    rendezvous_baton: bool = false,
 
     closed: bool = false,
 
@@ -78,6 +80,12 @@ const ChannelImpl = struct {
     fn sendCtx(node: *WaitNode) *AsyncSendImpl.Context {
         return @ptrFromInt(node.userdata);
     }
+
+    const Peer = union(enum) {
+        won: *WaitNode,
+        busy: *WaitNode,
+        none,
+    };
 
     /// Two arms of one select cannot rendezvous with each other: only one arm
     /// may be returned, so matching them would perform a transfer without a
@@ -132,10 +140,11 @@ const ChannelImpl = struct {
         return node;
     }
 
-    /// Under the mutex, find a peer whose select can be decided. A peer whose
-    /// select is currently committing another arm is dequeued and nudged; an
-    /// already-decided peer stays queued for its owner's rollback.
-    fn claimPeer(queue: *SimpleQueue(WaitNode), requester: ?*Waiter) ?*WaitNode {
+    /// Find an immediately claimable peer, remembering the oldest busy peer
+    /// only if no later waiter can complete now. Lost registrations remain for
+    /// their owner's rollback.
+    fn choosePeer(queue: *SimpleQueue(WaitNode), requester: ?*Waiter) Peer {
+        var first_busy: ?*WaitNode = null;
         var node = queue.head;
         while (node) |n| {
             const next = n.next;
@@ -149,23 +158,22 @@ const ChannelImpl = struct {
                 .won => {
                     const removed = queue.remove(n);
                     std.debug.assert(removed);
-                    return n;
+                    return .{ .won = n };
                 },
-                .busy => {
-                    const removed = queue.remove(n);
-                    std.debug.assert(removed);
-                    Waiter.fromNode(n).signal();
+                .busy => if (first_busy == null) {
+                    first_busy = n;
                 },
                 .lost => {},
             }
             node = next;
         }
-        return null;
+        return if (first_busy) |busy| .{ .busy = busy } else .none;
     }
 
-    /// Non-consuming readiness probe for a rendezvous peer. Busy peers are
-    /// nudged so they re-offer after their current select commit settles.
-    fn peerAvailable(queue: *SimpleQueue(WaitNode), requester: *Waiter) bool {
+    /// Non-consuming readiness probe. A busy peer is returned to the caller,
+    /// which can park itself and transfer the rendezvous baton atomically.
+    fn probePeer(queue: *SimpleQueue(WaitNode), requester: *Waiter) Peer {
+        var first_busy: ?*WaitNode = null;
         var node = queue.head;
         while (node) |n| {
             const next = n.next;
@@ -174,17 +182,70 @@ const ChannelImpl = struct {
                 continue;
             }
             switch (peekArm(Waiter.fromNode(n))) {
-                .won => return true,
-                .busy => {
-                    const removed = queue.remove(n);
-                    std.debug.assert(removed);
-                    Waiter.fromNode(n).signal();
+                .won => return .{ .won = n },
+                .busy => if (first_busy == null) {
+                    first_busy = n;
                 },
                 .lost => {},
             }
             node = next;
         }
-        return false;
+        return if (first_busy) |busy| .{ .busy = busy } else .none;
+    }
+
+    fn giveReceiverBaton(self: *Self, node: *WaitNode) *Waiter {
+        std.debug.assert(self.capacity == 0);
+        std.debug.assert(!self.rendezvous_baton);
+        const removed = self.receiver_queue.remove(node);
+        std.debug.assert(removed);
+        const ctx = recvCtx(node);
+        std.debug.assert(!ctx.has_rendezvous_baton);
+        ctx.has_rendezvous_baton = true;
+        self.rendezvous_baton = true;
+        return Waiter.fromNode(node);
+    }
+
+    fn giveSenderBaton(self: *Self, node: *WaitNode) *Waiter {
+        std.debug.assert(self.capacity == 0);
+        std.debug.assert(!self.rendezvous_baton);
+        const removed = self.sender_queue.remove(node);
+        std.debug.assert(removed);
+        const ctx = sendCtx(node);
+        std.debug.assert(!ctx.has_rendezvous_baton);
+        ctx.has_rendezvous_baton = true;
+        self.rendezvous_baton = true;
+        return Waiter.fromNode(node);
+    }
+
+    fn clearReceiverBaton(self: *Self, ctx: *AsyncReceiveImpl.Context) void {
+        std.debug.assert(self.rendezvous_baton);
+        std.debug.assert(ctx.has_rendezvous_baton);
+        ctx.has_rendezvous_baton = false;
+        self.rendezvous_baton = false;
+    }
+
+    fn clearSenderBaton(self: *Self, ctx: *AsyncSendImpl.Context) void {
+        std.debug.assert(self.rendezvous_baton);
+        std.debug.assert(ctx.has_rendezvous_baton);
+        ctx.has_rendezvous_baton = false;
+        self.rendezvous_baton = false;
+    }
+
+    /// If durable offers exist on both sides and nobody is already driving
+    /// them, dequeue exactly one receiver to try the next rendezvous.
+    fn scheduleRendezvous(self: *Self) ?*Waiter {
+        if (self.capacity != 0 or self.closed or self.rendezvous_baton) return null;
+
+        var receiver = self.receiver_queue.head;
+        while (receiver) |r| : (receiver = r.next) {
+            var sender = self.sender_queue.head;
+            while (sender) |s| : (sender = s.next) {
+                if (!sameSelect(Waiter.fromNode(r), Waiter.fromNode(s))) {
+                    return self.giveReceiverBaton(r);
+                }
+            }
+        }
+        return null;
     }
 
     fn receive(self: *Self, elem_ptr: [*]u8) !void {
@@ -211,9 +272,13 @@ const ChannelImpl = struct {
                     registered = true;
                     continue;
                 }
-                switch (impl.commit(ctx)) {
+                switch (impl.commit(waiter, ctx)) {
                     .done => |result| return result,
-                    .retry => continue,
+                    .pending => |pending| {
+                        registered = true;
+                        if (pending.notify) |notified| notified.signal();
+                        continue;
+                    },
                 }
             }
 
@@ -221,29 +286,40 @@ const ChannelImpl = struct {
                 var expected = absorbed;
                 const rollback_result = impl.rollback(waiter, ctx);
                 if (rollback_result == .signal_in_flight) expected += 1;
-                waiter.wait(expected, .no_cancel);
-                if (rollback_result == .signal_in_flight) {
-                    switch (impl.commit(ctx)) {
+                var notification_pending = rollback_result == .signal_in_flight;
+                while (notification_pending) {
+                    waiter.wait(expected, .no_cancel);
+                    switch (impl.commit(waiter, ctx)) {
                         .done => |result| {
                             if (waiter.mode.direct.task) |task| task.recancel();
                             return result;
                         },
-                        .retry => {},
+                        .pending => |pending| {
+                            if (pending.notify) |notified| notified.signal();
+                            const next_rollback = impl.rollback(waiter, ctx);
+                            if (next_rollback == .signal_in_flight) {
+                                expected += 1;
+                            } else {
+                                notification_pending = false;
+                            }
+                        },
                     }
                 }
                 return err;
             };
             absorbed = waiter.landedSignals();
             registered = false;
-            switch (impl.commit(ctx)) {
+            switch (impl.commit(waiter, ctx)) {
                 .done => |result| return result,
-                .retry => {},
+                .pending => |pending| {
+                    registered = true;
+                    if (pending.notify) |notified| notified.signal();
+                },
             }
         }
     }
 
     fn tryReceive(self: *Self, elem_ptr: [*]u8) !void {
-        var peer: ?*WaitNode = null;
         var to_signal: ?*WaitNode = null;
 
         self.mutex.lockUncancelable();
@@ -265,14 +341,18 @@ const ChannelImpl = struct {
             return;
         }
 
-        peer = claimPeer(&self.sender_queue, null);
-        if (peer) |node| {
-            const ctx = sendCtx(node);
-            @memcpy(elem_ptr[0..self.elem_size], ctx.item_ptr[0..self.elem_size]);
-            ctx.succeeded = true;
-            self.mutex.unlock();
-            Waiter.fromNode(node).signal();
-            return;
+        if (!self.rendezvous_baton) {
+            switch (choosePeer(&self.sender_queue, null)) {
+                .won => |node| {
+                    const ctx = sendCtx(node);
+                    @memcpy(elem_ptr[0..self.elem_size], ctx.item_ptr[0..self.elem_size]);
+                    ctx.succeeded = true;
+                    self.mutex.unlock();
+                    Waiter.fromNode(node).signal();
+                    return;
+                },
+                .busy, .none => {},
+            }
         }
         const closed = self.closed;
         self.mutex.unlock();
@@ -299,15 +379,21 @@ const ChannelImpl = struct {
             return;
         }
 
-        const peer = claimPeer(&self.receiver_queue, null) orelse {
-            self.mutex.unlock();
-            return error.WouldBlock;
-        };
-        const ctx = recvCtx(peer);
-        @memcpy(ctx.result_ptr[0..self.elem_size], elem_ptr[0..self.elem_size]);
-        ctx.result_set = true;
+        if (!self.rendezvous_baton) {
+            switch (choosePeer(&self.receiver_queue, null)) {
+                .won => |peer| {
+                    const ctx = recvCtx(peer);
+                    @memcpy(ctx.result_ptr[0..self.elem_size], elem_ptr[0..self.elem_size]);
+                    ctx.result_set = true;
+                    self.mutex.unlock();
+                    Waiter.fromNode(peer).signal();
+                    return;
+                },
+                .busy, .none => {},
+            }
+        }
         self.mutex.unlock();
-        Waiter.fromNode(peer).signal();
+        return error.WouldBlock;
     }
 
     fn close(self: *Self, mode: CloseMode) void {
@@ -341,41 +427,60 @@ const AsyncSendImpl = struct {
 
     pub const Context = struct {
         item_ptr: [*]const u8,
-        waiter: ?*Waiter = null,
         slot_reserved: bool = false,
         reservation_rolled_back: bool = false,
         succeeded: bool = false,
+        has_rendezvous_baton: bool = false,
     };
 
     pub fn prepare(self: *const SendSelf, waiter: *Waiter, ctx: *Context) Prepare {
         const ch = self.channel;
         ch.mutex.lockUncancelable();
-        defer ch.mutex.unlock();
-        ctx.waiter = waiter;
-        if (ctx.succeeded or ctx.slot_reserved or ch.closed) return .ready;
-        if (ch.capacity > 0) {
-            if (ch.capacity - ch.count > ch.reserved_slots) return .ready;
-        } else if (ChannelImpl.peerAvailable(&ch.receiver_queue, waiter)) {
+        waiter.node.userdata = @intFromPtr(ctx);
+        if (ctx.succeeded or ctx.slot_reserved or ch.closed) {
+            ch.mutex.unlock();
             return .ready;
         }
-        waiter.node.userdata = @intFromPtr(ctx);
+        if (ch.capacity > 0) {
+            if (ch.capacity - ch.count > ch.reserved_slots) {
+                ch.mutex.unlock();
+                return .ready;
+            }
+        } else if (!ch.rendezvous_baton) {
+            switch (ChannelImpl.probePeer(&ch.receiver_queue, waiter)) {
+                .won => {
+                    ch.mutex.unlock();
+                    return .ready;
+                },
+                .busy => |node| {
+                    ch.sender_queue.push(&waiter.node);
+                    const notify = ch.giveReceiverBaton(node);
+                    ch.mutex.unlock();
+                    notify.signal();
+                    return .pending;
+                },
+                .none => {},
+            }
+        }
         ch.sender_queue.push(&waiter.node);
+        ch.mutex.unlock();
         return .pending;
     }
 
-    pub fn commit(self: *const SendSelf, ctx: *Context) CommitResult(Closeable!void) {
+    pub fn commit(self: *const SendSelf, waiter: *Waiter, ctx: *Context) CommitResult(Closeable!void) {
         const ch = self.channel;
         var to_signal: ?*WaitNode = null;
-        var peer: ?*WaitNode = null;
+        var next_candidate: ?*Waiter = null;
 
         ch.mutex.lockUncancelable();
+        waiter.node.userdata = @intFromPtr(ctx);
+        if (ctx.has_rendezvous_baton) ch.clearSenderBaton(ctx);
         if (ctx.succeeded) {
             ch.mutex.unlock();
             return .{ .done = {} };
         }
         if (ctx.reservation_rolled_back) {
-            ch.mutex.unlock();
-            return .retry;
+            ctx.reservation_rolled_back = false;
         }
         if (ch.closed) {
             ctx.slot_reserved = false;
@@ -391,8 +496,9 @@ const AsyncSendImpl = struct {
                 ctx.slot_reserved = false;
             } else {
                 if (ch.capacity - ch.count <= ch.reserved_slots) {
+                    ch.sender_queue.push(&waiter.node);
                     ch.mutex.unlock();
-                    return .retry;
+                    return .{ .pending = .{} };
                 }
             }
             ch.appendItem(ctx.item_ptr);
@@ -402,26 +508,51 @@ const AsyncSendImpl = struct {
             return .{ .done = {} };
         }
 
-        peer = ChannelImpl.claimPeer(&ch.receiver_queue, ctx.waiter);
-        const node = peer orelse {
-            ch.mutex.unlock();
-            return .retry;
-        };
-        const rctx = ChannelImpl.recvCtx(node);
-        @memcpy(rctx.result_ptr[0..ch.elem_size], ctx.item_ptr[0..ch.elem_size]);
-        rctx.result_set = true;
+        if (!ch.rendezvous_baton) {
+            switch (ChannelImpl.choosePeer(&ch.receiver_queue, waiter)) {
+                .won => |node| {
+                    const rctx = ChannelImpl.recvCtx(node);
+                    @memcpy(rctx.result_ptr[0..ch.elem_size], ctx.item_ptr[0..ch.elem_size]);
+                    rctx.result_set = true;
+                    next_candidate = ch.scheduleRendezvous();
+                    ch.mutex.unlock();
+                    Waiter.fromNode(node).signal();
+                    if (next_candidate) |next| next.signal();
+                    return .{ .done = {} };
+                },
+                .busy => |node| {
+                    ch.sender_queue.push(&waiter.node);
+                    const notify = ch.giveReceiverBaton(node);
+                    ch.mutex.unlock();
+                    return .{ .pending = .{ .notify = notify } };
+                },
+                .none => {},
+            }
+        }
+
+        ch.sender_queue.push(&waiter.node);
         ch.mutex.unlock();
-        Waiter.fromNode(node).signal();
-        return .{ .done = {} };
+        return .{ .pending = .{} };
     }
 
     pub fn rollback(self: *const SendSelf, waiter: *Waiter, ctx: *Context) Rollback {
         const ch = self.channel;
         var to_signal: ?*WaitNode = null;
+        var next_candidate: ?*Waiter = null;
         ch.mutex.lockUncancelable();
         if (ch.sender_queue.remove(&waiter.node)) {
+            next_candidate = ch.scheduleRendezvous();
             ch.mutex.unlock();
+            if (next_candidate) |next| next.signal();
             return .removed;
+        }
+
+        if (ctx.has_rendezvous_baton) {
+            ch.clearSenderBaton(ctx);
+            next_candidate = ch.scheduleRendezvous();
+            ch.mutex.unlock();
+            if (next_candidate) |next| next.signal();
+            return .signal_in_flight;
         }
 
         if (ctx.slot_reserved) {
@@ -454,40 +585,63 @@ const AsyncReceiveImpl = struct {
 
     pub const Context = struct {
         result_ptr: [*]u8,
-        waiter: ?*Waiter = null,
         item_reserved: bool = false,
         reservation_rolled_back: bool = false,
         result_set: bool = false,
+        has_rendezvous_baton: bool = false,
     };
 
     pub fn prepare(self: *const RecvSelf, waiter: *Waiter, ctx: *Context) Prepare {
         const ch = self.channel;
         ch.mutex.lockUncancelable();
-        defer ch.mutex.unlock();
-        ctx.waiter = waiter;
-        if (ctx.result_set or ctx.item_reserved) return .ready;
-        if (ch.capacity > 0) {
-            if (ch.count > ch.reserved_items or (ch.closed and ch.count == 0)) return .ready;
-        } else {
-            if (ChannelImpl.peerAvailable(&ch.sender_queue, waiter) or ch.closed) return .ready;
-        }
         waiter.node.userdata = @intFromPtr(ctx);
+        if (ctx.result_set or ctx.item_reserved) {
+            ch.mutex.unlock();
+            return .ready;
+        }
+        if (ch.capacity > 0) {
+            if (ch.count > ch.reserved_items or (ch.closed and ch.count == 0)) {
+                ch.mutex.unlock();
+                return .ready;
+            }
+        } else if (ch.closed) {
+            ch.mutex.unlock();
+            return .ready;
+        } else if (!ch.rendezvous_baton) {
+            switch (ChannelImpl.probePeer(&ch.sender_queue, waiter)) {
+                .won => {
+                    ch.mutex.unlock();
+                    return .ready;
+                },
+                .busy => |node| {
+                    ch.receiver_queue.push(&waiter.node);
+                    const notify = ch.giveSenderBaton(node);
+                    ch.mutex.unlock();
+                    notify.signal();
+                    return .pending;
+                },
+                .none => {},
+            }
+        }
         ch.receiver_queue.push(&waiter.node);
+        ch.mutex.unlock();
         return .pending;
     }
 
-    pub fn commit(self: *const RecvSelf, ctx: *Context) CommitResult(Closeable!void) {
+    pub fn commit(self: *const RecvSelf, waiter: *Waiter, ctx: *Context) CommitResult(Closeable!void) {
         const ch = self.channel;
         var to_signal: ?*WaitNode = null;
+        var next_candidate: ?*Waiter = null;
 
         ch.mutex.lockUncancelable();
+        waiter.node.userdata = @intFromPtr(ctx);
+        if (ctx.has_rendezvous_baton) ch.clearReceiverBaton(ctx);
         if (ctx.result_set) {
             ch.mutex.unlock();
             return .{ .done = {} };
         }
         if (ctx.reservation_rolled_back) {
-            ch.mutex.unlock();
-            return .retry;
+            ctx.reservation_rolled_back = false;
         }
         if (ch.capacity > 0) {
             var can_take = false;
@@ -512,13 +666,26 @@ const AsyncReceiveImpl = struct {
                 if (to_signal) |node| Waiter.fromNode(node).signal();
                 return .{ .done = {} };
             }
-        } else if (ChannelImpl.claimPeer(&ch.sender_queue, ctx.waiter)) |node| {
-            const sctx = ChannelImpl.sendCtx(node);
-            @memcpy(ctx.result_ptr[0..ch.elem_size], sctx.item_ptr[0..ch.elem_size]);
-            sctx.succeeded = true;
-            ch.mutex.unlock();
-            Waiter.fromNode(node).signal();
-            return .{ .done = {} };
+        } else if (!ch.rendezvous_baton) {
+            switch (ChannelImpl.choosePeer(&ch.sender_queue, waiter)) {
+                .won => |node| {
+                    const sctx = ChannelImpl.sendCtx(node);
+                    @memcpy(ctx.result_ptr[0..ch.elem_size], sctx.item_ptr[0..ch.elem_size]);
+                    sctx.succeeded = true;
+                    next_candidate = ch.scheduleRendezvous();
+                    ch.mutex.unlock();
+                    Waiter.fromNode(node).signal();
+                    if (next_candidate) |next| next.signal();
+                    return .{ .done = {} };
+                },
+                .busy => |node| {
+                    ch.receiver_queue.push(&waiter.node);
+                    const notify = ch.giveSenderBaton(node);
+                    ch.mutex.unlock();
+                    return .{ .pending = .{ .notify = notify } };
+                },
+                .none => {},
+            }
         }
         if (ch.closed) {
             to_signal = ch.receiver_queue.pop();
@@ -526,17 +693,29 @@ const AsyncReceiveImpl = struct {
             if (to_signal) |node| Waiter.fromNode(node).signal();
             return .{ .done = error.Closed };
         }
+        ch.receiver_queue.push(&waiter.node);
         ch.mutex.unlock();
-        return .retry;
+        return .{ .pending = .{} };
     }
 
     pub fn rollback(self: *const RecvSelf, waiter: *Waiter, ctx: *Context) Rollback {
         const ch = self.channel;
         var to_signal: ?*WaitNode = null;
+        var next_candidate: ?*Waiter = null;
         ch.mutex.lockUncancelable();
         if (ch.receiver_queue.remove(&waiter.node)) {
+            next_candidate = ch.scheduleRendezvous();
             ch.mutex.unlock();
+            if (next_candidate) |next| next.signal();
             return .removed;
+        }
+
+        if (ctx.has_rendezvous_baton) {
+            ch.clearReceiverBaton(ctx);
+            next_candidate = ch.scheduleRendezvous();
+            ch.mutex.unlock();
+            if (next_candidate) |next| next.signal();
+            return .signal_in_flight;
         }
 
         if (ctx.item_reserved) {
@@ -763,10 +942,10 @@ pub fn AsyncReceive(comptime T: type) type {
                 return self.impl.prepare(waiter, &ctx.impl_ctx);
             }
 
-            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
+            pub fn commit(self: *const Self, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
                 ctx.impl_ctx.result_ptr = std.mem.asBytes(&ctx.result).ptr;
-                return switch (self.impl.commit(&ctx.impl_ctx)) {
-                    .retry => .retry,
+                return switch (self.impl.commit(waiter, &ctx.impl_ctx)) {
+                    .pending => |pending| .{ .pending = pending },
                     .done => |result| if (result) |_| .{ .done = ctx.result } else |err| .{ .done = err },
                 };
             }
@@ -819,8 +998,8 @@ pub fn AsyncSend(comptime T: type) type {
                 return self.impl.prepare(waiter, &ctx.impl_ctx);
             }
 
-            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
-                return self.impl.commit(&ctx.impl_ctx);
+            pub fn commit(self: *const Self, waiter: *Waiter, ctx: *Context) CommitResult(Result) {
+                return self.impl.commit(waiter, &ctx.impl_ctx);
             }
 
             pub fn rollback(self: *const Self, waiter: *Waiter, ctx: *Context) Rollback {
@@ -1813,9 +1992,9 @@ test "Channel: close dequeues registrations before signaling" {
 
     try std.testing.expect(channel.impl.receiver_queue.isEmpty());
     try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u32).AsyncWait.rollback(&receive, &receive_waiter, &receive_ctx));
-    switch (AsyncReceive(u32).AsyncWait.commit(&receive, &receive_ctx)) {
+    switch (AsyncReceive(u32).AsyncWait.commit(&receive, &receive_waiter, &receive_ctx)) {
         .done => |result| try std.testing.expectError(error.Closed, result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
 }
 
@@ -1846,13 +2025,9 @@ test "Channel: losing buffered receiver hands its item reservation to one waiter
     try std.testing.expect(second_ctx.impl_ctx.item_reserved);
     try std.testing.expectEqual(1, channel.impl.reserved_items);
 
-    switch (AsyncReceive(u32).AsyncWait.commit(&first, &first_ctx)) {
-        .retry => {},
-        .done => return error.TestUnexpectedResult,
-    }
-    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_waiter, &second_ctx)) {
         .done => |result| try std.testing.expectEqual(7, try result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
     try std.testing.expectEqual(0, channel.impl.reserved_items);
     try std.testing.expect(channel.impl.receiver_queue.isEmpty());
@@ -1887,13 +2062,9 @@ test "Channel: losing buffered sender hands its slot reservation to one waiter" 
     try std.testing.expect(second_ctx.impl_ctx.slot_reserved);
     try std.testing.expectEqual(1, channel.impl.reserved_slots);
 
-    switch (AsyncSend(u32).AsyncWait.commit(&first, &first_ctx)) {
-        .retry => {},
-        .done => return error.TestUnexpectedResult,
-    }
-    switch (AsyncSend(u32).AsyncWait.commit(&second, &second_ctx)) {
+    switch (AsyncSend(u32).AsyncWait.commit(&second, &second_waiter, &second_ctx)) {
         .done => |result| try result,
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
     try std.testing.expectEqual(0, channel.impl.reserved_slots);
     try std.testing.expectEqual(3, try channel.tryReceive());
@@ -1921,9 +2092,9 @@ test "Channel: close notification is handed off instead of broadcast" {
 
     try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u32).AsyncWait.rollback(&first, &first_waiter, &first_ctx));
     second_waiter.wait(1, .no_cancel);
-    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_waiter, &second_ctx)) {
         .done => |result| try std.testing.expectError(error.Closed, result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
     try std.testing.expect(channel.impl.receiver_queue.isEmpty());
 }
@@ -1945,15 +2116,15 @@ test "Channel: graceful close drains a reserved item before handing off close" {
 
     channel.close(.graceful);
     try std.testing.expect(!channel.impl.receiver_queue.isEmpty());
-    switch (AsyncReceive(u32).AsyncWait.commit(&first, &first_ctx)) {
+    switch (AsyncReceive(u32).AsyncWait.commit(&first, &first_waiter, &first_ctx)) {
         .done => |result| try std.testing.expectEqual(7, try result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
 
     second_waiter.wait(1, .no_cancel);
-    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_waiter, &second_ctx)) {
         .done => |result| try std.testing.expectError(error.Closed, result),
-        .retry => return error.TestUnexpectedResult,
+        .pending => return error.TestUnexpectedResult,
     }
     try std.testing.expect(channel.impl.receiver_queue.isEmpty());
     try std.testing.expectEqual(0, channel.impl.reserved_items);
@@ -2075,9 +2246,6 @@ test "Channel: unbuffered select send rendezvous with select receive" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var channel = Channel(u64).init(&.{});
-    var never = ResetEvent.init;
-
     const Tasks = struct {
         fn send(ch: *Channel(u64), other: *ResetEvent) !void {
             var operation = ch.asyncSend(42);
@@ -2098,12 +2266,144 @@ test "Channel: unbuffered select send rendezvous with select receive" {
         }
     };
 
-    var sender = try runtime.spawn(Tasks.send, .{ &channel, &never });
-    var receiver = try runtime.spawn(Tasks.receive, .{ &channel, &never });
-    try std.testing.expectEqual(42, try receiver.join());
-    try sender.join();
+    for (0..200) |_| {
+        var channel = Channel(u64).init(&.{});
+        var never = ResetEvent.init;
+        var sender = try runtime.spawn(Tasks.send, .{ &channel, &never });
+        var receiver = try runtime.spawn(Tasks.receive, .{ &channel, &never });
+        try std.testing.expectEqual(42, try receiver.join());
+        try sender.join();
+        try std.testing.expect(!channel.impl.rendezvous_baton);
+        try std.testing.expect(channel.impl.sender_queue.isEmpty());
+        try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+    }
+}
+
+test "Channel: busy rendezvous parks before its deferred notification" {
+    const committing = std.math.maxInt(usize) - 1;
+
+    var channel = Channel(u64).init(&.{});
+    var receive = channel.asyncReceive();
+    var receive_ctx: AsyncReceive(u64).AsyncWait.Context = .{};
+    var receive_parent = Waiter.init();
+    var receive_winner: std.atomic.Value(usize) = .init(NO_WINNER);
+    var receive_waiter = Waiter.initSelect(&receive_parent, &receive_winner, 0);
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u64).AsyncWait.prepare(&receive, &receive_waiter, &receive_ctx));
+
+    // The sender's prepare observed an open receiver, but the receiver's
+    // select began committing another arm before the sender reached commit.
+    var send = channel.asyncSend(42);
+    var send_ctx: AsyncSend(u64).AsyncWait.Context = .{};
+    var send_parent = Waiter.init();
+    var send_winner: std.atomic.Value(usize) = .init(NO_WINNER);
+    var send_waiter = Waiter.initSelect(&send_parent, &send_winner, 0);
+    try std.testing.expectEqual(Prepare.ready, AsyncSend(u64).AsyncWait.prepare(&send, &send_waiter, &send_ctx));
+
+    receive_winner.store(committing, .release);
+    send_winner.store(committing, .release);
+    const notify = switch (AsyncSend(u64).AsyncWait.commit(&send, &send_waiter, &send_ctx)) {
+        .pending => |pending| pending.notify orelse return error.TestUnexpectedResult,
+        .done => return error.TestUnexpectedResult,
+    };
+
+    // Commit only installed the sender and returned the baton notification;
+    // it did not reach into the select's COMMITTING state.
+    try std.testing.expectEqual(committing, send_winner.load(.acquire));
+    try std.testing.expectEqual(@as(u32, 0), receive_parent.landedSignals());
+    try std.testing.expect(channel.impl.rendezvous_baton);
+
+    // This is the select driver's pending publication order.
+    send_winner.store(NO_WINNER, .release);
+    notify.signal();
+    receive_parent.wait(1, .no_cancel);
+
+    switch (AsyncReceive(u64).AsyncWait.commit(&receive, &receive_waiter, &receive_ctx)) {
+        .done => |result| try std.testing.expectEqual(42, try result),
+        .pending => return error.TestUnexpectedResult,
+    }
+    receive_winner.store(0, .release);
+
+    send_parent.wait(1, .no_cancel);
+    try std.testing.expectEqual(@as(usize, 0), send_winner.load(.acquire));
+    switch (AsyncSend(u64).AsyncWait.commit(&send, &send_waiter, &send_ctx)) {
+        .done => |result| try result,
+        .pending => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(!channel.impl.rendezvous_baton);
     try std.testing.expect(channel.impl.sender_queue.isEmpty());
     try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+}
+
+test "Channel: losing busy receiver passes one rendezvous baton" {
+    const committing = std.math.maxInt(usize) - 1;
+
+    var channel = Channel(u64).init(&.{});
+    var first = channel.asyncReceive();
+    var second = channel.asyncReceive();
+    var first_ctx: AsyncReceive(u64).AsyncWait.Context = .{};
+    var second_ctx: AsyncReceive(u64).AsyncWait.Context = .{};
+    var first_parent = Waiter.init();
+    var second_parent = Waiter.init();
+    var first_winner: std.atomic.Value(usize) = .init(NO_WINNER);
+    var second_winner: std.atomic.Value(usize) = .init(NO_WINNER);
+    var first_waiter = Waiter.initSelect(&first_parent, &first_winner, 0);
+    var second_waiter = Waiter.initSelect(&second_parent, &second_winner, 0);
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u64).AsyncWait.prepare(&first, &first_waiter, &first_ctx));
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u64).AsyncWait.prepare(&second, &second_waiter, &second_ctx));
+    first_winner.store(committing, .release);
+    second_winner.store(committing, .release);
+
+    var send = channel.asyncSend(7);
+    var send_ctx: AsyncSend(u64).AsyncWait.Context = .{};
+    var send_waiter = Waiter.init();
+    try std.testing.expectEqual(Prepare.pending, AsyncSend(u64).AsyncWait.prepare(&send, &send_waiter, &send_ctx));
+    first_parent.wait(1, .no_cancel);
+    try std.testing.expectEqual(@as(u32, 0), second_parent.landedSignals());
+
+    // The first receiver chose another arm. Its rollback passes the durable
+    // sender offer to exactly one receiver.
+    first_winner.store(1, .release);
+    try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u64).AsyncWait.rollback(&first, &first_waiter, &first_ctx));
+    second_parent.wait(1, .no_cancel);
+    try std.testing.expectEqual(@as(u32, 1), first_parent.landedSignals());
+    try std.testing.expectEqual(@as(u32, 1), second_parent.landedSignals());
+
+    second_winner.store(committing, .release);
+    switch (AsyncReceive(u64).AsyncWait.commit(&second, &second_waiter, &second_ctx)) {
+        .done => |result| try std.testing.expectEqual(7, try result),
+        .pending => return error.TestUnexpectedResult,
+    }
+    send_waiter.wait(1, .no_cancel);
+    switch (AsyncSend(u64).AsyncWait.commit(&send, &send_waiter, &send_ctx)) {
+        .done => |result| try result,
+        .pending => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expect(!channel.impl.rendezvous_baton);
+    try std.testing.expect(channel.impl.sender_queue.isEmpty());
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+}
+
+test "Channel: trySend does not nudge a busy rendezvous receiver" {
+    const committing = std.math.maxInt(usize) - 1;
+
+    var channel = Channel(u64).init(&.{});
+    var receive = channel.asyncReceive();
+    var receive_ctx: AsyncReceive(u64).AsyncWait.Context = .{};
+    var parent = Waiter.init();
+    var winner: std.atomic.Value(usize) = .init(NO_WINNER);
+    var waiter = Waiter.initSelect(&parent, &winner, 0);
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u64).AsyncWait.prepare(&receive, &waiter, &receive_ctx));
+
+    winner.store(committing, .release);
+    try std.testing.expectError(error.WouldBlock, channel.trySend(1));
+    try std.testing.expectEqual(@as(u32, 0), parent.landedSignals());
+    try std.testing.expect(!channel.impl.rendezvous_baton);
+    try std.testing.expect(!channel.impl.receiver_queue.isEmpty());
+
+    try std.testing.expectEqual(Rollback.removed, AsyncReceive(u64).AsyncWait.rollback(&receive, &waiter, &receive_ctx));
 }
 
 test "Channel: cancel removes a parked select send" {

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -250,8 +250,9 @@ const ChannelImpl = struct {
         if (self.capacity > 0) {
             if (self.count <= self.reserved_items) {
                 const closed = self.closed;
+                const drained = self.count == 0;
                 self.mutex.unlock();
-                return if (closed and self.count == 0) error.Closed else error.WouldBlock;
+                return if (closed and drained) error.Closed else error.WouldBlock;
             }
             self.takeItem(elem_ptr);
             if (self.closed) {

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -6,14 +6,19 @@ const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
 const Group = @import("../group.zig").Group;
 const SimpleQueue = @import("../utils/simple_queue.zig").SimpleQueue;
-const SimpleStack = @import("../utils/simple_stack.zig").SimpleStack;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const select = @import("../select.zig").select;
+const Prepare = @import("../select.zig").Prepare;
+const CommitResult = @import("../select.zig").CommitResult;
+const Rollback = @import("../select.zig").Rollback;
+const claimArm = @import("../select.zig").claimArm;
+const peekArm = @import("../select.zig").peekArm;
 const common = @import("../common.zig");
 const Waiter = common.Waiter;
+const Cancelable = common.Cancelable;
 const Closeable = common.Closeable;
-const NO_WINNER = common.NO_WINNER;
 const Mutex = @import("Mutex.zig");
+const ResetEvent = @import("ResetEvent.zig");
 
 /// Specifies how a channel should be closed.
 pub const CloseMode = enum {
@@ -23,8 +28,12 @@ pub const CloseMode = enum {
     immediate,
 };
 
-/// Type-erased channel implementation that operates on raw bytes.
-/// This is the core implementation shared by all Channel(T) instances to reduce code size.
+/// Type-erased channel implementation. Preparation only observes readiness or
+/// queues a waiter; all transfers happen under the mutex in commit. Each new
+/// buffered item or slot is reserved for at most one queued waiter. A losing
+/// notified arm hands that reservation to the next waiter in rollback.
+/// Rendezvous readiness remains optimistic: commit claims the parked peer's
+/// select before copying its resident value.
 const ChannelImpl = struct {
     buffer: [*]u8,
     elem_size: usize,
@@ -32,6 +41,8 @@ const ChannelImpl = struct {
     head: usize = 0,
     tail: usize = 0,
     count: usize = 0,
+    reserved_items: usize = 0,
+    reserved_slots: usize = 0,
 
     mutex: Mutex = .init,
     receiver_queue: SimpleQueue(WaitNode) = .empty,
@@ -50,167 +61,274 @@ const ChannelImpl = struct {
     fn isEmpty(self: *Self) bool {
         self.mutex.lockUncancelable();
         defer self.mutex.unlock();
-        return self.count == 0;
+        return self.count <= self.reserved_items;
     }
 
     /// Checks if the channel is full.
     fn isFull(self: *Self) bool {
         self.mutex.lockUncancelable();
         defer self.mutex.unlock();
-        return self.count == self.capacity;
+        return self.capacity - self.count <= self.reserved_slots;
     }
 
-    /// Receives a value from the channel, blocking if empty.
-    fn receive(self: *Self, elem_ptr: [*]u8) !void {
-        const recv = AsyncReceiveImpl{ .channel = self };
-        var ctx: AsyncReceiveImpl.WaitContext = .{ .result_ptr = undefined };
-        var waiter = Waiter.init();
+    fn recvCtx(node: *WaitNode) *AsyncReceiveImpl.Context {
+        return @ptrFromInt(node.userdata);
+    }
 
-        if (!recv.asyncWait(&waiter, &ctx, elem_ptr)) {
-            return recv.getResult(&ctx);
-        }
+    fn sendCtx(node: *WaitNode) *AsyncSendImpl.Context {
+        return @ptrFromInt(node.userdata);
+    }
 
-        waiter.wait(1, .allow_cancel) catch |err| {
-            const was_removed = recv.asyncCancelWait(&waiter, &ctx);
-            if (!was_removed) {
-                waiter.wait(1, .no_cancel);
-                return recv.getResult(&ctx);
-            }
-            return err;
+    /// Two arms of one select cannot rendezvous with each other: only one arm
+    /// may be returned, so matching them would perform a transfer without a
+    /// second participant. Leave such peers queued for an outside operation.
+    fn sameSelect(a: *Waiter, b: *Waiter) bool {
+        return switch (a.mode) {
+            .direct => false,
+            .select => |a_select| switch (b.mode) {
+                .direct => false,
+                .select => |b_select| a_select.winner == b_select.winner,
+            },
         };
-
-        return recv.getResult(&ctx);
     }
 
-    /// Tries to receive a value without blocking.
-    fn tryReceive(self: *Self, elem_ptr: [*]u8) !void {
-        self.mutex.lockUncancelable();
-
-        if (self.count > 0) {
-            return self.takeItemAndWakeSender(elem_ptr);
-        }
-
-        while (self.sender_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const send_ctx: *AsyncSendImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(elem_ptr[0..self.elem_size], send_ctx.item_ptr[0..self.elem_size]);
-                send_ctx.succeeded = true;
-                self.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return;
-            }
-        }
-
-        const is_closed = self.closed;
-        self.mutex.unlock();
-        return if (is_closed) error.Closed else error.WouldBlock;
-    }
-
-    fn takeItemAndWakeSender(self: *Self, elem_ptr: [*]u8) void {
+    fn takeItem(self: *Self, dest: [*]u8) void {
         std.debug.assert(self.count > 0);
-
-        @memcpy(elem_ptr[0..self.elem_size], self.elemPtr(self.head)[0..self.elem_size]);
+        @memcpy(dest[0..self.elem_size], self.elemPtr(self.head)[0..self.elem_size]);
         self.head = (self.head + 1) % self.capacity;
         self.count -= 1;
+    }
 
-        while (self.sender_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const send_ctx: *AsyncSendImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(self.elemPtr(self.tail)[0..self.elem_size], send_ctx.item_ptr[0..self.elem_size]);
-                self.tail = (self.tail + 1) % self.capacity;
-                self.count += 1;
-                send_ctx.succeeded = true;
-                self.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return;
+    fn appendItem(self: *Self, src: [*]const u8) void {
+        std.debug.assert(self.count < self.capacity);
+        @memcpy(self.elemPtr(self.tail)[0..self.elem_size], src[0..self.elem_size]);
+        self.tail = (self.tail + 1) % self.capacity;
+        self.count += 1;
+    }
+
+    /// Reserve one buffered item for the oldest queued receiver. Must be
+    /// called under the channel mutex; the returned waiter is signaled after
+    /// unlocking.
+    fn reserveReceiver(self: *Self) ?*WaitNode {
+        const node = self.receiver_queue.pop() orelse return null;
+        const ctx = recvCtx(node);
+        std.debug.assert(!ctx.item_reserved);
+        ctx.item_reserved = true;
+        self.reserved_items += 1;
+        std.debug.assert(self.reserved_items <= self.count);
+        return node;
+    }
+
+    /// Reserve one buffered slot for the oldest queued sender. Must be called
+    /// under the channel mutex; the returned waiter is signaled after
+    /// unlocking.
+    fn reserveSender(self: *Self) ?*WaitNode {
+        const node = self.sender_queue.pop() orelse return null;
+        const ctx = sendCtx(node);
+        std.debug.assert(!ctx.slot_reserved);
+        ctx.slot_reserved = true;
+        self.reserved_slots += 1;
+        std.debug.assert(self.reserved_slots <= self.capacity - self.count);
+        return node;
+    }
+
+    /// Under the mutex, find a peer whose select can be decided. A peer whose
+    /// select is currently committing another arm is dequeued and nudged; an
+    /// already-decided peer stays queued for its owner's rollback.
+    fn claimPeer(queue: *SimpleQueue(WaitNode), requester: ?*Waiter) ?*WaitNode {
+        var node = queue.head;
+        while (node) |n| {
+            const next = n.next;
+            if (requester) |r| {
+                if (sameSelect(r, Waiter.fromNode(n))) {
+                    node = next;
+                    continue;
+                }
             }
+            switch (claimArm(Waiter.fromNode(n))) {
+                .won => {
+                    const removed = queue.remove(n);
+                    std.debug.assert(removed);
+                    return n;
+                },
+                .busy => {
+                    const removed = queue.remove(n);
+                    std.debug.assert(removed);
+                    Waiter.fromNode(n).signal();
+                },
+                .lost => {},
+            }
+            node = next;
         }
+        return null;
+    }
 
-        self.mutex.unlock();
+    /// Non-consuming readiness probe for a rendezvous peer. Busy peers are
+    /// nudged so they re-offer after their current select commit settles.
+    fn peerAvailable(queue: *SimpleQueue(WaitNode), requester: *Waiter) bool {
+        var node = queue.head;
+        while (node) |n| {
+            const next = n.next;
+            if (sameSelect(requester, Waiter.fromNode(n))) {
+                node = next;
+                continue;
+            }
+            switch (peekArm(Waiter.fromNode(n))) {
+                .won => return true,
+                .busy => {
+                    const removed = queue.remove(n);
+                    std.debug.assert(removed);
+                    Waiter.fromNode(n).signal();
+                },
+                .lost => {},
+            }
+            node = next;
+        }
+        return false;
+    }
+
+    fn receive(self: *Self, elem_ptr: [*]u8) !void {
+        const recv = AsyncReceiveImpl{ .channel = self };
+        var ctx: AsyncReceiveImpl.Context = .{ .result_ptr = elem_ptr };
+        var waiter = Waiter.init();
+        return blockingLoop(AsyncReceiveImpl, &recv, &waiter, &ctx);
     }
 
     fn send(self: *Self, elem_ptr: [*]const u8) !void {
         const send_op = AsyncSendImpl{ .channel = self };
-        var ctx: AsyncSendImpl.WaitContext = .{ .item_ptr = undefined };
+        var ctx: AsyncSendImpl.Context = .{ .item_ptr = elem_ptr };
         var waiter = Waiter.init();
+        return blockingLoop(AsyncSendImpl, &send_op, &waiter, &ctx);
+    }
 
-        if (!send_op.asyncWait(&waiter, &ctx, elem_ptr)) {
-            return send_op.getResult(&ctx);
+    fn blockingLoop(comptime Impl: type, impl: *const Impl, waiter: *Waiter, ctx: *Impl.Context) (Cancelable || Closeable)!void {
+        var registered = false;
+        var absorbed: u32 = 0;
+
+        while (true) {
+            if (!registered) {
+                if (impl.prepare(waiter, ctx) == .pending) {
+                    registered = true;
+                    continue;
+                }
+                switch (impl.commit(ctx)) {
+                    .done => |result| return result,
+                    .retry => continue,
+                }
+            }
+
+            waiter.wait(absorbed + 1, .allow_cancel) catch |err| {
+                var expected = absorbed;
+                const rollback_result = impl.rollback(waiter, ctx);
+                if (rollback_result == .signal_in_flight) expected += 1;
+                waiter.wait(expected, .no_cancel);
+                if (rollback_result == .signal_in_flight) {
+                    switch (impl.commit(ctx)) {
+                        .done => |result| {
+                            if (waiter.mode.direct.task) |task| task.recancel();
+                            return result;
+                        },
+                        .retry => {},
+                    }
+                }
+                return err;
+            };
+            absorbed = waiter.landedSignals();
+            registered = false;
+            switch (impl.commit(ctx)) {
+                .done => |result| return result,
+                .retry => {},
+            }
+        }
+    }
+
+    fn tryReceive(self: *Self, elem_ptr: [*]u8) !void {
+        var peer: ?*WaitNode = null;
+        var to_signal: ?*WaitNode = null;
+
+        self.mutex.lockUncancelable();
+        if (self.capacity > 0) {
+            if (self.count <= self.reserved_items) {
+                const closed = self.closed;
+                self.mutex.unlock();
+                return if (closed and self.count == 0) error.Closed else error.WouldBlock;
+            }
+            self.takeItem(elem_ptr);
+            if (self.closed) {
+                if (self.count == 0) to_signal = self.receiver_queue.pop();
+            } else {
+                to_signal = self.reserveSender();
+            }
+            self.mutex.unlock();
+            if (to_signal) |node| Waiter.fromNode(node).signal();
+            return;
         }
 
-        waiter.wait(1, .allow_cancel) catch |err| {
-            const was_removed = send_op.asyncCancelWait(&waiter, &ctx);
-            if (!was_removed) {
-                waiter.wait(1, .no_cancel);
-                return send_op.getResult(&ctx);
-            }
-            return err;
-        };
-
-        return send_op.getResult(&ctx);
+        peer = claimPeer(&self.sender_queue, null);
+        if (peer) |node| {
+            const ctx = sendCtx(node);
+            @memcpy(elem_ptr[0..self.elem_size], ctx.item_ptr[0..self.elem_size]);
+            ctx.succeeded = true;
+            self.mutex.unlock();
+            Waiter.fromNode(node).signal();
+            return;
+        }
+        const closed = self.closed;
+        self.mutex.unlock();
+        return if (closed) error.Closed else error.WouldBlock;
     }
 
     fn trySend(self: *Self, elem_ptr: [*]const u8) !void {
-        self.mutex.lockUncancelable();
+        var to_signal: ?*WaitNode = null;
 
+        self.mutex.lockUncancelable();
         if (self.closed) {
             self.mutex.unlock();
             return error.Closed;
         }
-
-        while (self.receiver_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const recv_ctx: *AsyncReceiveImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(recv_ctx.result_ptr[0..self.elem_size], elem_ptr[0..self.elem_size]);
-                recv_ctx.result_set = true;
+        if (self.capacity > 0) {
+            if (self.capacity - self.count <= self.reserved_slots) {
                 self.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return;
+                return error.WouldBlock;
             }
+            self.appendItem(elem_ptr);
+            to_signal = self.reserveReceiver();
+            self.mutex.unlock();
+            if (to_signal) |node| Waiter.fromNode(node).signal();
+            return;
         }
 
-        if (self.count == self.capacity) {
+        const peer = claimPeer(&self.receiver_queue, null) orelse {
             self.mutex.unlock();
             return error.WouldBlock;
-        }
-
-        @memcpy(self.elemPtr(self.tail)[0..self.elem_size], elem_ptr[0..self.elem_size]);
-        self.tail = (self.tail + 1) % self.capacity;
-        self.count += 1;
+        };
+        const ctx = recvCtx(peer);
+        @memcpy(ctx.result_ptr[0..self.elem_size], elem_ptr[0..self.elem_size]);
+        ctx.result_set = true;
         self.mutex.unlock();
+        Waiter.fromNode(peer).signal();
     }
 
     fn close(self: *Self, mode: CloseMode) void {
         self.mutex.lockUncancelable();
-
+        const was_closed = self.closed;
         self.closed = true;
-
         if (mode == .immediate) {
             self.head = 0;
             self.tail = 0;
             self.count = 0;
+            // Outstanding receiver reservations become close notifications.
+            self.reserved_items = 0;
         }
-
-        // Classify every waiter before unlocking; see Waiter.tryClaim().
-        var to_signal: SimpleStack(WaitNode) = .{};
-
-        while (self.receiver_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                to_signal.push(node);
-            }
-        }
-
-        while (self.sender_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                to_signal.push(node);
-            }
-        }
-
+        // No reserved sender may append after close. Their notifications turn
+        // into close notifications when they arrive.
+        self.reserved_slots = 0;
+        const receiver = if (!was_closed and self.count == 0) self.receiver_queue.pop() else null;
+        const sender = if (!was_closed) self.sender_queue.pop() else null;
         self.mutex.unlock();
 
-        while (to_signal.pop()) |node| {
-            Waiter.fromNode(node).signal();
-        }
+        if (receiver) |node| Waiter.fromNode(node).signal();
+        if (sender) |node| Waiter.fromNode(node).signal();
     }
 };
 
@@ -220,67 +338,110 @@ const AsyncSendImpl = struct {
 
     const SendSelf = @This();
 
-    pub const WaitContext = struct {
+    pub const Context = struct {
         item_ptr: [*]const u8,
+        waiter: ?*Waiter = null,
+        slot_reserved: bool = false,
+        reservation_rolled_back: bool = false,
         succeeded: bool = false,
     };
 
-    pub fn asyncWait(self: *const SendSelf, waiter: *Waiter, ctx: *WaitContext, item_ptr: [*]const u8) bool {
-        ctx.item_ptr = item_ptr;
-
-        self.channel.mutex.lockUncancelable();
-
-        if (self.channel.closed) {
-            self.channel.mutex.unlock();
-            return false;
+    pub fn prepare(self: *const SendSelf, waiter: *Waiter, ctx: *Context) Prepare {
+        const ch = self.channel;
+        ch.mutex.lockUncancelable();
+        defer ch.mutex.unlock();
+        ctx.waiter = waiter;
+        if (ctx.succeeded or ctx.slot_reserved or ch.closed) return .ready;
+        if (ch.capacity > 0) {
+            if (ch.capacity - ch.count > ch.reserved_slots) return .ready;
+        } else if (ChannelImpl.peerAvailable(&ch.receiver_queue, waiter)) {
+            return .ready;
         }
-
-        while (self.channel.receiver_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const recv_ctx: *AsyncReceiveImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(recv_ctx.result_ptr[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
-                recv_ctx.result_set = true;
-                ctx.succeeded = true;
-                self.channel.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return false;
-            }
-        }
-
-        if (self.channel.count < self.channel.capacity) {
-            @memcpy(self.channel.elemPtr(self.channel.tail)[0..self.channel.elem_size], ctx.item_ptr[0..self.channel.elem_size]);
-            self.channel.tail = (self.channel.tail + 1) % self.channel.capacity;
-            self.channel.count += 1;
-            ctx.succeeded = true;
-            self.channel.mutex.unlock();
-            return false;
-        }
-
         waiter.node.userdata = @intFromPtr(ctx);
-        self.channel.sender_queue.push(&waiter.node);
-        self.channel.mutex.unlock();
-        return true;
+        ch.sender_queue.push(&waiter.node);
+        return .pending;
     }
 
-    pub fn asyncCancelWait(self: *const SendSelf, waiter: *Waiter, ctx: *WaitContext) bool {
-        _ = ctx;
-        self.channel.mutex.lockUncancelable();
-        const was_in_queue = self.channel.sender_queue.remove(&waiter.node);
-        self.channel.mutex.unlock();
+    pub fn commit(self: *const SendSelf, ctx: *Context) CommitResult(Closeable!void) {
+        const ch = self.channel;
+        var to_signal: ?*WaitNode = null;
+        var peer: ?*WaitNode = null;
 
-        if (was_in_queue) {
-            return true;
-        }
-
-        return !waiter.didWin();
-    }
-
-    pub fn getResult(self: *const SendSelf, ctx: *WaitContext) Closeable!void {
+        ch.mutex.lockUncancelable();
         if (ctx.succeeded) {
-            return {};
+            ch.mutex.unlock();
+            return .{ .done = {} };
         }
-        std.debug.assert(self.channel.closed);
-        return error.Closed;
+        if (ctx.reservation_rolled_back) {
+            ch.mutex.unlock();
+            return .retry;
+        }
+        if (ch.closed) {
+            ctx.slot_reserved = false;
+            to_signal = ch.sender_queue.pop();
+            ch.mutex.unlock();
+            if (to_signal) |node| Waiter.fromNode(node).signal();
+            return .{ .done = error.Closed };
+        }
+        if (ch.capacity > 0) {
+            if (ctx.slot_reserved) {
+                std.debug.assert(ch.reserved_slots > 0);
+                ch.reserved_slots -= 1;
+                ctx.slot_reserved = false;
+            } else {
+                if (ch.capacity - ch.count <= ch.reserved_slots) {
+                    ch.mutex.unlock();
+                    return .retry;
+                }
+            }
+            ch.appendItem(ctx.item_ptr);
+            to_signal = ch.reserveReceiver();
+            ch.mutex.unlock();
+            if (to_signal) |node| Waiter.fromNode(node).signal();
+            return .{ .done = {} };
+        }
+
+        peer = ChannelImpl.claimPeer(&ch.receiver_queue, ctx.waiter);
+        const node = peer orelse {
+            ch.mutex.unlock();
+            return .retry;
+        };
+        const rctx = ChannelImpl.recvCtx(node);
+        @memcpy(rctx.result_ptr[0..ch.elem_size], ctx.item_ptr[0..ch.elem_size]);
+        rctx.result_set = true;
+        ch.mutex.unlock();
+        Waiter.fromNode(node).signal();
+        return .{ .done = {} };
+    }
+
+    pub fn rollback(self: *const SendSelf, waiter: *Waiter, ctx: *Context) Rollback {
+        const ch = self.channel;
+        var to_signal: ?*WaitNode = null;
+        ch.mutex.lockUncancelable();
+        if (ch.sender_queue.remove(&waiter.node)) {
+            ch.mutex.unlock();
+            return .removed;
+        }
+
+        if (ctx.slot_reserved) {
+            ctx.slot_reserved = false;
+            ctx.reservation_rolled_back = true;
+            if (ch.reserved_slots > 0) {
+                if (ch.sender_queue.pop()) |node| {
+                    ChannelImpl.sendCtx(node).slot_reserved = true;
+                    to_signal = node;
+                } else {
+                    ch.reserved_slots -= 1;
+                }
+            } else if (ch.closed) {
+                to_signal = ch.sender_queue.pop();
+            }
+        } else if (ch.closed) {
+            to_signal = ch.sender_queue.pop();
+        }
+        ch.mutex.unlock();
+        if (to_signal) |node| Waiter.fromNode(node).signal();
+        return .signal_in_flight;
     }
 };
 
@@ -290,76 +451,112 @@ const AsyncReceiveImpl = struct {
 
     const RecvSelf = @This();
 
-    pub const WaitContext = struct {
+    pub const Context = struct {
         result_ptr: [*]u8,
+        waiter: ?*Waiter = null,
+        item_reserved: bool = false,
+        reservation_rolled_back: bool = false,
         result_set: bool = false,
     };
 
-    pub fn asyncWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext, result_ptr: [*]u8) bool {
-        ctx.result_ptr = result_ptr;
-        ctx.result_set = false;
-
-        self.channel.mutex.lockUncancelable();
-
-        if (self.channel.count > 0) {
-            self.channel.takeItemAndWakeSender(ctx.result_ptr);
-            ctx.result_set = true;
-            return false;
+    pub fn prepare(self: *const RecvSelf, waiter: *Waiter, ctx: *Context) Prepare {
+        const ch = self.channel;
+        ch.mutex.lockUncancelable();
+        defer ch.mutex.unlock();
+        ctx.waiter = waiter;
+        if (ctx.result_set or ctx.item_reserved) return .ready;
+        if (ch.capacity > 0) {
+            if (ch.count > ch.reserved_items or (ch.closed and ch.count == 0)) return .ready;
+        } else {
+            if (ChannelImpl.peerAvailable(&ch.sender_queue, waiter) or ch.closed) return .ready;
         }
-
-        while (self.channel.sender_queue.pop()) |node| {
-            if (Waiter.fromNode(node).tryClaim()) {
-                const send_ctx: *AsyncSendImpl.WaitContext = @ptrFromInt(node.userdata);
-                @memcpy(ctx.result_ptr[0..self.channel.elem_size], send_ctx.item_ptr[0..self.channel.elem_size]);
-                send_ctx.succeeded = true;
-                ctx.result_set = true;
-                self.channel.mutex.unlock();
-                Waiter.fromNode(node).signal();
-                return false;
-            }
-        }
-
-        if (self.channel.closed) {
-            self.channel.mutex.unlock();
-            return false;
-        }
-
         waiter.node.userdata = @intFromPtr(ctx);
-        self.channel.receiver_queue.push(&waiter.node);
-        self.channel.mutex.unlock();
-        return true;
+        ch.receiver_queue.push(&waiter.node);
+        return .pending;
     }
 
-    pub fn asyncCancelWait(self: *const RecvSelf, waiter: *Waiter, ctx: *WaitContext) bool {
-        _ = ctx;
-        self.channel.mutex.lockUncancelable();
-        const was_in_queue = self.channel.receiver_queue.remove(&waiter.node);
-        self.channel.mutex.unlock();
+    pub fn commit(self: *const RecvSelf, ctx: *Context) CommitResult(Closeable!void) {
+        const ch = self.channel;
+        var to_signal: ?*WaitNode = null;
 
-        if (was_in_queue) {
-            return true;
-        }
-
-        return !waiter.didWin();
-    }
-
-    pub fn getResult(self: *const RecvSelf, ctx: *WaitContext) Closeable!void {
-        // Result already set by direct transfer or fast path
+        ch.mutex.lockUncancelable();
         if (ctx.result_set) {
-            return;
+            ch.mutex.unlock();
+            return .{ .done = {} };
+        }
+        if (ctx.reservation_rolled_back) {
+            ch.mutex.unlock();
+            return .retry;
+        }
+        if (ch.capacity > 0) {
+            var can_take = false;
+            if (ctx.item_reserved) {
+                ctx.item_reserved = false;
+                if (ch.reserved_items > 0) {
+                    ch.reserved_items -= 1;
+                    can_take = true;
+                }
+            } else if (ch.count > ch.reserved_items) {
+                can_take = true;
+            }
+            if (can_take) {
+                std.debug.assert(ch.count > 0);
+                ch.takeItem(ctx.result_ptr);
+                if (ch.closed) {
+                    if (ch.count == 0) to_signal = ch.receiver_queue.pop();
+                } else {
+                    to_signal = ch.reserveSender();
+                }
+                ch.mutex.unlock();
+                if (to_signal) |node| Waiter.fromNode(node).signal();
+                return .{ .done = {} };
+            }
+        } else if (ChannelImpl.claimPeer(&ch.sender_queue, ctx.waiter)) |node| {
+            const sctx = ChannelImpl.sendCtx(node);
+            @memcpy(ctx.result_ptr[0..ch.elem_size], sctx.item_ptr[0..ch.elem_size]);
+            sctx.succeeded = true;
+            ch.mutex.unlock();
+            Waiter.fromNode(node).signal();
+            return .{ .done = {} };
+        }
+        if (ch.closed) {
+            to_signal = ch.receiver_queue.pop();
+            ch.mutex.unlock();
+            if (to_signal) |node| Waiter.fromNode(node).signal();
+            return .{ .done = error.Closed };
+        }
+        ch.mutex.unlock();
+        return .retry;
+    }
+
+    pub fn rollback(self: *const RecvSelf, waiter: *Waiter, ctx: *Context) Rollback {
+        const ch = self.channel;
+        var to_signal: ?*WaitNode = null;
+        ch.mutex.lockUncancelable();
+        if (ch.receiver_queue.remove(&waiter.node)) {
+            ch.mutex.unlock();
+            return .removed;
         }
 
-        // Woken by close, check if there are items left (graceful close)
-        self.channel.mutex.lockUncancelable();
-
-        if (self.channel.count > 0) {
-            self.channel.takeItemAndWakeSender(ctx.result_ptr);
-            return;
+        if (ctx.item_reserved) {
+            ctx.item_reserved = false;
+            ctx.reservation_rolled_back = true;
+            if (ch.reserved_items > 0) {
+                if (ch.receiver_queue.pop()) |node| {
+                    ChannelImpl.recvCtx(node).item_reserved = true;
+                    to_signal = node;
+                } else {
+                    ch.reserved_items -= 1;
+                }
+            } else if (ch.closed) {
+                to_signal = ch.receiver_queue.pop();
+            }
+        } else if (ch.closed and ch.count == 0) {
+            to_signal = ch.receiver_queue.pop();
         }
-
-        std.debug.assert(self.channel.closed);
-        self.channel.mutex.unlock();
-        return error.Closed;
+        ch.mutex.unlock();
+        if (to_signal) |node| Waiter.fromNode(node).signal();
+        return .signal_in_flight;
     }
 };
 
@@ -545,37 +742,38 @@ pub fn AsyncReceive(comptime T: type) type {
 
         const Self = @This();
 
-        pub const Result = Closeable!T;
-
-        pub const WaitContext = struct {
-            impl_ctx: AsyncReceiveImpl.WaitContext = .{ .result_ptr = undefined },
-            result: T = undefined,
-        };
-
         fn init(channel: *ChannelImpl) Self {
             return .{
                 .impl = .{ .channel = channel },
             };
         }
 
-        /// Register for notification when receive can complete.
-        /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&ctx.result).ptr);
-        }
+        pub const AsyncWait = struct {
+            pub const Result = Closeable!T;
+            pub const claimable = true;
 
-        /// Cancel a pending wait operation.
-        /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncCancelWait(waiter, &ctx.impl_ctx);
-        }
+            pub const Context = struct {
+                impl_ctx: AsyncReceiveImpl.Context = .{ .result_ptr = undefined },
+                result: T = undefined,
+            };
 
-        /// Get the result of the receive operation.
-        /// Must only be called after asyncWait() returns false or the wait_node is woken.
-        pub fn getResult(self: *const Self, ctx: *WaitContext) Result {
-            try self.impl.getResult(&ctx.impl_ctx);
-            return ctx.result;
-        }
+            pub fn prepare(self: *const Self, waiter: *Waiter, ctx: *Context) Prepare {
+                ctx.impl_ctx.result_ptr = std.mem.asBytes(&ctx.result).ptr;
+                return self.impl.prepare(waiter, &ctx.impl_ctx);
+            }
+
+            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
+                ctx.impl_ctx.result_ptr = std.mem.asBytes(&ctx.result).ptr;
+                return switch (self.impl.commit(&ctx.impl_ctx)) {
+                    .retry => .retry,
+                    .done => |result| if (result) |_| .{ .done = ctx.result } else |err| .{ .done = err },
+                };
+            }
+
+            pub fn rollback(self: *const Self, waiter: *Waiter, ctx: *Context) Rollback {
+                return self.impl.rollback(waiter, &ctx.impl_ctx);
+            }
+        };
     };
 }
 
@@ -598,12 +796,6 @@ pub fn AsyncSend(comptime T: type) type {
 
         const Self = @This();
 
-        pub const Result = Closeable!void;
-
-        pub const WaitContext = struct {
-            impl_ctx: AsyncSendImpl.WaitContext = .{ .item_ptr = undefined },
-        };
-
         fn init(channel: *ChannelImpl, item: T) Self {
             return .{
                 .impl = .{ .channel = channel },
@@ -611,23 +803,29 @@ pub fn AsyncSend(comptime T: type) type {
             };
         }
 
-        /// Register for notification when send can complete.
-        /// Returns false if operation completed immediately (fast path).
-        pub fn asyncWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncWait(waiter, &ctx.impl_ctx, std.mem.asBytes(&self.item).ptr);
-        }
+        pub const AsyncWait = struct {
+            pub const Result = Closeable!void;
+            pub const claimable = true;
 
-        /// Cancel a pending wait operation.
-        /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: *const Self, waiter: *Waiter, ctx: *WaitContext) bool {
-            return self.impl.asyncCancelWait(waiter, &ctx.impl_ctx);
-        }
+            pub const Context = struct {
+                impl_ctx: AsyncSendImpl.Context = .{ .item_ptr = undefined },
+                item: T = undefined,
+            };
 
-        /// Get the result of the send operation.
-        /// Must only be called after asyncWait() returns false or the wait_node is woken.
-        pub fn getResult(self: *const Self, ctx: *WaitContext) Result {
-            return self.impl.getResult(&ctx.impl_ctx);
-        }
+            pub fn prepare(self: *const Self, waiter: *Waiter, ctx: *Context) Prepare {
+                ctx.item = self.item;
+                ctx.impl_ctx.item_ptr = std.mem.asBytes(&ctx.item).ptr;
+                return self.impl.prepare(waiter, &ctx.impl_ctx);
+            }
+
+            pub fn commit(self: *const Self, ctx: *Context) CommitResult(Result) {
+                return self.impl.commit(&ctx.impl_ctx);
+            }
+
+            pub fn rollback(self: *const Self, waiter: *Waiter, ctx: *Context) Rollback {
+                return self.impl.rollback(waiter, &ctx.impl_ctx);
+            }
+        };
     };
 }
 
@@ -1602,70 +1800,362 @@ test "Channel: close wakes blocked select sender" {
     try std.testing.expect(!group.hasFailed());
 }
 
-test "Channel: close classifies select waiters before signaling" {
-    const Helpers = struct {
-        fn notifyState(waiter: *Waiter) u32 {
-            return switch (waiter.mode) {
-                .direct => |*direct| direct.notify.state.load(.acquire),
-                .select => unreachable,
+test "Channel: close dequeues registrations before signaling" {
+    var channel = Channel(u32).init(&.{});
+    var receive = channel.asyncReceive();
+    var receive_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var receive_waiter = Waiter.init();
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&receive, &receive_waiter, &receive_ctx));
+    channel.close(.graceful);
+    receive_waiter.wait(1, .no_cancel);
+
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+    try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u32).AsyncWait.rollback(&receive, &receive_waiter, &receive_ctx));
+    switch (AsyncReceive(u32).AsyncWait.commit(&receive, &receive_ctx)) {
+        .done => |result| try std.testing.expectError(error.Closed, result),
+        .retry => return error.TestUnexpectedResult,
+    }
+}
+
+test "Channel: losing buffered receiver hands its item reservation to one waiter" {
+    var buffer: [1]u32 = undefined;
+    var channel = Channel(u32).init(&buffer);
+    var first = channel.asyncReceive();
+    var second = channel.asyncReceive();
+    var first_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var second_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var first_waiter = Waiter.init();
+    var second_waiter = Waiter.init();
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&first, &first_waiter, &first_ctx));
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&second, &second_waiter, &second_ctx));
+
+    try channel.trySend(7);
+    first_waiter.wait(1, .no_cancel);
+    try std.testing.expect(first_ctx.impl_ctx.item_reserved);
+    try std.testing.expect(!second_ctx.impl_ctx.item_reserved);
+    try std.testing.expectEqual(1, channel.impl.reserved_items);
+    try std.testing.expect(channel.isEmpty());
+    try std.testing.expectError(error.WouldBlock, channel.tryReceive());
+
+    try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u32).AsyncWait.rollback(&first, &first_waiter, &first_ctx));
+    second_waiter.wait(1, .no_cancel);
+    try std.testing.expect(!first_ctx.impl_ctx.item_reserved);
+    try std.testing.expect(second_ctx.impl_ctx.item_reserved);
+    try std.testing.expectEqual(1, channel.impl.reserved_items);
+
+    switch (AsyncReceive(u32).AsyncWait.commit(&first, &first_ctx)) {
+        .retry => {},
+        .done => return error.TestUnexpectedResult,
+    }
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+        .done => |result| try std.testing.expectEqual(7, try result),
+        .retry => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(0, channel.impl.reserved_items);
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+}
+
+test "Channel: losing buffered sender hands its slot reservation to one waiter" {
+    var buffer: [1]u32 = undefined;
+    var channel = Channel(u32).init(&buffer);
+    try channel.trySend(1);
+
+    var first = channel.asyncSend(2);
+    var second = channel.asyncSend(3);
+    var first_ctx: AsyncSend(u32).AsyncWait.Context = .{};
+    var second_ctx: AsyncSend(u32).AsyncWait.Context = .{};
+    var first_waiter = Waiter.init();
+    var second_waiter = Waiter.init();
+
+    try std.testing.expectEqual(Prepare.pending, AsyncSend(u32).AsyncWait.prepare(&first, &first_waiter, &first_ctx));
+    try std.testing.expectEqual(Prepare.pending, AsyncSend(u32).AsyncWait.prepare(&second, &second_waiter, &second_ctx));
+
+    try std.testing.expectEqual(1, try channel.tryReceive());
+    first_waiter.wait(1, .no_cancel);
+    try std.testing.expect(first_ctx.impl_ctx.slot_reserved);
+    try std.testing.expect(!second_ctx.impl_ctx.slot_reserved);
+    try std.testing.expectEqual(1, channel.impl.reserved_slots);
+    try std.testing.expect(channel.isFull());
+    try std.testing.expectError(error.WouldBlock, channel.trySend(4));
+
+    try std.testing.expectEqual(Rollback.signal_in_flight, AsyncSend(u32).AsyncWait.rollback(&first, &first_waiter, &first_ctx));
+    second_waiter.wait(1, .no_cancel);
+    try std.testing.expect(!first_ctx.impl_ctx.slot_reserved);
+    try std.testing.expect(second_ctx.impl_ctx.slot_reserved);
+    try std.testing.expectEqual(1, channel.impl.reserved_slots);
+
+    switch (AsyncSend(u32).AsyncWait.commit(&first, &first_ctx)) {
+        .retry => {},
+        .done => return error.TestUnexpectedResult,
+    }
+    switch (AsyncSend(u32).AsyncWait.commit(&second, &second_ctx)) {
+        .done => |result| try result,
+        .retry => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(0, channel.impl.reserved_slots);
+    try std.testing.expectEqual(3, try channel.tryReceive());
+    try std.testing.expect(channel.impl.sender_queue.isEmpty());
+}
+
+test "Channel: close notification is handed off instead of broadcast" {
+    var buffer: [1]u32 = undefined;
+    var channel = Channel(u32).init(&buffer);
+    var first = channel.asyncReceive();
+    var second = channel.asyncReceive();
+    var first_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var second_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var first_waiter = Waiter.init();
+    var second_waiter = Waiter.init();
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&first, &first_waiter, &first_ctx));
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&second, &second_waiter, &second_ctx));
+
+    channel.close(.graceful);
+    first_waiter.wait(1, .no_cancel);
+    // Close dequeued one waiter only; the other stays parked until commit or
+    // rollback hands the sticky close readiness onward.
+    try std.testing.expect(!channel.impl.receiver_queue.isEmpty());
+
+    try std.testing.expectEqual(Rollback.signal_in_flight, AsyncReceive(u32).AsyncWait.rollback(&first, &first_waiter, &first_ctx));
+    second_waiter.wait(1, .no_cancel);
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+        .done => |result| try std.testing.expectError(error.Closed, result),
+        .retry => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+}
+
+test "Channel: graceful close drains a reserved item before handing off close" {
+    var buffer: [1]u32 = undefined;
+    var channel = Channel(u32).init(&buffer);
+    var first = channel.asyncReceive();
+    var second = channel.asyncReceive();
+    var first_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var second_ctx: AsyncReceive(u32).AsyncWait.Context = .{};
+    var first_waiter = Waiter.init();
+    var second_waiter = Waiter.init();
+
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&first, &first_waiter, &first_ctx));
+    try std.testing.expectEqual(Prepare.pending, AsyncReceive(u32).AsyncWait.prepare(&second, &second_waiter, &second_ctx));
+    try channel.trySend(7);
+    first_waiter.wait(1, .no_cancel);
+
+    channel.close(.graceful);
+    try std.testing.expect(!channel.impl.receiver_queue.isEmpty());
+    switch (AsyncReceive(u32).AsyncWait.commit(&first, &first_ctx)) {
+        .done => |result| try std.testing.expectEqual(7, try result),
+        .retry => return error.TestUnexpectedResult,
+    }
+
+    second_waiter.wait(1, .no_cancel);
+    switch (AsyncReceive(u32).AsyncWait.commit(&second, &second_ctx)) {
+        .done => |result| try std.testing.expectError(error.Closed, result),
+        .retry => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+    try std.testing.expectEqual(0, channel.impl.reserved_items);
+}
+
+test "Channel: canceled select conserves a concurrently sent item" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
+
+    const State = struct {
+        channel: *Channel(u32),
+        never: *ResetEvent,
+        entered: std.atomic.Value(bool) = .init(false),
+        go: std.atomic.Value(bool) = .init(false),
+        received: std.atomic.Value(u32) = .init(0),
+
+        fn waitForItem(self: *@This()) !void {
+            var receive = self.channel.asyncReceive();
+            self.entered.store(true, .release);
+            const result = try select(.{ .item = &receive, .never = self.never });
+            switch (result) {
+                .item => |item| self.received.store(try item, .release),
+                .never => unreachable,
+            }
+        }
+
+        fn sendItem(self: *@This()) !void {
+            while (!self.go.load(.acquire)) try yield();
+            try self.channel.trySend(1);
+        }
+    };
+
+    // The outcome may be either cancellation or delivery. The item must be
+    // observable in exactly one place after the race.
+    for (0..200) |_| {
+        var buffer: [1]u32 = undefined;
+        var channel = Channel(u32).init(&buffer);
+        var never = ResetEvent.init;
+        var state = State{ .channel = &channel, .never = &never };
+
+        var receiver = try runtime.spawn(State.waitForItem, .{&state});
+        while (!state.entered.load(.acquire)) try yield();
+        try yield();
+        var sender = try runtime.spawn(State.sendItem, .{&state});
+        state.go.store(true, .release);
+        receiver.cancel();
+        _ = receiver.join() catch {};
+        try sender.join();
+
+        var observed: u32 = state.received.load(.acquire);
+        if (channel.tryReceive()) |item| {
+            observed += item;
+        } else |err| switch (err) {
+            error.WouldBlock => {},
+            else => return err,
+        }
+        try std.testing.expectEqual(1, observed);
+    }
+}
+
+test "Channel: ready arm does not clobber an earlier channel notification" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
+
+    const State = struct {
+        first: *Channel(u64),
+        second: *Channel(u64),
+        go: std.atomic.Value(bool) = .init(false),
+
+        fn choose(self: *@This()) !u64 {
+            var first = self.first.asyncReceive();
+            var second = self.second.asyncReceive();
+            self.go.store(true, .release);
+            const result = try select(.{ .first = &first, .second = &second });
+            return switch (result) {
+                .first => |item| try item,
+                .second => |item| try item,
+            };
+        }
+
+        fn sendFirst(self: *@This()) !void {
+            while (!self.go.load(.acquire)) try yield();
+            try self.first.trySend(1);
+        }
+    };
+
+    // Channel two is ready before registration starts while channel one is
+    // notified concurrently. Whichever arm wins, both values are conserved.
+    for (0..200) |_| {
+        var first_buffer: [1]u64 = undefined;
+        var second_buffer: [1]u64 = undefined;
+        var first = Channel(u64).init(&first_buffer);
+        var second = Channel(u64).init(&second_buffer);
+        try second.trySend(2);
+        var state = State{ .first = &first, .second = &second };
+
+        var chooser = try runtime.spawn(State.choose, .{&state});
+        var sender = try runtime.spawn(State.sendFirst, .{&state});
+        var sum = try chooser.join();
+        try sender.join();
+
+        if (first.tryReceive()) |item| {
+            sum += item;
+        } else |err| switch (err) {
+            error.WouldBlock => {},
+            else => return err,
+        }
+        if (second.tryReceive()) |item| {
+            sum += item;
+        } else |err| switch (err) {
+            error.WouldBlock => {},
+            else => return err,
+        }
+        try std.testing.expectEqual(3, sum);
+    }
+}
+
+test "Channel: unbuffered select send rendezvous with select receive" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
+
+    var channel = Channel(u64).init(&.{});
+    var never = ResetEvent.init;
+
+    const Tasks = struct {
+        fn send(ch: *Channel(u64), other: *ResetEvent) !void {
+            var operation = ch.asyncSend(42);
+            const result = try select(.{ .send = &operation, .never = other });
+            switch (result) {
+                .send => |sent| try sent,
+                .never => unreachable,
+            }
+        }
+
+        fn receive(ch: *Channel(u64), other: *ResetEvent) !u64 {
+            var operation = ch.asyncReceive();
+            const result = try select(.{ .receive = &operation, .never = other });
+            return switch (result) {
+                .receive => |item| try item,
+                .never => unreachable,
             };
         }
     };
 
-    // Closing a pending receive claims it and commits to exactly one signal.
-    var claimed_receive_channel = Channel(u32).init(&.{});
-    var claimed_receive = claimed_receive_channel.asyncReceive();
-    var claimed_receive_ctx: AsyncReceive(u32).WaitContext = .{};
-    var claimed_receive_parent = Waiter.init();
-    var claimed_receive_winner: std.atomic.Value(usize) = .init(NO_WINNER);
-    var claimed_receive_waiter = Waiter.initSelect(&claimed_receive_parent, &claimed_receive_winner, 0);
+    var sender = try runtime.spawn(Tasks.send, .{ &channel, &never });
+    var receiver = try runtime.spawn(Tasks.receive, .{ &channel, &never });
+    try std.testing.expectEqual(42, try receiver.join());
+    try sender.join();
+    try std.testing.expect(channel.impl.sender_queue.isEmpty());
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
+}
 
-    try std.testing.expect(claimed_receive.asyncWait(&claimed_receive_waiter, &claimed_receive_ctx));
-    claimed_receive_channel.close(.graceful);
-    try std.testing.expectEqual(0, claimed_receive_winner.load(.acquire));
-    try std.testing.expect(!claimed_receive.asyncCancelWait(&claimed_receive_waiter, &claimed_receive_ctx));
-    try std.testing.expectEqual(1, Helpers.notifyState(&claimed_receive_parent));
-    try std.testing.expectError(error.Closed, claimed_receive.getResult(&claimed_receive_ctx));
+test "Channel: cancel removes a parked select send" {
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    defer runtime.deinit();
 
-    // Exercise the same committed-signal handshake for a pending send.
-    var claimed_send_channel = Channel(u32).init(&.{});
-    var claimed_send = claimed_send_channel.asyncSend(42);
-    var claimed_send_ctx: AsyncSend(u32).WaitContext = .{};
-    var claimed_send_parent = Waiter.init();
-    var claimed_send_winner: std.atomic.Value(usize) = .init(NO_WINNER);
-    var claimed_send_waiter = Waiter.initSelect(&claimed_send_parent, &claimed_send_winner, 0);
+    var channel = Channel(u64).init(&.{});
+    var never = ResetEvent.init;
+    var entered: std.atomic.Value(bool) = .init(false);
 
-    try std.testing.expect(claimed_send.asyncWait(&claimed_send_waiter, &claimed_send_ctx));
-    claimed_send_channel.close(.graceful);
-    try std.testing.expectEqual(0, claimed_send_winner.load(.acquire));
-    try std.testing.expect(!claimed_send.asyncCancelWait(&claimed_send_waiter, &claimed_send_ctx));
-    try std.testing.expectEqual(1, Helpers.notifyState(&claimed_send_parent));
-    try std.testing.expectError(error.Closed, claimed_send.getResult(&claimed_send_ctx));
+    const Task = struct {
+        fn run(ch: *Channel(u64), other: *ResetEvent, started: *std.atomic.Value(bool)) !void {
+            var operation = ch.asyncSend(42);
+            started.store(true, .release);
+            const result = try select(.{ .send = &operation, .never = other });
+            switch (result) {
+                .send => |sent| try sent,
+                .never => unreachable,
+            }
+        }
+    };
 
-    // Simulate another select arm having already won before close removes a
-    // pending receive. The losing waiter must be discarded without a signal.
-    var receive_channel = Channel(u32).init(&.{});
-    var receive = receive_channel.asyncReceive();
-    var receive_ctx: AsyncReceive(u32).WaitContext = .{};
-    var receive_parent = Waiter.init();
-    var receive_winner: std.atomic.Value(usize) = .init(1);
-    var receive_waiter = Waiter.initSelect(&receive_parent, &receive_winner, 0);
+    var sender = try runtime.spawn(Task.run, .{ &channel, &never, &entered });
+    while (!entered.load(.acquire)) try yield();
+    try yield();
+    sender.cancel();
+    try std.testing.expectError(error.Canceled, sender.join());
+    try std.testing.expect(channel.impl.sender_queue.isEmpty());
+    try std.testing.expectError(error.WouldBlock, channel.tryReceive());
+}
 
-    try std.testing.expect(receive.asyncWait(&receive_waiter, &receive_ctx));
-    receive_channel.close(.graceful);
-    try std.testing.expect(receive.asyncCancelWait(&receive_waiter, &receive_ctx));
-    try std.testing.expectEqual(0, Helpers.notifyState(&receive_parent));
+test "Channel: one select cannot rendezvous its own send and receive arms" {
+    const runtime = try Runtime.init(std.testing.allocator, .{});
+    defer runtime.deinit();
 
-    // Exercise the same arbitration for a pending send.
-    var send_channel = Channel(u32).init(&.{});
-    var send = send_channel.asyncSend(42);
-    var send_ctx: AsyncSend(u32).WaitContext = .{};
-    var send_parent = Waiter.init();
-    var send_winner: std.atomic.Value(usize) = .init(1);
-    var send_waiter = Waiter.initSelect(&send_parent, &send_winner, 0);
+    var channel = Channel(u64).init(&.{});
+    var entered: std.atomic.Value(bool) = .init(false);
 
-    try std.testing.expect(send.asyncWait(&send_waiter, &send_ctx));
-    send_channel.close(.graceful);
-    try std.testing.expect(send.asyncCancelWait(&send_waiter, &send_ctx));
-    try std.testing.expectEqual(0, Helpers.notifyState(&send_parent));
+    const Task = struct {
+        fn run(ch: *Channel(u64), started: *std.atomic.Value(bool)) !void {
+            var send = ch.asyncSend(42);
+            var receive = ch.asyncReceive();
+            started.store(true, .release);
+            _ = try select(.{ .send = &send, .receive = &receive });
+        }
+    };
+
+    var waiter = try runtime.spawn(Task.run, .{ &channel, &entered });
+    while (!entered.load(.acquire)) try yield();
+    try yield();
+    try yield();
+    waiter.cancel();
+    try std.testing.expectError(error.Canceled, waiter.join());
+    try std.testing.expect(channel.impl.sender_queue.isEmpty());
+    try std.testing.expect(channel.impl.receiver_queue.isEmpty());
 }

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -104,34 +104,31 @@ pub fn Future(comptime T: type) type {
             return select.wait(self);
         }
 
-        // Future protocol implementation for use with select()
-        pub const Result = T;
+        // AsyncWait protocol (see select.zig). Completion is the sticky queue
+        // flag, set after the value lands; set() dequeues and notifies every
+        // registration while setting it.
+        pub const AsyncWait = struct {
+            pub const Result = T;
+            pub const Context = struct {};
 
-        /// Gets the result value.
-        /// This is part of the Future protocol for select().
-        /// Asserts that the future has been set.
-        pub fn getResult(self: *Self) T {
-            return self.value.get().?;
-        }
-
-        /// Registers a waiter to be notified when the future is set.
-        /// This is part of the Future protocol for select().
-        /// Returns false if the future is already set (no wait needed), true if added to queue.
-        pub fn asyncWait(self: *Self, waiter: *Waiter) bool {
-            // Fast path: check if already set
-            if (self.value.isSet()) {
-                return false;
+            pub fn prepare(self: *Self, waiter: *Waiter, ctx: *Context) select.Prepare {
+                _ = ctx;
+                if (!self.wait_queue.pushUnlessFlag(&waiter.node)) return .ready;
+                return .pending;
             }
-            // Try to push to queue - only succeeds if future is not done (flag not set)
-            return self.wait_queue.pushUnlessFlag(&waiter.node);
-        }
 
-        /// Cancels a pending wait operation by removing the waiter.
-        /// This is part of the Future protocol for select().
-        /// Returns true if removed, false if already removed by completion (wake in-flight).
-        pub fn asyncCancelWait(self: *Self, waiter: *Waiter) bool {
-            return self.wait_queue.remove(&waiter.node);
-        }
+            pub fn commit(self: *Self, ctx: *Context) select.CommitResult(T) {
+                _ = ctx;
+                std.debug.assert(self.wait_queue.isFlagSet());
+                const value: T = self.value.get().?;
+                return .{ .done = value };
+            }
+
+            pub fn rollback(self: *Self, waiter: *Waiter, ctx: *Context) select.Rollback {
+                _ = ctx;
+                return if (self.wait_queue.remove(&waiter.node)) .removed else .signal_in_flight;
+            }
+        };
     };
 }
 

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -117,7 +117,8 @@ pub fn Future(comptime T: type) type {
                 return .pending;
             }
 
-            pub fn commit(self: *Self, ctx: *Context) select.CommitResult(T) {
+            pub fn commit(self: *Self, waiter: *Waiter, ctx: *Context) select.CommitResult(T) {
+                _ = waiter;
                 _ = ctx;
                 std.debug.assert(self.wait_queue.isFlagSet());
                 const value: T = self.value.get().?;

--- a/src/time.zig
+++ b/src/time.zig
@@ -590,10 +590,11 @@ pub const Timeout = union(enum) {
             waiter.signal();
         }
 
-        pub fn commit(self: *const Timeout, ctx: *Context) CommitResult(void) {
-            _ = self;
+        pub fn commit(self: *const Timeout, waiter: *Waiter, ctx: *Context) CommitResult(void) {
             if (ctx.fired.load(.acquire)) return .{ .done = {} };
-            return .retry;
+            const prepared = prepare(self, waiter, ctx);
+            std.debug.assert(prepared == .pending);
+            return .{ .pending = .{} };
         }
 
         pub fn rollback(self: *const Timeout, waiter: *Waiter, ctx: *Context) Rollback {

--- a/src/time.zig
+++ b/src/time.zig
@@ -14,6 +14,9 @@ const Runtime = @import("runtime.zig").Runtime;
 const getCurrentExecutor = @import("runtime.zig").getCurrentExecutor;
 const loopClearTimer = @import("runtime.zig").loopClearTimer;
 const Waiter = @import("common.zig").Waiter;
+const Prepare = @import("select.zig").Prepare;
+const CommitResult = @import("select.zig").CommitResult;
+const Rollback = @import("select.zig").Rollback;
 
 // Time configuration - adjust these for different platforms
 const TimePrecision = enum { nanoseconds, microseconds, milliseconds };
@@ -542,54 +545,68 @@ pub const Timeout = union(enum) {
         }
     }
 
-    // Future protocol implementation for use with select()
+    // AsyncWait protocol (see select.zig). The timer is armed by prepare; the
+    // callback latches `fired` before notifying, and the latch is the
+    // resident state commit reads. The timer never dequeues a wait node, so
+    // rollback runs the clearTimer handshake instead of a queue removal.
 
-    pub const Result = void;
+    pub const AsyncWait = struct {
+        pub const Result = void;
 
-    pub const WaitContext = struct {
-        timer: ev.Timer = ev.Timer.init(.{ .duration = .zero }),
-        waiter: ?*Waiter = null,
-    };
+        pub const Context = struct {
+            timer: ev.Timer = ev.Timer.init(.{ .duration = .zero }),
+            waiter: ?*Waiter = null,
+            fired: std.atomic.Value(bool) = .init(false),
+            armed: bool = false,
+        };
 
-    pub fn asyncWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
-        // Timeout.none means wait forever - never completes
-        if (self.* == .none) {
-            return true;
+        pub fn prepare(self: *const Timeout, waiter: *Waiter, ctx: *Context) Prepare {
+            // Timeout.none means wait forever - never completes, never arms.
+            if (self.* == .none) return .pending;
+
+            if (ctx.armed) {
+                // Re-prepared after a notification that lost the round.
+                return if (ctx.fired.load(.acquire)) .ready else .pending;
+            }
+
+            ctx.timer = ev.Timer.init(self.*);
+            ctx.waiter = waiter;
+            ctx.timer.c.userdata = ctx;
+            ctx.timer.c.callback = timerCallback;
+
+            const executor = getCurrentExecutor();
+            executor.loopAdd(&ctx.timer.c);
+            ctx.armed = true;
+            return .pending;
         }
 
-        ctx.timer = ev.Timer.init(self.*);
-        ctx.waiter = waiter;
-        ctx.timer.c.userdata = ctx;
-        ctx.timer.c.callback = timerCallback;
+        fn timerCallback(_: *ev.Loop, c: *ev.Completion) void {
+            const ctx: *Context = @ptrCast(@alignCast(c.userdata.?));
+            // Read the waiter before signaling: the caller keeps `ctx` alive
+            // until it has absorbed the signal rollback reported, and nothing
+            // here may touch `ctx` after the signal lands.
+            const waiter = ctx.waiter.?;
+            ctx.fired.store(true, .release);
+            waiter.signal();
+        }
 
-        const executor = getCurrentExecutor();
-        executor.loopAdd(&ctx.timer.c);
-        return true;
-    }
+        pub fn commit(self: *const Timeout, ctx: *Context) CommitResult(void) {
+            _ = self;
+            if (ctx.fired.load(.acquire)) return .{ .done = {} };
+            return .retry;
+        }
 
-    fn timerCallback(_: *ev.Loop, c: *ev.Completion) void {
-        const ctx: *WaitContext = @ptrCast(@alignCast(c.userdata.?));
-        // Every dispatch signals: the wait protocol keeps `ctx` alive until the
-        // signal arrives whenever `asyncCancelWait` reported the timer as still
-        // completing, so a missed signal would park the waiter forever.
-        ctx.waiter.?.signal();
-    }
-
-    pub fn asyncCancelWait(self: *const Timeout, waiter: *Waiter, ctx: *WaitContext) bool {
-        _ = self;
-        _ = waiter;
-        // `.none` never arms a timer, so there is nothing to remove.
-        const loop = ctx.timer.c.getLoop() orelse return true;
-        // Disarmed: no callback, no signal. Otherwise the timer is completing
-        // and its callback still signals `ctx.waiter`, so report the wake as
-        // in flight and let the caller wait for it.
-        return loopClearTimer(loop, &ctx.timer);
-    }
-
-    pub fn getResult(self: *const Timeout, ctx: *WaitContext) void {
-        _ = self;
-        _ = ctx;
-    }
+        pub fn rollback(self: *const Timeout, waiter: *Waiter, ctx: *Context) Rollback {
+            _ = self;
+            _ = waiter;
+            if (!ctx.armed) return .removed;
+            ctx.armed = false;
+            const loop = ctx.timer.c.getLoop() orelse return .removed;
+            // Disarmed: no callback, no signal. Otherwise the timer completed
+            // or is completing and its callback signals exactly once.
+            return if (loopClearTimer(loop, &ctx.timer)) .removed else .signal_in_flight;
+        }
+    };
 };
 
 /// A monotonic, high performance stopwatch for measuring elapsed time.


### PR DESCRIPTION
## Problem

The existing boolean `asyncWait` protocol combines observing source readiness, consuming from that source, and deciding the winning select arm. That makes several races impossible to represent correctly:

- cancellation can discard a channel item that a sender already copied into the select frame (#700)
- a later ready arm can overwrite an earlier arm claimed by another thread, losing both the item and signal accounting (#701)
- a stale CompletionQueue notification can be treated as a successful selection even though there is no completion to consume
- unbuffered select-send versus select-receive needs to defer a rendezvous when the peer select is committing another arm

The invariant this branch establishes is: **an arm's side effect happens if and only if select returns that arm.** Data remains owned by its source until the winning arm commits it.

Fixes #700.
Fixes #701.
Fixes #706.

This supersedes #702. That PR used claim-before-consume and cancel-path result delivery to repair #700 and #701, but an irrevocably claimed select arm could not safely handle unbuffered select-to-select rendezvous. This branch replaces that approach with explicit preparation, commit, and rollback, including a targeted rendezvous handoff when either select is busy.

## Design

Every selectable source now implements an `AsyncWait` protocol with per-operation context:

- `prepare(waiter, context) -> .ready | .pending` atomically checks readiness and, when needed, registers the waiter without consuming anything
- `commit(waiter, context) -> .done(Result) | .pending(Pending)` performs the consuming operation; if readiness decayed, the source atomically installs its next registration before returning pending
- `rollback(waiter, context) -> .removed | .signal_in_flight` removes a registration or tells the select loop that a notifier already owns it and one signal must still be absorbed

A pending commit may return one deferred notification. The driver first records its arm as pending and releases the `COMMITTING` winner fence, then delivers that notification. Sources therefore never manipulate select arbitration directly.

The select loop owns arm state, winner publication, and signal accounting. It rolls back every losing attempt and absorbs all owed signals before its stack-backed waiters and contexts can go out of scope. The winner-word fence is compiled in only when a source can be decided externally, currently channel rendezvous arms.

Select supports at most 64 arms. The limit is documented and enforced at compile time.

## Channel behavior

Buffered channels use explicit item and slot reservations. Producing an item wakes one receiver; freeing a slot wakes one sender. If that notified arm loses its select, rollback transfers the reservation directly to one other waiter. Close readiness is handed through the queue the same way, so none of these paths broadcast or create a thundering herd.

Unreserved direct operations cannot consume capacity promised to a select arm, and `isEmpty`/`isFull` report the corresponding unreserved availability.

Unbuffered channels use a single rendezvous baton when an operation encounters a select peer that is currently committing another arm. The requester parks before the driver delivers a deferred notification to that peer. The baton owner either completes the rendezvous, transfers the baton to a busy peer, or passes it to exactly one compatible waiter from rollback. Blocking operations therefore retain their data without broadcasting; `trySend` and `tryReceive` return `WouldBlock` when only busy peers exist.

Direct/select and select/select handoffs remain claim-before-copy under the channel mutex. One select cannot rendezvous its own send and receive arms, and cancellation conserves the item regardless of which side wins.

## Other wait sources

The protocol is implemented across Awaitable/JoinHandle, Future, ResetEvent, Group, Signal, Timeout, broadcast channel, CompletionQueue, and the runtime/common adapters. Sources whose readiness decays now re-register inside commit instead of leaking a retry loop into the select driver.

CompletionQueue registers its single driver in an explicit waiter slot protected by the queue mutex. A notification whose completion was consumed elsewhere atomically installs the next registration instead of producing a false win. Notification is also the final source-related action in close and completion callbacks, so a remote select may safely return and destroy a stack-owned queue.

This is an API break for out-of-tree selectable sources: their nested `AsyncWait` implementation must provide `Result`, `Context`, `prepare`, `commit`, and `rollback`, and `commit` now receives the waiter.

## Verification

- Debug: 666 tests passed, 1 skipped
- ReleaseSafe: 666 tests passed, 1 skipped
- ReleaseFast: 666 tests passed, 1 skipped
- deterministic busy-rendezvous, deferred-notification, rollback-handoff, and `trySend` coverage
- 200-iteration select-to-select rendezvous coverage
- 16-arm select regression coverage
- `git diff --check`
