### PR TITLE
freebsd: drop the umutex/ucond Mutex and Condition

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed a FreeBSD bug where `Condition.wait` and `Condition.timedWait` returned without
+  the mutex. Both were built on `UMTX_OP_CV_WAIT`, which unlocks the mutex before
+  sleeping and, in the words of `_umtx_op(2)`, "after wakeup, the uaddr umutex is not
+  relocked". Re-acquiring it is the caller's job, which libthr does with
+  `_mutex_cv_lock` and we did not, so every caller ran its critical section unlocked
+  from its first wait onwards. In the thread pool that let two workers pop from the same
+  queue at once (seen in CI as an `integer overflow` panic on `queue_size -= 1`), and an
+  idle worker could spin at 100%, because a second wait on a mutex it no longer owned
+  returned `EPERM` immediately instead of sleeping.
+
+  FreeBSD now uses the same futex-backed `Mutex` and `Condition` as every other
+  platform, on top of the `UMTX_OP_WAIT_UINT_PRIVATE` wrappers that were already there.
+  This is what Go's runtime does too. It is also faster: an uncontended lock or unlock is
+  now a userspace CAS, where the umutex path made a syscall every time, contended or not.
+
 - Renamed `ResetEvent` to `Event`, matching `std.Io.Event`. `zio.ResetEvent` stays as a
   deprecated alias, so existing code keeps working, but it will be removed in a future
   release.

--- a/src/os/freebsd.zig
+++ b/src/os/freebsd.zig
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Lukáš Lalinský
 // SPDX-License-Identifier: MIT
 
-const std = @import("std");
-
 /// FreeBSD specific system calls and definitions
 
 // umtx operations
@@ -11,35 +9,6 @@ pub const UMTX_OP_WAIT_UINT: c_int = 11;
 pub const UMTX_OP_WAIT_UINT_PRIVATE: c_int = 15;
 pub const UMTX_OP_WAKE: c_int = 3;
 pub const UMTX_OP_WAKE_PRIVATE: c_int = 16;
-pub const UMTX_OP_MUTEX_TRYLOCK: c_int = 4;
-pub const UMTX_OP_MUTEX_LOCK: c_int = 5;
-pub const UMTX_OP_MUTEX_UNLOCK: c_int = 6;
-pub const UMTX_OP_CV_WAIT: c_int = 8;
-pub const UMTX_OP_CV_SIGNAL: c_int = 9;
-pub const UMTX_OP_CV_BROADCAST: c_int = 10;
-
-// umutex flags
-pub const UMUTEX_UNOWNED: c_int = 0x0;
-pub const UMUTEX_CONTESTED: u32 = 0x80000000;
-
-// Condition variable flags for UMTX_OP_CV_WAIT
-pub const CVWAIT_ABSTIME: c_ulong = 0x02;
-pub const CVWAIT_CLOCKID: c_ulong = 0x04;
-
-pub const umutex = extern struct {
-    m_owner: std.c.pid_t, // lwpid_t - thread ID or 0 if unowned
-    m_flags: u32,
-    m_ceilings: [2]u32,
-    m_rb_lnk: usize,
-    m_spare: [2]u32,
-};
-
-pub const ucond = extern struct {
-    c_has_waiters: u32,
-    c_flags: u32,
-    c_clockid: u32,
-    c_spare: [1]u32,
-};
 
 pub extern "c" fn _umtx_op(obj: *const anyopaque, op: c_int, val: c_ulong, uaddr: ?*anyopaque, uaddr2: ?*anyopaque) c_int;
 

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -108,7 +108,6 @@ pub const Notify = NotifyFutex;
 /// ```
 pub const Mutex = if (builtin.single_threaded) MutexNoop else switch (builtin.os.tag) {
     .windows => MutexWindows,
-    .freebsd => MutexFreeBSD,
     else => |t| if (t.isDarwin()) MutexDarwin else MutexFutex,
 };
 
