### PR TITLE
Move compile-time config to the root module, add zio_options.scheduling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,33 @@ jobs:
           done
       env:
         TEST_VERBOSE: 2
+
+  # The scheduling discipline is a compile-time choice, so the pinned and
+  # single-executor paths are only covered by building against them.
+  scheduling:
+    strategy:
+      fail-fast: false
+      matrix:
+        zig_version: ['0.16.0']
+        mode: [debug, release]
+        scheduling: [pinned, single_executor]
+
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Zig
+      uses: mlugg/setup-zig@v2
+      with:
+        version: ${{ matrix.zig_version }}
+
+    - name: Build and test
+      shell: bash
+      run: |
+        ./check.sh --full --scheduling ${{ matrix.scheduling }} \
+          ${{ matrix.mode == 'release' && '--release' || '' }}
+      timeout-minutes: 10
+      env:
+        TEST_VERBOSE: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
     tags:
   pull_request:
 
+# Test-only workflow: nothing here needs to write to the repository.
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -35,6 +39,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
@@ -126,6 +132,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Zig
       uses: mlugg/setup-zig@v2

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ zig build examples
 Running tests (with options to run specific tests, or select a non-default I/O backend)
 
 ```bash
-zig build test -Dtest-filter="foo" -Dbackend=epoll
+zig build test -Dtest-filter="foo" -Dbackend=epoll -Dscheduling=pinned
 ```
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for more details.

--- a/build.zig
+++ b/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
     const backend = b.option(BackendOption, "backend", "Override the default event loop backend");
 
     const SchedulingOption = enum { single_executor, pinned, work_stealing };
-    const scheduling = b.option(SchedulingOption, "scheduling", "Scheduling discipline compiled into the scheduler (default work_stealing, or single_executor when -fsingle-threaded)");
+    const scheduling = b.option(SchedulingOption, "scheduling", "Scheduling discipline compiled into the scheduler: single_executor (default), pinned, or work_stealing");
 
     const ResolveBeneathMode = enum { strict, best_effort };
     const resolve_beneath_mode = b.option(ResolveBeneathMode, "resolve-beneath-mode", "How to handle resolve_beneath on platforms without kernel support: strict (error.Unsupported) or best_effort (log warning, continue)");

--- a/build.zig
+++ b/build.zig
@@ -7,32 +7,30 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const backend = b.option(
-        []const u8,
-        "backend",
-        "Override the default event loop backend (linux, io_uring, epoll, kqueue, iocp, poll)",
-    );
+    // Defaults for the compile-time options in src/options.zig, for zio's own
+    // test and example builds. A root module's `zio_options` declaration wins
+    // over anything set here; consumers configure zio that way, not with these.
+    const BackendOption = enum { poll, linux, epoll, kqueue, io_uring, iocp };
+    const backend = b.option(BackendOption, "backend", "Override the default event loop backend");
+
+    const SchedulingOption = enum { single_executor, pinned, work_stealing };
+    const scheduling = b.option(SchedulingOption, "scheduling", "Scheduling discipline compiled into the scheduler (default work_stealing, or single_executor when -fsingle-threaded)");
 
     const ResolveBeneathMode = enum { strict, best_effort };
-    const resolve_beneath_mode = b.option(
-        ResolveBeneathMode,
-        "resolve-beneath-mode",
-        "How to handle resolve_beneath on platforms without kernel support: strict (error.Unsupported) or best_effort (log warning, continue)",
-    ) orelse .strict;
+    const resolve_beneath_mode = b.option(ResolveBeneathMode, "resolve-beneath-mode", "How to handle resolve_beneath on platforms without kernel support: strict (error.Unsupported) or best_effort (log warning, continue)");
 
-    const no_hacks = b.option(bool, "no-hacks", "Avoid unsafe performance tricks (bool smuggling, etc.)") orelse false;
+    const no_hacks = b.option(bool, "no-hacks", "Avoid unsafe performance tricks (bool smuggling, etc.)");
 
-    const task_migration = b.option(bool, "task-migration", "Compile in task migration / work-stealing support. When false, tasks are pinned to their home executor and the scheduler can drop the machinery it needs (default true)") orelse true;
+    const scheduler_metrics = b.option(bool, "scheduler_metrics", "Count scheduler events (parks, steals, wake batches) in per-executor counters readable via Runtime.schedulerMetrics (default true)");
 
-    const scheduler_metrics = b.option(bool, "scheduler_metrics", "Count scheduler events (parks, steals, wake batches) in per-executor counters readable via Runtime.schedulerMetrics (default true; the counters sit on executor-local paths and cost one plain increment per event)") orelse true;
-
-    // Create options for backend selection
     var options = b.addOptions();
-    options.addOption(?[]const u8, "backend", backend);
-    options.addOption(ResolveBeneathMode, "resolve_beneath_mode", resolve_beneath_mode);
-    options.addOption(bool, "no_hacks", no_hacks);
-    options.addOption(bool, "task_migration", task_migration);
-    options.addOption(bool, "scheduler_metrics", scheduler_metrics);
+    // Stored as tag names: the CLI still validates against the enums above, but
+    // an optional enum makes addOptions emit an unresolvable type reference.
+    options.addOption(?[]const u8, "backend", if (backend) |v| @tagName(v) else null);
+    options.addOption(?[]const u8, "scheduling", if (scheduling) |v| @tagName(v) else null);
+    options.addOption(?[]const u8, "resolve_beneath_mode", if (resolve_beneath_mode) |v| @tagName(v) else null);
+    options.addOption(?bool, "no_hacks", no_hacks);
+    options.addOption(?bool, "scheduler_metrics", scheduler_metrics);
 
     const zio = b.addModule("zio", .{
         .root_source_file = b.path("src/zio.zig"),
@@ -40,7 +38,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = target.result.os.tag != .freestanding,
     });
