### PR TITLE
freebsd: time futex waits on CLOCK_MONOTONIC

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,20 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Fixed a FreeBSD bug where `Condition.wait` and `Condition.timedWait` returned without
-  the mutex. Both were built on `UMTX_OP_CV_WAIT`, which unlocks the mutex before
-  sleeping and, in the words of `_umtx_op(2)`, "after wakeup, the uaddr umutex is not
-  relocked". Re-acquiring it is the caller's job, which libthr does with
-  `_mutex_cv_lock` and we did not, so every caller ran its critical section unlocked
-  from its first wait onwards. In the thread pool that let two workers pop from the same
-  queue at once (seen in CI as an `integer overflow` panic on `queue_size -= 1`), and an
-  idle worker could spin at 100%, because a second wait on a mutex it no longer owned
-  returned `EPERM` immediately instead of sleeping.
+- Timed `Futex` waits on FreeBSD now use `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME`,
+  where a wall clock step could cut a wait short or stretch it.
 
-  FreeBSD now uses the same futex-backed `Mutex` and `Condition` as every other
-  platform, on top of the `UMTX_OP_WAIT_UINT_PRIVATE` wrappers that were already there.
-  This is what Go's runtime does too. It is also faster: an uncontended lock or unlock is
-  now a userspace CAS, where the umutex path made a syscall every time, contended or not.
+- Fixed a FreeBSD bug where the internal condition variable returned without
+  re-acquiring its mutex, corrupting the thread pool's queue or spinning an idle worker
+  at 100%; `Mutex` and `Condition` are now futex-backed there, like everywhere else.
 
 - Renamed `ResetEvent` to `Event`, matching `std.Io.Event`. `zio.ResetEvent` stays as a
   deprecated alias, so existing code keeps working, but it will be removed in a future

--- a/src/os/freebsd.zig
+++ b/src/os/freebsd.zig
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Lukáš Lalinský
 // SPDX-License-Identifier: MIT
 
+const std = @import("std");
+
 /// FreeBSD specific system calls and definitions
 
 // umtx operations
@@ -9,6 +11,19 @@ pub const UMTX_OP_WAIT_UINT: c_int = 11;
 pub const UMTX_OP_WAIT_UINT_PRIVATE: c_int = 15;
 pub const UMTX_OP_WAKE: c_int = 3;
 pub const UMTX_OP_WAKE_PRIVATE: c_int = 16;
+
+/// Timeout for the `UMTX_OP_WAIT_*` requests, passed in `uaddr2` with its own
+/// size in `uaddr`. The kernel distinguishes it from a bare `timespec` by that
+/// size alone (`umtx_copyin_umtx_time`), and the bare form carries no clock, so
+/// this is the only way to ask for anything but `CLOCK_REALTIME`.
+///
+/// `flags` is zero for an interval; `UMTX_ABSTIME` (0x01) would make `timeout` a
+/// deadline instead.
+pub const umtx_time = extern struct {
+    timeout: std.c.timespec,
+    flags: u32,
+    clockid: u32,
+};
 
 pub extern "c" fn _umtx_op(obj: *const anyopaque, op: c_int, val: c_ulong, uaddr: ?*anyopaque, uaddr2: ?*anyopaque) c_int;
 

--- a/src/os/thread.zig
+++ b/src/os/thread.zig
@@ -337,19 +337,34 @@ const FutexFreeBSD = struct {
     }
 
     pub fn timedWait(ptr: *const std.atomic.Value(u32), expected: u32, timeout: Duration) error{Timeout}!void {
-        const timeout_ts = timeout.toTimespec();
+        // The interval has to travel as a `umtx_time` rather than a bare
+        // `timespec`, because the bare form is read on CLOCK_REALTIME: the
+        // kernel turns it into a deadline on that clock right away, so a wall
+        // clock step then moves a wait that should only have measured elapsed
+        // time. Which of the two forms the kernel reads is decided purely by
+        // the size handed to it in `uaddr`.
+        const interval: sys.umtx_time = .{
+            .timeout = timeout.toTimespec(),
+            .flags = 0, // an interval, not an absolute deadline
+            .clockid = @intFromEnum(posix.system.CLOCK.MONOTONIC),
+        };
 
         const rc = sys._umtx_op(
             &ptr.raw,
             sys.UMTX_OP_WAIT_UINT_PRIVATE,
             expected,
-            null,
-            @ptrCast(@constCast(&timeout_ts)),
+            @ptrFromInt(@sizeOf(sys.umtx_time)),
+            @ptrCast(@constCast(&interval)),
         );
 
         if (rc == -1) {
             const err = posix.errno(rc);
             if (err == .TIMEDOUT) return error.Timeout;
+            // A signal is the only other failure this request can produce once
+            // it is well formed, so anything else means we built it wrong (a
+            // malformed interval or the wrong size in `uaddr` both surface as
+            // EINVAL) and every wait would be returning without waiting.
+            std.debug.assert(err == .INTR);
         }
     }
 


