### PR TITLE
Drain one overflow task per work check on a busy ring

### DIFF
--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -895,8 +895,7 @@ pub const Executor = struct {
                     pending / @max(self.runtime.executors.items.len, 1) + 1
                 else
                     pending;
-                self.run_queue.refill(batch);
-                if (!self.run_queue.isEmpty()) {
+                if (self.run_queue.refill(batch, .block) > 0) {
                     _ = self.runtime.searchers.cmpxchgStrong(1, 0, .acq_rel, .monotonic);
                     if (!self.run_queue.overflow.isEmpty()) self.runtime.armSearcher(null);
                     return;
@@ -928,26 +927,33 @@ pub const Executor = struct {
         // a pre-park check can sleep on the only work in existence.
         self.drainDispatched();
         const main_ready = check_main_ready and self.main_task.state.load(.acquire).tag == .ready;
-        // Overflow work counts too: if the ring is empty but the overflow queue
-        // still holds tasks (e.g. a local ring spill, which doesn't wake the
-        // loop), don't block — return promptly and refill from it below.
-        var has_work = main_ready or !self.run_queue.isEmpty();
-        // Pull a fair batch from the overflow queue (global when migration is
-        // on, this executor's own when off) back into the ring.
-        const pending = self.run_queue.overflow.len();
-        if (pending != 0 and !has_work) {
-            // With migration on the overflow is the shared global queue, so
-            // take only a fair ~1/n_exec slice to avoid monopolizing it. With
-            // migration off it is this executor's own private queue and we are
-            // its sole drainer, so take as much as fits (refill caps it).
-            const batch = if (self.runtime.options.enable_task_migration)
-                pending / @max(self.runtime.executors.items.len, 1) + 1
-            else
-                pending;
-            self.run_queue.refill(batch);
-            has_work = !self.run_queue.isEmpty();
+        if (main_ready or !self.run_queue.isEmpty()) {
+            // The batch refill below is reached only on an empty ring, but a ring
+            // that keeps refilling itself (tasks yielding to each other, a steady
+            // completion stream) never empties: it exits the run loop's drain on
+            // tick budget instead. Its overflow queue would then hold cross-thread
+            // wakes indefinitely, with no other rescue — the sole drainer is this
+            // executor, stealing takes from rings rather than from here, and
+            // armSearcher is a no-op while nobody is idle. One task per check
+            // bounds that wait to a tick without displacing local work.
+            _ = self.run_queue.refill(1, .try_only);
+            return true;
         }
-        return has_work;
+        // Ring empty: pull a fair batch from the overflow queue (global when
+        // migration is on, this executor's own when off) back into it. Overflow
+        // work counts as work, so a local ring spill (which doesn't wake the
+        // loop) can't put this executor to sleep.
+        const pending = self.run_queue.overflow.len();
+        if (pending == 0) return false;
+        // With migration on the overflow is the shared global queue, so take
+        // only a fair ~1/n_exec slice to avoid monopolizing it. With migration
+        // off it is this executor's own private queue and we are its sole
+        // drainer, so take as much as fits (refill caps it).
+        const batch = if (self.runtime.options.enable_task_migration)
+            pending / @max(self.runtime.executors.items.len, 1) + 1
+        else
+            pending;
+        return self.run_queue.refill(batch, .block) > 0;
     }
 
     /// Steal half of a random victim's ring into ours. Reached only from
@@ -2615,4 +2621,75 @@ test "runtime: installs a SIGPIPE handler while the disposition is default" {
         os.posix.sigaction(os.posix.SIG.PIPE, null, &current);
         try std.testing.expect(current.handler.handler == saved.handler.handler);
     }
+}
+
+test "runtime: a busy ring still drains cross-thread wakes from the overflow queue" {
+    // A ring that keeps refilling itself never empties, so it never reaches the
+    // batch refill: the inner drain exits on tick budget with tasks still queued.
+    // A task woken from a foreign thread lands in the overflow queue, whose only
+    // consumer is this executor, so without the per-check single-task peek it
+    // waits for the spinners to finish rather than for the wake.
+    if (builtin.single_threaded) return error.SkipZigTest;
+
+    const ResetEvent = @import("sync/ResetEvent.zig");
+
+    const H = struct {
+        // Bounds the failing case: without the peek the spinners run to the cap
+        // instead of being stopped by the woken task, so the test fails rather
+        // than hangs.
+        const spin_cap: u32 = 2_000_000;
+        // The foreign thread waits for this many yields before signaling, so the
+        // wake is guaranteed to land while the ring is busy.
+        const spin_before_wake: u32 = 1_000;
+
+        fn spinner(stop: *std.atomic.Value(bool), ticks: *std.atomic.Value(u32), hit_cap: *std.atomic.Value(bool)) !void {
+            var i: u32 = 0;
+            while (!stop.load(.acquire)) : (i += 1) {
+                if (i == spin_cap) {
+                    hit_cap.store(true, .release);
+                    return;
+                }
+                _ = ticks.fetchAdd(1, .monotonic);
+                try yield();
+            }
+        }
+
+        fn waiter(event: *ResetEvent, stop: *std.atomic.Value(bool), woken: *std.atomic.Value(bool)) !void {
+            try event.wait();
+            woken.store(true, .release);
+            stop.store(true, .release);
+        }
+
+        fn signaler(event: *ResetEvent, ticks: *std.atomic.Value(u32)) void {
+            while (ticks.load(.monotonic) < spin_before_wake) os.thread.yield();
+            event.set();
+        }
+    };
+
+    // One executor: the overflow queue then has exactly one possible consumer,
+    // and no thief can rescue the woken task.
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(1) });
+    defer runtime.deinit();
+
+    var event = ResetEvent.init;
+    var stop = std.atomic.Value(bool).init(false);
+    var ticks = std.atomic.Value(u32).init(0);
+    var hit_cap = std.atomic.Value(bool).init(false);
+    var woken = std.atomic.Value(bool).init(false);
+
+    var group: Group = .init;
+    defer group.cancel();
+
+    try group.spawn(H.waiter, .{ &event, &stop, &woken });
+    try group.spawn(H.spinner, .{ &stop, &ticks, &hit_cap });
+
+    const thread = try std.Thread.spawn(.{}, H.signaler, .{ &event, &ticks });
+    defer thread.join();
+
+    try group.wait();
+    try std.testing.expect(!group.hasFailed());
+
+    try std.testing.expect(woken.load(.acquire));
+    // The spinner was stopped by the wake, not by its own cap.
+    try std.testing.expect(!hit_cap.load(.acquire));
 }

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -28,6 +28,11 @@ const builtin = @import("builtin");
 const SimpleQueue = @import("simple_queue.zig").SimpleQueue;
 const OsMutex = @import("../os/thread.zig").Mutex;
 
+/// Whether a drain may wait for the overflow queue's lock. A caller that already
+/// has work to run picks `try_only`: losing the race defers one task, whereas
+/// blocking would park a runnable executor in a futex.
+pub const LockMode = enum { block, try_only };
+
 /// Thread-safe FIFO overflow queue: a mutex-guarded intrusive list plus an atomic
 /// length so the drain fast-path can skip the lock when empty. `count` is mutated
 /// only while holding the mutex, so it always equals the queue length whenever the
@@ -59,9 +64,12 @@ pub fn OverflowQueue(comptime T: type) type {
         }
 
         /// Pop up to `out.len` tasks into `out`; returns how many were taken.
-        pub fn popBatch(self: *Self, out: []*T) usize {
+        pub fn popBatch(self: *Self, out: []*T, comptime lock_mode: LockMode) usize {
             if (self.count.load(.acquire) == 0) return 0;
-            self.mutex.lock();
+            switch (lock_mode) {
+                .block => self.mutex.lock(),
+                .try_only => if (!self.mutex.tryLock()) return 0,
+            }
             defer self.mutex.unlock();
             var i: usize = 0;
             while (i < out.len) : (i += 1) {
@@ -239,8 +247,11 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
         }
 
         /// Pull up to `max` tasks from the overflow queue into the ring (owner,
-        /// once per tick). Only fills available space, so it never overflows.
-        pub fn refill(self: *Self, max: usize) void {
+        /// once per tick), returning how many moved. Only fills available space,
+        /// so it never overflows. The tasks land straight in the ring's own slots
+        /// and the tail is published once, so this costs strictly less than a pop
+        /// followed by a push.
+        pub fn refill(self: *Self, max: usize, comptime lock_mode: LockMode) usize {
             const t = self.ownTail();
             const h = self.loadHead();
             const space: usize = capacity - (t -% h);
@@ -248,10 +259,11 @@ pub fn LocalRunQueue(comptime T: type, comptime stealable: bool) type {
             const start: usize = t & mask;
             const contiguous = capacity - start;
             const want = @min(contiguous, @min(space, @min(max, max_batch)));
-            if (want == 0) return;
+            if (want == 0) return 0;
 
-            const got = self.overflow.popBatch(self.buffer[start .. start + want]);
+            const got = self.overflow.popBatch(self.buffer[start .. start + want], lock_mode);
             if (got > 0) self.storeTail(t +% @as(u32, @intCast(got)));
+            return got;
         }
 
         /// Number of tasks currently in the ring (used for maybeYield fairness).
@@ -350,7 +362,7 @@ test "LocalRunQueue: overflow spills to the overflow queue and everything drains
     }
     var buf: [64]*TestNode = undefined;
     while (true) {
-        const got = ov.popBatch(&buf);
+        const got = ov.popBatch(&buf, .block);
         if (got == 0) break;
         for (buf[0..got]) |n| {
             try testing.expect(!seen[n.id]);
@@ -404,7 +416,7 @@ test "LocalRunQueue: non-stealable variant pushes, pops, and overflows" {
     while (q.pop()) |_| count += 1;
     var buf: [64]*TestNode = undefined;
     while (true) {
-        const got = ov.popBatch(&buf);
+        const got = ov.popBatch(&buf, .block);
         if (got == 0) break;
         count += got;
     }
@@ -431,7 +443,7 @@ test "LocalRunQueue: refill writes directly on both sides of ring wrap" {
         node.* = .{ .id = id };
         ov.push(node);
     }
-    q.refill(20);
+    _ = q.refill(20, .block);
     try testing.expectEqual(6, q.len());
     try testing.expectEqual(14, ov.len());
     for (250..256) |id| {
@@ -439,7 +451,7 @@ test "LocalRunQueue: refill writes directly on both sides of ring wrap" {
     }
 
     // Once tail wraps, the next refill writes directly at the ring's start.
-    q.refill(20);
+    _ = q.refill(20, .block);
     try testing.expectEqual(14, q.len());
     try testing.expect(ov.isEmpty());
     for (256..270) |id| {
@@ -559,7 +571,7 @@ test "LocalRunQueue: concurrent push/pop and steal loses or duplicates no task" 
         if (i % 64 == 0) {
             if (owner.pop()) |n| ctx.mark(n);
         }
-        const got = owner_ov.popBatch(&buf);
+        const got = owner_ov.popBatch(&buf, .block);
         for (buf[0..got]) |n| ctx.mark(n);
     }
     ctx.stop.store(true, .release);
@@ -568,13 +580,13 @@ test "LocalRunQueue: concurrent push/pop and steal loses or duplicates no task" 
     // Drain everything that remains anywhere.
     while (owner.pop()) |n| ctx.mark(n);
     while (true) {
-        const got = owner_ov.popBatch(&buf);
+        const got = owner_ov.popBatch(&buf, .block);
         if (got == 0) break;
         for (buf[0..got]) |n| ctx.mark(n);
     }
     while (thief.pop()) |n| ctx.mark(n);
     while (true) {
-        const got = thief_ov.popBatch(&buf);
+        const got = thief_ov.popBatch(&buf, .block);
         if (got == 0) break;
         for (buf[0..got]) |n| ctx.mark(n);
     }
@@ -643,13 +655,13 @@ test "LocalRunQueue: multiple concurrent stealers lose or duplicate no task" {
     var buf: [64]*TestNode = undefined;
     while (owner.pop()) |n| ctx.mark(n);
     while (true) {
-        const got = owner_ov.popBatch(&buf);
+        const got = owner_ov.popBatch(&buf, .block);
         if (got == 0) break;
         for (buf[0..got]) |n| ctx.mark(n);
     }
     for (&thieves) |*t| while (t.pop()) |n| ctx.mark(n);
     for (&thief_ovs) |*o| while (true) {
-        const got = o.popBatch(&buf);
+        const got = o.popBatch(&buf, .block);
         if (got == 0) break;
         for (buf[0..got]) |n| ctx.mark(n);
     };
@@ -673,13 +685,13 @@ test "OverflowQueue: push and popBatch are FIFO" {
     try testing.expectEqual(5, ov.len());
 
     var buf: [3]*TestNode = undefined;
-    try testing.expectEqual(3, ov.popBatch(&buf));
+    try testing.expectEqual(3, ov.popBatch(&buf, .block));
     try testing.expectEqual(0, buf[0].id);
     try testing.expectEqual(2, buf[2].id);
     try testing.expectEqual(2, ov.len());
 
     var buf2: [10]*TestNode = undefined;
-    try testing.expectEqual(2, ov.popBatch(&buf2));
+    try testing.expectEqual(2, ov.popBatch(&buf2, .block));
     try testing.expect(ov.isEmpty());
-    try testing.expectEqual(0, ov.popBatch(&buf2));
+    try testing.expectEqual(0, ov.popBatch(&buf2, .block));
 }


### PR DESCRIPTION
## Problem

A local ring that keeps refilling itself never empties. The run loop's inner `while (getNextTask())` drain exits on **tick budget** with tasks still queued (tasks yielding to each other, or a steady completion stream), so `checkLocalWork` sees a non-empty ring, takes the `has_work` branch, polls, and loops.

But the overflow queue was only ever drained on the empty-ring path. So a task woken from another thread lands in `overflow` and waits indefinitely, and nothing else rescues it:

- that queue's only consumer is its own executor,
- `stealWork` steals from *rings*, not from the overflow queue,
- `armSearcher` is a no-op while `idle_mask == 0`.

`scheduleTaskRemote`'s `loop.wake()` doesn't help: it breaks the poll, but the run loop still takes the `has_work` branch.

This is a liveness bug in both pinned and stealing mode. In pinned mode there is no recourse at all.

## History

The unconditional per-tick drain was lost in `fbd5c2cf` ("runtime: replace local run queue with a bounded ring buffer"), which moved the overflow drain behind the empty-ring check. Before that, `drainGlobalQueue()` ran at the top of every run-loop iteration regardless of local work, and earlier still had an explicit "local queue has work but space available, take one from global queue" branch.

## Fix

`checkLocalWork` takes a single task from the overflow queue on the has-work path, bounding the wait to one tick without displacing local work.

It reuses `refill`, which claims ring space, drains straight into the ring's own slots and publishes the tail once, so it costs less than a pop followed by a push. It acquires the lock with `tryLock`: an executor that already has work to run must never park in a futex looking for more, and losing the race just defers one task to the next tick.

`refill` now returns how many tasks it moved, which lets the two existing callers drop an `isEmpty()` each.

## Test

`runtime: a busy ring still drains cross-thread wakes from the overflow queue` keeps a ring busy with a spinning task, then wakes a parked task from a foreign thread and asserts the spinner was stopped by that wake rather than by its own iteration cap. The cap means the failing case fails rather than hangs.

- with the peek: passes in 9.4ms
- with the peek stubbed out: fails at 447ms (spinner ran to its 2M yield cap)

`./check.sh --full` passes, as does `zig build test -Dtask-migration=false`.