-    zio.addOptions("zio_options", options);
+    zio.addOptions("zio_build_options", options);
+    // Lets test_runner.zig (the root file of the test binary, which lives outside
+    // src/ and so cannot reach it by relative path) name the `zio.Options` type
+    // for its `zio_options` declaration.
+    zio.addImport("zio", zio);
 
     const zio_lib = b.addLibrary(.{
         .name = "zio",

--- a/check.sh
+++ b/check.sh
@@ -11,6 +11,7 @@ RELEASE_MODE=false
 TEST_FILTER=""
 TARGET=""
 BACKEND=""
+SCHEDULING=""
 USE_WINE=false
 USE_QEMU=false
 NO_EXEC=false
@@ -19,7 +20,7 @@ TIMEOUT=""
 
 # Parse arguments
 usage() {
-  echo "Usage: $0 [--filter \"test name\"] [--target <target>] [--backend <backend>] [--wine] [--qemu] [--no-exec] [--coverage] [--ci] [--full] [--release] [--verbose] [--timeout <seconds>]"
+  echo "Usage: $0 [--filter \"test name\"] [--target <target>] [--backend <backend>] [--scheduling <mode>] [--wine] [--qemu] [--no-exec] [--coverage] [--ci] [--full] [--release] [--verbose] [--timeout <seconds>]"
 }
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -38,6 +39,10 @@ while [[ $# -gt 0 ]]; do
         --backend)
             [[ $# -ge 2 ]] || { echo "--backend requires an argument"; usage; exit 1; }
             BACKEND="$2"; shift 2
+            ;;
+        --scheduling)
+            [[ $# -ge 2 ]] || { echo "--scheduling requires an argument"; usage; exit 1; }
+            SCHEDULING="$2"; shift 2
             ;;
         --wine)
             USE_WINE=true
@@ -102,6 +107,11 @@ if [ -n "$TARGET" ]; then
     echo "Target: $TARGET"
     BUILD_ARGS+=("-Dtarget=$TARGET")
 fi
+if [ -n "$SCHEDULING" ]; then
+    echo "Scheduling: $SCHEDULING"
+    BUILD_ARGS+=("-Dscheduling=$SCHEDULING")
+fi
+
 if [ -n "$BACKEND" ]; then
     echo "Backend: $BACKEND"
     BUILD_ARGS+=("-Dbackend=$BACKEND")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Compile-time configuration moved from build options to the root module. Declare
+  `pub const zio_options: zio.Options = .{ ... }` in your `main.zig` instead of passing
+  `-D` flags through `b.dependency`. Every zio in a binary (yours, and any library's that
+  depends on zio) now sees one configuration, where per-dependency build options could
+  produce two incompatible copies of `Runtime`. The `-D` options remain in zio's own
+  `build.zig` as defaults for its test and example builds; a root declaration wins.
+
+- Replaced the `task-migration` build option and `RuntimeOptions.enable_task_migration`
+  with a single compile-time `zio_options.scheduling`, which names the three modes the
+  runtime actually has: `.single_executor`, `.pinned`, and `.work_stealing`. Because the
+  discipline is now fixed at compile time, each step down removes the machinery rather
+  than branching around it, and `.single_executor` additionally makes the executor count
+  comptime-known.
+
+- **Breaking:** running on more than one thread is now opt-in. `zio_options.scheduling`
+  defaults to `.single_executor`, matching `RuntimeOptions.executors`, which has always
+  defaulted to a single executor. To use more, declare this in your root module:
+
+  ```zig
+  pub const zio_options: zio.Options = .{ .scheduling = .work_stealing };
+  ```
+
+  Without it, `.executors = .exact(N)` is a **compile error** naming that declaration,
+  and `.auto` resolves to one executor. The failure is at compile time by design: a
+  default that silently began running tasks in parallel would turn correct programs
+  into racy ones, and nothing in Zig would flag it.
+
+- `ExecutorCount.exact` now takes its count as `anytype`, so a literal stays
+  comptime-known: under `.single_executor`, asking for more than one (or for a count
+  computed at runtime) is rejected at the call site rather than when the runtime is
+  built. `.exact(1)` still compiles everywhere, and `RuntimeOptions.executors` still
+  defaults to it.
+
+- `Runtime.init` no longer returns `error.TaskMigrationNotCompiledIn`, which had no
+  remaining source.
+
 - Renamed `ResetEvent` to `Event`, matching `std.Io.Event`. `zio.ResetEvent` stays as a
   deprecated alias, so existing code keeps working, but it will be removed in a future
   release.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Under `.single_executor` scheduling, task spawn no longer goes through the round-robin
+  cursor: with one executor there is nothing to rotate, so the shared atomic increment
+  and the division by a runtime executor count both go away. Measured ~5% faster spawns
+  (median 189ns vs 199ns per spawn, 5/5 interleaved A/B pairs).
+
+- The state that exists only to move work between executors (the global overflow queue,
+  the searcher count, the stealable flag, the per-executor steal PRNG and doze flag, and
+  the round-robin cursor) is now zero-bit under the disciplines that never use it, on the
+  same pattern as the idle mask. This also drops a per-executor PRNG seeding at init.
+
 - Compile-time configuration moved from build options to the root module. Declare
   `pub const zio_options: zio.Options = .{ ... }` in your `main.zig` instead of passing
   `-D` flags through `b.dependency`. Every zio in a binary (yours, and any library's that

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,15 @@ zio is built in layers, and each layer is usable on its own:
 - **`zio.coro`**: stackful coroutine primitives (context switching, growable stacks, manual scheduling), with no I/O or scheduler attached. This is what you'd build a different kind of scheduler on top of, if `zio.Runtime`'s isn't the one you want.
 - **`zio.Runtime`**: the full runtime. It schedules `zio.coro` coroutines across executor threads, drives their I/O through `zio.ev`, and adds structured concurrency (task groups), cancellation, synchronization primitives, and the `std.Io` implementation. Most programs use this directly and never touch the layers below it.
 
-A runtime can run single-threaded, or multi-threaded in one of two modes. With work-stealing (the default), idle executors steal work from busy ones. This keeps every thread busy when runnable work is spread unevenly to begin with. With pinned scheduling, a task stays on whichever executor it was spawned on for its entire life, with no migration and no cross-executor synchronization on the scheduling path, at the cost of no rebalancing if load is uneven.
+A runtime can run single-threaded, or multi-threaded in one of two modes, chosen at compile time with `zio_options.scheduling` in your root module. The default is `.single_executor`, so running on more than one thread is opt-in:
+
+```zig
+pub const zio_options: zio.Options = .{ .scheduling = .pinned };
+```
+
+With `.work_stealing`, idle executors steal work from busy ones. This keeps every thread busy when runnable work is spread unevenly to begin with. With `.pinned`, a task stays on whichever executor it was spawned on for its entire life, with no migration and no cross-executor synchronization on the scheduling path, at the cost of no rebalancing if load is uneven. With `.single_executor`, the default, there is one executor and the count is known at compile time, which drops the executor topology entirely. `RuntimeOptions.executors` then only accepts `.exact(1)` or `.auto`, both meaning one; `.exact(N)` for larger N is a compile error that names the declaration to add.
+
+Because the choice is made at compile time, the default removes the multi-executor machinery rather than branching around it, and `.pinned` removes the stealing machinery.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ zio is built in layers, and each layer is usable on its own:
 - **`zio.coro`**: stackful coroutine primitives (context switching, growable stacks, manual scheduling), with no I/O or scheduler attached. This is what you'd build a different kind of scheduler on top of, if `zio.Runtime`'s isn't the one you want.
 - **`zio.Runtime`**: the full runtime. It schedules `zio.coro` coroutines across executor threads, drives their I/O through `zio.ev`, and adds structured concurrency (task groups), cancellation, synchronization primitives, and the `std.Io` implementation. Most programs use this directly and never touch the layers below it.
 
-A runtime can run single-threaded, or multi-threaded in one of two modes, chosen at compile time with `zio_options.scheduling` in your root module. The default is `.single_executor`, so running on more than one thread is opt-in:
+A runtime runs on one executor, or on many in one of two modes, chosen at compile time with `zio_options.scheduling` in your root module. The default is `.single_executor`, so running tasks on more than one thread is opt-in:
 
 ```zig
 pub const zio_options: zio.Options = .{ .scheduling = .pinned };

--- a/docs/parallel-grep.md
+++ b/docs/parallel-grep.md
@@ -139,10 +139,18 @@ The worker allocates memory for each matching line, sends ownership through the 
 
 ### Multi-threaded Execution
 
-ZIO's runtime can use multiple OS threads (executors) to run tasks in parallel:
+ZIO's runtime can use multiple OS threads (executors) to run tasks in parallel. Running
+more than one executor is opt-in at compile time, declared in your root module:
+
+```zig
+pub const zio_options: zio.Options = .{ .scheduling = .work_stealing };
+```
+
+Without that declaration the build compiles in `.single_executor` scheduling, `.exact(N)`
+is a compile error, and `.auto` resolves to one. With it, you choose the count per runtime:
 
 - `.executors = .auto` - auto-detect based on CPU count (good for CPU-bound work)
-- `.executors = .exact(1)` - single-threaded (default, good for I/O-bound work)
+- `.executors = .exact(1)` - a single executor (the default, good for I/O-bound work)
 - `.executors = .exact(N)` - explicit number of threads
 
 Tasks are automatically distributed across executors. Channels handle synchronization, so you don't need locks or atomic operations - just send and receive messages safely between tasks.

--- a/examples/parallel_grep.zig
+++ b/examples/parallel_grep.zig
@@ -3,6 +3,10 @@ const zio = @import("zio");
 
 pub const std_options_debug_io = zio.debug_io;
 
+// This example spreads work across cores, so it opts out of the default
+// single-executor scheduling.
+pub const zio_options: zio.Options = .{ .scheduling = .work_stealing };
+
 const SearchResult = struct {
     file_path: []const u8,
     line_number: usize,

--- a/examples/stderr_smoke.zig
+++ b/examples/stderr_smoke.zig
@@ -25,6 +25,9 @@ const zio = @import("zio");
 pub const std_options: std.Options = .{ .log_level = .info };
 pub const std_options_debug_io = zio.debug_io;
 
+// The smoke test wants two executors logging concurrently.
+pub const zio_options: zio.Options = .{ .scheduling = .work_stealing };
+
 fn taskLog(id: usize) void {
     std.log.info("smoke: task {d}", .{id});
 }

--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -395,7 +395,7 @@ test "AutoCancel: set with Duration.max clears prior timer" {
 }
 
 test "AutoCancel: attributed when it fires on a task running elsewhere" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.migrates()) return error.SkipZigTest;
     // Attribution under churn: the callback hands the cancellation over from
     // the loop that armed the timer, which after a migration is not the
     // executor the task runs on. This does not reproduce the ordering window
@@ -636,7 +636,7 @@ test "withTimeout: nested, outer deadline fires while inner is running" {
 }
 
 test "AutoCancel: re-armed while the previous arm is still live on another executor" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.migrates()) return error.SkipZigTest;
     // The deadline is far past the end of the test, so every `set` below
     // re-arms a timer that is still sitting in some loop's heap. After a
     // migration that loop is not the one the task is running on, which is

--- a/src/autocancel.zig
+++ b/src/autocancel.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const zio_options = @import("options.zig").options;
 const ev = @import("ev/root.zig");
 const Runtime = @import("runtime.zig").Runtime;
 const getCurrentTask = @import("runtime.zig").getCurrentTask;
@@ -394,6 +395,7 @@ test "AutoCancel: set with Duration.max clears prior timer" {
 }
 
 test "AutoCancel: attributed when it fires on a task running elsewhere" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     // Attribution under churn: the callback hands the cancellation over from
     // the loop that armed the timer, which after a migration is not the
     // executor the task runs on. This does not reproduce the ordering window
@@ -634,6 +636,7 @@ test "withTimeout: nested, outer deadline fires while inner is running" {
 }
 
 test "AutoCancel: re-armed while the previous arm is still live on another executor" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     // The deadline is far past the end of the test, so every `set` below
     // re-arms a timer that is still sitting in some loop's heap. After a
     // migration that loop is not the one the task is running on, which is

--- a/src/completion_queue.zig
+++ b/src/completion_queue.zig
@@ -58,6 +58,7 @@
 //! operations in it.
 
 const std = @import("std");
+const zio_options = @import("options.zig").options;
 
 const ev = @import("ev/root.zig");
 const os = @import("os/root.zig");
@@ -1626,6 +1627,7 @@ test "CompletionQueue: a claim landing on a canceled select is delivered, never 
 }
 
 test "CompletionQueue: teardown drain leaves the queue memory quiescent" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     var rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer rt.deinit();
 

--- a/src/ev/backend.zig
+++ b/src/ev/backend.zig
@@ -1,41 +1,14 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const options = @import("zio_options");
+const zio_options = @import("../options.zig").options;
 
-pub const BackendType = enum {
-    poll,
-    linux,
-    epoll,
-    kqueue,
-    io_uring,
-    iocp,
-};
+pub const BackendType = @import("../options.zig").BackendType;
 
-pub const backend = blk: {
-    if (options.backend) |backend_name| {
-        if (std.mem.eql(u8, backend_name, "linux")) {
-            break :blk BackendType.linux;
-        } else if (std.mem.eql(u8, backend_name, "epoll")) {
-            break :blk BackendType.epoll;
-        } else if (std.mem.eql(u8, backend_name, "poll")) {
-            break :blk BackendType.poll;
-        } else if (std.mem.eql(u8, backend_name, "kqueue")) {
-            break :blk BackendType.kqueue;
-        } else if (std.mem.eql(u8, backend_name, "io_uring")) {
-            break :blk BackendType.io_uring;
-        } else if (std.mem.eql(u8, backend_name, "iocp")) {
-            break :blk BackendType.iocp;
-        } else {
-            @compileError("Unknown backend: " ++ backend_name);
-        }
-    }
-
-    switch (builtin.os.tag) {
-        .linux => break :blk BackendType.linux,
-        .macos, .ios, .tvos, .visionos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => break :blk BackendType.kqueue,
-        .windows => break :blk BackendType.iocp,
-        else => break :blk BackendType.poll,
-    }
+pub const backend: BackendType = zio_options.backend orelse switch (builtin.os.tag) {
+    .linux => .linux,
+    .macos, .ios, .tvos, .visionos, .watchos, .freebsd, .netbsd, .openbsd, .dragonfly => .kqueue,
+    .windows => .iocp,
+    else => .poll,
 };
 
 pub const Backend = switch (backend) {

--- a/src/io.zig
+++ b/src/io.zig
@@ -51,7 +51,7 @@ const zio_net = @import("net.zig");
 const zio_dns = @import("dns/root.zig");
 const fillBuf = @import("utils/writer.zig").fillBuf;
 const MemoryPool = @import("utils/memory_pool.zig").MemoryPool;
-const zio_options = @import("zio_options");
+const zio_options = @import("options.zig").options;
 
 /// Must match `net.Stream.max_iovecs_len` in std.Io. Used as the cap on
 /// scatter/gather vector counts for netRead/netWrite so we never promise
@@ -4461,6 +4461,7 @@ test "io: batch awaitConcurrent times out when no data arrives" {
 }
 
 test "io: concurrent cross-executor cancel of N blocked recvmsg fibers is UAF-free" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const N = 8;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();

--- a/src/net.zig
+++ b/src/net.zig
@@ -2651,7 +2651,7 @@ test "Stream.Reader/Writer.fromStd" {
 // an error; std.testing.allocator also fails on any leak, exercising the shared
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.migrates()) return error.SkipZigTest;
 
     const H = struct {
         const executors = 3;
@@ -2853,7 +2853,7 @@ fn errName(code: u16) []const u8 {
 }
 
 test "multi-executor: timeout cancel racing a cross-loop readiness edge" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.migrates()) return error.SkipZigTest;
 
     const H = struct {
         const pairs = 8;

--- a/src/net.zig
+++ b/src/net.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const zio_options = @import("options.zig").options;
 const ev = @import("ev/root.zig");
 const os = @import("os/root.zig");
 const runtime_mod = @import("runtime.zig");
@@ -2650,7 +2651,7 @@ test "Stream.Reader/Writer.fromStd" {
 // an error; std.testing.allocator also fails on any leak, exercising the shared
 // table teardown.
 test "multi-executor: cross-loop socket stress (full-duplex + migration + fd reuse)" {
-    if (builtin.single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
 
     const H = struct {
         const executors = 3;
@@ -2852,7 +2853,7 @@ fn errName(code: u16) []const u8 {
 }
 
 test "multi-executor: timeout cancel racing a cross-loop readiness edge" {
-    if (builtin.single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
 
     const H = struct {
         const pairs = 8;
@@ -3007,13 +3008,14 @@ test "multi-executor: timeout cancel racing a cross-loop readiness edge" {
     try std.testing.expect(sh.timeouts.load(.monotonic) > 0);
 }
 
-// Migration-disabled bypass: with enable_task_migration=false the executors do
-// not share a loop group, so each loop registers its sockets purely locally. A
+// Migration-disabled bypass: under pinned scheduling the executors do not share
+// a loop group, so each loop registers its sockets purely locally. A
 // connection's reader and writer still run as separate tasks that land on
 // different executors, so the same fd is driven from two loops at once (each
 // owning its own direction in its own table) - verify that still works.
 test "multi-executor: full-duplex with task migration disabled" {
-    if (builtin.single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (zio_options.scheduling != .pinned) return error.SkipZigTest;
 
     const H = struct {
         const conns = 16;
@@ -3133,10 +3135,7 @@ test "multi-executor: full-duplex with task migration disabled" {
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{
-        .executors = .exact(3),
-        .enable_task_migration = false,
-    });
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 
     var sh: H.Shared = .{};

--- a/src/options.zig
+++ b/src/options.zig
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025 Lukáš Lalinský
+// SPDX-License-Identifier: MIT
+
+//! Compile-time configuration, declared by the root module:
+//!
+//! ```zig
+//! // main.zig
+//! pub const zio_options: @import("zio").Options = .{ .scheduling = .pinned };
+//! ```
+//!
+//! Because the options live in the root module rather than in a build-time
+//! options module, every zio in a binary (the app's, and any library's that
+//! depends on zio) sees the same configuration. Passing them as `b.dependency`
+//! arguments instead would produce a distinct module per argument set, and a
+//! binary that ended up with two of them would have two incompatible `Runtime`
+//! types.
+//!
+//! The `-D` build options of zio's own `build.zig` supply the defaults when the
+//! root module declares nothing. They exist so zio's test and example builds can
+//! sweep the configuration matrix from the command line; a root declaration
+//! always wins over them.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const root = @import("root");
+const build_options = @import("zio_build_options");
+
+/// How tasks are scheduled onto executors. This is the ceiling on what the
+/// scheduler compiles in, so each step down removes machinery rather than
+/// merely disabling it.
+pub const Scheduling = enum {
+    /// One executor. No stealing, no migration, and no executor topology: the
+    /// executor count is comptime-known, so the run-queue routing, the
+    /// round-robin in `getNextExecutor`, the idle mask and the per-executor
+    /// metrics fold all collapse.
+    ///
+    /// This is about executors, not threads: unless the build is also
+    /// `-fsingle-threaded`, the blocking thread pool still exists and foreign
+    /// threads can still wake tasks, so the cross-thread wake path stays.
+    single_executor,
+    /// Many executors, but a task stays on the executor it was spawned on for
+    /// its entire life. Drops the steal machinery and the atomics that exist
+    /// only to move a running task between threads, at the cost of no
+    /// rebalancing when load is uneven.
+    pinned,
+    /// Many executors, and idle ones steal work from busy ones.
+    work_stealing,
+
+    /// Whether more than one executor can exist.
+    pub inline fn multiExecutor(self: Scheduling) bool {
+        return self != .single_executor;
+    }
+
+    /// Whether a task can move between executors after it starts running.
+    pub inline fn migrates(self: Scheduling) bool {
+        return self == .work_stealing;
+    }
+};
+
+/// Event loop backend. The default is the best one for the target.
+pub const BackendType = enum { poll, linux, epoll, kqueue, io_uring, iocp };
+
+/// How to handle `resolve_beneath` on platforms without kernel support.
+pub const ResolveBeneathMode = enum {
+    /// Fail with `error.Unsupported`.
+    strict,
+    /// Log a warning and continue.
+    best_effort,
+};
+
+pub const Options = struct {
+    /// Scheduling discipline, and thus the scheduler machinery compiled in.
+    /// Defaults to `.single_executor`, matching the default runtime, which runs
+    /// one executor. Programs that want more than one executor set this to
+    /// `.pinned` or `.work_stealing`; `RuntimeOptions.exact()` is a compile
+    /// error until they do.
+    scheduling: Scheduling = default_scheduling,
+    /// Override the event loop backend. Null picks the target's default.
+    backend: ?BackendType = default_backend,
+    resolve_beneath_mode: ResolveBeneathMode = default_resolve_beneath_mode,
+    /// Avoid unsafe performance tricks (bool smuggling, etc.).
+    no_hacks: bool = default_no_hacks,
+    /// Count scheduler events (parks, steals, wake batches) in per-executor
+    /// counters readable via `Runtime.schedulerMetrics`. The counters sit on
+    /// executor-local paths and cost one plain increment per event.
+    scheduler_metrics: bool = default_scheduler_metrics,
+};
+
+/// The resolved configuration. Everything in zio reads this.
+pub const options: Options = if (@hasDecl(root, "zio_options")) root.zio_options else .{};
+
+comptime {
+    if (builtin.single_threaded and options.scheduling.multiExecutor()) {
+        @compileError("zio: a -fsingle-threaded build cannot spawn executors; " ++
+            "set zio_options.scheduling = .single_executor");
+    }
+}
+
+/// The build options carry enums as tag names, so map them back here.
+fn fromBuildName(comptime T: type, comptime name: []const u8) T {
+    return std.meta.stringToEnum(T, name) orelse
+        @compileError("zio: unknown " ++ @typeName(T) ++ " build option: " ++ name);
+}
+
+/// The discipline zio's own `-Dscheduling` build option asked for, if any.
+/// This exists for zio's test runner and examples, which are root modules of
+/// builds driven from the command line; consumers declare `zio_options`.
+pub const build_scheduling: ?Scheduling = if (build_options.scheduling) |s|
+    fromBuildName(Scheduling, s)
+else
+    null;
+
+const default_scheduling: Scheduling = build_scheduling orelse .single_executor;
+
+const default_backend: ?BackendType = if (build_options.backend) |b|
+    fromBuildName(BackendType, b)
+else
+    null;
+
+const default_resolve_beneath_mode: ResolveBeneathMode = if (build_options.resolve_beneath_mode) |m|
+    fromBuildName(ResolveBeneathMode, m)
+else
+    .strict;
+
+const default_no_hacks: bool = build_options.no_hacks orelse false;
+
+const default_scheduler_metrics: bool = build_options.scheduler_metrics orelse true;

--- a/src/os/fs.zig
+++ b/src/os/fs.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const posix = @import("posix.zig");
 const darwin = @import("darwin.zig");
 const w = @import("windows.zig");
-const options = @import("zio_options");
+const options = @import("../options.zig").options;
 
 const unexpectedError = @import("base.zig").unexpectedError;
 const syscall_cancel = @import("syscall_cancel.zig");

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -357,6 +357,10 @@ pub fn getNextExecutor(rt: *Runtime) error{RuntimeShutdown}!*Executor {
         return error.RuntimeShutdown;
     }
 
+    // One executor is the whole rotation: skip the shared cursor and the
+    // division by a runtime value.
+    if (comptime !zio_options.scheduling.multiExecutor()) return rt.executors.items[0];
+
     const index = rt.next_executor_index.fetchAdd(1, .monotonic);
     return rt.executors.items[index % rt.executors.items.len];
 }
@@ -404,6 +408,21 @@ const metrics_storage_init: MetricsStorage = if (metrics_enabled) .{} else {};
 const IdleMask = if (zio_options.scheduling.migrates()) std.atomic.Value(usize) else void;
 const idle_mask_init: IdleMask = if (zio_options.scheduling.migrates()) .init(0) else {};
 
+// State that exists only to move work between executors. Zero-bit under the
+// disciplines that never do, on the same pattern as IdleMask above.
+const Searchers = if (zio_options.scheduling.migrates()) std.atomic.Value(u32) else void;
+const searchers_init: Searchers = if (zio_options.scheduling.migrates()) .init(0) else {};
+const Stealable = if (zio_options.scheduling.migrates()) std.atomic.Value(bool) else void;
+const stealable_init: Stealable = if (zio_options.scheduling.migrates()) .init(false) else {};
+const GlobalOverflow = if (zio_options.scheduling.migrates()) OverflowQueue(WaitNode) else void;
+const global_overflow_init: GlobalOverflow = if (zio_options.scheduling.migrates()) .{} else {};
+const StealPrng = if (zio_options.scheduling.migrates()) std.Random.DefaultPrng else void;
+const Dozed = if (zio_options.scheduling.migrates()) bool else void;
+const dozed_init: Dozed = if (zio_options.scheduling.migrates()) false else {};
+// The round-robin cursor is meaningless when there is only one executor.
+const NextExecutor = if (zio_options.scheduling.multiExecutor()) std.atomic.Value(usize) else void;
+const next_executor_init: NextExecutor = if (zio_options.scheduling.multiExecutor()) .init(0) else {};
+
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
     pub const max_executors = std.math.maxInt(ExecutorId) + 1;
@@ -418,7 +437,7 @@ pub const Executor = struct {
 
     /// Cheap PRNG for steal victim selection; the CSPRNG is for user-facing
     /// random() and too heavy for the park/steal path.
-    steal_prng: std.Random.DefaultPrng,
+    steal_prng: StealPrng,
 
     // Per-executor local run queue: bounded FIFO ring buffer (Go runq / Tokio
     // style). Overflow and cross-thread wakes go to `run_queue.overflow`, which
@@ -461,7 +480,7 @@ pub const Executor = struct {
     // Whether this executor has already spent its doze (the steal-free grace
     // park, see parkAndSearch) since it last had local work. Reset by any
     // local work; while set, empty passes go straight to the full park.
-    dozed: bool = false,
+    dozed: Dozed = dozed_init,
 
     // Scheduler event counters; written only by this executor's thread.
     metrics: MetricsStorage = metrics_storage_init,
@@ -570,7 +589,9 @@ pub const Executor = struct {
 
         // Initialize this executor's random state from OS entropy.
         try random_mod.setup(&self.random_state);
-        self.steal_prng = std.Random.DefaultPrng.init(self.random_state.csprng.random().int(u64));
+        if (comptime zio_options.scheduling.migrates()) {
+            self.steal_prng = std.Random.DefaultPrng.init(self.random_state.csprng.random().int(u64));
+        }
 
         try self.loop.init(.{
             .allocator = self.runtime.allocator,
@@ -738,7 +759,7 @@ pub const Executor = struct {
 
         // Entering the run loop means the main task just ran (or this executor
         // just started): that was productive work, a fresh doze is due.
-        self.dozed = false;
+        self.resetDoze();
 
         // When entered with the tick budget already spent (e.g. the main task
         // yielded because its slice ran out), ready tasks must get one
@@ -765,7 +786,7 @@ pub const Executor = struct {
             // as the tick budget, but consulted here rather than in the
             // retune below: the park decision runs between the two, and it
             // must see the fresh value.
-            if (self.tick_task_count > 0) self.dozed = false;
+            if (self.tick_task_count > 0) self.resetDoze();
 
             // Exit if loop is stopped
             if (self.loop.stopped()) {
@@ -827,6 +848,12 @@ pub const Executor = struct {
     /// parks indefinitely with stealing folded into the pre-park check — by
     /// then idleness is proven and the steal is also what makes the park's
     /// wake protocol sound (see park).
+    /// Reset the doze grace window. A no-op where there is no stealing churn
+    /// for the window to absorb, so the run loop's two calls compile away.
+    inline fn resetDoze(self: *Executor) void {
+        if (comptime zio_options.scheduling.migrates()) self.dozed = false;
+    }
+
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
         if (comptime !zio_options.scheduling.migrates()) {
             self.bump("parks_full", 1);
@@ -1456,16 +1483,16 @@ pub const Runtime = struct {
     options: RuntimeOptions,
 
     executors: std.ArrayList(*Executor) = .empty,
-    executors_stealable: std.atomic.Value(bool) = .init(false),
+    executors_stealable: Stealable = stealable_init,
     // Shared global run queue (used when task migration is on): external
     // submissions, cross-thread wakes, and per-executor ring overflow land here,
     // and every executor drains a fair batch from it once per tick.
-    global_overflow: OverflowQueue(WaitNode) = .{},
+    global_overflow: GlobalOverflow = global_overflow_init,
     idle_mask: IdleMask = idle_mask_init,
-    searchers: std.atomic.Value(u32) = .init(0),
+    searchers: Searchers = searchers_init,
     loop_group: ev.LoopGroup = .{},
     main_executor: Executor,
-    next_executor_index: std.atomic.Value(usize) = .init(0),
+    next_executor_index: NextExecutor = next_executor_init,
     workers: std.ArrayList(Worker) = .empty,
     task_count: std.atomic.Value(u32) = std.atomic.Value(u32).init(0), // Active task counter
     shutting_down: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -1559,7 +1586,7 @@ pub const Runtime = struct {
             }
             // With no workers there is nobody to steal from or to; leaving this
             // false lets single-executor runtimes skip the steal machinery.
-            if (num_workers > 0) self.executors_stealable.store(true, .release);
+            if (num_workers > 0) self.setStealable(true);
         }
 
         if (options.metrics_log_interval.value > 0) {
@@ -1603,7 +1630,7 @@ pub const Runtime = struct {
 
     /// Stop worker executors and join threads. Used by deinit() and init() error path.
     fn shutdownWorkers(self: *Runtime) void {
-        self.executors_stealable.store(false, .release);
+        self.setStealable(false);
         // Wait for all workers to finish initialization, then stop their event loops.
         // Workers that failed to initialize (err != null) don't have valid executors.
         for (self.workers.items) |*worker| {
@@ -1787,6 +1814,14 @@ pub const Runtime = struct {
             }
         }
         return total;
+    }
+
+    /// Publish whether other executors may steal from this runtime's queues.
+    /// Compiles away where nothing steals.
+    inline fn setStealable(self: *Runtime, stealable: bool) void {
+        if (comptime zio_options.scheduling.migrates()) {
+            self.executors_stealable.store(stealable, .release);
+        }
     }
 
     /// Whether other executors can currently steal from this runtime's queues.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
 const assert = std.debug.assert;
-const zio_options = @import("zio_options");
+const zio_options = @import("options.zig").options;
 
 const ev = @import("ev/root.zig");
 const os = @import("os/root.zig");
@@ -99,17 +99,33 @@ const mod = @This();
 
 /// Number of executor threads to run (including main).
 pub const ExecutorCount = enum(u8) {
-    /// Auto-detect based on CPU count
+    /// Auto-detect based on CPU count. Resolves to 1 under `.single_executor`
+    /// scheduling, where there is nothing to detect.
     auto = 0,
     _,
 
-    /// Create an exact executor count (1 = single-threaded, no worker threads)
-    pub fn exact(n: u8) ExecutorCount {
-        assert(n >= 1 and n <= Executor.max_executors);
-        return @enumFromInt(n);
+    /// Create an exact executor count (1 = a single executor, no worker threads).
+    ///
+    /// `n` is `anytype` so that a literal stays comptime-known here: under
+    /// `.single_executor` scheduling, asking for more than one is then a compile
+    /// error at the call site rather than a failure when the runtime is built.
+    pub fn exact(n: anytype) ExecutorCount {
+        if (comptime !zio_options.scheduling.multiExecutor()) {
+            const msg = "zio: this build compiles in `.scheduling = .single_executor`, so " ++
+                "the executor count is fixed at one. Declare " ++
+                "`pub const zio_options: zio.Options = .{ .scheduling = .work_stealing }` " ++
+                "in your root module to choose a count.";
+            if (@typeInfo(@TypeOf(n)) != .comptime_int) @compileError(msg);
+            if (n != 1) @compileError(msg);
+        }
+        const count: u8 = n;
+        assert(count >= 1 and count <= Executor.max_executors);
+        return @enumFromInt(count);
     }
 
     pub fn resolve(self: ExecutorCount) u8 {
+        // Nothing to detect and nothing to honor when only one is compiled in.
+        if (comptime !zio_options.scheduling.multiExecutor()) return 1;
         return switch (self) {
             .auto => autoDetect(),
             _ => @intFromEnum(self),
@@ -149,11 +165,6 @@ pub const RuntimeOptions = struct {
     /// Set to false when creating runtimes in background threads that should not block
     /// the creating thread in an event loop. Requires executors >= 1 to have any workers.
     enable_main_executor: bool = true,
-    /// Allow tasks to migrate between executors when true. Requires migration
-    /// support to be compiled in (the `task-migration` build option, default on);
-    /// enabling it in a build compiled without support is an error at init.
-    /// Defaults to whether support is compiled in.
-    enable_task_migration: bool = zio_options.task_migration,
     /// DNS resolver configuration.
     dns: DnsOptions = .{},
 };
@@ -318,14 +329,14 @@ comptime {
 // the per-dispatch re-publish is skipped entirely (it would only rewrite the same
 // value), making parent_context_ptr effectively write-once.
 inline fn storeParentContext(field: **Context, ctx: *Context) void {
-    if (zio_options.task_migration) {
+    if (zio_options.scheduling.migrates()) {
         @atomicStore(*Context, field, ctx, .release);
     } else {
         field.* = ctx;
     }
 }
 inline fn updateParentContext(task: *AnyTask, ctx: *Context) void {
-    if (zio_options.task_migration) {
+    if (zio_options.scheduling.migrates()) {
         @atomicStore(*Context, &task.coro.parent_context_ptr, ctx, .release);
     } else {
         // Pinned task: parent_context_ptr is constant, so there is nothing to
@@ -335,7 +346,7 @@ inline fn updateParentContext(task: *AnyTask, ctx: *Context) void {
     }
 }
 inline fn loadParentContext(field: *const *Context) *Context {
-    return if (zio_options.task_migration)
+    return if (zio_options.scheduling.migrates())
         @atomicLoad(*Context, field, .acquire)
     else
         field.*;
@@ -390,8 +401,8 @@ pub const SchedulerMetrics = struct {
 
 const MetricsStorage = if (metrics_enabled) SchedulerMetrics else void;
 const metrics_storage_init: MetricsStorage = if (metrics_enabled) .{} else {};
-const IdleMask = if (zio_options.task_migration) std.atomic.Value(usize) else void;
-const idle_mask_init: IdleMask = if (zio_options.task_migration) .init(0) else {};
+const IdleMask = if (zio_options.scheduling.migrates()) std.atomic.Value(usize) else void;
+const idle_mask_init: IdleMask = if (zio_options.scheduling.migrates()) .init(0) else {};
 
 // Executor - per-thread execution unit for running coroutines
 pub const Executor = struct {
@@ -413,7 +424,7 @@ pub const Executor = struct {
     // style). Overflow and cross-thread wakes go to `run_queue.overflow`, which
     // is wired at init to either the runtime global queue (migration on) or this
     // executor's own `overflow` queue below (migration off).
-    run_queue: LocalRunQueue(WaitNode, zio_options.task_migration) = .{},
+    run_queue: LocalRunQueue(WaitNode, zio_options.scheduling.migrates()) = .{},
 
     // This executor's own overflow queue, used ONLY when task migration is
     // disabled — cross-thread wakes and ring overflow for this executor land here
@@ -531,7 +542,7 @@ pub const Executor = struct {
         // overflow queue when off (tasks stay on their home executor). Worker
         // executors live in a pre-sized, non-reallocating list, so &self.overflow
         // is a stable address.
-        self.run_queue.overflow = if (runtime.options.enable_task_migration)
+        self.run_queue.overflow = if (comptime zio_options.scheduling.migrates())
             &runtime.global_overflow
         else
             &self.overflow;
@@ -817,7 +828,7 @@ pub const Executor = struct {
     /// then idleness is proven and the steal is also what makes the park's
     /// wake protocol sound (see park).
     fn parkAndSearch(self: *Executor, check_ready: bool) !void {
-        if (comptime !zio_options.task_migration) {
+        if (comptime !zio_options.scheduling.migrates()) {
             self.bump("parks_full", 1);
             try self.loop.poll(.max);
             self.drainDispatched();
@@ -891,7 +902,7 @@ pub const Executor = struct {
 
             const pending = self.run_queue.overflow.len();
             if (pending != 0) {
-                const batch = if (self.runtime.options.enable_task_migration)
+                const batch = if (comptime zio_options.scheduling.migrates())
                     pending / @max(self.runtime.executors.items.len, 1) + 1
                 else
                     pending;
@@ -949,7 +960,7 @@ pub const Executor = struct {
         // only a fair ~1/n_exec slice to avoid monopolizing it. With migration
         // off it is this executor's own private queue and we are its sole
         // drainer, so take as much as fits (refill caps it).
-        const batch = if (self.runtime.options.enable_task_migration)
+        const batch = if (comptime zio_options.scheduling.migrates())
             pending / @max(self.runtime.executors.items.len, 1) + 1
         else
             pending;
@@ -1142,7 +1153,7 @@ pub const Executor = struct {
             // spawns and round-robin homes (migration off). Only already-running
             // tasks may migrate to the current executor (cache locality with the
             // waker).
-            if (zio_options.task_migration and old.tag != .new and current_exec.runtime == home_exec.runtime and home_exec.runtime.options.enable_task_migration) {
+            if (zio_options.scheduling.migrates() and old.tag != .new and current_exec.runtime == home_exec.runtime) {
                 // Migrate to the current executor
                 current_exec.scheduleTaskLocal(task);
                 return;
@@ -1486,11 +1497,6 @@ pub const Runtime = struct {
     }
 
     pub fn initStatic(self: *Runtime, allocator: Allocator, options: RuntimeOptions) !void {
-        // Task migration can only be enabled at runtime if it was compiled in.
-        if (!zio_options.task_migration and options.enable_task_migration) {
-            return error.TaskMigrationNotCompiledIn;
-        }
-
         const num_executors = options.executors.resolve();
         const num_workers = if (options.enable_main_executor) num_executors - 1 else num_executors;
 
@@ -1785,11 +1791,11 @@ pub const Runtime = struct {
 
     /// Whether other executors can currently steal from this runtime's queues.
     pub inline fn stealingActive(self: *Runtime) bool {
-        return zio_options.task_migration and self.options.enable_task_migration and self.executors_stealable.load(.acquire);
+        return zio_options.scheduling.migrates() and self.executors_stealable.load(.acquire);
     }
 
     fn armSearcher(self: *Runtime, hint: ?ExecutorId) void {
-        if (comptime !zio_options.task_migration) return;
+        if (comptime !zio_options.scheduling.migrates()) return;
 
         // The two early-return loads pair with the parker: an executor sets its
         // idle bit (seq_cst RMW) and only then makes its final work check, while
@@ -1843,7 +1849,7 @@ pub const Runtime = struct {
     /// that lets one extra election through, it never loses a wake.
     /// Returns the number of sleepers actually woken.
     fn batchWakeSleepers(self: *Runtime, ready: usize, hint: ExecutorId) u64 {
-        if (comptime !zio_options.task_migration) return 0;
+        if (comptime !zio_options.scheduling.migrates()) return 0;
 
         if (!self.stealingActive() or ready < 2) return 0;
         if (self.idle_mask.load(.seq_cst) == 0) return 0;
@@ -1930,6 +1936,7 @@ pub const Runtime = struct {
 };
 
 test "Runtime: scheduler metrics count parks and drained wakes" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     if (!metrics_enabled) return error.SkipZigTest;
 
     const runtime = try Runtime.init(std.testing.allocator, .{
@@ -2313,17 +2320,17 @@ test "runtime: sleep from main allows tasks to run" {
     try std.testing.expectEqual(10, counter);
 }
 
-test "runtime: enabling task migration at runtime errors when compiled out" {
-    // Only meaningful in a build without migration support; a normal build
-    // compiles migration in, so there is nothing to reject.
-    if (zio_options.task_migration) return error.SkipZigTest;
-    try std.testing.expectError(
-        error.TaskMigrationNotCompiledIn,
-        Runtime.init(std.testing.allocator, .{ .enable_task_migration = true }),
-    );
+test "runtime: .auto resolves to one executor when only one is compiled in" {
+    // .exact() does not compile under .single_executor, so .auto is the only way
+    // to ask for a count there; it must resolve rather than reject.
+    if (comptime zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .auto });
+    defer runtime.deinit();
+    try std.testing.expectEqual(1, runtime.executors.items.len);
 }
 
 test "runtime: multi-threaded execution with 2 executors" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -2352,26 +2359,25 @@ test "runtime: multi-threaded execution with 2 executors" {
 }
 
 test "runtime: local ring overflow spills and drains with task migration disabled" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    // Pinned scheduling only: the private-overflow path exists only there.
+    if (zio_options.scheduling != .pinned) return error.SkipZigTest;
     // With migration disabled, spawn far more ready tasks than the local ring
     // holds (capacity 256) so the ring spills into the executor's own overflow
     // queue (the runqputslow path) and must drain every task back out. All are
     // spawned before any drain, so the ring genuinely overflows. Two executors
     // also covers the remote sub-path: tasks whose round-robin home is the other
     // executor go straight to that executor's overflow queue.
-    if (builtin.single_threaded) return error.SkipZigTest;
 
     const H = struct {
-        const n_tasks = 2 * LocalRunQueue(WaitNode, zio_options.task_migration).capacity; // 512 >> 256
+        const n_tasks = 2 * LocalRunQueue(WaitNode, zio_options.scheduling.migrates()).capacity; // 512 >> 256
 
         fn child(counter: *std.atomic.Value(u32)) void {
             _ = counter.fetchAdd(1, .monotonic);
         }
     };
 
-    const runtime = try Runtime.init(std.testing.allocator, .{
-        .executors = .exact(2),
-        .enable_task_migration = false,
-    });
+    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
     var counter = std.atomic.Value(u32).init(0);
@@ -2389,6 +2395,7 @@ test "runtime: local ring overflow spills and drains with task migration disable
 }
 
 test "runtime: multi-threaded execution with max executors" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(Executor.max_executors) });
     defer runtime.deinit();
 
@@ -2396,6 +2403,7 @@ test "runtime: multi-threaded execution with max executors" {
 }
 
 test "Runtime: multi-threaded with task migration" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(8) });
     defer runtime.deinit();
 
@@ -2445,18 +2453,19 @@ test "Runtime: multi-threaded with task migration" {
 }
 
 test "runtime: wake-before-park awaken bit stress (single executor)" {
-    try wakeBeforeParkStress(1);
+    try wakeBeforeParkStress(.exact(1));
 }
 
 test "runtime: wake-before-park awaken bit stress (two executors)" {
-    try wakeBeforeParkStress(2);
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    try wakeBeforeParkStress(.exact(2));
 }
 
-fn wakeBeforeParkStress(executor_count: u6) !void {
+fn wakeBeforeParkStress(executors: ExecutorCount) !void {
     const Event = @import("sync/Event.zig");
 
     const runtime = try Runtime.init(std.testing.allocator, .{
-        .executors = .exact(executor_count),
+        .executors = executors,
     });
     defer runtime.deinit();
 
@@ -2508,6 +2517,7 @@ fn wakeBeforeParkStress(executor_count: u6) !void {
 }
 
 test "runtime: mutex contention with task migration" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const Mutex = @import("sync/Mutex.zig");
 
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
@@ -2538,7 +2548,7 @@ test "runtime: mutex contention with task migration" {
 }
 
 test "runtime: disable main executor" {
-    if (builtin.single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
 
     // Create a runtime where the calling thread is not an executor.
     // All tasks run on background worker threads.

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -114,7 +114,8 @@ pub const ExecutorCount = enum(u8) {
             const msg = "zio: this build compiles in `.scheduling = .single_executor`, so " ++
                 "the executor count is fixed at one. Declare " ++
                 "`pub const zio_options: zio.Options = .{ .scheduling = .work_stealing }` " ++
-                "in your root module to choose a count.";
+                "(or `.pinned`, if tasks should not migrate) in your root module to " ++
+                "choose a count.";
             if (@typeInfo(@TypeOf(n)) != .comptime_int) @compileError(msg);
             if (n != 1) @compileError(msg);
         }
@@ -2438,7 +2439,7 @@ test "runtime: multi-threaded execution with max executors" {
 }
 
 test "Runtime: multi-threaded with task migration" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.migrates()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(8) });
     defer runtime.deinit();
 

--- a/src/stderr.zig
+++ b/src/stderr.zig
@@ -35,6 +35,7 @@
 //! only happens while a task actually holds the user lock.
 
 const std = @import("std");
+const zio_options = @import("options.zig").options;
 const Io = std.Io;
 
 const Mutex = @import("sync/Mutex.zig");
@@ -459,6 +460,7 @@ test "stderr lock: the crash path takes over the mounted task's lock" {
 }
 
 test "stderr lock: a task waits for another task and is handed the lock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try runtime.Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 

--- a/src/sync/Barrier.zig
+++ b/src/sync/Barrier.zig
@@ -47,6 +47,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const Group = @import("../group.zig").Group;
 const Cancelable = @import("../common.zig").Cancelable;
@@ -128,6 +129,7 @@ pub fn wait(self: *Barrier) (Cancelable || error{BrokenBarrier})!bool {
 }
 
 test "Barrier: basic synchronization" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 
@@ -165,6 +167,7 @@ test "Barrier: basic synchronization" {
 }
 
 test "Barrier: leader detection" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 
@@ -195,6 +198,7 @@ test "Barrier: leader detection" {
 }
 
 test "Barrier: reusable for multiple cycles" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -234,6 +238,7 @@ test "Barrier: reusable for multiple cycles" {
 }
 
 test "Barrier: single coroutine barrier" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -244,6 +249,7 @@ test "Barrier: single coroutine barrier" {
 }
 
 test "Barrier: ordering test" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 
@@ -288,6 +294,7 @@ test "Barrier: ordering test" {
 }
 
 test "Barrier: many coroutines" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(5) });
     defer runtime.deinit();
 

--- a/src/sync/Condition.zig
+++ b/src/sync/Condition.zig
@@ -49,6 +49,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const beginShield = @import("../runtime.zig").beginShield;
 const endShield = @import("../runtime.zig").endShield;
@@ -255,6 +256,7 @@ pub fn broadcast(self: *Condition) void {
 }
 
 test "Condition basic wait/signal" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -301,6 +303,7 @@ test "Condition basic wait/signal" {
 }
 
 test "Condition waitTimeout timeout" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -315,6 +318,7 @@ test "Condition waitTimeout timeout" {
 }
 
 test "Condition broadcast" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 

--- a/src/sync/Event.zig
+++ b/src/sync/Event.zig
@@ -44,6 +44,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const builtin = @import("builtin");
 const Runtime = @import("../runtime.zig").Runtime;
 const os = @import("../os/root.zig");
@@ -222,6 +223,7 @@ pub fn asyncCancelWait(self: *Event, waiter: *Waiter) bool {
 }
 
 test "Event basic set/reset/isSet" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -248,6 +250,7 @@ test "Event basic set/reset/isSet" {
 }
 
 test "Event wait/set signaling" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -285,6 +288,7 @@ test "Event wait/set signaling" {
 }
 
 test "Event waitTimeout timeout" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -296,6 +300,7 @@ test "Event waitTimeout timeout" {
 }
 
 test "Event multiple waiters broadcast" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -335,6 +340,7 @@ test "Event multiple waiters broadcast" {
 }
 
 test "Event wait on already set event" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -354,6 +360,7 @@ test "Event size" {
 }
 
 test "Event: cancel waiting task" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -384,6 +391,7 @@ test "Event: cancel waiting task" {
 }
 
 test "Event: select" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const select = @import("../select.zig").select;
 
     const TestContext = struct {
@@ -412,6 +420,7 @@ test "Event: select" {
 }
 
 test "Event: foreign thread signals async task" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -448,6 +457,7 @@ test "Event: foreign thread signals async task" {
 }
 
 test "Event: async task signals foreign thread" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 

--- a/src/sync/Futex.zig
+++ b/src/sync/Futex.zig
@@ -26,6 +26,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const builtin = @import("builtin");
 
 const Runtime = @import("../runtime.zig").Runtime;
@@ -282,6 +283,7 @@ pub fn cancelWait(node: *FutexWaiter) bool {
 }
 
 test "Futex: basic wait/wake" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const Main = struct {
         fn waiterFunc(v: *u32, w: *bool) !void {
             while (@atomicLoad(u32, v, .acquire) == 0) {
@@ -322,6 +324,7 @@ test "Futex: basic wait/wake" {
 }
 
 test "Futex: spurious wakeup - value already changed" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -332,6 +335,7 @@ test "Futex: spurious wakeup - value already changed" {
 }
 
 test "Futex: wake with no waiters" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -343,6 +347,7 @@ test "Futex: wake with no waiters" {
 }
 
 test "Futex: multiple waiters same address" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const Main = struct {
         fn waiterFunc(v: *u32, w: *u32, ready: *std.atomic.Value(u32)) !void {
             _ = ready.fetchAdd(1, .release);
@@ -393,6 +398,7 @@ test "Futex: multiple waiters same address" {
 }
 
 test "Futex: multiple waiters different addresses" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const Main = struct {
         fn waiterFunc(v: *u32, w: *u32) !void {
             while (@atomicLoad(u32, v, .acquire) == 0) {
@@ -445,6 +451,7 @@ test "Futex: multiple waiters different addresses" {
 }
 
 test "Futex: waitTimeout timeout" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 

--- a/src/sync/Mutex.zig
+++ b/src/sync/Mutex.zig
@@ -25,6 +25,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const Executor = @import("../runtime.zig").Executor;
 const getCurrentTaskOrNull = @import("../runtime.zig").getCurrentTaskOrNull;
@@ -151,6 +152,7 @@ fn lockSlow(self: *Mutex, comptime cancel_mode: Executor.YieldCancelMode) if (ca
 }
 
 test "Mutex basic lock/unlock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -180,6 +182,7 @@ test "Mutex basic lock/unlock" {
 }
 
 test "Mutex tryLock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -193,6 +196,7 @@ test "Mutex tryLock" {
 }
 
 test "Mutex contention" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -246,7 +250,7 @@ test "Mutex foreign threads" {
 }
 
 test "Mutex mixed tasks and threads" {
-    if (@import("builtin").single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
 
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
@@ -285,6 +289,7 @@ test "Mutex mixed tasks and threads" {
 }
 
 test "Mutex cancellation while parked under churn" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -330,7 +335,7 @@ test "Mutex cancellation while parked under churn" {
 }
 
 test "Mutex repeated cancellation generations under churn" {
-    if (@import("builtin").single_threaded) return error.SkipZigTest;
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
 
     // Regression stress for lost wakeups on weakly ordered CPUs (both found
     // via this test hanging or stalling on Apple Silicon in release mode):

--- a/src/sync/Mutex/Recursive.zig
+++ b/src/sync/Mutex/Recursive.zig
@@ -35,6 +35,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../../options.zig").options;
 const Runtime = @import("../../runtime.zig").Runtime;
 const Group = @import("../../group.zig").Group;
 const Cancelable = @import("../../common.zig").Cancelable;
@@ -173,6 +174,7 @@ pub fn isLocked(self: *const Recursive) bool {
 }
 
 test "Recursive basic lock/unlock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -202,6 +204,7 @@ test "Recursive basic lock/unlock" {
 }
 
 test "Recursive tryLock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -220,6 +223,7 @@ test "Recursive tryLock" {
 }
 
 test "Recursive recursive lock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -254,6 +258,7 @@ test "Recursive recursive lock" {
 }
 
 test "Recursive mutual exclusion with recursion" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -289,6 +294,7 @@ test "Recursive mutual exclusion with recursion" {
 }
 
 test "Recursive different owners cannot recurse" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -320,6 +326,7 @@ test "Recursive different owners cannot recurse" {
 }
 
 test "Recursive cancel waiting on first acquisition" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 

--- a/src/sync/RwLock.zig
+++ b/src/sync/RwLock.zig
@@ -29,6 +29,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const beginShield = @import("../runtime.zig").beginShield;
 const endShield = @import("../runtime.zig").endShield;
@@ -210,6 +211,7 @@ pub fn unlockShared(self: *RwLock) void {
 }
 
 test "RwLock basic write lock/unlock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -224,6 +226,7 @@ test "RwLock basic write lock/unlock" {
 }
 
 test "RwLock basic shared lock/unlock" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const rt = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer rt.deinit();
 
@@ -239,6 +242,7 @@ test "RwLock basic shared lock/unlock" {
 }
 
 test "RwLock last reader wakes writer when reader is queued first" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -301,6 +305,7 @@ test "RwLock last reader wakes writer when reader is queued first" {
 }
 
 test "RwLock concurrent readers and writers" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -351,6 +356,7 @@ test "RwLock concurrent readers and writers" {
 }
 
 test "RwLock writer exclusion" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 
@@ -381,6 +387,7 @@ test "RwLock writer exclusion" {
 }
 
 test "RwLock cancel waiting writer" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -420,6 +427,7 @@ test "RwLock cancel waiting writer" {
 }
 
 test "RwLock canceled writer must not leave a semaphore permit" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 

--- a/src/sync/Semaphore.zig
+++ b/src/sync/Semaphore.zig
@@ -41,6 +41,7 @@
 //! ```
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const beginShield = @import("../runtime.zig").beginShield;
 const endShield = @import("../runtime.zig").endShield;
@@ -166,6 +167,7 @@ pub fn post(self: *Semaphore) void {
 }
 
 test "Semaphore: basic wait/post" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 
@@ -195,6 +197,7 @@ test "Semaphore: basic wait/post" {
 }
 
 test "Semaphore: waitTimeout timeout" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -206,6 +209,7 @@ test "Semaphore: waitTimeout timeout" {
 }
 
 test "Semaphore: waitTimeout success" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -242,6 +246,7 @@ test "Semaphore: waitTimeout success" {
 }
 
 test "Semaphore: multiple permits" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(3) });
     defer runtime.deinit();
 

--- a/src/sync/broadcast_channel.zig
+++ b/src/sync/broadcast_channel.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
 const Group = @import("../group.zig").Group;
@@ -990,6 +991,7 @@ test "BroadcastChannel: position counter overflow handling" {
 }
 
 test "BroadcastChannel: cancelling parked consumers does not re-queue a live wait node" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     // Regression test for a reused `Waiter` in `receive`. Cancelling a consumer
     // that is parked in `receive` hands its pending signal to the next queued
     // consumer, which then wakes with nothing to read and loops. With a single

--- a/src/sync/channel.zig
+++ b/src/sync/channel.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
 const Group = @import("../group.zig").Group;
@@ -1899,6 +1900,7 @@ test "Channel: close classifies select waiters before signaling" {
 }
 
 test "Channel: canceled select conserves a concurrently sent item" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -1954,6 +1956,7 @@ test "Channel: canceled select conserves a concurrently sent item" {
 }
 
 test "Channel: ready arm does not clobber an earlier channel notification" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -2011,6 +2014,7 @@ test "Channel: ready arm does not clobber an earlier channel notification" {
 }
 
 test "Channel: unbuffered select send rendezvous with select receive" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -2047,6 +2051,7 @@ test "Channel: unbuffered select send rendezvous with select receive" {
 }
 
 test "Channel: select over two rendezvous channels racing select senders" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     // The composition main deadlocked on: a select whose arms are two
     // rendezvous channels, racing senders that are themselves selects. Every
     // pairing must go through the commit fence and re-poll machinery.
@@ -2102,6 +2107,7 @@ test "Channel: select over two rendezvous channels racing select senders" {
 }
 
 test "Channel: cancel removes a parked select send" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -2127,6 +2133,7 @@ test "Channel: cancel removes a parked select send" {
 }
 
 test "Channel: rendezvous racing a level source in the same select" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     // Exercises the fence-window wake: the Event can fire while the
     // select's sweep holds its commit fence on the rendezvous arm, in which
     // case the event's signal claims nothing and the select must recover the

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 const std = @import("std");
+const zio_options = @import("../options.zig").options;
 const builtin = @import("builtin");
 const Runtime = @import("../runtime.zig").Runtime;
 const yield = @import("../runtime.zig").yield;
@@ -132,6 +133,7 @@ pub fn Future(comptime T: type) type {
 }
 
 test "Future: basic set and get" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -153,6 +155,7 @@ test "Future: basic set and get" {
 }
 
 test "Future: await from coroutine" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
     defer runtime.deinit();
 
@@ -191,6 +194,7 @@ test "Future: await from coroutine" {
 }
 
 test "Future: multiple waiters" {
+    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
     const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(4) });
     defer runtime.deinit();
 

--- a/src/sync/future.zig
+++ b/src/sync/future.zig
@@ -133,8 +133,8 @@ pub fn Future(comptime T: type) type {
 }
 
 test "Future: basic set and get" {
-    if (comptime !zio_options.scheduling.multiExecutor()) return error.SkipZigTest;
-    const runtime = try Runtime.init(std.testing.allocator, .{ .executors = .exact(2) });
+    // Runs entirely inside one task, so it needs no particular executor count.
+    const runtime = try Runtime.init(std.testing.allocator, .{});
     defer runtime.deinit();
 
     const TestContext = struct {

--- a/src/task.zig
+++ b/src/task.zig
@@ -247,8 +247,8 @@ pub const AnyTask = struct {
         return Executor.fromCoroutine(&self.coro);
     }
 
-    /// Migration of tasks is controlled by Runtime.options.enable_task_migration.
-    /// Use task.getRuntime().options.enable_task_migration to check at runtime.
+    /// Whether tasks migrate at all is fixed at compile time by
+    /// `zio_options.scheduling`.
     pub inline fn getRuntime(self: *AnyTask) *Runtime {
         return self.getExecutor().runtime;
     }

--- a/src/utils/local_run_queue.zig
+++ b/src/utils/local_run_queue.zig
@@ -11,16 +11,16 @@
 //! stack has.
 //!
 //! When the ring is full, half of it plus the new task spill to an `OverflowQueue`
-//! (Go's `runqputslow` → global queue). Which overflow queue is chosen by the
-//! `enable_task_migration` flag, via the `overflow` pointer set at init:
-//!   * migration on  -> the shared runtime global queue (load-balanced across all).
-//!   * migration off -> this executor's own queue (tasks never leave home).
+//! (Go's `runqputslow` → global queue). Which overflow queue is chosen by
+//! `zio_options.scheduling`, via the `overflow` pointer set at init:
+//!   * work_stealing -> the shared runtime global queue (load-balanced across all).
+//!   * pinned        -> this executor's own queue (tasks never leave home).
 //!
 //! Concurrency (stealable queues): `head` is CAS'd by the owner pop and (phase 2)
 //! stealers; `tail` is written only by the owning thread (store-release) and read
 //! plain by the owner, acquire by stealers. When the queue is built non-stealable
-//! (task migration compiled out) it is single-owner, so the cursors are plain and
-//! `steal` is a compile error. `T` must have a `next: ?*T` field (for the overflow
+//! (pinned or single-executor scheduling) it is single-owner, so the cursors
+//! are plain and `steal` is a compile error. `T` must have a `next: ?*T` field (for the overflow
 //! list) and, in debug, `in_list: bool` (managed by the overflow queue, not ring).
 
 const std = @import("std");

--- a/src/zio.zig
+++ b/src/zio.zig
@@ -4,6 +4,19 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const zio_options = @import("options.zig");
+/// Compile-time configuration. Declare `pub const zio_options: zio.Options` in
+/// your root module to override the defaults.
+pub const Options = zio_options.Options;
+/// The resolved configuration, after the root module's declaration is applied.
+pub const options = zio_options.options;
+/// The discipline zio's own `-Dscheduling` build option asked for, for zio's
+/// test runner and examples. Consumers declare `zio_options` instead.
+pub const build_scheduling = zio_options.build_scheduling;
+pub const Scheduling = zio_options.Scheduling;
+pub const BackendType = zio_options.BackendType;
+pub const ResolveBeneathMode = zio_options.ResolveBeneathMode;
+
 const runtime = @import("runtime.zig");
 pub const Runtime = runtime.Runtime;
 pub const RuntimeOptions = runtime.RuntimeOptions;

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -1,3 +1,9 @@
+// zio's own suite exercises multi-executor scheduling, so it opts out of the
+// library's .single_executor default. `-Dscheduling=` still wins.
+pub const zio_options: @import("zio").Options = .{
+    .scheduling = @import("zio").build_scheduling orelse .work_stealing,
+};
+
 // in your build.zig, you can specify a custom test runner:
 // const tests = b.addTest(.{
 //    .root_module = $MODULE_BEING_TESTED,


### PR DESCRIPTION
## Root-module configuration

Compile-time configuration moves out of build options and into the root module, read the way std reads `std_options`:

```zig
// main.zig
pub const zio_options: zio.Options = .{ .scheduling = .work_stealing };
```

Every zio in a binary (yours, and any library's that depends on zio) now sees one configuration. Passing options as `b.dependency` arguments produced a distinct module per argument set, so a binary could end up with two incompatible `Runtime` types. The `-D` options stay in zio's own `build.zig` as defaults for its test and example builds; a root declaration always wins over them.

`backend` also becomes a real enum instead of a string parsed by comparison chain in `ev/backend.zig`.

## zio_options.scheduling

The `task-migration` build option and `RuntimeOptions.enable_task_migration` collapse into one compile-time setting naming the three modes the runtime actually has:

| | |
|---|---|
| `.single_executor` | one executor, count comptime-known, no executor topology |
| `.pinned` | many executors, a task stays on the one it was spawned on |
| `.work_stealing` | many executors, idle ones steal from busy ones |

They nest, so each step down removes machinery rather than branching around it. The five runtime branches on `enable_task_migration` are gone, and the `pending / n_exec` overflow split now compiles to plain `pending` where the overflow queue is executor-local.

## Breaking: multi-threading is opt-in

`scheduling` defaults to `.single_executor`, matching `RuntimeOptions.executors`, which has always defaulted to a single executor. Without the declaration, `.exact(N)` for N > 1 is a **compile error** naming the declaration to add, and `.auto` resolves to one. `ExecutorCount.exact` takes its count as `anytype` so a literal stays comptime-known and the error lands at the call site.

Compile time is deliberate here. A default that silently started running tasks in parallel would turn correct programs into racy ones, and nothing in Zig would flag it. That is not hypothetical: trying `.auto` as the executors default made `runtime.zig`'s "maybeYield yields once the tick budget is spent" (18 tasks incrementing a plain `usize`) fail 4 runs in 5 under `.pinned`, while passing consistently under `.work_stealing`, where the same race just loses fewer increments.

`Runtime.init` no longer returns `error.TaskMigrationNotCompiledIn`, which had no remaining source.

## Optimizations enabled by the above

- `getNextExecutor` homed every new task through a shared round-robin cursor: an atomic increment plus a division by a runtime executor count, once per spawn. With one executor there is nothing to rotate. Interleaved A/B on a spawn loop, 12 rounds of 20k trivial tasks, medians of 5 pairs: **189ns vs 199ns per spawn, ~5% faster**, every pair favouring the fast path.
- State that exists only to move work between executors is zero-bit where nothing moves, following what `IdleMask` already did: the global overflow queue, the searcher count, the stealable flag, and per-executor the steal PRNG and doze flag. Negligible in bytes against a 183KB `Runtime`, but it also drops a PRNG seeding from every executor's init and two dead stores from the run loop.

## Testing

The discipline is comptime-only, so the non-default modes need their own builds to be covered at all. `check.sh` gains `--scheduling` and CI gains a job for `pinned` and `single_executor` (debug and release). Tests needing more than one executor skip where it is not compiled in.

| build | result |
|---|---|
| default | 678 passed, 4 skipped |
| `-Dscheduling=pinned` | 680 passed, 2 skipped |
| `-Dscheduling=single_executor` | 608 passed, 68 skipped |

Examples build on all three, including the `-fsingle-threaded` canary; `-Dbackend=` epoll/io_uring/poll all build.

Two tests now live only in the pinned build: the private-overflow spill test and `net.zig`'s full-duplex-without-loop-group test.