@@ -143,7 +142,6 @@ pub const Mutex = if (builtin.single_threaded) MutexNoop else switch (builtin.os
 /// ```
 pub const Condition = if (builtin.single_threaded) ConditionNoop else switch (builtin.os.tag) {
     .windows => ConditionWindows,
-    .freebsd => ConditionFreeBSD,
     else => if (Futex == void) ConditionNotify else ConditionFutex,
 };
 
@@ -367,114 +365,6 @@ const FutexFreeBSD = struct {
             null,
             null,
         );
-    }
-};
-
-/// FreeBSD umutex-based mutex.
-///
-/// Uses FreeBSD's native UMTX_OP_MUTEX_* operations which provide
-/// kernel-assisted locking with automatic priority inheritance support.
-const MutexFreeBSD = struct {
-    mutex: sys.umutex = .{
-        .m_owner = sys.UMUTEX_UNOWNED,
-        .m_flags = 0,
-        .m_ceilings = .{ 0, 0 },
-        .m_rb_lnk = 0,
-        .m_spare = .{ 0, 0 },
-    },
-
-    pub fn init() MutexFreeBSD {
-        return .{};
-    }
-
-    pub fn deinit(self: *MutexFreeBSD) void {
-        _ = self;
-    }
-
-    pub fn lock(self: *MutexFreeBSD) void {
-        // UMTX_OP_MUTEX_LOCK blocks until the mutex is acquired
-        _ = sys._umtx_op(&self.mutex, sys.UMTX_OP_MUTEX_LOCK, 0, null, null);
-    }
-
-    pub fn unlock(self: *MutexFreeBSD) void {
-        // UMTX_OP_MUTEX_UNLOCK releases the mutex and wakes one waiter if any
-        _ = sys._umtx_op(&self.mutex, sys.UMTX_OP_MUTEX_UNLOCK, 0, null, null);
-    }
-
-    pub fn tryLock(self: *MutexFreeBSD) bool {
-        // UMTX_OP_MUTEX_TRYLOCK returns 0 on success, EBUSY if already locked
-        const result = sys._umtx_op(&self.mutex, sys.UMTX_OP_MUTEX_TRYLOCK, 0, null, null);
-        return result == 0;
-    }
-};
-
-/// FreeBSD ucond-based condition variable.
-///
-/// Uses FreeBSD's native UMTX_OP_CV_* operations which provide
-/// kernel-assisted condition variables with automatic signal-before-wait race handling.
-const ConditionFreeBSD = struct {
-    cond: sys.ucond = .{
-        .c_has_waiters = 0,
-        .c_flags = 0,
-        .c_clockid = 0,
-        .c_spare = .{0},
-    },
-
-    pub fn init() ConditionFreeBSD {
-        return .{};
-    }
-
-    pub fn deinit(self: *ConditionFreeBSD) void {
-        _ = self;
-    }
-
-    /// Wait for a signal. The mutex must be held when calling this.
-    /// The mutex is atomically released and the thread blocks.
-    /// When signaled, the mutex is automatically reacquired before returning.
-    pub fn wait(self: *ConditionFreeBSD, mutex: *Mutex) void {
-        // UMTX_OP_CV_WAIT atomically releases the mutex and waits
-        // The kernel ensures no signal is lost between unlock and wait
-        _ = sys._umtx_op(&self.cond, sys.UMTX_OP_CV_WAIT, 0, &mutex.mutex, null);
-    }
-
-    /// Wait for a signal with a timeout.
-    /// Returns error.Timeout if the timeout expires before being signaled.
-    pub fn timedWait(self: *ConditionFreeBSD, mutex: *Mutex, timeout: Timeout) error{Timeout}!void {
-        if (timeout == .none) {
-            return self.wait(mutex);
-        }
-
-        const deadline = timeout.toDeadline();
-        const remaining = deadline.durationFromNow();
-        if (remaining.value <= 0) {
-            return error.Timeout;
-        }
-
-        const timeout_ts = remaining.toTimespec();
-
-        // UMTX_OP_CV_WAIT with relative timeout (no CVWAIT_ABSTIME flag)
-        const result = sys._umtx_op(
-            &self.cond,
-            sys.UMTX_OP_CV_WAIT,
-            0, // No flags = relative timeout
-            &mutex.mutex,
-            @ptrCast(@constCast(&timeout_ts)),
-        );
-
-        // Check if we timed out
-        if (result == -1 and posix.errno(result) == .TIMEDOUT) {
-            return error.Timeout;
-        }
-    }
-
-    /// Wake one waiting thread.
-    pub fn signal(self: *ConditionFreeBSD) void {
-        _ = sys._umtx_op(&self.cond, sys.UMTX_OP_CV_SIGNAL, 0, null, null);
-    }
-
-    /// Wake all waiting threads.
-    pub fn broadcast(self: *ConditionFreeBSD) void {
-        _ = sys._umtx_op(&self.cond, sys.UMTX_OP_CV_BROADCAST, 0, null, null);
     }
 };
 
