### PR TITLE
AutoCancel: arm against a chosen clock with setClock

### DIFF
--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -12,6 +12,8 @@ const loopClearTimer = @import("runtime.zig").loopClearTimer;
 const JoinHandle = @import("runtime.zig").JoinHandle;
 const Duration = @import("time.zig").Duration;
 const Timeout = @import("time.zig").Timeout;
+const Clock = @import("time.zig").Clock;
+const Timestamp = @import("time.zig").Timestamp;
 const AnyTask = @import("task.zig").AnyTask;
 const meta = @import("meta.zig");
 const Timeoutable = @import("common.zig").Timeoutable;
@@ -56,7 +58,18 @@ pub const AutoCancel = struct {
         self.task = null;
     }
 
+    /// Arms against the monotonic clock. See `setClock` to pick another.
     pub fn set(self: *AutoCancel, timeout: Timeout) void {
+        self.setClock(timeout, .awake);
+    }
+
+    /// Same as `set`, but measures `timeout` against `clock`.
+    ///
+    /// A `.deadline` is an absolute timestamp in that clock's epoch, so one on
+    /// `.real` follows wall-clock adjustments where a monotonic deadline
+    /// cannot. Only the wall clocks are valid for a timer; the CPU-time clocks
+    /// are rejected when the timer is armed.
+    pub fn setClock(self: *AutoCancel, timeout: Timeout, clock: Clock) void {
         // Retire the previous arm before touching this struct again. Two
         // things make that necessary: a timer still live on another
         // executor's loop cannot be re-armed from this one, and a callback
@@ -84,6 +97,10 @@ pub const AutoCancel = struct {
         // Initialize ev.Timer
         self.timer.c.userdata = self;
         self.timer.c.callback = autoCancelCallback;
+        // Only ever written while disarmed. The clock picks which heap the
+        // timer lives in, so moving it under an armed timer would disarm it
+        // from the wrong one; the `clear` above is what makes this safe.
+        self.timer.clock = clock;
 
         // Activate the timer
         executor.loopSetTimer(&self.timer, timeout);
@@ -645,4 +662,104 @@ test "AutoCancel: re-armed while the previous arm is still live on another execu
         handle.* = try rt.spawn(worker, .{@as(usize, 200)});
     }
     for (&handles) |*handle| handle.join();
+}
+
+test "AutoCancel: set arms against the monotonic clock" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    timeout.set(.fromMilliseconds(50));
+    try std.testing.expectEqual(Clock.awake, timeout.timer.clock);
+}
+
+test "AutoCancel: setClock fires a duration measured on the real clock" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    timeout.setClock(.fromMilliseconds(10), .real);
+    try std.testing.expectEqual(Clock.real, timeout.timer.clock);
+
+    rt.sleep(.fromMilliseconds(500)) catch |err| {
+        try std.testing.expect(timeout.check(err));
+        return;
+    };
+
+    return error.TestUnexpectedResult;
+}
+
+test "AutoCancel: setClock takes an absolute deadline in the clock's own epoch" {
+    // The deadline is a wall-clock timestamp, not an offset from now. Passing
+    // it to a monotonic timer would read it as a point in the monotonic epoch,
+    // which is time since boot and so already long past.
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    const deadline = Timestamp.now(.real).addDuration(.fromMilliseconds(10));
+    timeout.setClock(.{ .deadline = deadline }, .real);
+
+    rt.sleep(.fromMilliseconds(500)) catch |err| {
+        try std.testing.expect(timeout.check(err));
+        return;
+    };
+
+    return error.TestUnexpectedResult;
+}
+
+test "AutoCancel: re-arming on another clock leaves the first heap" {
+    // Each clock has its own timer heap, and a disarm removes from the heap
+    // named by `timer.clock`. Re-arming has to disarm under the old clock
+    // before adopting the new one, or it corrupts the wrong heap.
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    // Far enough out that it is still armed, in the real clock's heap, when
+    // the second arm moves it.
+    timeout.setClock(.fromSeconds(60), .real);
+    timeout.setClock(.fromMilliseconds(10), .awake);
+    try std.testing.expectEqual(Clock.awake, timeout.timer.clock);
+
+    rt.sleep(.fromMilliseconds(500)) catch |err| {
+        try std.testing.expect(timeout.check(err));
+        return;
+    };
+
+    return error.TestUnexpectedResult;
+}
+
+test "AutoCancel: a cleared real-clock timer does not fire" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    timeout.setClock(.fromMilliseconds(10), .real);
+    timeout.clear();
+
+    try rt.sleep(.fromMilliseconds(50));
+}
+
+test "AutoCancel: setClock with .none arms nothing" {
+    const rt = try Runtime.init(std.testing.allocator, .{});
+    defer rt.deinit();
+
+    var timeout: AutoCancel = .init;
+    defer timeout.clear();
+
+    timeout.setClock(.fromMilliseconds(10), .real);
+    timeout.setClock(.none, .real);
+
+    try rt.sleep(.fromMilliseconds(50));
 }

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -44,6 +44,7 @@ pub const time = @import("time.zig"); // TODO: make non-pub
 pub const Duration = time.Duration;
 pub const Timestamp = time.Timestamp;
 pub const Timeout = time.Timeout;
