### PR TITLE
ev: per-clock wall timer modes, and drop Darwin's realtime kernel timer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Darwin no longer arms a kernel timer for realtime deadlines, since XNU converts one to
+  a Mach deadline at arming and never rebases it across a wall-clock step.
+
 - Timed `Futex` waits on FreeBSD now use `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME`,
   where a wall clock step could cut a wait short or stretch it.
 

--- a/src/ev/backends/iocp.zig
+++ b/src/ev/backends/iocp.zig
@@ -163,10 +163,14 @@ pub const NetHandle = net.fd_t;
 
 const Op = @import("../completion.zig").Op;
 const Support = @import("../completion.zig").Support;
+const WallTimerMode = @import("../completion.zig").WallTimerMode;
 
-// Boot/real deadlines are armed via per-loop waitable timers whose
-// completion-routine APC fires during the alertable poll wait.
-pub const native_wall_timers = true;
+// Real deadlines are armed via a per-loop waitable timer whose completion-
+// routine APC fires during the alertable poll wait, and an absolute due time is
+// interpreted against the system clock on every evaluation, so it needs no cap.
+// Windows has no clock that separates suspend from awake, so boot timers live in
+// the awake heap and never reach the backend.
+pub const wall_timer_modes: [3]WallTimerMode = .{ .fallback, .fallback, .native };
 pub const supports_nonblocking_file_io = true;
 
 pub fn capability(comptime op: Op) Support {

--- a/src/ev/backends/kqueue.zig
+++ b/src/ev/backends/kqueue.zig
@@ -33,12 +33,30 @@ pub const NetHandle = net.fd_t;
 
 const Op = @import("../completion.zig").Op;
 const Support = @import("../completion.zig").Support;
+const WallTimerMode = @import("../completion.zig").WallTimerMode;
 
-// Only Darwin has usable absolute wall-clock EVFILT_TIMER semantics
-// (NOTE_ABSOLUTE = gettimeofday, NOTE_MACH_CONTINUOUS_TIME = suspend-aware).
-// The BSDs' EVFILT_TIMER absolute clock is monotonic-only and underspecified
-// with no CLOCK_REALTIME timer, so they keep the capped poll-timeout fallback.
-pub const native_wall_timers = builtin.os.tag.isDarwin();
+// Boot is the one wall clock worth arming here, and only on Darwin. It is a
+// relative NOTE_MACH_CONTINUOUS_TIME timer, so XNU computes the deadline in its
+// own continuous timebase and nothing can invalidate it later; that also makes
+// it the only way to fire a boot deadline that comes due while the system is
+// asleep, which a poll timeout measured on the awake clock would sleep through.
+// It is capped rather than trusted outright because the kernel is free to
+// coalesce it (see armWall), and the poll timeout is the prompter of the two.
+//
+// Real is not armed at all. XNU converts a NOTE_ABSOLUTE calendar deadline to a
+// Mach deadline once at registration, with an explicit "if the relationship
+// between MAT and gettimeofday changes, the underlying timer does not update"
+// in filt_timervalidate, so a wall-clock step afterwards leaves it pointing at
+// the wrong moment. Re-deriving the interval from now(.real) on every scan,
+// which is what the fallback does, is both correct across steps and no less
+// prompt, so the timer would only add a syscall and a wake to ignore.
+//
+// The other BSDs arm neither: their EVFILT_TIMER absolute clock is
+// monotonic-only and underspecified, with no CLOCK_REALTIME timer at all.
+pub const wall_timer_modes: [3]WallTimerMode = if (builtin.os.tag.isDarwin())
+    .{ .fallback, .native_capped, .fallback }
+else
+    .{ .fallback, .fallback, .fallback };
 pub const supports_nonblocking_file_io = false;
 
 pub fn capability(comptime op: Op) Support {
@@ -186,11 +204,10 @@ fn filterForDir(dir: sockreg.Dir) i16 {
     };
 }
 
-// EVFILT_TIMER idents for the boot/real wall-clock timers (Darwin only). They
-// share the EVFILT_TIMER filter, which nothing else uses, so plain 0/1 idents
-// don't collide with fd-based idents on other filters.
+// EVFILT_TIMER ident for the boot wall-clock timer (Darwin only). It has the
+// EVFILT_TIMER filter to itself, so a plain 0 ident doesn't collide with the
+// fd-based idents on the other filters.
 const WALL_BOOT_IDENT: usize = 0;
-const WALL_REAL_IDENT: usize = 1;
 
 const PollEntry = struct {
     completions: Queue(Completion),
@@ -205,9 +222,9 @@ waker_ident: usize = undefined,
 poll_queue: std.AutoHashMapUnmanaged(u64, PollEntry) = .empty,
 change_buffer: std.ArrayList(std.c.Kevent) = .empty,
 events: []std.c.Kevent,
-/// Currently-armed absolute deadline (ns in the clock's epoch) for the boot/real
-/// EVFILT_TIMER, or null if disarmed. Index 0 = boot, 1 = real. Darwin only.
-wall_armed: [2]?u64 = .{ null, null },
+/// Currently-armed absolute deadline (ns in the boot epoch) for the boot
+/// EVFILT_TIMER, or null if disarmed. Darwin only.
+wall_armed: ?u64 = null,
 
 fn makeKey(ident: usize, filter: i32) u64 {
     std.debug.assert(ident <= std.math.maxInt(u32));
@@ -294,24 +311,21 @@ pub fn wake(self: *Self, state: *LoopState) void {
     }
 }
 
-/// Arm/update/disarm the given wall clock's EVFILT_TIMER to an absolute deadline
-/// (ns in that clock's epoch; null = disarm). Returns false only if it couldn't
-/// arm a pending deadline, so the loop folds that clock into the capped poll
-/// timeout. Darwin only; other kqueue platforms keep the fallback (the comptime
-/// guard also keeps the Darwin-only NOTE_* references out of their builds).
+/// Arm/update/disarm the boot clock's EVFILT_TIMER to an absolute deadline (ns
+/// in the boot epoch; null = disarm). Returns false only if it couldn't arm a
+/// pending deadline, so the loop falls back to its poll timeout alone. Darwin
+/// only; other kqueue platforms keep the fallback (the comptime guard also keeps
+/// the Darwin-only NOTE_* references out of their builds).
 pub fn syncWallTimer(self: *Self, clock: Clock, deadline: ?u64) bool {
     if (comptime builtin.os.tag.isDarwin()) {
-        return switch (clock) {
-            .boot => self.armWall(0, WALL_BOOT_IDENT, deadline),
-            .real => self.armWall(1, WALL_REAL_IDENT, deadline),
-            else => unreachable,
-        };
+        std.debug.assert(clock == .boot);
+        return self.armWall(deadline);
     }
     return true;
 }
 
-fn armWall(self: *Self, idx: usize, ident: usize, deadline: ?u64) bool {
-    if (self.wall_armed[idx] == deadline) return true; // unchanged (incl. both null)
+fn armWall(self: *Self, deadline: ?u64) bool {
+    if (self.wall_armed == deadline) return true; // unchanged (incl. both null)
     // reserveChange only fails on OOM: the change buffer grows and is reused
     // across polls (clearRetainingCapacity), so there's no "full" condition like
     // io_uring's fixed SQ ring. On OOM while arming a pending deadline, report
@@ -323,22 +337,29 @@ fn armWall(self: *Self, idx: usize, ident: usize, deadline: ?u64) bool {
         return deadline == null;
     };
     if (deadline) |d| {
-        var fflags: u32 = std.c.NOTE.NSECONDS;
-        var data: isize = undefined;
-        if (idx == 0) {
-            // boot: relative continuous-time timer — counts suspend, and being
-            // relative it needs no epoch match with our boot clock.
-            const now_ns = time.now(.boot).toNanoseconds();
-            fflags |= std.c.NOTE.MACH_CONTINUOUS_TIME;
-            data = @intCast(if (d > now_ns) d - now_ns else 0);
-        } else {
-            // real: absolute gettimeofday timer — fires at the wall moment and
-            // is re-evaluated by the kernel across clock steps.
-            fflags |= std.c.NOTE.ABSOLUTE;
-            data = @intCast(d);
-        }
+        // A relative interval on the continuous timebase: XNU computes the
+        // deadline with clock_continuoustime_interval_to_deadline and arms the
+        // thread_call with THREAD_CALL_CONTINUOUS, so it counts suspend and
+        // there is no foreign epoch for the kernel to snapshot. Our `.boot` is
+        // CLOCK_MONOTONIC_RAW, the same counter, and an interval needs no epoch
+        // match anyway.
+        //
+        // Deliberately not NOTE_CRITICAL. The kernel coalesces this against the
+        // thread's latency QoS (timer_compute_leeway), and NOTE_CRITICAL is the
+        // only lever that narrows that window: NOTE_LEEWAY can only widen it,
+        // and timer_call_slop skips coalescing only for TIMER_CALL_SYS_CRITICAL,
+        // which no kevent can ask for. But the flag asks the system for
+        // realtime-tier treatment of every boot deadline a program sets, which
+        // is the application's call to make and not a library's; libdispatch
+        // exposes the same thing as an opt-in (DISPATCH_TIMER_STRICT) and
+        // coalesces by default. The lateness it would buy back is already
+        // covered: `native_capped` keeps the loop's own poll timeout, and that
+        // is what actually decides when a due timer fires.
+        const now_ns = time.now(.boot).toNanoseconds();
+        const fflags: u32 = std.c.NOTE.NSECONDS | std.c.NOTE.MACH_CONTINUOUS_TIME;
+        const data: isize = @intCast(if (d > now_ns) d - now_ns else 0);
         change.* = .{
-            .ident = ident,
+            .ident = WALL_BOOT_IDENT,
             .filter = std.c.EVFILT.TIMER,
             .flags = std.c.EV.ADD | std.c.EV.ONESHOT,
             .fflags = fflags,
@@ -347,7 +368,7 @@ fn armWall(self: *Self, idx: usize, ident: usize, deadline: ?u64) bool {
         };
     } else {
         change.* = .{
-            .ident = ident,
+            .ident = WALL_BOOT_IDENT,
             .filter = std.c.EVFILT.TIMER,
             .flags = std.c.EV.DELETE,
             .fflags = 0,
@@ -355,7 +376,7 @@ fn armWall(self: *Self, idx: usize, ident: usize, deadline: ?u64) bool {
             .udata = 0,
         };
     }
-    self.wall_armed[idx] = deadline;
+    self.wall_armed = deadline;
     return true;
 }
 
@@ -734,14 +755,13 @@ pub fn poll(self: *Self, state: *LoopState, timeout: Duration) !bool {
             continue;
         }
 
-        // A boot/real wall timer event. Forget the armed deadline in both the
+        // A boot wall timer event. Forget the armed deadline in both the
         // fired and the failed-registration case: on a successful one-shot fire
         // the kernel already removed it (EV_ONESHOT), and on EV_ERROR the ADD
         // never stuck, so the stored deadline is stale either way — clearing it
         // lets syncWallTimer re-queue the ADD on the next scan.
         if (event.filter == std.c.EVFILT.TIMER) {
-            if (event.ident == WALL_BOOT_IDENT) self.wall_armed[0] = null;
-            if (event.ident == WALL_REAL_IDENT) self.wall_armed[1] = null;
+            self.wall_armed = null;
             // EV_ERROR surfaces a changelist (ADD/DELETE) failure with errno in
             // event.data; no timer actually fired, so don't report a timeout.
             if (event.flags & EV_ERROR != 0) {

--- a/src/ev/backends/linux.zig
+++ b/src/ev/backends/linux.zig
@@ -5,6 +5,7 @@ const Epoll = @import("linux/epoll.zig");
 const Completion = @import("../completion.zig").Completion;
 const Op = @import("../completion.zig").Op;
 const Support = @import("../completion.zig").Support;
+const WallTimerMode = @import("../completion.zig").WallTimerMode;
 const LoopState = @import("../loop.zig").LoopState;
 const Duration = @import("../../time.zig").Duration;
 const Clock = @import("../../time.zig").Clock;
@@ -35,7 +36,10 @@ pub fn Backend(comptime mode: Mode) type {
         };
 
         pub const NetHandle = IoUring.NetHandle;
-        pub const native_wall_timers = true;
+        /// Both engines arm boot and real natively (timerfd or io_uring
+        /// timeouts), and the kernel rebases an absolute CLOCK_REALTIME timer
+        /// across a clock step, so neither needs a cap.
+        pub const wall_timer_modes: [3]WallTimerMode = .{ .fallback, .native, .native };
         // In auto mode a delegated open means epoll was selected; probePollable
         // applies O_NONBLOCK after opening, matching the old epoll behavior.
         pub const supports_nonblocking_file_io = mode == .io_uring;

--- a/src/ev/backends/linux/epoll.zig
+++ b/src/ev/backends/linux/epoll.zig
@@ -32,8 +32,12 @@ const sockreg = @import("../../sockreg.zig");
 pub const NetHandle = net.fd_t;
 
 const Support = @import("../../completion.zig").Support;
+const WallTimerMode = @import("../../completion.zig").WallTimerMode;
 
-pub const native_wall_timers = true;
+/// timerfds on CLOCK_BOOTTIME and CLOCK_REALTIME, armed with TFD_TIMER_ABSTIME.
+/// The kernel rebases an absolute CLOCK_REALTIME timer across a clock step, so
+/// neither needs a cap.
+pub const wall_timer_modes: [3]WallTimerMode = .{ .fallback, .native, .native };
 pub const supports_nonblocking_file_io = false;
 
 pub fn capability(comptime op: Op) Support {

--- a/src/ev/backends/linux/io_uring.zig
+++ b/src/ev/backends/linux/io_uring.zig
@@ -82,8 +82,12 @@ pub const NetHandle = net.fd_t;
 
 const Op = @import("../../completion.zig").Op;
 const Support = @import("../../completion.zig").Support;
+const WallTimerMode = @import("../../completion.zig").WallTimerMode;
 
-pub const native_wall_timers = true;
+/// IORING_TIMEOUT_BOOTTIME and IORING_TIMEOUT_REALTIME|ABS are kernel hrtimers
+/// on CLOCK_BOOTTIME and CLOCK_REALTIME, and the kernel rebases an absolute
+/// CLOCK_REALTIME timer when the wall clock is stepped, so neither needs a cap.
+pub const wall_timer_modes: [3]WallTimerMode = .{ .fallback, .native, .native };
 pub const supports_nonblocking_file_io = true;
 
 pub fn capability(comptime op: Op) Support {

--- a/src/ev/backends/poll.zig
+++ b/src/ev/backends/poll.zig
@@ -24,9 +24,11 @@ const PipeClose = @import("../completion.zig").PipeClose;
 pub const NetHandle = net.fd_t;
 
 const Support = @import("../completion.zig").Support;
+const WallTimerMode = @import("../completion.zig").WallTimerMode;
 const fs = @import("../../os/fs.zig");
 
-pub const native_wall_timers = false;
+/// Nothing but the poll timeout, so every wall deadline rides the cap.
+pub const wall_timer_modes: [3]WallTimerMode = .{ .fallback, .fallback, .fallback };
 pub const supports_nonblocking_file_io = false;
 
 pub fn capability(comptime op: Op) Support {

--- a/src/ev/completion.zig
+++ b/src/ev/completion.zig
@@ -23,6 +23,25 @@ pub const Support = enum {
     maybe,
 };
 
+/// How a backend handles timers on a wall clock (`boot`, `real`). The loop's
+/// poll timeout is measured on `awake`, which tracks neither suspend nor a
+/// wall-clock step, so a wall deadline the backend does not own has to be
+/// re-examined on a cap instead.
+///
+/// `native_capped` is for a kernel timer that is worth having for a property
+/// only it provides, while the loop's own timeout stays the schedule. Darwin's
+/// boot timer is the case: it is the only thing that can fire a deadline coming
+/// due during suspend, but the kernel may coalesce it by tens of milliseconds,
+/// so the poll timeout is what fires a timer that comes due while awake.
+pub const WallTimerMode = enum {
+    /// The loop drives this clock entirely through the capped poll timeout.
+    fallback,
+    /// The backend owns the deadline; the loop stops timing this clock.
+    native,
+    /// The backend arms the deadline as a backstop, and the loop keeps timing it.
+    native_capped,
+};
+
 /// The route selected for a `maybe` operation. It is recorded at submission so
 /// cancellation follows the original route rather than repeating a feature or
 /// handle probe whose answer might no longer describe the in-flight work.

--- a/src/ev/loop.zig
+++ b/src/ev/loop.zig
@@ -968,7 +968,9 @@ pub const Loop = struct {
     /// Fire every timer whose deadline has passed and report the earliest one
     /// still pending. Scans against the current snapshot; `poll` owns the tick.
     fn checkTimers(self: *Loop) TimerCheckResult {
-        const native_wall = Backend.native_wall_timers;
+        // Per wall clock: whether the backend arms the deadline itself, and
+        // whether the loop still has to re-examine it on the cap anyway.
+        const modes = Backend.wall_timer_modes;
 
         var fired = false;
         var next_timeout: ?Duration = null;
@@ -1004,26 +1006,28 @@ pub const Loop = struct {
                 while (self.state.timers[idx].peek()) |timer| {
                     const now_clock = self.state.nowFor(clock);
                     if (timer.deadline.value > now_clock.value) {
-                        if (native_wall and clock != .awake) {
-                            // Backend arms this clock natively; record its
-                            // earliest deadline, plus a capped remaining to fold
-                            // only if the backend later reports it couldn't arm.
-                            wall_deadline[idx] = timer.deadline.value;
-                            var remaining = now_clock.durationTo(timer.deadline);
-                            if (remaining.value > self.wall_clock_cap.value) {
-                                remaining = self.wall_clock_cap;
-                            }
-                            wall_remaining[idx] = remaining;
-                        } else {
-                            var remaining = now_clock.durationTo(timer.deadline);
-                            // boot/real can't be tracked by the awake poll clock,
-                            // so bound the wait to re-evaluate across suspend/steps.
-                            if (clock != .awake and remaining.value > self.wall_clock_cap.value) {
-                                remaining = self.wall_clock_cap;
-                            }
-                            if (next_timeout == null or remaining.value < next_timeout.?.value) {
-                                next_timeout = remaining;
-                            }
+                        var remaining = now_clock.durationTo(timer.deadline);
+                        // boot/real can't be tracked by the awake poll clock, so
+                        // bound the wait to re-evaluate across suspend/steps.
+                        if (clock != .awake and remaining.value > self.wall_clock_cap.value) {
+                            remaining = self.wall_clock_cap;
+                        }
+                        // A clock the backend arms records its earliest deadline
+                        // for syncWallTimer below, and keeps the capped remaining
+                        // to fold only if that arming fails. `native_capped` folds
+                        // it either way: there the kernel timer is a backstop for
+                        // what the poll clock cannot see (a deadline coming due
+                        // during suspend), and this timeout is still the schedule.
+                        const fold = switch (modes[idx]) {
+                            .fallback => true,
+                            .native, .native_capped => blk: {
+                                wall_deadline[idx] = timer.deadline.value;
+                                wall_remaining[idx] = remaining;
+                                break :blk modes[idx] == .native_capped;
+                            },
+                        };
+                        if (fold and (next_timeout == null or remaining.value < next_timeout.?.value)) {
+                            next_timeout = remaining;
                         }
                         break;
                     }
@@ -1050,17 +1054,17 @@ pub const Loop = struct {
         // syncWallTimer returns false only when it couldn't arm a pending
         // deadline (e.g. SQ full); then fold that clock's capped remaining into
         // the poll timeout so it's still re-evaluated within the cap.
-        if (comptime native_wall) {
-            // Always arm real; arm boot only where it is a distinct clock —
-            // otherwise boot timers live in the awake heap and are never handed
-            // to the backend (e.g. Windows/IOCP has no boot-clock timer).
-            const wall_idxs = comptime if (time.boot_distinct_from_awake) [_]usize{ 1, 2 } else [_]usize{2};
-            for (wall_idxs) |idx| {
-                const clock = indexClock(idx);
-                if (self.backend.syncWallTimer(clock, wall_deadline[idx])) continue;
-                const remaining = wall_remaining[idx];
-                if (next_timeout == null or remaining.value < next_timeout.?.value) {
-                    next_timeout = remaining;
+        inline for (1..wall_clock_count) |idx| {
+            // A clock left on the fallback never reaches the backend, and where
+            // boot is not distinct from awake its timers live in the awake heap,
+            // so its entry stays null and there is nothing to arm.
+            if (comptime modes[idx] != .fallback and (idx != 1 or time.boot_distinct_from_awake)) {
+                const clock = comptime indexClock(idx);
+                if (!self.backend.syncWallTimer(clock, wall_deadline[idx])) {
+                    const remaining = wall_remaining[idx];
+                    if (next_timeout == null or remaining.value < next_timeout.?.value) {
+                        next_timeout = remaining;
+                    }
                 }
             }
         }

--- a/src/ev/test/timer.zig
+++ b/src/ev/test/timer.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const time = @import("../../time.zig");
 const Loop = @import("../loop.zig").Loop;
 const Timer = @import("../completion.zig").Timer;
+const Timestamp = @import("../../time.zig").Timestamp;
 const FileReadStreaming = @import("../completion.zig").FileReadStreaming;
 const ReadBuf = @import("../buf.zig").ReadBuf;
 const fs = @import("../../os/fs.zig");
@@ -180,6 +181,23 @@ test "timer with explicit deadline" {
     std.log.info("deadline timer: expected=100ms, actual={f}", .{elapsed});
 }
 
+/// How late a wall-clock timer may fire before the test calls it a failure. This
+/// is a latency budget, not a semantic bound: what the assertions mean is that
+/// the timer did not fire before its deadline and that it fired at all. Every
+/// platform is held to the same one, because on every platform it is the loop's
+/// own poll timeout that fires a timer coming due while the process is awake.
+const max_lateness_ms = 150;
+
+/// A wall-clock timer's deadline is only meaningful in its own clock, so a
+/// test measures the firing moment there rather than on an awake stopwatch: a
+/// suspend or a wall-clock step moves the two apart, and only the timer's clock
+/// keeps "now" and the deadline crossing together.
+fn expectFiredAt(deadline: Timestamp, fired_at: Timestamp) !void {
+    // durationTo saturates at zero, so each direction reads as its own slack.
+    try std.testing.expect(fired_at.durationTo(deadline).toMilliseconds() <= 1);
+    try std.testing.expect(deadline.durationTo(fired_at).toMilliseconds() <= max_lateness_ms);
+}
+
 test "timer on boot clock fires (duration)" {
     var loop: Loop = undefined;
     try loop.init(.{});
@@ -189,14 +207,15 @@ test "timer on boot clock fires (duration)" {
     loop.setTimer(&timer, .{ .duration = .fromMilliseconds(100) });
     try std.testing.expectEqual(.running, timer.c.loadState().phase);
 
-    var wall_timer = time.Stopwatch.start();
+    // The loop turned the duration into a deadline in the boot epoch; assert
+    // against that rather than against a nominal 100ms measured elsewhere.
+    const deadline = timer.deadline;
     try loop.run();
-    const elapsed = wall_timer.read();
+    const fired_at = time.Timestamp.now(.boot);
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
-    try std.testing.expect(elapsed.toMilliseconds() >= 90);
-    try std.testing.expect(elapsed.toMilliseconds() <= 250);
-    std.log.info("boot timer: expected=100ms, actual={f}", .{elapsed});
+    try expectFiredAt(deadline, fired_at);
+    std.log.info("boot timer: late by {f}", .{deadline.durationTo(fired_at)});
 }
 
 test "timer on real clock fires (absolute deadline)" {
@@ -221,12 +240,11 @@ test "timer on real clock fires (absolute deadline)" {
     // moment in monotonic terms and made this test flaky; in the timer's own
     // clock domain a step moves "now" and the crossing together, so the
     // elapsed time stays ~100ms plus firing latency either way.
-    const elapsed = start.durationTo(time.Timestamp.now(.real));
+    const fired_at = time.Timestamp.now(.real);
 
     try std.testing.expectEqual(.dead, timer.c.loadState().phase);
-    try std.testing.expect(elapsed.toMilliseconds() >= 90);
-    try std.testing.expect(elapsed.toMilliseconds() <= 250);
-    std.log.info("real timer: expected=100ms, actual={f}", .{elapsed});
+    try expectFiredAt(deadline, fired_at);
+    std.log.info("real timer: late by {f}", .{deadline.durationTo(fired_at)});
 }
 
 test "clearTimer racing a firing timer (cross-thread)" {


### PR DESCRIPTION
Darwin's realtime `EVFILT_TIMER` stopped tracking the wall clock the moment it was armed, and its boot timer put a nominal 100ms deadline 60 to 130ms late. Both were hidden behind one boolean per backend, `native_wall_timers`, which Darwin does not fit.

## `native_wall_timers: bool` becomes a per-clock mode

The boolean answered two questions at once: does the backend arm boot and real deadlines, and may the loop stop timing them itself. It is now `Backend.wall_timer_modes: [3]WallTimerMode`, indexed by clock:

| mode | the backend arms it | the loop keeps timing it |
|---|---|---|
| `fallback` | no | yes |
| `native` | yes | no |
| `native_capped` | yes | yes |

- **Darwin boot** is `native_capped`.
- **Darwin real** is `fallback`; its kernel timer is gone entirely.
- **Linux** (io_uring and epoll) and **Windows** are `native` for both clocks, unchanged in effect: their kernels own an absolute realtime deadline and rebase it when the clock is stepped.
- **poll**, and **kqueue on the non-Darwin BSDs**, are `fallback` throughout, unchanged.

`checkTimers` computes the capped remaining once and reads the mode to decide whether to fold it into the poll timeout. The awake clock is always `fallback` by construction, so no backend gained or lost a code path it did not already have.

## Darwin realtime deadlines are no longer armed with the kernel

`armWall` gave them `NOTE_ABSOLUTE`, which hands the kernel a calendar deadline it has to translate into the timebase it arms on. `filt_timervalidate` does that exactly once and says so:

```c
			/*
			 * Note that the conversion through wall-time is only done once.
			 *
			 * If the relationship between MAT and gettimeofday changes,
			 * the underlying timer does not update.
			 *
			 * TODO: build a wall-time denominated timer_call queue
			 * and a flag to request DTRTing with wall-time timers
			 */
			clock_get_calendar_nanotime(&seconds, &nanoseconds);
```

So a step of the wall clock after arming left the timer pointing at the wrong moment, while the comment above it claimed the opposite.

Nothing is lost by dropping it. Re-deriving the interval from `now(.real)` on every scan, which is what `fallback` does, is correct across steps, and it is no less prompt: for any deadline inside `wall_clock_cap` the poll timeout *is* the remaining time. Keeping the kernel timer would only add a changelist entry per arm and a wake to ignore.

## Darwin boot deadlines still are, as a backstop

This one is worth keeping, and it is worth being precise about why. It is a *relative* timer with `NOTE_MACH_CONTINUOUS_TIME`, so the kernel computes the deadline in its own continuous timebase:

```c
		if (kev->fflags & NOTE_MACH_CONTINUOUS_TIME) {
			clock_continuoustime_interval_to_deadline(interval_abs, &deadline);
```

There is no foreign epoch to snapshot, so no later event can invalidate it, and it is the only mechanism that fires a boot deadline coming due while the system is asleep. A poll timeout cannot: it is measured on the awake clock, which does not advance during suspend, so the loop would sleep straight through the deadline and only notice on resume.

It is `native_capped` rather than `native` because the kernel may coalesce it. Between the two, the poll timeout is the prompter, so it fires anything coming due while awake and the kernel timer covers the case only it can. From this branch's own CI, same runner, same job, nominal 100ms:

| | boot | real |
|---|---|---|
| kqueue, before this change | 231.24ms | — |
| poll | 102.23ms | 102.18ms |

The 231ms was the coalesced kernel timer deciding when to fire. With the cap it is the 102ms path, and the kernel timer only wins the race after a suspend.

## Why there is no NOTE_CRITICAL

It would narrow the coalescing window, and it is the only thing that would: `NOTE_LEEWAY` can only widen it (`thread_call_enter_delayed_internal` takes a caller's leeway only when `leeway > slop`), and `timer_call_slop` skips coalescing outright only for `TIMER_CALL_SYS_CRITICAL`, which no kevent can request.

It is still not set. The flag asks the system for realtime-tier treatment of every boot deadline any program using zio sets, and that is the application's decision rather than a library's; libdispatch exposes the same thing as an opt-in (`DISPATCH_TIMER_STRICT`) and coalesces by default. With the cap in place there is also no lateness left for it to buy back. `armWall` carries that reasoning, so the flag does not get rediscovered and re-argued.

## The two wall-clock timer tests

They measured a nominal 100ms with an awake-clock stopwatch and asserted 90ms to 250ms. An awake stopwatch does not count a suspend a boot timer is supposed to include; 90ms and 250ms describe a duration nobody arms rather than the deadline the loop computed; and 250ms was quietly asserting that the platform does not coalesce.

Each test now takes the deadline the loop derived (`timer.deadline` for the duration timer, the explicit one for the absolute timer), reads the firing moment in the timer's own clock, and asserts that it did not fire before its deadline (within 1ms, for the read after `loop.run` returns) and that it fired within `max_lateness_ms` of it. That budget is 150ms on every platform, because on every platform it is now the loop's own poll timeout that fires a timer coming due while the process is awake.

The lateness is logged rather than implied. On Linux:

```
boot timer: late by 122.097us
real timer: late by 194.862us
```

## Checks

- `./check.sh --full` on Linux, plus `--backend poll`: green
- Cross-builds: `aarch64-macos`/kqueue, `x86_64-windows`/iocp, `x86_64-freebsd`/kqueue