@@ -1651,4 +1541,92 @@ test "Condition - timedWait timeout" {
 test "ConditionNotify - timedWait timeout" {
     if (builtin.single_threaded) return error.SkipZigTest;
     try checkConditionTimedWaitTimeout(Mutex, ConditionNotify);
+}
+
+/// A condvar wait owes the caller the mutex back. Nothing above this file can
+/// check that for itself: a wait that returns without the lock still runs the
+/// caller's critical section, just without mutual exclusion, so the damage shows
+/// up as corrupted state somewhere else entirely. The waiter proves ownership by
+/// trying to take the lock it should already be holding. The signaler has
+/// released it by then, so a tryLock that succeeds means the wait handed the
+/// mutex back to nobody.
+fn checkConditionReacquiresMutex(
+    comptime MutexType: type,
+    comptime ConditionType: type,
+    comptime timed: bool,
+) !void {
+    var mutex = MutexType.init();
+    defer mutex.deinit();
+    var cond = ConditionType.init();
+    defer cond.deinit();
+    var ready = std.atomic.Value(bool).init(false);
+    var thread_ready = std.atomic.Value(bool).init(false);
+    var held_after_wait = std.atomic.Value(bool).init(false);
+
+    const Context = struct {
+        mutex: *MutexType,
+        cond: *ConditionType,
+        ready: *std.atomic.Value(bool),
+        thread_ready: *std.atomic.Value(bool),
+        held_after_wait: *std.atomic.Value(bool),
+    };
+
+    const waiter = struct {
+        fn run(ctx: *Context) void {
+            ctx.mutex.lock();
+            ctx.thread_ready.store(true, .release);
+            while (!ctx.ready.load(.acquire)) {
+                if (timed) {
+                    // Long enough that only the signal ends the wait.
+                    ctx.cond.timedWait(ctx.mutex, .{ .duration = .fromSeconds(10) }) catch return;
+                } else {
+                    ctx.cond.wait(ctx.mutex);
+                }
+            }
+            ctx.held_after_wait.store(!ctx.mutex.tryLock(), .release);
+            ctx.mutex.unlock();
+        }
+    }.run;
+
+    var ctx = Context{
+        .mutex = &mutex,
+        .cond = &cond,
+        .ready = &ready,
+        .thread_ready = &thread_ready,
+        .held_after_wait = &held_after_wait,
+    };
+    const thread = try std.Thread.spawn(.{}, waiter, .{&ctx});
+
+    while (!thread_ready.load(.acquire)) {
+        yield();
+    }
+
+    mutex.lock();
+    ready.store(true, .release);
+    mutex.unlock();
+    cond.signal();
+
+    thread.join();
+
+    try std.testing.expect(held_after_wait.load(.acquire));
+}
+
+test "Condition - wait returns holding the mutex" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+    try checkConditionReacquiresMutex(Mutex, Condition, false);
+}
+
+test "Condition - timedWait returns holding the mutex" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+    try checkConditionReacquiresMutex(Mutex, Condition, true);
+}
+
+test "ConditionNotify - wait returns holding the mutex" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+    try checkConditionReacquiresMutex(Mutex, ConditionNotify, false);
+}
+
+test "ConditionNotify - timedWait returns holding the mutex" {
+    if (builtin.single_threaded) return error.SkipZigTest;
+    try checkConditionReacquiresMutex(Mutex, ConditionNotify, true);
 }


### PR DESCRIPTION
`ConditionFreeBSD.wait` and `timedWait` returned **without the mutex**.

They are `UMTX_OP_CV_WAIT`, which unlocks the umutex before sleeping and, quoting `_umtx_op(2)`:

> The request must be issued by the thread owning the mutex pointed to by the `uaddr` argument.
>
> After wakeup, the `uaddr` umutex is not relocked.

The kernel (`do_cv_wait` in `sys/kern/kern_umtx.c`) calls `do_unlock_umutex` before `umtxq_sleep` and never touches the mutex again. Re-acquiring is the caller's job, which libthr does in `cond_wait_kernel`:

