### PR TITLE
ci: allow this branch's CI to be triggered manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, zig-0.17 ]
     tags:
   pull_request:
+  # Lets the daily "Zig master drift" job on main run this workflow at this
+  # ref, to catch stdlib changes that land while nothing is pushed here.
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Companion to #727. GitHub only schedules workflows from the default branch, so the daily drift job lives on `main` and runs this workflow by dispatching it at this ref — which only works if the trigger is present here.

One line, no behaviour change to the existing push and PR runs.
