### PR TITLE
ci: run the zig-0.17 port against Zig master daily

### DIFF
--- a/.github/workflows/zig-master-drift.yml
+++ b/.github/workflows/zig-master-drift.yml
@@ -1,0 +1,40 @@
+# The zig-0.17 branch is the port to current Zig master, and its own CI only
+# runs when something is pushed to it. Zig master moves underneath it in
+# between, so a break can sit there unnoticed until a user reports it (#725).
+# This is the heartbeat that turns that silent drift into a daily signal.
+#
+# It only triggers the branch's own CI, it does not reimplement it: the matrix
+# lives on zig-0.17, next to the code it builds, and stays the single place to
+# change it.
+#
+# The schedule has to live on the default branch, because GitHub only schedules
+# workflows from there. A `schedule:` trigger added to test.yml on zig-0.17
+# would never fire, so instead we dispatch that workflow at that ref from here.
+name: Zig master drift
+
+on:
+  schedule:
+    # Daily, deliberately off the top of the hour: GitHub's scheduler is
+    # congested there and delays runs.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+concurrency:
+  group: zig-master-drift
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+    # Runs test.yml as defined on zig-0.17, against Zig master, with that
+    # branch's full matrix. Dispatching with GITHUB_TOKEN does start a real
+    # run: workflow_dispatch and repository_dispatch are the two events
+    # exempt from the rule that token-triggered events do not chain.
+    - name: Trigger the port branch's CI
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh workflow run test.yml --repo "$GITHUB_REPOSITORY" --ref zig-0.17


### PR DESCRIPTION
The port branch only builds when something is pushed to it, so drift in Zig master goes unnoticed in between. #725 is what that looks like from the outside: the stdlib changed `HostName.max_len` about ten hours after the last push to `zig-0.17`, CI had already run and passed, and it surfaced eight days later as a user's bug report.

This adds a daily job that triggers the branch's own CI at that ref, so the matrix stays on `zig-0.17` next to the code it builds rather than being duplicated here.

The schedule has to live on `main`: GitHub only schedules workflows from the default branch, so a `schedule:` trigger on `zig-0.17` would never fire. Dispatching with `GITHUB_TOKEN` does start a real run — `workflow_dispatch` and `repository_dispatch` are the two events exempt from the rule that token-triggered events don't chain.

Needs #728 for the matching `workflow_dispatch` trigger on `test.yml` on the branch, otherwise the dispatch fails.
