### PR TITLE
CompletionQueue: a select arm can win with the queue empty and open

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -77,6 +77,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "coro-demo", .file = "examples/coro_demo.zig" },
         .{ .name = "ev-demo", .file = "examples/ev_demo.zig" },
         .{ .name = "stderr-smoke", .file = "examples/stderr_smoke.zig" },
+        .{ .name = "cq-spurious-select-repro", .file = "examples/cq_spurious_select_repro.zig" },
     };
 
     // Create examples step. -Dexample=<name> limits it to a single example

--- a/examples/cq_spurious_select_repro.zig
+++ b/examples/cq_spurious_select_repro.zig
@@ -1,0 +1,190 @@
+//! Reproducer for a select CompletionQueue arm winning with the queue EMPTY
+//! and OPEN: `getResult` hits `std.debug.assert(drained)` (Debug and
+//! ReleaseSafe abort with a stack through completion_queue.zig getResult and
+//! select.zig:465), or returns `error.Closed` for an open queue in
+//! ReleaseFast.
+//!
+//! Single-driver by construction: each queue is owned by exactly ONE task,
+//! which consumes it through the select arm and through `next()` pops
+//! between selects, strictly sequentially, and tears it down with
+//! `close(); cancelAll(.keep);` drain.
+//!
+//! The route (all in one driver task): `ownerCallback` is publish-then-wake
+//! and the two halves are not atomic. In the window between the `completed`
+//! push (mutex unlocked) and the `Futex.wake`, the driver's channel arm wins
+//! a select, the CQ arm's `cancelWait` succeeds (the wake has not dequeued
+//! anything yet, so no in-flight signal is counted — correctly), the driver
+//! pops the published item via `next()` and resubmits, and the NEXT select
+//! registers a fresh waiter on the same signal word. The old wake then
+//! fires, dequeues the new waiter, and claims the new select's CQ arm with
+//! nothing to take.
+//!
+//! Run: `zig build examples -Dexample=cq-spurious-select-repro && ./zig-out/bin/cq-spurious-select-repro`
+//! Args: [workers] [generations] [selects_per_gen], default 8 20000 64.
+//! Reproduces within ~1 s on macOS/kqueue and Linux/io_uring, Debug and
+//! ReleaseSafe, with 8 workers; 1-2 workers run clean (the window needs
+//! runtime-wide concurrency; each queue still has exactly one driver).
+//! On plain main the `getResult` assert aborts (exit 134). On this branch,
+//! where the assert is replaced by a tolerant `error.Closed`, the repro
+//! detects the spurious win itself: a SPURIOUS line and exit 2.
+//! Exit 0 = no reproduction within the budget.
+const std = @import("std");
+const zio = @import("zio");
+
+const Shared = struct {
+    ch: *zio.Channel(u64),
+    stop: std.atomic.Value(bool) = .init(false),
+    /// The write end of the driver's current socketpair, -1 between
+    /// generations. The flooder feeds it so recv completions keep coming
+    /// from the backend's harvest path.
+    feed_fd: std.atomic.Value(std.c.fd_t) = .init(-1),
+};
+
+fn flooder(sh: *Shared) !void {
+    // Keep the channel arm ready most of the time, and keep the driver's
+    // socket fed; yield so the driver runs.
+    while (!sh.stop.load(.acquire)) {
+        sh.ch.trySend(1) catch {};
+        const fd = sh.feed_fd.load(.acquire);
+        if (fd >= 0) _ = std.c.write(fd, "y", 1);
+        try zio.yield();
+    }
+}
+
+fn driver(sh: *Shared, generations: u64, selects_per_gen: u64, spurious: *std.atomic.Value(u64)) !void {
+    var g: u64 = 0;
+    while (g < generations) : (g += 1) {
+        // A fresh queue, ops, and socketpair every generation, on this
+        // coroutine's stack: the addresses recycle, as they do for a
+        // connection struct. The recv op makes the completion source the
+        // backend's own CQE harvest, as a server's socket recv is.
+        var fds: [2]std.c.fd_t = undefined;
+        if (std.c.socketpair(std.c.AF.UNIX, std.c.SOCK.STREAM, 0, &fds) != 0) return error.SocketPair;
+        // Darwin's socketpair takes no NONBLOCK flag; set it portably.
+        for (fds) |fd| {
+            const fl = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+            _ = std.c.fcntl(fd, std.c.F.SETFL, fl | @as(c_int, 1 << @bitOffsetOf(std.c.O, "NONBLOCK")));
+        }
+        defer _ = std.c.close(fds[0]);
+        defer _ = std.c.close(fds[1]);
+        // Prime some bytes so recv completes quickly, and keep feeding.
+        _ = std.c.write(fds[1], "xxxxxxxx", 8);
+        sh.feed_fd.store(fds[1], .release);
+        defer sh.feed_fd.store(-1, .release);
+
+        var cq = zio.CompletionQueue.init();
+        var recv_buf: [64]u8 = undefined;
+        var iov: [1]std.c.iovec = undefined;
+        var recv_op = zio.ev.NetRecv.init(fds[0], zio.ev.ReadBuf.fromSlice(&recv_buf, &iov), .{});
+        try cq.submit(&recv_op.c);
+        var t1 = zio.ev.Timer.init(.{ .duration = .fromMicroseconds(50) });
+        try cq.submit(&t1.c);
+        var closed_by_us = false;
+
+        var s: u64 = 0;
+        while (s < selects_per_gen) : (s += 1) {
+            const winner = try zio.select(.{
+                .io = &cq,
+                .msg = sh.ch.asyncReceive(),
+            });
+            switch (winner) {
+                .io => |r| {
+                    const c = r catch |err| {
+                        if (err == error.Closed and !closed_by_us) {
+                            _ = spurious.fetchAdd(1, .monotonic);
+                            std.debug.print("SPURIOUS error.Closed on an open queue (gen={d} select={d})\n", .{ g, s });
+                            return error.Spurious;
+                        }
+                        return err;
+                    };
+                    // Re-arm whichever op completed, as a server re-arms its
+                    // recv. getResult inside select already popped it.
+                    if (c == &recv_op.c) {
+                        recv_op = zio.ev.NetRecv.init(fds[0], zio.ev.ReadBuf.fromSlice(&recv_buf, &iov), .{});
+                        try cq.submit(&recv_op.c);
+                    } else if (c == &t1.c) {
+                        t1 = zio.ev.Timer.init(.{ .duration = .fromMicroseconds(50) });
+                        try cq.submit(&t1.c);
+                    }
+                },
+                .msg => |r| {
+                    _ = r catch {};
+                    // The second consumption path: a non-blocking pop between
+                    // selects, exactly like a driver's poll turn.
+                    while (cq.next()) |c| {
+                        if (c == &recv_op.c) {
+                            recv_op = zio.ev.NetRecv.init(fds[0], zio.ev.ReadBuf.fromSlice(&recv_buf, &iov), .{});
+                            try cq.submit(&recv_op.c);
+                        } else if (c == &t1.c) {
+                            t1 = zio.ev.Timer.init(.{ .duration = .fromMicroseconds(50) });
+                            try cq.submit(&t1.c);
+                        }
+                    }
+                },
+            }
+        }
+
+        // Teardown, as a connection does it: close, cancel with results
+        // kept, drain.
+        closed_by_us = true;
+        cq.close();
+        cq.cancelAll(.keep);
+        while (cq.next()) |_| {}
+    }
+}
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+    var args = try std.process.Args.Iterator.initAllocator(init.minimal.args, gpa);
+    defer args.deinit();
+    _ = args.next();
+    var workers: u32 = 8;
+    var generations: u64 = 20000;
+    var selects_per_gen: u64 = 64;
+    if (args.next()) |a| workers = try std.fmt.parseInt(u32, a, 10);
+    if (args.next()) |a| generations = try std.fmt.parseInt(u64, a, 10);
+    if (args.next()) |a| selects_per_gen = try std.fmt.parseInt(u64, a, 10);
+
+    const rt = try zio.Runtime.init(gpa, .{ .executors = .auto });
+    defer rt.deinit();
+
+    var handle = try rt.spawn(struct {
+        fn go(runtime: *zio.Runtime, alloc: std.mem.Allocator, n_workers: u32, gens: u64, spg: u64) !void {
+            var spurious: std.atomic.Value(u64) = .init(0);
+            const bufs = try alloc.alloc([4]u64, n_workers);
+            defer alloc.free(bufs);
+            const chans = try alloc.alloc(zio.Channel(u64), n_workers);
+            defer alloc.free(chans);
+            const shs = try alloc.alloc(Shared, n_workers);
+            defer alloc.free(shs);
+            var drivers = try alloc.alloc(zio.JoinHandle(@typeInfo(@TypeOf(driver)).@"fn".return_type.?), n_workers);
+            defer alloc.free(drivers);
+            var flooders = try alloc.alloc(zio.JoinHandle(@typeInfo(@TypeOf(flooder)).@"fn".return_type.?), n_workers);
+            defer alloc.free(flooders);
+
+            var i: u32 = 0;
+            while (i < n_workers) : (i += 1) {
+                chans[i] = zio.Channel(u64).init(&bufs[i]);
+                shs[i] = .{ .ch = &chans[i] };
+                flooders[i] = try runtime.spawn(flooder, .{&shs[i]});
+                drivers[i] = try runtime.spawn(driver, .{ &shs[i], gens, spg, &spurious });
+            }
+            var failed = false;
+            i = 0;
+            while (i < n_workers) : (i += 1) {
+                drivers[i].join() catch {
+                    failed = true;
+                };
+                shs[i].stop.store(true, .release);
+                flooders[i].join() catch {};
+            }
+            const n = spurious.load(.acquire);
+            if (failed or n > 0) {
+                std.debug.print("RESULT spurious={d}\n", .{n});
+                std.process.exit(2);
+            }
+            std.debug.print("clean: {d} workers x {d} generations x {d} selects\n", .{ n_workers, gens, spg });
+        }
+    }.go, .{ rt, gpa, workers, generations, selects_per_gen });
+    try handle.join();
+}