+pub const Clock = time.Clock;
 pub const Stopwatch = time.Stopwatch;
 
 const fs = @import("fs.zig");


### PR DESCRIPTION
Closes #716.

## Problem

`AutoCancel` always armed on `.awake`. Everything beneath it already understood clocks:

- `ev.Timer` carries a `clock` field and an `initClock` constructor (`src/ev/completion.zig:540`)
- `Loop` keeps one timer heap per wall clock and resolves durations against the matching `now` (`armTimer`, `src/ev/loop.zig:417`)
- `Timeout.fromStd` is deliberately clockless, and says so: *"The clock itself travels separately on the `ev.Timer`"* (`src/time.zig`)
- `Clock.fromStdTimeout` exists to carry that other half

`AutoCancel.set` never assigned `self.timer.clock`, so it kept the `.awake` default from `.init` — and the two `fromStd` helpers had no caller able to use both halves.

The practical consequence is that a `std.Io`-facing wrapper cannot pass an absolute deadline through. dusty exposes `Request.setTimeout(std.Io.Timeout)`, so a handler can hand it a `.real` deadline; on the zio path it has to flatten that with `toDurationFromNow` into a relative monotonic duration measured at arm time. A settable clock stops being settable the moment it is armed, and the same call behaves differently depending on which runtime the application linked.

## Change

```zig
pub fn setClock(self: *AutoCancel, timeout: Timeout, clock: Clock) void
```

It assigns `timer.clock` alongside the `userdata` and `callback` that `set` already writes. `set(timeout)` becomes `setClock(timeout, .awake)`, so existing behaviour is untouched.

The clock is written *after* the `clear()` that opens the function, and only because of it: `disarmTimer` removes from `timers[clockIndex(timer.clock)]`, so moving the clock under an armed timer would take it out of the wrong heap. That `clear` is already there for the cross-executor re-arm and the in-flight-callback race; this just depends on it, with a comment saying so.

Also exports `zio.Clock`, which was missing next to `Duration`, `Timestamp` and `Timeout` and was reachable only as `zio.time.Clock`.

On the dusty side this collapses the whole conversion to a pass-through:

```zig
self.inner.setClock(.fromStd(timeout), .fromStdTimeout(timeout));
```

## Tests

Six added; `./check.sh --full` is green (674 unit tests, examples build, smoke test).

The absolute-deadline test is the one that actually needs the feature — a `.real` timestamp is ~1.7e18 ns against an awake epoch of ~1e13 ns, so on the monotonic heap it reads as far-future and never fires. I checked it discriminates rather than passing for free: swapping its `.real` for `.awake` fails the test.

The clock-switch test covers the ordering constraint above, re-arming a still-live real-clock timer onto `.awake`. The duration-on-`.real` test is weaker by nature (10ms is 10ms on either clock) and mainly shows the real heap gets driven.

## Not included

- A `withTimeoutClock` companion — worth deciding separately.
- `docs/changelog.md`, which is curated at release time.