### PR DESCRIPTION
Follow-up to #722, which mentioned this but left it out.

`FutexFreeBSD.timedWait` passed the interval to `UMTX_OP_WAIT_UINT_PRIVATE` as a bare `timespec`, with `uaddr` left `null`:

```zig
const timeout_ts = timeout.toTimespec();
const rc = sys._umtx_op(&ptr.raw, sys.UMTX_OP_WAIT_UINT_PRIVATE, expected, null, @ptrCast(@constCast(&timeout_ts)));
```

The kernel accepts that, but it means something other than what we want. `umtx_copyin_umtx_time` picks the form by the size it is handed in `uaddr`, and fills in the clock itself for the short one:

```c
	if (size <= sizeof(struct timespec)) {
		tp->_clockid = CLOCK_REALTIME;
		tp->_flags = 0;
		error = copyin(uaddr, &tp->_timeout, sizeof(struct timespec));
	} else {
		error = copyin(uaddr, tp, sizeof(struct _umtx_time));
	}
```

`do_wait` then calls `umtx_abs_timeout_init2` up front, so the interval becomes a deadline on `CLOCK_REALTIME` at the moment of the call. A wall clock step (NTP correction, `settimeofday`) after that moves the end of a wait that should only have counted elapsed time. Everything above `Futex` assumes an interval: `ConditionFutex.timedWait`, `Condition.waitTimeout`, `Waiter.timedWait`, and the thread pool's 60s idle reap.

## The fix

Send a `umtx_time`, which carries its own clock, with `CLOCK_MONOTONIC` and no `UMTX_ABSTIME`, and put its size in `uaddr` so the kernel reads the long form. That is the encoding libthr uses in `_thr_umtx_timedwait_uint`, and the same choice Go's runtime makes:

```go
var ut umtx_time
ut._clockid = _CLOCK_MONOTONIC
ut._timeout.setNsec(ns)
utp = &ut
ret := sys_umtx_op(addr, _UMTX_OP_WAIT_UINT_PRIVATE, val, unsafe.Sizeof(*utp), utp)
```

The untimed `wait` and `wake` are unchanged; neither takes a timeout.

## Also: stop discarding the return code

Past `ETIMEDOUT`, only `EINTR` is reachable for a well formed request (`do_wait` returns `0`, `EINTR` from `ERESTART`, `ETIMEDOUT` from `umtxq_sleep`, or `EFAULT`), so anything else is now asserted.

This is not decoration, it is how the new encoding is checked. Both ways of getting it wrong, a malformed interval or the wrong size in `uaddr`, come back as `EINVAL`, and the old code swallowed every errno that was not `ETIMEDOUT`. A rejected request returns instantly and reads as a spurious wake, so `ConditionFutex` would spin to its deadline instead of sleeping and the tests would still pass. That is the same shape as the bug in #722, where a discarded `EPERM` turned an idle worker into a busy loop. Happy to drop this hunk if you would rather keep the wrapper thin.

## Checks

- `./check.sh` native debug: green
- `./check.sh --target x86_64-freebsd --backend kqueue --no-exec --release` and `--backend poll --no-exec`: both build
- Probed against the `x86_64-freebsd` target: `CLOCK.MONOTONIC` is `4`, and `umtx_time` is 24 bytes with `flags` at 16 and `clockid` at 20, matching `struct _umtx_time` in `sys/sys/_umtx.h` on LP64. 24 is also `> sizeof(struct timespec)`, so the kernel takes the long-form branch (it still does on 32-bit, where the sizes are 16 and 8)
- The FreeBSD CI job exercises this through `Futex - timedWait times out and sees changed values`, the `Condition - timedWait timeout` tests, and the pool's idle reap, so a malformed request now trips the assert instead of passing quietly
