### PR TITLE
Rename ResetEvent to Event and timedWait to waitTimeout

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Renamed `ResetEvent` to `Event`, matching `std.Io.Event`. `zio.ResetEvent` stays as a
+  deprecated alias, so existing code keeps working, but it will be removed in a future
+  release.
+
+- Renamed `timedWait` to `waitTimeout` on `Event`, `Condition`, `Semaphore`, `Futex`,
+  `Signal` and `CompletionQueue`, matching `std.Io.Event.waitTimeout`. `Futex.timedWaitClock`
+  became `Futex.waitTimeoutClock`. The old names stay as deprecated aliases, so existing code
+  keeps working, but they will be removed in a future release.
+
 - Fixed relative paths containing `.` or `..` failing on Windows with
   `unexpected error: .INVALID_NAME` (#714). This affected every path API taking a `Dir`,
   down to `dir.createDir("./data", ...)`.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -4,7 +4,7 @@ TODO
 
 - [`Channel`](/zio/apidocs/#zio.Channel)
 - [`BroadcastChannel`](/zio/apidocs/#zio.BroadcastChannel)
-- [`ResetEvent`](/zio/apidocs/#zio.ResetEvent)
+- [`Event`](/zio/apidocs/#zio.Event)
 - [`Mutex`](/zio/apidocs/#zio.Mutex)
 - [`Condition`](/zio/apidocs/#zio.Condition)
 - [`Semaphore`](/zio/apidocs/#zio.Semaphore)

--- a/examples/stderr_smoke.zig
+++ b/examples/stderr_smoke.zig
@@ -38,7 +38,7 @@ fn poolWorker() void {
 /// call returns, so an implementation that let the waiter through early fails
 /// rather than producing the same output.
 const Contend = struct {
-    has_lock: zio.ResetEvent = .init,
+    has_lock: zio.Event = .init,
     released: std.atomic.Value(bool) = .init(false),
 };
 

--- a/src/common.zig
+++ b/src/common.zig
@@ -161,7 +161,7 @@ pub const Waiter = struct {
         /// commit fence. Such a notification consumed nothing, but its
         /// identity would otherwise be lost, and re-polling only recovers it
         /// for sources whose readiness is still standing afterwards (a
-        /// drained Group can take new tasks, a set ResetEvent can be reset).
+        /// drained Group can take new tasks, a set Event can be reset).
         /// The owning select promotes this into `winner` once the fence is
         /// down; see `promotePending`.
         pending: *std.atomic.Value(usize),
@@ -561,7 +561,7 @@ pub const Waiter = struct {
 };
 
 /// Shared `asyncWait` body for level sources backed by a sticky-flag
-/// WaitQueue (Future, ResetEvent, Awaitable): readiness is the flag,
+/// WaitQueue (Future, Event, Awaitable): readiness is the flag,
 /// completion pops every waiter and signals it. Idempotent under re-poll,
 /// and claims the select before reporting ready.
 pub fn waitOnFlagQueue(queue: *WaitQueue(WaitNode), waiter: *Waiter) AsyncWaitState {

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -9,7 +9,7 @@
 //!
 //! Runtime-only: must be used from within an async task context.
 //!
-//! One task drives the queue: `wait`, `timedWait`, `next`, `cancel` and
+//! One task drives the queue: `wait`, `waitTimeout`, `next`, `cancel` and
 //! `cancelAll` belong to it, and the rule is enforced: any of them called
 //! while another task's select is parked on the queue panics. `submit` and `close` are thread-safe, so other
 //! tasks can park their own operations here for the driver to process. An
@@ -78,7 +78,7 @@ pub const CompletionQueue = struct {
     mutex: os.Mutex,
     pending: Queue,
     completed: Queue,
-    /// Futex word the blocking driver paths (`wait`, `timedWait`, `cancel`,
+    /// Futex word the blocking driver paths (`wait`, `waitTimeout`, `cancel`,
     /// `cancelAll`) snapshot and park on. Counts completion arrivals and a
     /// close with nothing in flight (a close over in-flight operations stays
     /// silent, each of them wakes the driver on its own way to `completed`).
@@ -235,7 +235,7 @@ pub const CompletionQueue = struct {
     /// ready before the timeout expires.
     ///
     /// Returns `error.Closed` when the queue is closed and fully drained.
-    pub fn timedWait(self: *CompletionQueue, timeout: Timeout) (Timeoutable || Cancelable || Closeable)!*Completion {
+    pub fn waitTimeout(self: *CompletionQueue, timeout: Timeout) (Timeoutable || Cancelable || Closeable)!*Completion {
         if (timeout == .none) {
             return self.wait();
         }
@@ -252,7 +252,7 @@ pub const CompletionQueue = struct {
             if (node) |n| return completionFromGroup(n);
             if (drained) return error.Closed;
 
-            Futex.timedWait(&self.signal.raw, seen, timeout) catch |err| switch (err) {
+            Futex.waitTimeout(&self.signal.raw, seen, timeout) catch |err| switch (err) {
                 error.Canceled => {
                     self.closeAndKeepResults();
                     return error.Canceled;
@@ -271,6 +271,9 @@ pub const CompletionQueue = struct {
             };
         }
     }
+
+    /// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+    pub const timedWait = waitTimeout;
 
     /// Returns true if there are no pending or completed operations.
     pub fn isEmpty(self: *CompletionQueue) bool {
@@ -487,7 +490,7 @@ pub const CompletionQueue = struct {
     ///
     /// NOT thread-safe, unlike `submit` and `close`: this belongs to the task
     /// that drives the queue and must never run concurrently with `wait`,
-    /// `timedWait`, `next` or `cancelAll`. A concurrent consumer could take
+    /// `waitTimeout`, `next` or `cancelAll`. A concurrent consumer could take
     /// the finished `c` out of the queue first, leaving the wait below stuck
     /// forever on a node that already left; the single-driver rule is what
     /// makes that impossible. To cancel a specific operation from another
@@ -692,7 +695,7 @@ test "CompletionQueue: wait on a closed empty queue returns error.Closed" {
 
     cq.close();
     try std.testing.expectError(error.Closed, cq.wait());
-    try std.testing.expectError(error.Closed, cq.timedWait(.fromMilliseconds(10)));
+    try std.testing.expectError(error.Closed, cq.waitTimeout(.fromMilliseconds(10)));
 
     // Idempotent.
     cq.close();
@@ -790,7 +793,7 @@ test "CompletionQueue: dynamic submit during iteration" {
     try std.testing.expectEqual(2, count);
 }
 
-test "CompletionQueue: wait then timedWait does not false-timeout" {
+test "CompletionQueue: wait then waitTimeout does not false-timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -802,14 +805,14 @@ test "CompletionQueue: wait then timedWait does not false-timeout" {
     const c1 = try cq.wait();
     try std.testing.expectEqual(&timer1.c, c1);
 
-    // Second: submit and timedWait() — must not return false Timeout
+    // Second: submit and waitTimeout() — must not return false Timeout
     var timer2 = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
     try cq.submit(&timer2.c);
-    const c2 = try cq.timedWait(.{ .duration = .fromSeconds(1) });
+    const c2 = try cq.waitTimeout(.{ .duration = .fromSeconds(1) });
     try std.testing.expectEqual(&timer2.c, c2);
 }
 
-test "CompletionQueue: timedWait completes before timeout" {
+test "CompletionQueue: waitTimeout completes before timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -818,11 +821,11 @@ test "CompletionQueue: timedWait completes before timeout" {
     var timer = ev.Timer.init(.{ .duration = .fromMilliseconds(10) });
     try cq.submit(&timer.c);
 
-    const c = try cq.timedWait(.{ .duration = .fromSeconds(1) });
+    const c = try cq.waitTimeout(.{ .duration = .fromSeconds(1) });
     try std.testing.expectEqual(&timer.c, c);
 }
 
-test "CompletionQueue: timedWait returns timeout" {
+test "CompletionQueue: waitTimeout returns timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
@@ -832,20 +835,20 @@ test "CompletionQueue: timedWait returns timeout" {
     var timer = ev.Timer.init(.{ .duration = .fromSeconds(10) });
     try cq.submit(&timer.c);
 
-    try std.testing.expectError(error.Timeout, cq.timedWait(.fromMilliseconds(10)));
+    try std.testing.expectError(error.Timeout, cq.waitTimeout(.fromMilliseconds(10)));
 
     // Clean up
     cq.cancelAll(.discard);
 }
 
-test "CompletionQueue: timedWait on an open empty queue waits for the timeout" {
+test "CompletionQueue: waitTimeout on an open empty queue waits for the timeout" {
     var rt = try Runtime.init(std.testing.allocator, .{});
     defer rt.deinit();
 
     // An open queue blocks on empty rather than reporting exhaustion, so
     // with nothing submitted the timeout is the only way out.
     var cq = CompletionQueue.init();
-    try std.testing.expectError(error.Timeout, cq.timedWait(.fromMilliseconds(10)));
+    try std.testing.expectError(error.Timeout, cq.waitTimeout(.fromMilliseconds(10)));
 }
 
 test "CompletionQueue: cancel pending operations" {
@@ -884,7 +887,7 @@ test "CompletionQueue: a finished completion can be submitted again (#673)" {
     try cq.submit(&timer.c);
     try std.testing.expect(cq.hasPending());
 
-    const second = try cq.timedWait(.fromSeconds(5));
+    const second = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&timer.c, second);
     try std.testing.expect(cq.isEmpty());
 }
@@ -901,7 +904,7 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
     try cq.submit(&fast.c);
     try cq.submit(&slow.c);
 
-    const first = try cq.timedWait(.fromSeconds(5));
+    const first = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&fast.c, first);
 
     try cq.submit(&fast.c);
@@ -910,8 +913,8 @@ test "CompletionQueue: re-submitting the completion that fired leaves the others
     // across the re-submission. Which lands first is a wall-clock question and
     // not what this pins, so take them in either order. A lost queue link
     // shows up as `error.Timeout` here rather than as a test that hangs.
-    const second = try cq.timedWait(.fromSeconds(5));
-    const third = try cq.timedWait(.fromSeconds(5));
+    const second = try cq.waitTimeout(.fromSeconds(5));
+    const third = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expect(
         (second == &fast.c and third == &slow.c) or
             (second == &slow.c and third == &fast.c),
@@ -939,7 +942,7 @@ test "CompletionQueue: a notify that lands while an Async is unarmed is not lost
     mailbox.notify();
     try cq.submit(&mailbox.c);
 
-    const second = try cq.timedWait(.fromSeconds(5));
+    const second = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&mailbox.c, second);
 }
 
@@ -1129,7 +1132,7 @@ test "CompletionQueue: close hands out in-flight completions before error.Closed
 
     // Closed but not drained: the wait still blocks for the in-flight
     // operation and delivers it.
-    const c = try cq.timedWait(.fromSeconds(5));
+    const c = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&timer.c, c);
     try timer.getResult();
 
@@ -1159,7 +1162,7 @@ test "CompletionQueue: another task's submit satisfies a wait blocked on an empt
     defer handle.cancel();
 
     // Empty and open: parks until the producer's operation completes.
-    const c = try cq.timedWait(.fromSeconds(5));
+    const c = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&timer.c, c);
     try timer.getResult();
     try handle.join();
@@ -1182,7 +1185,7 @@ test "CompletionQueue: race group of I/O and timer works as an idle timeout (#67
     try cq.submit(&grp1.c);
 
     mail1.notify();
-    const first = try cq.timedWait(.fromSeconds(5));
+    const first = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&grp1.c, first);
     try grp1.getResult();
     try mail1.getResult();
@@ -1198,7 +1201,7 @@ test "CompletionQueue: race group of I/O and timer works as an idle timeout (#67
     grp2.add(&idle2.c);
     try cq.submit(&grp2.c);
 
-    const second = try cq.timedWait(.fromSeconds(5));
+    const second = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&grp2.c, second);
     try grp2.getResult();
     try idle2.getResult();
@@ -1342,7 +1345,7 @@ test "CompletionQueue: losing a select does not lose the completion" {
 
     // The queue was only deregistered from; the operation is still armed and
     // comes back through the ordinary wait.
-    const c = try cq.timedWait(.fromSeconds(5));
+    const c = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&timer.c, c);
     try std.testing.expect(cq.isEmpty());
 }
@@ -1451,7 +1454,7 @@ test "CompletionQueue: canceling a select leaves the queue open" {
     try std.testing.expect(cq.hasPending());
     var other = ev.Timer.init(.{ .duration = .fromMilliseconds(5) });
     try cq.submit(&other.c);
-    const c = try cq.timedWait(.fromSeconds(5));
+    const c = try cq.waitTimeout(.fromSeconds(5));
     try std.testing.expectEqual(&other.c, c);
 }
 
@@ -1615,7 +1618,7 @@ test "CompletionQueue: a claim landing on a canceled select is delivered, never 
         } else |err| {
             try std.testing.expectEqual(error.Canceled, err);
             // No claim: the completion stays at its source.
-            const c = try cq.timedWait(.fromSeconds(5));
+            const c = try cq.waitTimeout(.fromSeconds(5));
             try std.testing.expectEqual(&mail.c, c);
             try std.testing.expect(cq.isEmpty());
         }

--- a/src/io.zig
+++ b/src/io.zig
@@ -422,7 +422,7 @@ fn checkCancelImpl(_: ?*anyopaque) Io.Cancelable!void {
 }
 
 fn futexWaitImpl(_: ?*anyopaque, ptr: *const u32, expected: u32, timeout: Io.Timeout) Io.Cancelable!void {
-    Futex.timedWaitClock(ptr, expected, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
+    Futex.waitTimeoutClock(ptr, expected, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
         error.Timeout => return,
         error.Canceled => return error.Canceled,
     };
@@ -716,7 +716,7 @@ fn batchAwaitConcurrentImpl(userdata: ?*anyopaque, batch: *Io.Batch, timeout: Io
         if (batch.completed.head != .none or batch.pending.head == .none) return;
 
         // Wait for ready_count to become non-zero
-        Futex.timedWaitClock(&state.ready_count.raw, 0, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
+        Futex.waitTimeoutClock(&state.ready_count.raw, 0, .fromStd(timeout), .fromStdTimeout(timeout)) catch |err| switch (err) {
             error.Timeout => {
                 // Drain one more time before returning timeout
                 batchDrainReady(batch, state);

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -2241,13 +2241,13 @@ test "runtime: maybeYield yields once the tick budget is spent" {
     const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
-    const ResetEvent = @import("sync/ResetEvent.zig");
+    const Event = @import("sync/Event.zig");
 
-    var event: ResetEvent = .init;
+    var event: Event = .init;
     var counter: usize = 0;
 
     const waiterTask = struct {
-        fn call(reset_event: *ResetEvent, counter_ptr: *usize) !void {
+        fn call(reset_event: *Event, counter_ptr: *usize) !void {
             try reset_event.wait();
             counter_ptr.* += 1;
         }
@@ -2399,14 +2399,14 @@ test "Runtime: multi-threaded with task migration" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(8) });
     defer runtime.deinit();
 
-    const ResetEvent = @import("sync/ResetEvent.zig");
+    const Event = @import("sync/Event.zig");
 
     const TestContext = struct {
         group: *Group,
-        done: ResetEvent = .{},
+        done: Event = .{},
         counter: std.atomic.Value(u32) = .init(0),
 
-        fn task(ctx: *@This(), parent: *ResetEvent) !void {
+        fn task(ctx: *@This(), parent: *Event) !void {
             parent.set();
 
             const n = ctx.counter.fetchAdd(1, .acquire);
@@ -2415,7 +2415,7 @@ test "Runtime: multi-threaded with task migration" {
                 return;
             }
 
-            var event: ResetEvent = .{};
+            var event: Event = .{};
             ctx.group.spawn(task, .{ ctx, &event }) catch |err| {
                 std.debug.print("task migration failed: {}\n", .{err});
                 return err;
@@ -2432,7 +2432,7 @@ test "Runtime: multi-threaded with task migration" {
 
     var ctx: TestContext = .{ .group = &group };
 
-    var event: ResetEvent = .{};
+    var event: Event = .{};
 
     try group.spawn(TestContext.task, .{ &ctx, &event });
 
@@ -2453,7 +2453,7 @@ test "runtime: wake-before-park awaken bit stress (two executors)" {
 }
 
 fn wakeBeforeParkStress(executor_count: u6) !void {
-    const ResetEvent = @import("sync/ResetEvent.zig");
+    const Event = @import("sync/Event.zig");
 
     const runtime = try Runtime.init(std.testing.allocator, .{
         .executors = .exact(executor_count),
@@ -2464,8 +2464,8 @@ fn wakeBeforeParkStress(executor_count: u6) !void {
         // Number of ping-pong iterations to exercise the wake-before-park window.
         const iterations: u32 = 10_000;
 
-        ping: ResetEvent = .{},
-        pong: ResetEvent = .{},
+        ping: Event = .{},
+        pong: Event = .{},
         counter: std.atomic.Value(u32) = .init(0),
 
         // Waits on ping each iteration — this is the task that parks, and the one
@@ -2631,7 +2631,7 @@ test "runtime: a busy ring still drains cross-thread wakes from the overflow que
     // waits for the spinners to finish rather than for the wake.
     if (builtin.single_threaded) return error.SkipZigTest;
 
-    const ResetEvent = @import("sync/ResetEvent.zig");
+    const Event = @import("sync/Event.zig");
 
     const H = struct {
         // Bounds the failing case: without the peek the spinners run to the cap
@@ -2654,13 +2654,13 @@ test "runtime: a busy ring still drains cross-thread wakes from the overflow que
             }
         }
 
-        fn waiter(event: *ResetEvent, stop: *std.atomic.Value(bool), woken: *std.atomic.Value(bool)) !void {
+        fn waiter(event: *Event, stop: *std.atomic.Value(bool), woken: *std.atomic.Value(bool)) !void {
             try event.wait();
             woken.store(true, .release);
             stop.store(true, .release);
         }
 
-        fn signaler(event: *ResetEvent, ticks: *std.atomic.Value(u32)) void {
+        fn signaler(event: *Event, ticks: *std.atomic.Value(u32)) void {
             while (ticks.load(.monotonic) < spin_before_wake) os.thread.yield();
             event.set();
         }
@@ -2671,7 +2671,7 @@ test "runtime: a busy ring still drains cross-thread wakes from the overflow que
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(1) });
     defer runtime.deinit();
 
-    var event = ResetEvent.init;
+    var event = Event.init;
     var stop = std.atomic.Value(bool).init(false);
     var ticks = std.atomic.Value(u32).init(0);
     var hit_cap = std.atomic.Value(bool).init(false);

--- a/src/select.zig
+++ b/src/select.zig
@@ -66,7 +66,7 @@ const meta = @import("meta.zig");
 //         reported: a notification whose claim bounced off the commit fence
 //         records its arm, and select() promotes that record. So a source
 //         whose readiness can lapse (a drained Group taking new tasks, a set
-//         ResetEvent being reset) may report itself unready here without
+//         Event being reset) may report itself unready here without
 //         losing the event.
 //       - Thread-safe with respect to the source; only the owning select's
 //         sweep calls asyncWait for a given waiter.
@@ -1104,10 +1104,10 @@ test "select: promotes a notification that bounced off the commit fence" {
     // The synthetic arm becomes ready on its second poll, so a regression in
     // the promotion or settle wiring shows up as the wrong arm winning rather
     // than as a hang.
-    const ResetEvent = @import("sync/ResetEvent.zig");
+    const Event = @import("sync/Event.zig");
 
     const FenceArm = struct {
-        event: *ResetEvent,
+        event: *Event,
 
         pub const Result = void;
         pub const WaitContext = struct { fenced: bool = false };
@@ -1147,7 +1147,7 @@ test "select: promotes a notification that bounced off the commit fence" {
 
     const Body = struct {
         fn run() !void {
-            var event = ResetEvent.init;
+            var event = Event.init;
             var fence_arm = FenceArm{ .event = &event };
 
             const result = try select(.{ .event = &event, .fence = &fence_arm });

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -316,7 +316,7 @@ pub const Signal = struct {
     ///
     /// Arguments:
     /// - timeout: Timeout
-    pub fn timedWait(self: *Signal, timeout: Timeout) (Timeoutable || Cancelable)!void {
+    pub fn waitTimeout(self: *Signal, timeout: Timeout) (Timeoutable || Cancelable)!void {
         // Check if we already have pending signals
         if (self.entry.counter.swap(0, .acquire) > 0) {
             return;
@@ -350,6 +350,9 @@ pub const Signal = struct {
         // Consume the counter
         _ = self.entry.counter.swap(0, .acquire);
     }
+
+    /// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+    pub const timedWait = waitTimeout;
 
     /// Registers a waiter to be notified when the signal is received, or
     /// claims the select if one already was.
@@ -472,7 +475,7 @@ test "Signal: multiple handlers for same signal" {
     try std.testing.expectEqual(3, count.load(.monotonic));
 }
 
-test "Signal: timedWait timeout" {
+test "Signal: waitTimeout timeout" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
     var rt = try Runtime.init(std.testing.allocator, .{});
@@ -481,11 +484,11 @@ test "Signal: timedWait timeout" {
     var sig = try Signal.init(.interrupt);
     defer sig.deinit();
 
-    const result = sig.timedWait(.{ .duration = .fromMilliseconds(50) });
+    const result = sig.waitTimeout(.{ .duration = .fromMilliseconds(50) });
     try std.testing.expectError(error.Timeout, result);
 }
 
-test "Signal: timedWait receives signal before timeout" {
+test "Signal: waitTimeout receives signal before timeout" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
     var rt = try Runtime.init(std.testing.allocator, .{});
@@ -497,7 +500,7 @@ test "Signal: timedWait receives signal before timeout" {
         fn call(flag: *bool) !void {
             var sig = try Signal.init(.interrupt);
             defer sig.deinit();
-            try sig.timedWait(.{ .duration = .fromSeconds(1) });
+            try sig.waitTimeout(.{ .duration = .fromSeconds(1) });
             flag.* = true;
         }
     }.call;

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -156,7 +156,7 @@ pub fn waitUncancelable(self: *Condition, mutex: *Mutex) void {
 /// Returns `error.Canceled` if the task is cancelled while waiting. Cancellation
 /// takes priority over timeout - if both occur, `error.Canceled` is returned.
 /// The mutex will be held when returning with any error.
-pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable || Cancelable)!void {
+pub fn waitTimeout(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable || Cancelable)!void {
     // Stack-allocated waiter - separates operation wait node from task wait node
     var waiter: Waiter = .init();
 
@@ -208,6 +208,9 @@ pub fn timedWait(self: *Condition, mutex: *Mutex, timeout: Timeout) (Timeoutable
         return error.Timeout;
     }
 }
+
+/// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+pub const timedWait = waitTimeout;
 
 /// Wakes one task waiting on this condition variable.
 ///
@@ -297,7 +300,7 @@ test "Condition basic wait/signal" {
     try std.testing.expect(ready);
 }
 
-test "Condition timedWait timeout" {
+test "Condition waitTimeout timeout" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -307,7 +310,7 @@ test "Condition timedWait timeout" {
     try mutex.lock();
     defer mutex.unlock();
 
-    const result = condition.timedWait(&mutex, .{ .duration = .fromMilliseconds(10) });
+    const result = condition.waitTimeout(&mutex, .{ .duration = .fromMilliseconds(10) });
     try std.testing.expectError(error.Timeout, result);
 }
 

--- a/src/sync/Event.zig
+++ b/src/sync/Event.zig
@@ -3,7 +3,7 @@
 
 //! A manual-reset synchronization event for async tasks.
 //!
-//! ResetEvent is a boolean flag that tasks can wait on. It can be in one of two
+//! Event is a boolean flag that tasks can wait on. It can be in one of two
 //! states: set or unset. Tasks can wait for the event to become set, and once set,
 //! all waiting tasks are released. The event remains set until explicitly reset.
 //!
@@ -17,18 +17,18 @@
 //!
 //! The event provides memory ordering guarantees: memory accesses before `set()`
 //! happen-before any task observing the set state via `isSet()`, `wait()`, or
-//! `timedWait()`.
+//! `waitTimeout()`.
 //!
 //! ## Example
 //!
 //! ```zig
-//! fn worker(event: *zio.ResetEvent, id: u32) !void {
+//! fn worker(event: *zio.Event, id: u32) !void {
 //!     // Wait for event to be signaled
 //!     try event.wait();
 //!     std.debug.print("Worker {} proceeding\n", .{id});
 //! }
 //!
-//! fn coordinator(rt: *Runtime, event: *zio.ResetEvent) !void {
+//! fn coordinator(rt: *Runtime, event: *zio.Event) !void {
 //!     // Do some initialization work
 //!     // ...
 //!
@@ -36,7 +36,7 @@
 //!     event.set();
 //! }
 //!
-//! var event = zio.ResetEvent.init;
+//! var event = zio.Event.init;
 //!
 //! var task1 = try runtime.spawn(worker, .{runtime, &event, 1 });
 //! var task2 = try runtime.spawn(worker, .{runtime, &event, 2 });
@@ -60,25 +60,25 @@ const Waiter = @import("../common.zig").Waiter;
 /// Wait queue with flag indicating whether event is set.
 wait_queue: WaitQueue(WaitNode) = .empty,
 
-const ResetEvent = @This();
+const Event = @This();
 
-/// Creates a new ResetEvent in the unset state.
-pub const init: ResetEvent = .{};
+/// Creates a new Event in the unset state.
+pub const init: Event = .{};
 
 /// Returns whether the event is currently set.
 ///
 /// Returns `true` if `set()` has been called and `reset()` has not been called since.
 /// Returns `false` otherwise.
-pub fn isSet(self: *const ResetEvent) bool {
+pub fn isSet(self: *const Event) bool {
     return self.wait_queue.isFlagSet();
 }
 
 /// Sets the event and wakes all waiting tasks.
 ///
-/// Marks the event as set and unblocks all tasks waiting in `wait()` or `timedWait()`.
+/// Marks the event as set and unblocks all tasks waiting in `wait()` or `waitTimeout()`.
 /// The event remains set until `reset()` is called. Multiple calls to `set()` while
 /// already set have no effect.
-pub fn set(self: *ResetEvent) void {
+pub fn set(self: *Event) void {
     // Pop and wake all waiters while setting the flag.
     //
     // UAF safety: `self` may live on a coroutine stack belonging to a waiting task.
@@ -95,8 +95,8 @@ pub fn set(self: *ResetEvent) void {
 ///
 /// After calling `reset()`, the event is back in the unset state and tasks can wait
 /// on it again. It is undefined behavior to call `reset()` while tasks are waiting
-/// in `wait()` or `timedWait()`.
-pub fn reset(self: *ResetEvent) void {
+/// in `wait()` or `waitTimeout()`.
+pub fn reset(self: *Event) void {
     std.debug.assert(!self.wait_queue.hasWaiters());
     self.wait_queue.clearFlag();
 }
@@ -107,7 +107,7 @@ pub fn reset(self: *ResetEvent) void {
 /// already set when called, returns immediately without suspending.
 ///
 /// Returns `error.Canceled` if the task is cancelled while waiting.
-pub fn wait(self: *ResetEvent) Cancelable!void {
+pub fn wait(self: *Event) Cancelable!void {
     // Fast path: already set
     if (self.wait_queue.isFlagSet()) {
         return;
@@ -147,7 +147,7 @@ pub fn wait(self: *ResetEvent) Cancelable!void {
 ///
 /// Returns `error.Timeout` if the timeout expires before the event is set.
 /// Returns `error.Canceled` if the task is cancelled while waiting.
-pub fn timedWait(self: *ResetEvent, timeout: Timeout) (Timeoutable || Cancelable)!void {
+pub fn waitTimeout(self: *Event, timeout: Timeout) (Timeoutable || Cancelable)!void {
     // Fast path: already set
     if (self.wait_queue.isFlagSet()) {
         return;
@@ -188,18 +188,21 @@ pub fn timedWait(self: *ResetEvent, timeout: Timeout) (Timeoutable || Cancelable
     _ = self.wait_queue.isFlagSet();
 }
 
+/// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+pub const timedWait = waitTimeout;
+
 // Future protocol implementation for use with select()
 pub const Result = void;
 
 /// Returns true if the event is set (has a result).
 /// This is part of the Future protocol for select().
-pub fn hasResult(self: *const ResetEvent) bool {
+pub fn hasResult(self: *const Event) bool {
     return self.isSet();
 }
 
 /// Gets the result (void) of the event.
 /// This is part of the Future protocol for select().
-pub fn getResult(self: *const ResetEvent) void {
+pub fn getResult(self: *const Event) void {
     _ = self;
     return;
 }
@@ -207,22 +210,22 @@ pub fn getResult(self: *const ResetEvent) void {
 /// Registers a waiter to be notified when the event is set, or claims the
 /// select if it already is.
 /// This is part of the Future protocol for select().
-pub fn asyncWait(self: *ResetEvent, waiter: *Waiter) common.AsyncWaitState {
+pub fn asyncWait(self: *Event, waiter: *Waiter) common.AsyncWaitState {
     return common.waitOnFlagQueue(&self.wait_queue, waiter);
 }
 
 /// Cancels a pending wait operation by removing the waiter.
 /// This is part of the Future protocol for select().
 /// Returns true if removed, false if already removed by completion (wake in-flight).
-pub fn asyncCancelWait(self: *ResetEvent, waiter: *Waiter) bool {
+pub fn asyncCancelWait(self: *Event, waiter: *Waiter) bool {
     return self.wait_queue.remove(&waiter.node);
 }
 
-test "ResetEvent basic set/reset/isSet" {
+test "Event basic set/reset/isSet" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
 
     // Initially unset
     try std.testing.expect(!reset_event.isSet());
@@ -244,22 +247,22 @@ test "ResetEvent basic set/reset/isSet" {
     try std.testing.expect(!reset_event.isSet());
 }
 
-test "ResetEvent wait/set signaling" {
+test "Event wait/set signaling" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
     var waiter_finished = false;
     var waiter_ready = std.atomic.Value(bool).init(false);
 
     const TestFn = struct {
-        fn waiter(event: *ResetEvent, finished: *bool, ready_flag: *std.atomic.Value(bool)) !void {
+        fn waiter(event: *Event, finished: *bool, ready_flag: *std.atomic.Value(bool)) !void {
             ready_flag.store(true, .release);
             try event.wait();
             finished.* = true;
         }
 
-        fn setter(event: *ResetEvent, ready_flag: *std.atomic.Value(bool)) !void {
+        fn setter(event: *Event, ready_flag: *std.atomic.Value(bool)) !void {
             // Wait for waiter to be ready
             while (!ready_flag.load(.acquire)) {
                 try yield();
@@ -281,33 +284,33 @@ test "ResetEvent wait/set signaling" {
     try std.testing.expect(reset_event.isSet());
 }
 
-test "ResetEvent timedWait timeout" {
+test "Event waitTimeout timeout" {
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
 
     // Should timeout after 10ms
-    try std.testing.expectError(error.Timeout, reset_event.timedWait(.fromMilliseconds(10)));
+    try std.testing.expectError(error.Timeout, reset_event.waitTimeout(.fromMilliseconds(10)));
     try std.testing.expect(!reset_event.isSet());
 }
 
-test "ResetEvent multiple waiters broadcast" {
+test "Event multiple waiters broadcast" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
     var waiter_count = std.atomic.Value(u32).init(0);
     var waiters_ready = std.atomic.Value(u32).init(0);
 
     const TestFn = struct {
-        fn waiter(event: *ResetEvent, counter: *std.atomic.Value(u32), ready_flag: *std.atomic.Value(u32)) !void {
+        fn waiter(event: *Event, counter: *std.atomic.Value(u32), ready_flag: *std.atomic.Value(u32)) !void {
             _ = ready_flag.fetchAdd(1, .release);
             try event.wait();
             _ = counter.fetchAdd(1, .monotonic);
         }
 
-        fn setter(event: *ResetEvent, ready_flag: *std.atomic.Value(u32)) !void {
+        fn setter(event: *Event, ready_flag: *std.atomic.Value(u32)) !void {
             // Wait for all waiters to be ready
             while (ready_flag.load(.acquire) < 3) {
                 try yield();
@@ -331,11 +334,11 @@ test "ResetEvent multiple waiters broadcast" {
     try std.testing.expectEqual(3, waiter_count.load(.monotonic));
 }
 
-test "ResetEvent wait on already set event" {
+test "Event wait on already set event" {
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
 
     // Set event before waiting
     reset_event.set();
@@ -344,21 +347,21 @@ test "ResetEvent wait on already set event" {
     try std.testing.expect(reset_event.isSet());
 }
 
-test "ResetEvent size" {
+test "Event size" {
     // ConcurrentQueue with mutex will be larger than a single pointer
     // but still reasonably sized
-    _ = @sizeOf(ResetEvent);
+    _ = @sizeOf(Event);
 }
 
-test "ResetEvent: cancel waiting task" {
+test "Event: cancel waiting task" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
     var started = std.atomic.Value(bool).init(false);
 
     const TestFn = struct {
-        fn waiter(event: *ResetEvent, started_flag: *std.atomic.Value(bool)) !void {
+        fn waiter(event: *Event, started_flag: *std.atomic.Value(bool)) !void {
             // Signal that we're about to wait
             started_flag.store(true, .release);
             try event.wait();
@@ -380,18 +383,18 @@ test "ResetEvent: cancel waiting task" {
     try std.testing.expectError(error.Canceled, waiter_task.join());
 }
 
-test "ResetEvent: select" {
+test "Event: select" {
     const select = @import("../select.zig").select;
 
     const TestContext = struct {
-        fn setterTask(rt: *Runtime, event: *ResetEvent) !void {
+        fn setterTask(rt: *Runtime, event: *Event) !void {
             try rt.sleep(.fromMilliseconds(5));
             event.set();
             try rt.sleep(.fromMilliseconds(5));
         }
 
         fn asyncTask(rt: *Runtime) !void {
-            var reset_event = ResetEvent.init;
+            var reset_event = Event.init;
 
             var task = try rt.spawn(setterTask, .{ rt, &reset_event });
             defer task.cancel();
@@ -408,22 +411,22 @@ test "ResetEvent: select" {
     try handle.join();
 }
 
-test "ResetEvent: foreign thread signals async task" {
+test "Event: foreign thread signals async task" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
     var task_ready = std.atomic.Value(bool).init(false);
     var finished = std.atomic.Value(bool).init(false);
 
     const TestFn = struct {
-        fn taskWait(event: *ResetEvent, ready: *std.atomic.Value(bool), done: *std.atomic.Value(bool)) !void {
+        fn taskWait(event: *Event, ready: *std.atomic.Value(bool), done: *std.atomic.Value(bool)) !void {
             ready.store(true, .release);
             try event.wait();
             done.store(true, .release);
         }
 
-        fn threadSet(event: *ResetEvent, ready: *std.atomic.Value(bool)) void {
+        fn threadSet(event: *Event, ready: *std.atomic.Value(bool)) void {
             // Wait for task to be ready
             while (!ready.load(.acquire)) {
                 os.thread.yield();
@@ -444,22 +447,22 @@ test "ResetEvent: foreign thread signals async task" {
     try std.testing.expect(reset_event.isSet());
 }
 
-test "ResetEvent: async task signals foreign thread" {
+test "Event: async task signals foreign thread" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
-    var reset_event = ResetEvent.init;
+    var reset_event = Event.init;
     var thread_ready = std.atomic.Value(bool).init(false);
     var thread_done = std.atomic.Value(bool).init(false);
 
     const TestFn = struct {
-        fn threadWait(event: *ResetEvent, ready: *std.atomic.Value(bool), done: *std.atomic.Value(bool)) void {
+        fn threadWait(event: *Event, ready: *std.atomic.Value(bool), done: *std.atomic.Value(bool)) void {
             ready.store(true, .release);
             event.wait() catch unreachable;
             done.store(true, .release);
         }
 
-        fn taskSet(event: *ResetEvent, ready: *std.atomic.Value(bool)) !void {
+        fn taskSet(event: *Event, ready: *std.atomic.Value(bool)) !void {
             // Wait for thread to be ready
             while (!ready.load(.acquire)) {
                 try yield();
@@ -481,14 +484,14 @@ test "ResetEvent: async task signals foreign thread" {
     try std.testing.expect(reset_event.isSet());
 }
 
-test "ResetEvent: a set that races the commit fence is not lost" {
+test "Event: a set that races the commit fence is not lost" {
     // The select's sweep holds the commit fence for another arm when set()
     // pops this arm and signals it. That signal cannot claim the winner word,
     // and a re-poll afterwards cannot recover it either, because reset() has
     // since cleared the flag. The bounced arm must be recorded instead.
     const NO_WINNER = common.NO_WINNER;
 
-    var event = ResetEvent.init;
+    var event = Event.init;
 
     var parent = Waiter.init();
     var winner: std.atomic.Value(usize) = .init(NO_WINNER);

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -16,7 +16,7 @@
 //! try Futex.wait(ptr, expect);
 //!
 //! // Wait with timeout
-//! Futex.timedWait(ptr, expect, .{ .duration = .fromMilliseconds(100) }) catch |err| switch (err) {
+//! Futex.waitTimeout(ptr, expect, .{ .duration = .fromMilliseconds(100) }) catch |err| switch (err) {
 //!     error.Timeout => // timed out,
 //!     error.Canceled => // task was cancelled,
 //! };
@@ -121,7 +121,7 @@ pub fn waitUncancelable(ptr: *const u32, expect: u32) void {
 /// Stack-allocated waiter node for the global futex buckets.
 ///
 /// `waiter` references an externally-owned `Waiter`: the blocking `wait()` /
-/// `timedWait()` paths point it at a local direct waiter, while the non-blocking
+/// `waitTimeout()` paths point it at a local direct waiter, while the non-blocking
 /// `prepareWait()` path used by select() points it at a caller-owned select
 /// waiter. All fields default so the node can serve as a select `WaitContext`.
 pub const FutexWaiter = struct {
@@ -137,12 +137,15 @@ pub const FutexWaiter = struct {
 };
 
 /// Like `wait`, but also returns `error.Timeout` if the timeout elapses.
-pub fn timedWait(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable || Cancelable)!void {
-    return timedWaitClock(ptr, expect, timeout, .awake);
+pub fn waitTimeout(ptr: *const u32, expect: u32, timeout: Timeout) (Timeoutable || Cancelable)!void {
+    return waitTimeoutClock(ptr, expect, timeout, .awake);
 }
 
-/// Like `timedWait`, but the timeout is measured against `clock`.
-pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
+/// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+pub const timedWait = waitTimeout;
+
+/// Like `waitTimeout`, but the timeout is measured against `clock`.
+pub fn waitTimeoutClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clock) (Timeoutable || Cancelable)!void {
     // No deadline: delegate to the untimed `wait`. This skips the timer setup
     // and, more importantly, the unconditional post-wake `removeFromBucket`
     // below (a second bucket-mutex acquisition per wait) that can never observe
@@ -199,6 +202,9 @@ pub fn timedWaitClock(ptr: *const u32, expect: u32, timeout: Timeout, clock: Clo
         },
     };
 }
+
+/// Alias for `waitTimeoutClock`. Deprecated, will be removed in a future release.
+pub const timedWaitClock = waitTimeoutClock;
 
 /// Remove a waiter from its bucket (for cancellation/timeout).
 /// Returns true if the waiter was in the queue, false if already removed by wake.
@@ -438,13 +444,13 @@ test "Futex: multiple waiters different addresses" {
     try std.testing.expectEqual(1, woken);
 }
 
-test "Futex: timedWait timeout" {
+test "Futex: waitTimeout timeout" {
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
     var value: u32 = 0;
 
     // Wait with timeout, no one will wake it, so should timeout
-    const result = Futex.timedWait(&value, 0, .{ .duration = .fromMilliseconds(10) });
+    const result = Futex.waitTimeout(&value, 0, .{ .duration = .fromMilliseconds(10) });
     try std.testing.expectError(error.Timeout, result);
 }

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -119,7 +119,7 @@ pub fn waitUncancelable(self: *Semaphore) void {
 ///
 /// Returns `error.Timeout` if the timeout expires before a permit becomes available.
 /// Returns `error.Canceled` if the task is cancelled while waiting.
-pub fn timedWait(self: *Semaphore, timeout: Timeout) (Timeoutable || Cancelable)!void {
+pub fn waitTimeout(self: *Semaphore, timeout: Timeout) (Timeoutable || Cancelable)!void {
     if (timeout == .none) {
         return self.wait();
     }
@@ -130,7 +130,7 @@ pub fn timedWait(self: *Semaphore, timeout: Timeout) (Timeoutable || Cancelable)
     defer self.mutex.unlock();
 
     while (self.permits == 0) {
-        self.cond.timedWait(&self.mutex, deadline) catch |err| switch (err) {
+        self.cond.waitTimeout(&self.mutex, deadline) catch |err| switch (err) {
             error.Timeout => return error.Timeout,
             error.Canceled => {
                 // Wake another waiter to handle any race with permit availability
@@ -147,6 +147,9 @@ pub fn timedWait(self: *Semaphore, timeout: Timeout) (Timeoutable || Cancelable)
         self.cond.signal();
     }
 }
+
+/// Alias for `waitTimeout`. Deprecated, will be removed in a future release.
+pub const timedWait = waitTimeout;
 
 /// Releases a permit.
 ///
@@ -191,18 +194,18 @@ test "Semaphore: basic wait/post" {
     try std.testing.expectEqual(3, n);
 }
 
-test "Semaphore: timedWait timeout" {
+test "Semaphore: waitTimeout timeout" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var sem = Semaphore{};
 
-    const result = sem.timedWait(.{ .duration = .fromMilliseconds(10) });
+    const result = sem.waitTimeout(.{ .duration = .fromMilliseconds(10) });
     try std.testing.expectError(error.Timeout, result);
     try std.testing.expectEqual(0, sem.permits);
 }
 
-test "Semaphore: timedWait success" {
+test "Semaphore: waitTimeout success" {
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -213,7 +216,7 @@ test "Semaphore: timedWait success" {
     const TestFn = struct {
         fn waiter(s: *Semaphore, flag: *bool, ready_flag: *std.atomic.Value(bool)) void {
             ready_flag.store(true, .release);
-            s.timedWait(.{ .duration = .fromMilliseconds(100) }) catch return;
+            s.waitTimeout(.{ .duration = .fromMilliseconds(100) }) catch return;
             flag.* = true;
         }
 

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -9,7 +9,7 @@ const SimpleQueue = @import("../utils/simple_queue.zig").SimpleQueue;
 const SimpleStack = @import("../utils/simple_stack.zig").SimpleStack;
 const WaitNode = @import("../utils/wait_queue.zig").WaitNode;
 const select = @import("../select.zig").select;
-const ResetEvent = @import("ResetEvent.zig");
+const Event = @import("Event.zig");
 const common = @import("../common.zig");
 const Waiter = common.Waiter;
 const Closeable = common.Closeable;
@@ -1904,7 +1904,7 @@ test "Channel: canceled select conserves a concurrently sent item" {
 
     const State = struct {
         channel: *Channel(u32),
-        never: *ResetEvent,
+        never: *Event,
         entered: std.atomic.Value(bool) = .init(false),
         go: std.atomic.Value(bool) = .init(false),
         received: std.atomic.Value(u32) = .init(0),
@@ -1930,7 +1930,7 @@ test "Channel: canceled select conserves a concurrently sent item" {
     for (0..200) |_| {
         var buffer: [1]u32 = undefined;
         var channel = Channel(u32).init(&buffer);
-        var never = ResetEvent.init;
+        var never = Event.init;
         var state = State{ .channel = &channel, .never = &never };
 
         var receiver = try runtime.spawn(State.waitForItem, .{&state});
@@ -2015,7 +2015,7 @@ test "Channel: unbuffered select send rendezvous with select receive" {
     defer runtime.deinit();
 
     const Tasks = struct {
-        fn send(ch: *Channel(u64), other: *ResetEvent) !void {
+        fn send(ch: *Channel(u64), other: *Event) !void {
             var operation = ch.asyncSend(42);
             const result = try select(.{ .send = &operation, .never = other });
             switch (result) {
@@ -2024,7 +2024,7 @@ test "Channel: unbuffered select send rendezvous with select receive" {
             }
         }
 
-        fn receive(ch: *Channel(u64), other: *ResetEvent) !u64 {
+        fn receive(ch: *Channel(u64), other: *Event) !u64 {
             var operation = ch.asyncReceive();
             const result = try select(.{ .receive = &operation, .never = other });
             return switch (result) {
@@ -2036,7 +2036,7 @@ test "Channel: unbuffered select send rendezvous with select receive" {
 
     for (0..200) |_| {
         var channel = Channel(u64).init(&.{});
-        var never = ResetEvent.init;
+        var never = Event.init;
         var sender = try runtime.spawn(Tasks.send, .{ &channel, &never });
         var receiver = try runtime.spawn(Tasks.receive, .{ &channel, &never });
         try std.testing.expectEqual(42, try receiver.join());
@@ -2127,7 +2127,7 @@ test "Channel: cancel removes a parked select send" {
 }
 
 test "Channel: rendezvous racing a level source in the same select" {
-    // Exercises the fence-window wake: the ResetEvent can fire while the
+    // Exercises the fence-window wake: the Event can fire while the
     // select's sweep holds its commit fence on the rendezvous arm, in which
     // case the event's signal claims nothing and the select must recover the
     // standing readiness by re-polling. The item must never be lost.
@@ -2136,7 +2136,7 @@ test "Channel: rendezvous racing a level source in the same select" {
 
     const State = struct {
         channel: *Channel(u32),
-        event: *ResetEvent,
+        event: *Event,
         received: std.atomic.Value(u32) = .init(0),
 
         fn choose(self: *@This()) !void {
@@ -2163,7 +2163,7 @@ test "Channel: rendezvous racing a level source in the same select" {
 
     for (0..200) |_| {
         var channel = Channel(u32).init(&.{});
-        var event = ResetEvent.init;
+        var event = Event.init;
         var state = State{ .channel = &channel, .event = &event };
 
         var chooser = try runtime.spawn(State.choose, .{&state});

--- a/src/utils/wait_queue.zig
+++ b/src/utils/wait_queue.zig
@@ -50,7 +50,7 @@ pub const WaitNode = struct {
 ///
 /// ## Usage Examples
 ///
-/// For ResetEvent (flag = "is set"):
+/// For Event (flag = "is set"):
 /// - `isFlagSet()` → check if event is signaled
 /// - `pushUnlessFlag()` → wait unless already set
 /// - `setFlag()` + `pop()` loop → signal and wake all waiters
@@ -299,7 +299,7 @@ pub fn WaitQueue(comptime T: type) type {
         /// Add item to the end of the queue, unless the flag is set.
         /// Returns true if item was pushed, false if flag was set.
         ///
-        /// This is useful for ResetEvent/Future wait - don't wait if already signaled.
+        /// This is useful for Event/Future wait - don't wait if already signaled.
         pub fn pushUnlessFlag(self: *Self, item: *T) bool {
             const old_state = self.acquireMutationLock();
 
@@ -433,7 +433,7 @@ pub fn WaitQueue(comptime T: type) type {
         /// `is_last == true` means this node was the final waiter and callers must not
         /// call popAndSetFlag again - it is safe to stop iterating without touching self.
         ///
-        /// This matters for use cases like ResetEvent where `self` lives on a coroutine
+        /// This matters for use cases like Event where `self` lives on a coroutine
         /// stack: signaling the last waiter can resume the parent task on another
         /// executor in parallel, which may return and free the stack before we get a
         /// chance to touch `self` again.
@@ -446,7 +446,7 @@ pub fn WaitQueue(comptime T: type) type {
         /// Returns the popped waiter and whether it was the last one, or null if no
         /// waiters (flag is still set).
         ///
-        /// This is useful for ResetEvent.set() / Future.set() - set the flag and
+        /// This is useful for Event.set() / Future.set() - set the flag and
         /// wake all waiters. Callers MUST break out of the loop once `is_last` is true
         /// without calling popAndSetFlag again, because signaling the last waiter can
         /// cause `self` to be freed.

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -68,7 +68,7 @@ pub const net = @import("net.zig");
 
 pub const Mutex = @import("sync/Mutex.zig");
 pub const Condition = @import("sync/Condition.zig");
-pub const ResetEvent = @import("sync/ResetEvent.zig");
+pub const Event = @import("sync/Event.zig");
 pub const RwLock = @import("sync/RwLock.zig");
 pub const Semaphore = @import("sync/Semaphore.zig");
 pub const Barrier = @import("sync/Barrier.zig");
@@ -76,6 +76,9 @@ pub const Futex = @import("sync/Futex.zig");
 pub const Channel = @import("sync/channel.zig").Channel;
 pub const BroadcastChannel = @import("sync/broadcast_channel.zig").BroadcastChannel;
 pub const Future = @import("sync/future.zig").Future;
+
+/// Alias for `Event`. Deprecated, will be removed in a future release.
+pub const ResetEvent = Event;
 
 pub const Signal = @import("signal.zig").Signal;
 pub const SignalKind = @import("signal.zig").SignalKind;


### PR DESCRIPTION
Aligns two names with `std.Io`:

- `zio.ResetEvent` becomes `zio.Event`, matching `std.Io.Event`.
- `timedWait` becomes `waitTimeout` on `Event`, `Condition`, `Semaphore`, `Futex`, `Signal` and `CompletionQueue`, matching `std.Io.Event.waitTimeout`. `Futex.timedWaitClock` becomes `Futex.waitTimeoutClock`.

The old names stay as deprecated aliases, so existing code keeps working. They will be removed in a future release.

Tests: 677 passed, 2 skipped.