### PR TITLE
net: measure host names by what they cost on the wire

### DIFF
--- a/src/dns/posix.zig
+++ b/src/dns/posix.zig
@@ -23,10 +23,13 @@ pub fn fillResultsFromAddrinfo(
             if (h.canonname) |name_ptr| {
                 if (i >= storage.len) return i;
                 const name_slice = std.mem.sliceTo(name_ptr, 0);
-                @memcpy(cname_buf[0..name_slice.len], name_slice);
-                cname_buf[name_slice.len] = 0;
-                storage[i] = .{ .canonical_name = .{ .bytes = cname_buf[0..name_slice.len] } };
-                i += 1;
+                // A resolver that answers with a name too long to be encodable
+                // has told us nothing usable; drop it rather than truncate.
+                if (name_slice.len <= cname_buf.len) {
+                    @memcpy(cname_buf[0..name_slice.len], name_slice);
+                    storage[i] = .{ .canonical_name = .{ .bytes = cname_buf[0..name_slice.len] } };
+                    i += 1;
+                }
             }
         }
     }

--- a/src/dns/test.zig
+++ b/src/dns/test.zig
@@ -24,7 +24,8 @@ test "HostName: validate" {
     try HostName.validate("::1");
     try HostName.validate("2001:db8::1");
     try HostName.validate(@as([63]u8, @splat('a')) ++ ".com"); // Label exactly 63 chars (valid)
-    try HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "a"); // Total length 255 (valid)
+    try HostName.validate(@as([126 * 2]u8, @bitCast(@as([126][2]u8, @splat(.{ 'a', '.' })))) ++ "a"); // 253 chars, the longest encodable bare name (valid)
+    try HostName.validate(@as([126 * 2]u8, @bitCast(@as([126][2]u8, @splat(.{ 'a', '.' })))) ++ "a."); // 254 chars, the same name with the root dot (valid)
 
     // Invalid hostnames
     try std.testing.expectError(error.InvalidHostName, HostName.validate(""));
@@ -38,8 +39,9 @@ test "HostName: validate" {
     try std.testing.expectError(error.InvalidHostName, HostName.validate("."));
     try std.testing.expectError(error.InvalidHostName, HostName.validate(".."));
     try std.testing.expectError(error.InvalidHostName, HostName.validate(@as([64]u8, @splat('a')) ++ ".com")); // Label length 64 (too long)
-    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "a.")); // Total length 255 + trailing dot (too long)
-    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "ab")); // Total length 256 (too long)
+    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([126 * 2]u8, @bitCast(@as([126][2]u8, @splat(.{ 'a', '.' })))) ++ "aa")); // 254 chars bare: one octet too long on the wire
+    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "a")); // 255 chars bare (too long)
+    try std.testing.expectError(error.NameTooLong, HostName.validate(@as([127 * 2]u8, @bitCast(@as([127][2]u8, @splat(.{ 'a', '.' })))) ++ "a.")); // 255 chars plus the root dot (too long)
 }
 
 test "HostName: eql" {

--- a/src/dns/windows.zig
+++ b/src/dns/windows.zig
@@ -119,7 +119,6 @@ fn fillBuffers(
                 if (i >= storage.len) return i;
                 const name_slice = std.mem.sliceTo(name_ptr, 0);
                 const len = std.unicode.utf16LeToUtf8(cname_buf, name_slice) catch return error.UnknownHostName;
-                cname_buf[len] = 0;
                 storage[i] = .{ .canonical_name = .{ .bytes = cname_buf[0..len] } };
                 i += 1;
             }

--- a/src/net.zig
+++ b/src/net.zig
@@ -73,7 +73,20 @@ pub const HostName = struct {
     /// Externally managed memory. Already checked to be valid.
     bytes: []const u8,
 
-    pub const max_len = 255;
+    /// Size of a buffer that holds any host name, canonical names included.
+    /// Taken from the standard library so the `canonical_name_buffer` types in
+    /// `LookupOptions` stay identical to `std.Io.net.HostName`'s and cannot
+    /// drift apart as Zig changes the value (see #725). It is always at least
+    /// `max_encodable_len`, and on Zig 0.16 one byte more.
+    pub const max_len = std.Io.net.HostName.max_len;
+
+    /// The longest host name the DNS wire format can carry, in text form. A
+    /// name is capped at 255 octets on the wire, where every label carries a
+    /// one-octet length prefix and the root label is a single zero octet
+    /// (RFC 1035, Section 3.1). That leaves 254 characters with the trailing
+    /// dot standing in for the root label, or 253 without it.
+    const max_encodable_len = 254;
+    const max_encodable_len_without_root = max_encodable_len - 1;
 
     pub const ValidateError = error{
         NameTooLong,
@@ -86,16 +99,17 @@ pub const HostName = struct {
         if (IpAddress.parseIp(bytes, 0)) |_| return else |_| {}
         if (bytes[0] == '.') return error.InvalidHostName;
 
-        // The trailing dot of an FQDN counts toward the length. In a DNS packet it is
-        // the zero-length root label, which still takes up a byte. Checking the full
-        // length here also keeps `max_len` big enough to hold any validated hostname.
-        if (bytes.len > max_len) return error.NameTooLong;
-
-        // Ignore trailing dot (FQDN) when validating labels.
+        // Ignore the trailing dot of an FQDN when measuring and validating
+        // labels. In a packet it is the zero-length root label, so it costs an
+        // octet either way and the limit below already accounts for it.
         const end = if (bytes[bytes.len - 1] == '.') end: {
             if (bytes.len == 1) return error.InvalidHostName;
             break :end bytes.len - 1;
         } else bytes.len;
+
+        // Measured without the trailing dot, so that a name is judged by what
+        // it costs on the wire rather than by how it happens to be spelled.
+        if (end > max_encodable_len_without_root) return error.NameTooLong;
 
         // Hostnames are divided into dot-separated "labels", which:
         // - Start with a letter or digit


### PR DESCRIPTION
Cherry-pick of 4ed01b9 (#729) from `main`, which fixes this branch too: deriving `max_len` from the standard library is what makes the `canonical_name_buffer` types line up again.

Replaces the branch-only fix this PR originally carried. That version tightened `max_len` to 254 here, which fixed the compile error but left `validate` measuring the full length before stripping the trailing dot — so a 254-character bare name still got through. Doing it on `main` instead split the buffer size from the wire limit, which is correct on both branches from one source, and also removed the canonical-name terminator overrun CodeRabbit flagged on the earlier diff.

Applies cleanly. `./check.sh` green on `0.17.0-dev.1978+c961124d9`.

Fixes #725