```c
	error = _thr_ucond_wait(&cvp->kcond, &mp->m_lock, abstime, NULL, ...);
	...
	if (error == 0) {
		error2 = _mutex_cv_lock(mp, recurse, true);
	} else if (error == EINTR || error == ETIMEDOUT) {
		error2 = _mutex_cv_lock(mp, recurse, true);
	} else {
		/* We know that it didn't unlock the mutex. */
		_mutex_cv_attach(mp, recurse);
```

We never did, and the doc comment on `wait` claimed the opposite ("When signaled, the mutex is automatically reacquired before returning").

## What that broke

From its first wait onwards, a caller ran every critical section without the lock. `ThreadPool.runTasks` holds `queue_mutex` across its whole loop and only drops it around the work itself, so a woken worker ran `queue.pop()` and `queue_size -= 1` unsynchronized against a submitter, which pushes the node *before* it bumps the counter:

```
queue_size = 0, worker W parked in timedWait
submit(op1): lock, push(n1), queue_size = 1, unlock, signal   -> W wakes holding nothing
submit(op2): lock (free, W does not hold it), push(n2), ...preempted...
W:           pop -> n1, queue_size 1 -> 0
W:           pop -> n2 (already linked), queue_size 0 -> underflow, panic
```

That is the `thread NNNNN panic: integer overflow` in `runTasks` that hit the FreeBSD release job twice on 2026-08-29, both times in `fs.test.File: prep functions drive concurrent reads through a CompletionQueue`, the one test that feeds the pool four ops back to back.

Worse than the panic: the *next* wait passed a umutex the worker no longer owned, so `do_unlock_umutex` returned `EPERM`, `do_cv_wait` skipped `umtxq_sleep` entirely, and `timedWait` returned instantly. Since only `ETIMEDOUT` was treated as an error, that reads as "signaled", so an idle worker that woke to find no work spun at 100% and never reached its 60s idle exit. A spinning worker is also doing unlocked `pop()` millions of times a second, which is probably why those jobs also show 5s to 320s for the same prefix of the suite.

## The fix

Rather than add the conditional re-lock (only on `0`, `EINTR` and `ETIMEDOUT`; on any other errno the kernel still holds it, and re-locking there self-deadlocks), use the futex-backed `Mutex`/`Condition` that every other non-Windows platform already uses, on top of the `UMTX_OP_WAIT_UINT_PRIVATE`/`WAKE_PRIVATE` wrappers that were already in the file. That is what Go's runtime does:

```go
// FreeBSD's umtx_op syscall is effectively the same as Linux's futex, and
// thus the code is largely similar. See Linux implementation
// and lock_futex.go for comments.
```

The umutex/ucond ops are the POSIX-completeness primitive, for priority-inherit, priority-protect, robust and process-shared mutexes. We set `m_flags = 0` and `c_flags = 0`, so we used none of it.

It is also faster. `MutexFreeBSD` entered the kernel on **every** lock and unlock, contended or not, where libthr settles the uncontended case with `atomic_cmpset_acq_32` on `m_owner` and only calls `_umtx_op` on contention, exactly like `MutexFutex`. `os.Mutex` is what `OverflowQueue` uses, so that syscall pair was on the cross-thread task wake path, not just in the pool.

## Test

Added `checkConditionReacquiresMutex` for both `wait` and `timedWait`, against `Condition` and `ConditionNotify`. Nothing above `os/thread.zig` can catch this class of bug: a wait that returns without the lock still runs the caller's critical section, just without mutual exclusion, so the damage surfaces somewhere else entirely. The waiter tries to take the lock it should already hold and asserts that it fails.

Verified as a negative control by deleting the `defer mutex.lock()` from `ConditionFutex.wait`, which makes it fail on Linux.

## Checks

- `./check.sh` (native, debug) green, including the four new tests
- `./check.sh --target x86_64-freebsd --backend kqueue --no-exec --release` and `--backend poll --no-exec` both build
- A comptime probe confirms FreeBSD now resolves to `os.thread.MutexFutex` / `os.thread.ConditionFutex` on `os.thread.FutexFreeBSD`

## Follow-up, not in this PR

`FutexFreeBSD.timedWait` passes `uaddr1 = 0` with a bare `timespec`. The kernel accepts it (`umtx_copyin_umtx_time` treats `size <= sizeof(struct timespec)` as a plain timespec) but pins it to `CLOCK_REALTIME`, so a wall-clock step can stretch a relative wait. Go passes `sizeof(umtx_time)` with `_clockid = CLOCK_MONOTONIC`.