--- a/examples/cq_spurious_select_repro.zig
+++ b/examples/cq_spurious_select_repro.zig
@@ -73,6 +73,15 @@ fn driver(sh: *Shared, generations: u64, selects_per_gen: u64, spurious: *std.at
         defer sh.feed_fd.store(-1, .release);
 
         var cq = zio.CompletionQueue.init();
+        // Error paths (the SPURIOUS detection included) must not unwind past
+        // live operations: their callbacks would touch this dead frame. The
+        // normal path runs the explicit teardown at the end of the
+        // generation instead, so this fires only on early returns.
+        errdefer {
+            cq.close();
+            cq.cancelAll(.keep);
+            while (cq.next()) |_| {}
+        }
         var recv_buf: [64]u8 = undefined;
         var iov: [1]std.c.iovec = undefined;
         var recv_op = zio.ev.NetRecv.init(fds[0], zio.ev.ReadBuf.fromSlice(&recv_buf, &iov), .{});

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -303,14 +303,20 @@ pub const CompletionQueue = struct {
         _ = ctx;
         self.mutex.lock();
         const node = self.completed.pop();
-        const drained = node == null and self.closed and self.pending.isEmpty();
         self.mutex.unlock();
 
         if (node) |n| return completionFromGroup(n);
-        // A wake on `signal` means a completion was pushed (and only the
-        // caller, as the driver, takes completions out) or the queue is
-        // drained; a close over in-flight operations stays silent.
-        std.debug.assert(drained);
+        // A wake on `signal` normally means a completion was pushed (and only
+        // the caller, as the driver, takes completions out) or the queue is
+        // drained. Under select, a stale wake can also win this arm with the
+        // queue EMPTY and OPEN: a signal dispatched for a registration that a
+        // concurrent winner canceled can outlive the select's signal
+        // accounting and land on a later select's re-used waiter slot. That
+        // is a protocol bug upstream of this function; asserting here turned
+        // it into a crash (ReleaseSafe) or an undefined-behavior return
+        // (ReleaseFast). `error.Closed` is the only outcome this contract can
+        // express, so the caller that knows it never closed the queue must
+        // treat it as spurious and re-poll rather than tear down.
         return error.Closed;
     }
 

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -52,9 +52,15 @@
 //! The queue also implements the future protocol, so the driver can wait for
 //! the next completion alongside other futures:
 //! `select(.{ .io = &cq, .msg = ch.asyncReceive() })`. The winning result is
-//! what `wait` would have returned, with one difference: canceling a select
+//! what `wait` would have returned, with two differences. Canceling a select
 //! only stops the waiting, it does not close the queue or cancel the
-//! operations in it.
+//! operations in it. And under select, `error.Closed` is NOT proof of the
+//! terminal state: a stale wake can win the queue arm while the queue is
+//! open, or while a close still has operations in flight whose completions
+//! arrive later. A select driver therefore checks `isDrained()` after
+//! `error.Closed` and keeps driving while it is `false`; only
+//! `isDrained() == true` is the drained state the blocking `wait` loop above
+//! breaks on.
 
 const std = @import("std");
 
@@ -594,6 +600,32 @@ test "CompletionQueue: wait on a closed empty queue returns error.Closed" {
     // Idempotent.
     cq.close();
     try std.testing.expectError(error.Closed, cq.wait());
+}
+
+test "CompletionQueue: isDrained classifies the three error.Closed cases" {
+    var rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var cq = CompletionQueue.init();
+
+    // Open and empty: a stale-wake `error.Closed` from `getResult` must read
+    // as NOT drained, so a select driver re-polls instead of stopping.
+    try std.testing.expect(!cq.isDrained());
+
+    // Closed with an operation still in flight: still not drained. The
+    // completion arrives later via `ownerCallback`; a driver that stopped
+    // here would leak it.
+    var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
+    try cq.submit(&timer.c);
+    cq.close();
+    try std.testing.expect(!cq.isDrained());
+
+    // Drain the in-flight completion, then the queue is drained: closed,
+    // nothing pending, nothing left to take.
+    const c = try cq.wait();
+    try std.testing.expectEqual(&timer.c, c);
+    try std.testing.expectError(error.Closed, cq.wait());
+    try std.testing.expect(cq.isDrained());
 }
 
 test "CompletionQueue: single timer" {

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -315,8 +315,9 @@ pub const CompletionQueue = struct {
         // is a protocol bug upstream of this function; asserting here turned
         // it into a crash (ReleaseSafe) or an undefined-behavior return
         // (ReleaseFast). `error.Closed` is the only outcome this contract can
-        // express, so the caller that knows it never closed the queue must
-        // treat it as spurious and re-poll rather than tear down.
+        // express, so a driver disambiguates with `isDrained()`: false means
+        // keep driving (stale wake, or a close with operations still in
+        // flight), true means the terminal state this error describes.
         return error.Closed;
     }
 
@@ -376,6 +377,22 @@ pub const CompletionQueue = struct {
 
         ctx.pending_signal = false;
         return if (had_signal) .requeued else .queued;
+    }
+
+    /// Whether the queue is closed AND fully drained: no pending operation
+    /// can deliver another completion, and none is waiting to be taken. This
+    /// is the predicate a select driver checks after `error.Closed` from its
+    /// queue arm, and it answers the action question directly: `true` means
+    /// stop (the terminal state `error.Closed` describes); `false` means
+    /// keep driving — whether the win was a stale wake on an open queue, or
+    /// a `close` raced in with operations still in flight whose completions
+    /// `ownerCallback` will still deliver. `isClosed` alone was wrong for
+    /// the second case: closed-but-not-drained must keep draining or those
+    /// completions leak.
+    pub fn isDrained(self: *CompletionQueue) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.closed and self.pending.isEmpty() and self.completed.isEmpty();
     }
 
     pub fn asyncCancelWait(self: *CompletionQueue, waiter: *Waiter, ctx: *WaitContext) bool {


### PR DESCRIPTION
## Problem

Under `select`, the CompletionQueue arm can win with the queue EMPTY and OPEN. `getResult` then pops nothing and hits `std.debug.assert(drained)`: a crash in ReleaseSafe, and in ReleaseFast (assert compiled out) an `error.Closed` return for a queue that is not closed — which a driver has no choice but to read as transport death.

Caught live in an HTTP/2 server (one `zio.select` per actor turn over {CompletionQueue, channels, timer}; 200 concurrent TLS SSE streams on one connection; io_uring; 24-core x86_64). ReleaseSafe stack:

```
panic: reached unreachable code
completion_queue.zig:314  getResult
select.zig:465            select
(driver's select loop above)
```

Rate: roughly one occurrence per 10–60 s of that load — 30–60% of 10-second rounds lost a healthy connection in ReleaseFast. The driver never closes its own queue mid-loop, and a driver-side probe one millisecond before each occurrence showed a healthy pump (`recv_armed=true send_armed=true`, nothing pending).

## Analysis

The CQ arm parks via `Futex.prepareWait` on `signal`; `wake` dequeues the FutexWaiter and signals the select's stack-frame waiter. When a different arm wins first, the canceled CQ arm's already-dispatched signal has to be outwaited by the select's signal accounting (`expected`). Some interleaving undercounts, the leftover signal outlives the select frame, and it lands on the next select's re-used waiter slot — winning that arm with nothing to consume. `WaitContext.pending_signal` covers the re-registration path, but not a signal that crosses select generations.

Two supporting observations:

- On a pre-#709 protocol (producer claims before signaling, so a signal always carries a claimed item), the same server and harness produce zero occurrences.
- `getResult`'s assert converts the protocol bug into either a crash or an undefined return, depending on optimize mode.

## This PR (mitigation, not the protocol fix)

`getResult` no longer asserts. `error.Closed` is the only outcome the `Closeable!*Completion` contract can express, so it is returned with a comment naming the spurious case: a caller that knows it never closed its own queue treats a mid-drive `Closed` as spurious and re-polls. With that caller behavior, 15 rounds of the same harness show 0 lost connections against the 30–60% baseline, with 5 spurious wins observed and absorbed.

The real fix belongs in the select signal accounting (or producer-side claiming), which is your freshest design territory after #709 — happy to test any protocol fix against this harness; it flags an occurrence within a few 10-second rounds and the ReleaseSafe assert (if you keep it during development) turns each one into a stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)